### PR TITLE
Rewrite dotnet watch command line parsing 

### DIFF
--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
+using System.Collections.Immutable;
 using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Data;
+using System.Diagnostics;
 using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 
@@ -10,86 +14,59 @@ namespace Microsoft.DotNet.Watcher;
 
 internal sealed class CommandLineOptions
 {
-    private const string Description = @"
-Environment variables:
+    private static readonly ImmutableArray<string> s_knownCommands =
+    [
+        "add",
+        "build",
+        "build-server",
+        "clean",
+        "format",
+        "help",
+        "list",
+        "msbuild",
+        "new",
+        "nuget",
+        "pack",
+        "publish",
+        "remove",
+        "restore",
+        "run",
+        "sdk",
+        "sln",
+        "store",
+        "test",
+        "tool",
+        "vstest",
+        "workload"
+    ];
 
-  DOTNET_USE_POLLING_FILE_WATCHER
-  When set to '1' or 'true', dotnet-watch will poll the file system for
-  changes. This is required for some file systems, such as network shares,
-  Docker mounted volumes, and other virtual file systems.
+    public const string DefaultCommand = "run";
 
-  DOTNET_WATCH
-  dotnet-watch sets this variable to '1' on all child processes launched.
-
-  DOTNET_WATCH_ITERATION
-  dotnet-watch sets this variable to '1' and increments by one each time
-  a file is changed and the command is restarted.
-
-  DOTNET_WATCH_SUPPRESS_EMOJIS
-  When set to '1' or 'true', dotnet-watch will not show emojis in the 
-  console output.
-
-Remarks:
-  The special option '--' is used to delimit the end of the options and
-  the beginning of arguments that will be passed to the child dotnet process.
-
-  For example: dotnet watch -- --verbose run
-
-  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
-  indicates that '--verbose' should be treated instead as an argument for
-  dotnet-run.
-
-Examples:
-  dotnet watch run
-  dotnet watch test
-";
-
-    private const string NoLaunchProfileOptionName = "--no-launch-profile";
-    private const string LaunchProfileOptionName = "--launch-profile";
-    private const string TargetFrameworkOptionName = "--framework";
-    private const string BuildPropertyOptionName = "--property";
-
-    public string? ExplicitCommand { get; init; }
     public string? Project { get; init; }
     public string? TargetFramework { get; init; }
     public IReadOnlyList<(string name, string value)>? BuildProperties { get; init; }
     public bool BinaryLogger { get; init; }
-    public bool WatchNoLaunchProfile { get; init; }
-    public string? WatchLaunchProfileName { get; init; }
-    public bool? CommandNoLaunchProfile { get; init; }
-    public string? CommandLaunchProfileName { get; init; }
+    public bool NoLaunchProfile { get; init; }
+    public string? LaunchProfileName { get; init; }
     public bool Quiet { get; init; }
     public bool Verbose { get; init; }
     public bool List { get; init; }
     public bool NoHotReload { get; init; }
     public bool NonInteractive { get; init; }
-    public required IReadOnlyList<string> RemainingArguments { get; init; }
+    public required IReadOnlyList<string> LaunchProcessArguments { get; init; }
+    public string? ExplicitCommand { get; init; }
 
-    public string Command => ExplicitCommand ?? "run";
+    public string Command => ExplicitCommand ?? DefaultCommand;
 
-    /// <summary>
-    /// Command line parsing attempts to mimic `dotnet run`, in the sense that `run` can be replaced with `watch` and the arguments are processed the same way.
-    /// E.g. `dotnet run x y z` runs the app with arguments `x`, `y`, `z`, and so does `dotnet watch x y z` or `dotnet watch run x y z`.
-    ///
-    /// `dotnet watch` also uses Hot Reload mode by default. `--no-hot-reload` can be passed to disable.
-    /// However, we can't run `build` and `test` commands in Hot Reload mode. To support these commands we need to special-case them.
-    ///
-    /// This design prevents us from supporting arbitrary commands and passing the verb and all arguments through.
-    ///
-    /// To pass `run`, `build` and `test` commands through, we use the `--` delimiter.
-    /// E.g. `dotnet watch -- test x y z` runs the project with arguments `x`, `y`, `z` in Hot Reload mode.
-    /// </summary>
-    public static CommandLineOptions? Parse(string[] args, IReporter reporter, out int errorCode, TextWriter? output = null, TextWriter? error = null)
+    public static CommandLineOptions? Parse(string[] args, IReporter reporter, TextWriter output, out int errorCode)
     {
-        var quietOption = new CliOption<bool>("--quiet", "-q")
-        {
-            Description = "Suppresses all output except warnings and errors"
-        };
+        // dotnet watch specific options:
 
-        var verboseOption = new CliOption<bool>("--verbose", "-v")
-        {
-            Description = "Show verbose output"
-        };
+        var quietOption = new CliOption<bool>("--quiet", "-q") { Description = Resources.Help_Quiet };
+        var verboseOption = new CliOption<bool>("--verbose", "-v") { Description = Resources.Help_Verbose };
+        var listOption = new CliOption<bool>("--list") { Description = Resources.Help_List };
+        var noHotReloadOption = new CliOption<bool>("--no-hot-reload") { Description = Resources.Help_NoHotReload };
+        var nonInteractiveOption = new CliOption<bool>("--non-interactive") { Description = Resources.Help_NonInteractive };
 
         verboseOption.Validators.Add(v =>
         {
@@ -99,220 +76,182 @@ Examples:
             }
         });
 
-        var listOption = new CliOption<bool>("--list") { Description = "Lists all discovered files without starting the watcher." };
-        var shortProjectOption = new CliOption<string>("-p") { Description = "The project to watch.", Hidden = true };
-        var longProjectOption = new CliOption<string>("--project") { Description = "The project to watch" };
+        CliOption[] watchOptions =
+        [
+            quietOption,
+            verboseOption,
+            noHotReloadOption,
+            nonInteractiveOption,
+            listOption,
+        ];
 
-        // launch profile used by dotnet-watch
-        var launchProfileRootOption = new CliOption<string>(LaunchProfileOptionName, "-lp")
-        {
-            Description = "The launch profile to start the project with (case-sensitive)."
-        };
-        var noLaunchProfileRootOption = new CliOption<bool>(NoLaunchProfileOptionName)
-        {
-            Description = "Do not attempt to use launchSettings.json to configure the application."
-        };
+        // Options we need to know about that are passed through to the subcommand:
 
-        // launch profile used by dotnet-run
-        var launchProfileCommandOption = new CliOption<string>(LaunchProfileOptionName, "-lp") { Hidden = true };
-        var noLaunchProfileCommandOption = new CliOption<bool>(NoLaunchProfileOptionName) { Hidden = true };
+        var shortProjectOption = new CliOption<string>("-p") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+        var longProjectOption = new CliOption<string>("--project") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+        var launchProfileOption = new CliOption<string>("--launch-profile", "-lp") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+        var noLaunchProfileOption = new CliOption<bool>("--no-launch-profile") { Hidden = true };
+        var targetFrameworkOption = new CliOption<string>("--framework", "-f") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+        var propertyOption = new CliOption<string[]>("--property") { Hidden = true, Arity = ArgumentArity.OneOrMore, AllowMultipleArgumentsPerToken = false };
 
-        var targetFrameworkOption = new CliOption<string>("--framework", "-f")
-        {
-            Description = "The target framework to run for. The target framework must also be specified in the project file."
-        };
-        var propertyOption = new CliOption<string[]>("--property")
-        {
-            Description = "Properties to be passed to MSBuild."
-        };
-
-        propertyOption.Validators.Add(v =>
-        {
-            var invalidProperty = v.GetValue(propertyOption)?.FirstOrDefault(
-                property => !(property.IndexOf('=') is > 0 and var index && index < property.Length - 1 && property[..index].Trim().Length > 0));
-
-            if (invalidProperty != null)
-            {
-                v.AddError($"Invalid property format: '{invalidProperty}'. Expected 'name=value'.");
-            }
-        });
-
-        var noHotReloadOption = new CliOption<bool>("--no-hot-reload") { Description = "Suppress hot reload for supported apps." };
-        var nonInteractiveOption = new CliOption<bool>("--non-interactive")
-        {
-            Description = "Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled. " +
-            "Use this option to prevent console input from being captured."
-        };
-
-        var remainingWatchArgs = new CliArgument<string[]>("forwardedArgs") { Description = "Arguments to pass to the child dotnet process." };
-        var remainingCommandArgs = new CliArgument<string[]>("remainingCommandArgs");
-
-        var runCommand = new CliCommand("run") { Hidden = true };
-        var testCommand = new CliCommand("test") { Hidden = true };
-        var buildCommand = new CliCommand("build") { Hidden = true };
-        var rootCommand = new CliRootCommand(Description)
+        var rootCommand = new CliRootCommand(Resources.Help)
         {
             Directives = { new EnvironmentVariablesDirective() }
         };
 
-        void AddSymbols(CliCommand command)
+        foreach (var watchOption in watchOptions)
         {
-            command.Options.Add(quietOption);
-            command.Options.Add(verboseOption);
+            rootCommand.Options.Add(watchOption);
+        }
 
-            if (command == runCommand || command == rootCommand)
+        rootCommand.Options.Add(longProjectOption);
+        rootCommand.Options.Add(shortProjectOption);
+        rootCommand.Options.Add(launchProfileOption);
+        rootCommand.Options.Add(noLaunchProfileOption);
+        rootCommand.Options.Add(targetFrameworkOption);
+        rootCommand.Options.Add(propertyOption);
+
+        // We process all tokens that do not match any of the above options
+        // to find the subcommand (the first unmatched token preceding "--")
+        // and all its options and arguments.
+        rootCommand.TreatUnmatchedTokensAsErrors = false;
+
+        // We parse the command line outside of the action since the action
+        // might not be invoked in presence of unmatched tokens.
+        // We just need to know if the root command was invoked to handle --help.
+        var rootCommandInvoked = false;
+        rootCommand.SetAction(parseResult => rootCommandInvoked = true);
+
+        var cliConfig = new CliConfiguration(rootCommand)
+        {
+            Output = output,
+            Error = output,
+        };
+
+        var parseResult = rootCommand.Parse(args, cliConfig);
+        if (parseResult.Errors.Any())
+        {
+            foreach (var error in parseResult.Errors)
             {
-                command.Options.Add(noHotReloadOption);
+                reporter.Error(error.Message);
             }
 
-            command.Options.Add(nonInteractiveOption);
-            command.Options.Add(longProjectOption);
-            command.Options.Add(shortProjectOption);
+            errorCode = 1;
+            return null;
+        }
 
-            if (command == rootCommand)
+        // invoke to execute default actions for displaying help
+        errorCode = parseResult.Invoke();
+        if (!rootCommandInvoked)
+        {
+            // help displayed:
+            return null;
+        }
+
+        var projectValue = parseResult.GetValue(longProjectOption);
+        if (string.IsNullOrEmpty(projectValue))
+        {
+            var projectShortValue = parseResult.GetValue(shortProjectOption);
+            if (!string.IsNullOrEmpty(projectShortValue))
             {
-                command.Options.Add(launchProfileRootOption);
-                command.Options.Add(noLaunchProfileRootOption);
+                reporter.Warn(Resources.Warning_ProjectAbbreviationDeprecated);
+                projectValue = projectShortValue;
+            }
+        }
+
+        return new()
+        {
+            Quiet = parseResult.GetValue(quietOption),
+            List = parseResult.GetValue(listOption),
+            NoHotReload = parseResult.GetValue(noHotReloadOption),
+            NonInteractive = parseResult.GetValue(nonInteractiveOption),
+            Verbose = parseResult.GetValue(verboseOption),
+            LaunchProcessArguments = GetLaunchProcessArguments(parseResult, watchOptions, out var explicitCommand),
+
+            ExplicitCommand = explicitCommand,
+            Project = projectValue,
+            LaunchProfileName = parseResult.GetValue(launchProfileOption),
+            NoLaunchProfile = parseResult.GetValue(noLaunchProfileOption),
+            TargetFramework = parseResult.GetValue(targetFrameworkOption),
+            BuildProperties = ParseBuildProperties(parseResult.GetValue(propertyOption) ?? []).ToArray(),
+        };
+
+        // Parses name=value pairs passed to --property. Skips invalid input. 
+        // We don't report error here as it will be reported by dotnet run.
+        static IEnumerable<(string key, string value)> ParseBuildProperties(string[] properties)
+            => from property in properties
+               let index = property.IndexOf('=')
+               where index >= 0
+               let name = property[..index].Trim()
+               let value = property[(index + 1)..]
+               where name is not []
+               select (name, value);
+    }
+
+    private static IReadOnlyList<string> GetLaunchProcessArguments(ParseResult parseResult, IReadOnlyList<CliOption> watchOptions, out string? explicitCommand)
+    {
+        explicitCommand = null;
+        var launchProcessArguments = new List<string>();
+
+        foreach (var child in parseResult.CommandResult.Children)
+        {
+            var optionResult = (OptionResult)child;
+
+            // skip watch options:
+            if (!watchOptions.Contains(optionResult.Option))
+            {
+                Debug.Assert(optionResult.IdentifierToken != null);
+
+                if (optionResult.Tokens.Count == 0)
+                {
+                    launchProcessArguments.Add(optionResult.IdentifierToken.Value);
+                }
+                else
+                {
+                    foreach (var token in optionResult.Tokens)
+                    {
+                        launchProcessArguments.Add(optionResult.IdentifierToken.Value);
+                        launchProcessArguments.Add(token.Value);
+                    }
+                }
+            }
+        }
+
+        var tokens = parseResult.UnmatchedTokens.ToArray();
+
+        // Assuming that all tokens after "--" are unmatched:
+        var dashDashIndex = IndexOf(parseResult.Tokens, t => t.Value == "--");
+        var unmatchedTokensBeforeDashDash = parseResult.UnmatchedTokens.Count - (dashDashIndex >= 0 ? parseResult.Tokens.Count - dashDashIndex - 1 : 0);
+
+        for (int i = 0; i < parseResult.UnmatchedTokens.Count; i++)
+        {
+            var token = parseResult.UnmatchedTokens[i];
+
+            // command token can't follow "--"
+            if (i < unmatchedTokensBeforeDashDash && explicitCommand == null && s_knownCommands.Contains(token))
+            {
+                explicitCommand = token;
             }
             else
             {
-                command.Options.Add(launchProfileCommandOption);
-                command.Options.Add(noLaunchProfileCommandOption);
+                launchProcessArguments.Add(token);
             }
-
-            command.Options.Add(targetFrameworkOption);
-            command.Options.Add(propertyOption);
-            command.Options.Add(listOption);
-
-            command.Arguments.Add(remainingCommandArgs);
-        };
-
-        foreach (var command in new[] { runCommand, testCommand, buildCommand })
-        {
-            AddSymbols(command);
-            rootCommand.Subcommands.Add(command);
-            command.SetAction(parseResult => Handler(parseResult, command.Name));
         }
 
-        CommandLineOptions? options = null;
-        AddSymbols(rootCommand);
-        rootCommand.SetAction(parseResult => Handler(parseResult, commandName: null));
-
-        void Handler(ParseResult parseResult, string? commandName)
-        {
-            var projectValue = parseResult.GetValue(longProjectOption);
-            if (string.IsNullOrEmpty(projectValue))
-            {
-                var projectShortValue = parseResult.GetValue(shortProjectOption);
-                if (!string.IsNullOrEmpty(projectShortValue))
-                {
-                    reporter.Warn(Resources.Warning_ProjectAbbreviationDeprecated);
-                    projectValue = projectShortValue;
-                }
-            }
-
-            string[] remainingArgs =
-            [
-                .. parseResult.GetValue(remainingWatchArgs),
-                .. parseResult.GetValue(remainingCommandArgs)
-            ];
-
-            options = new()
-            {
-                ExplicitCommand = commandName,
-                Quiet = parseResult.GetValue(quietOption),
-                List = parseResult.GetValue(listOption),
-                NoHotReload = parseResult.GetValue(noHotReloadOption),
-                NonInteractive = parseResult.GetValue(nonInteractiveOption),
-                Verbose = parseResult.GetValue(verboseOption),
-                Project = projectValue,
-                WatchLaunchProfileName = parseResult.GetValue(launchProfileRootOption),
-                WatchNoLaunchProfile = parseResult.GetValue(noLaunchProfileRootOption),
-                CommandLaunchProfileName = (commandName != null) ? parseResult.GetValue(launchProfileCommandOption) : null,
-                CommandNoLaunchProfile = (commandName != null) ? parseResult.GetValue(noLaunchProfileCommandOption) : null,
-                TargetFramework = parseResult.GetValue(targetFrameworkOption),
-                BuildProperties = parseResult.GetValue(propertyOption)?
-                    .Select(p => (p[..p.IndexOf('=')].Trim(), p[(p.IndexOf('=') + 1)..])).ToArray(),
-                RemainingArguments = remainingArgs,
-            };
-        }
-
-        errorCode = new CliConfiguration(rootCommand)
-        {
-            Output = output ?? Console.Out,
-            Error = error ?? Console.Error,
-
-        }.Invoke(args);
-
-        return options;
+        launchProcessArguments.Insert(0, explicitCommand ?? DefaultCommand);
+        return launchProcessArguments;
     }
 
-    public IReadOnlyList<string> GetLaunchProcessArguments(bool hotReload, IReporter reporter, out bool watchNoLaunchProfile, out string? watchLaunchProfileName)
+    private static int IndexOf<T>(IReadOnlyList<T> list, Func<T, bool> predicate)
     {
-        var argsBuilder = new List<string>();
-        if (!hotReload)
+        for (var i = 0; i < list.Count; i++)
         {
-            // Arguments are passed to dotnet and the first argument is interpreted as a command.
-            argsBuilder.Add(Command);
-
-            // add options that are applicable to dotnet run:
-
-            if (TargetFramework != null)
+            if (predicate(list[i]))
             {
-                argsBuilder.Add(TargetFrameworkOptionName);
-                argsBuilder.Add(TargetFramework);
-            }
-
-            if (BuildProperties != null)
-            {
-                foreach (var (name, value) in BuildProperties)
-                {
-                    if (Command == "build")
-                    {
-                        argsBuilder.Add($"/p:{name}={value}");
-                    }
-                    else
-                    {
-                        argsBuilder.Add(BuildPropertyOptionName);
-                        argsBuilder.Add($"{name}={value}");
-                    }
-                }
+                return i;
             }
         }
 
-        // launch profile:
-        if (hotReload)
-        {
-            watchNoLaunchProfile = WatchNoLaunchProfile || CommandNoLaunchProfile == true;
-            watchLaunchProfileName = WatchLaunchProfileName ?? CommandLaunchProfileName;
-
-            if (WatchLaunchProfileName != null && CommandLaunchProfileName != null)
-            {
-                reporter.Warn($"Using launch profile name '{WatchLaunchProfileName}', ignoring '{CommandLaunchProfileName}'.");
-            }
-        }
-        else
-        {
-            var runNoLaunchProfile = (ExplicitCommand != null) ? CommandNoLaunchProfile == true : WatchNoLaunchProfile;
-            watchNoLaunchProfile = WatchNoLaunchProfile;
-
-            var runLaunchProfileName = (ExplicitCommand != null) ? CommandLaunchProfileName : WatchLaunchProfileName;
-            watchLaunchProfileName = WatchLaunchProfileName;
-
-            if (runNoLaunchProfile)
-            {
-                argsBuilder.Add(NoLaunchProfileOptionName);
-            }
-
-            if (runLaunchProfileName != null)
-            {
-                argsBuilder.Add(LaunchProfileOptionName);
-                argsBuilder.Add(runLaunchProfileName);
-            }
-        }
-
-        argsBuilder.AddRange(RemainingArguments);
-
-        return argsBuilder.ToArray();
+        return -1;
     }
 }

--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -85,10 +85,8 @@ namespace Microsoft.DotNet.Watcher
                 using var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, currentRunCancellationSource.Token);
                 using var fileSetWatcher = new FileSetWatcher(fileSet, context.Reporter);
 
-                context.Reporter.Verbose($"Running {processSpec.ShortDisplayName()} with the following arguments: '{processSpec.GetArgumentsDisplay()}'");
                 var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);
-
-                context.Reporter.Output("Started", emoji: "🚀");
+                context.Reporter.Output("Started");
 
                 Task<FileItem?> fileSetTask;
                 Task finishedTask;

--- a/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Watcher
     internal sealed record EnvironmentOptions(
         string WorkingDirectory,
         string MuxerPath,
+        bool IsPollingEnabled = false,
         bool SuppressHandlingStaticContentFiles = false,
         bool SuppressMSBuildIncrementalism = false,
         bool SuppressLaunchBrowser = false,
@@ -27,6 +28,7 @@ namespace Microsoft.DotNet.Watcher
         (
             WorkingDirectory: Directory.GetCurrentDirectory(),
             MuxerPath: GetMuxerPathFromEnvironment(),
+            IsPollingEnabled: EnvironmentVariables.IsPollingEnabled,
             SuppressHandlingStaticContentFiles: EnvironmentVariables.SuppressHandlingStaticContentFiles,
             SuppressMSBuildIncrementalism: EnvironmentVariables.SuppressMSBuildIncrementalism,
             SuppressLaunchBrowser: EnvironmentVariables.SuppressLaunchBrowser,

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
@@ -38,5 +38,19 @@ namespace Microsoft.DotNet.Watcher
             variables.Add(EnvironmentVariables.Names.DotnetStartupHooks, string.Join(s_startupHooksSeparator, DotNetStartupHooks));
             variables.Add(EnvironmentVariables.Names.AspNetCoreHostingStartupAssemblies, string.Join(AssembliesSeparator, AspNetCoreHostingStartupAssemblies));
         }
+
+        public IEnumerable<string> ToCommandLineDirectives()
+        {
+            foreach (var (name, value) in this)
+            {
+                yield return MakeDirective(name, value);
+            }
+
+            yield return MakeDirective(EnvironmentVariables.Names.DotnetStartupHooks, string.Join(s_startupHooksSeparator, DotNetStartupHooks));
+            yield return MakeDirective(EnvironmentVariables.Names.AspNetCoreHostingStartupAssemblies, string.Join(AssembliesSeparator, AspNetCoreHostingStartupAssemblies));
+
+            static string MakeDirective(string name, string value)
+                => $"[env:{name}={value}]";
+        }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -8,17 +8,8 @@ using IReporter = Microsoft.Extensions.Tools.Internal.IReporter;
 
 namespace Microsoft.DotNet.Watcher.Internal
 {
-    internal sealed class ProcessRunner
+    internal sealed class ProcessRunner(IReporter reporter)
     {
-        private readonly IReporter _reporter;
-
-        public ProcessRunner(IReporter reporter)
-        {
-            Ensure.NotNull(reporter, nameof(reporter));
-
-            _reporter = reporter;
-        }
-
         // May not be necessary in the future. See https://github.com/dotnet/corefx/issues/12039
         public async Task<int> RunAsync(ProcessSpec processSpec, CancellationToken cancellationToken)
         {
@@ -28,63 +19,81 @@ namespace Microsoft.DotNet.Watcher.Internal
 
             var stopwatch = new Stopwatch();
 
-            using (var process = CreateProcess(processSpec))
-            using (var processState = new ProcessState(process, _reporter))
+            using var process = CreateProcess(processSpec);
+            using var processState = new ProcessState(process, reporter);
+
+            cancellationToken.Register(() => processState.TryKill());
+
+            var readOutput = false;
+            var readError = false;
+            if (processSpec.IsOutputCaptured)
             {
-                cancellationToken.Register(() => processState.TryKill());
-
-                var readOutput = false;
-                var readError = false;
-                if (processSpec.IsOutputCaptured)
+                readOutput = true;
+                readError = true;
+                process.OutputDataReceived += (_, a) =>
                 {
-                    readOutput = true;
-                    readError = true;
-                    process.OutputDataReceived += (_, a) =>
+                    if (!string.IsNullOrEmpty(a.Data))
                     {
-                        if (!string.IsNullOrEmpty(a.Data))
-                        {
-                            processSpec.OutputCapture.AddLine(a.Data);
-                        }
-                    };
-                    process.ErrorDataReceived += (_, a) =>
+                        processSpec.OutputCapture.AddLine(a.Data);
+                    }
+                };
+                process.ErrorDataReceived += (_, a) =>
+                {
+                    if (!string.IsNullOrEmpty(a.Data))
                     {
-                        if (!string.IsNullOrEmpty(a.Data))
-                        {
-                            processSpec.OutputCapture.AddLine(a.Data);
-                        }
-                    };
-                }
-                else if (processSpec.OnOutput != null)
-                {
-                    readOutput = true;
-                    process.OutputDataReceived += processSpec.OnOutput;
-                }
-
-                stopwatch.Start();
-                process.Start();
-
-                _reporter.Verbose($"Started '{processSpec.Executable}' with arguments '{processSpec.GetArgumentsDisplay()}': process id {process.Id}", emoji: "🚀");
-
-                if (readOutput)
-                {
-                    process.BeginOutputReadLine();
-                }
-                if (readError)
-                {
-                    process.BeginErrorReadLine();
-                }
-
-                await processState.Task;
-
-                exitCode = process.ExitCode;
-                stopwatch.Stop();
-                _reporter.Verbose($"Process id {process.Id} ran for {stopwatch.ElapsedMilliseconds}ms");
+                        processSpec.OutputCapture.AddLine(a.Data);
+                    }
+                };
             }
+            else if (processSpec.OnOutput != null)
+            {
+                readOutput = true;
+                process.OutputDataReceived += processSpec.OnOutput;
+            }
+
+            stopwatch.Start();
+
+            int? processId = null;
+            try
+            {
+                if (process.Start())
+                {
+                    processId = process.Id;
+                }
+            }
+            finally
+            {
+                var argsDisplay = processSpec.GetArgumentsDisplay();
+
+                if (processId.HasValue)
+                {
+                    reporter.Verbose($"Launched '{processSpec.Executable}' with arguments '{argsDisplay}': process id {processId.Value}", emoji: "🚀");
+                }
+                else
+                {
+                    reporter.Verbose($"Failed to launch '{processSpec.Executable}' with arguments '{argsDisplay}'");
+                }
+            }
+
+            if (readOutput)
+            {
+                process.BeginOutputReadLine();
+            }
+            if (readError)
+            {
+                process.BeginErrorReadLine();
+            }
+
+            await processState.Task;
+
+            exitCode = process.ExitCode;
+            stopwatch.Stop();
+            reporter.Verbose($"Process id {process.Id} ran for {stopwatch.ElapsedMilliseconds}ms");
 
             return exitCode;
         }
 
-        private Process CreateProcess(ProcessSpec processSpec)
+        private static Process CreateProcess(ProcessSpec processSpec)
         {
             var process = new Process
             {
@@ -119,7 +128,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             return process;
         }
 
-        private class ProcessState : IDisposable
+        private sealed class ProcessState : IDisposable
         {
             private readonly IReporter _reporter;
             private readonly Process _process;

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         public string? CommandName { get; init; }
         public bool LaunchBrowser { get; init; }
         public string? LaunchUrl { get; init; }
-        public string? CommandLineArgs { get; init; }
-        public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; init; }
 
         internal static LaunchSettingsProfile? ReadLaunchProfile(string projectDirectory, string? launchProfileName, IReporter reporter)
         {

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "dotnet-watch": {
       "commandName": "Project",
       "commandLineArgs": "--verbose",
-      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
+      "workingDirectory": "D:\\Temp\\webapp9",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"
       }

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "dotnet-watch": {
       "commandName": "Project",
       "commandLineArgs": "--verbose",
-      "workingDirectory": "D:\\Temp\\webapp9",
+      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"
       }

--- a/src/BuiltInTools/dotnet-watch/Resources.resx
+++ b/src/BuiltInTools/dotnet-watch/Resources.resx
@@ -132,4 +132,67 @@
   <data name="Warning_ProjectAbbreviationDeprecated" xml:space="preserve">
     <value>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</value>
   </data>
+  <data name="Help_NonInteractive" xml:space="preserve">
+    <value>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </value>
+  </data>
+  <data name="Help_NoHotReload" xml:space="preserve">
+    <value>
+      Suppress hot reload for supported apps.
+    </value>
+  </data>
+  <data name="Help_List" xml:space="preserve">
+    <value>
+      Lists all discovered files without starting the watcher.
+    </value>
+  </data>
+  <data name="Help_Verbose" xml:space="preserve">
+    <value>
+      Show verbose output
+    </value>
+  </data>
+  <data name="Help_Quiet" xml:space="preserve">
+    <value>
+      Suppresses all output except warnings and errors
+    </value>
+  </data>
+  <data name="Help" xml:space="preserve">
+    <value>
+<![CDATA[
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+]]>
+    </value>
+  </data>
 </root>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.cs.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.cs.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Možnosti --quiet a --verbose se nedají zadat spolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Upozornění NETSDK1174: Zkratka -p pro --project je zastaralá. Použijte prosím --project.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.de.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.de.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Die Optionen "--quiet" und "--verbose" können nicht gleichzeitig angegeben werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Warnung NETSDK1174: Die Abkürzung von „-p“ für „--project“ ist veraltet. Verwenden Sie „--project“.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.es.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.es.xlf
@@ -22,6 +22,126 @@
         <target state="translated">No se pueden especificar ambas opciones, "--quiet" y "--verbose".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Advertencia NETSDK1174: La abreviatura de -p para --project está en desuso. Use --project.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.fr.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.fr.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Impossible de spécifier les options '--quiet' et '--verbose'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">AVERTISSEMENT NETSDK1174 : l’abréviation de-p pour--Project est déconseillée. Veuillez utiliser--Project.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.it.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.it.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Non è possibile specificare entrambe le opzioni '--quiet' e '--verbose'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Avviso NETSDK1174: l'abbreviazione di -p per --project è deprecata. Usare --project.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.ja.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.ja.xlf
@@ -22,6 +22,126 @@
         <target state="translated">'--quiet' と '--verbose' の両方のオプションを指定することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: --project の省略形である -p は推奨されていません。--Project を使用してください。</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.ko.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.ko.xlf
@@ -22,6 +22,126 @@
         <target state="translated">'--quiet' 옵션과 '--verbose' 옵션을 둘 다 지정할 수는 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">경고 NETSDK1174: --project에 대한 약어 -p는 더 이상 사용되지 않습니다. --project를 사용하세요.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.pl.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.pl.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Nie można jednocześnie określić opcji „--quiet” i „--verbose”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Ostrzeżenie NETSDK1174: Skrót -p dla polecenia --project jest przestarzały. Użyj polecenia --project.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.pt-BR.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.pt-BR.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Não é possível especificar as opções '--quiet' e '--verbose'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Aviso NETSDK1174: a abreviação de-p para--projeto é preterida. Use --projeto.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.ru.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.ru.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Невозможно одновременно указать параметры "--quiet" и "--verbose".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Предупреждение NETSDK1174: сокращение "-p" для "--project" не рекомендуется. Используйте "--project".</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.tr.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.tr.xlf
@@ -22,6 +22,126 @@
         <target state="translated">Hem '--quiet' hem de '--verbose' seçenekleri belirtilemez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Uyarı NETSDK1174: --project için -p kısaltması kullanımdan kaldırıldı. Lütfen --project kullanın.</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.zh-Hans.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.zh-Hans.xlf
@@ -22,6 +22,126 @@
         <target state="translated">不能同时指定 "--quiet" 和 "--verbose" 选项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: 已弃用使用缩写“-p”来代表“--project”。请使用“--project”。</target>

--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.zh-Hant.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.zh-Hant.xlf
@@ -22,6 +22,126 @@
         <target state="translated">無法同時指定 '--quiet' 和 '--verbose' 選項。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Help">
+        <source>
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </source>
+        <target state="new">
+
+Environment variables:
+
+  DOTNET_USE_POLLING_FILE_WATCHER
+  When set to '1' or 'true', dotnet-watch will poll the file system for
+  changes. This is required for some file systems, such as network shares,
+  Docker mounted volumes, and other virtual file systems.
+
+  DOTNET_WATCH
+  dotnet-watch sets this variable to '1' on all child processes launched.
+
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '1' and increments by one each time
+  a file is changed and the command is restarted.
+
+  DOTNET_WATCH_SUPPRESS_EMOJIS
+  When set to '1' or 'true', dotnet-watch will not show emojis in the 
+  console output.
+
+Remarks:
+  The special option '--' is used to delimit the end of the options and
+  the beginning of arguments that will be passed to the child dotnet process.
+
+  For example: dotnet watch -- --verbose run
+
+  Even though '--verbose' is an option dotnet-watch supports, the use of '--'
+  indicates that '--verbose' should be treated instead as an argument for
+  dotnet-run.
+
+Examples:
+  dotnet watch run
+  dotnet watch test
+
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_List">
+        <source>
+      Lists all discovered files without starting the watcher.
+    </source>
+        <target state="new">
+      Lists all discovered files without starting the watcher.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NoHotReload">
+        <source>
+      Suppress hot reload for supported apps.
+    </source>
+        <target state="new">
+      Suppress hot reload for supported apps.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_NonInteractive">
+        <source>
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </source>
+        <target state="new">
+      Runs dotnet-watch in non-interactive mode. This option is only supported when running with Hot Reload enabled.
+      Use this option to prevent console input from being captured.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Quiet">
+        <source>
+      Suppresses all output except warnings and errors
+    </source>
+        <target state="new">
+      Suppresses all output except warnings and errors
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Help_Verbose">
+        <source>
+      Show verbose output
+    </source>
+        <target state="new">
+      Show verbose output
+    </target>
+        <note />
+      </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: --project 已取代縮寫 -p。請使用 --project。</target>

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -7,6 +7,34 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         private readonly MockReporter _testReporter = new();
 
+        private CommandLineOptions VerifyOptions(string[] args, string expectedOutput = "", string[] expectedMessages = null)
+            => VerifyOptions(args, actualOutput => AssertEx.Equal(expectedOutput, actualOutput), expectedMessages ?? []);
+
+        private CommandLineOptions VerifyOptions(string[] args, Action<string> outputValidator, string[] expectedMessages)
+        {
+            var output = new StringWriter();
+            var options = CommandLineOptions.Parse(args, _testReporter, output: output, errorCode: out var errorCode);
+
+            Assert.Equal(expectedMessages, _testReporter.Messages);
+            outputValidator(output.ToString());
+
+            Assert.NotNull(options);
+            Assert.Equal(0, errorCode);
+            return options;
+        }
+
+        private void VerifyErrors(string[] args, params string[] expectedErrors)
+        {
+            var output = new StringWriter();
+            var options = CommandLineOptions.Parse(args, _testReporter, output: output, errorCode: out var errorCode);
+
+            AssertEx.Equal(expectedErrors, _testReporter.Messages);
+            Assert.Empty(output.ToString());
+
+            Assert.Null(options);
+            Assert.NotEqual(0, errorCode);
+        }
+
         [Theory]
         [InlineData(new object[] { new[] { "-h" } })]
         [InlineData(new object[] { new[] { "-?" } })]
@@ -14,8 +42,9 @@ namespace Microsoft.DotNet.Watcher.Tools
         [InlineData(new object[] { new[] { "--help", "--bogus" } })]
         public void HelpArgs(string[] args)
         {
-            StringWriter output = new();
-            Assert.Null(CommandLineOptions.Parse(args, _testReporter, out var errorCode, output: output));
+            var output = new StringWriter();
+            var options = CommandLineOptions.Parse(args, _testReporter, output: output, errorCode: out var errorCode);
+            Assert.Null(options);
             Assert.Equal(0, errorCode);
 
             Assert.Empty(_testReporter.Messages);
@@ -27,260 +56,171 @@ namespace Microsoft.DotNet.Watcher.Tools
         [InlineData("P==", "P", "=")]
         [InlineData("P=A=B", "P", "A=B")]
         [InlineData(" P\t = V ", "P", " V ")]
+        [InlineData("P=", "P", "")]
         public void BuildProperties_Valid(string argValue, string name, string value)
         {
-            StringWriter error = new();
-            var args = new[] { "--property", argValue };
-            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, error: error);
-            Assert.Equal(new[] { (name, value) }, options.BuildProperties);
-            Assert.Equal(0, errorCode);
-            Assert.Equal("", error.ToString());
+            var options = VerifyOptions(["--property", argValue]);
+            Assert.Equal([(name, value)], options.BuildProperties);
         }
 
         [Theory]
-        [InlineData("P2=")]
+        [InlineData("P")]
         [InlineData("=P3")]
         [InlineData("=")]
         [InlineData("==")]
         public void BuildProperties_Invalid(string value)
         {
-            StringWriter error = new();
-            var args = new[] { "--property", value };
-            CommandLineOptions.Parse(args, _testReporter, out var errorCode, error: error);
-            Assert.Equal(1, errorCode);
-            Assert.Equal($"Invalid property format: '{value}'. Expected 'name=value'.", error.ToString().Trim());
+            var options = VerifyOptions(["--property", value]);
+            Assert.Empty(options.BuildProperties);
         }
 
         [Fact]
-        public void RunOptions_NoRun()
+        public void ImplicitCommand()
         {
-            StringWriter output = new();
-            var args = new[] { "--verbose" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-
-            Assert.True(options.Verbose);
-            Assert.False(options.WatchNoLaunchProfile);
-            Assert.Null(options.WatchLaunchProfileName);
-            Assert.Empty(options.RemainingArguments);
-
-            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
-            Assert.False(watchNoProfile);
-            Assert.Null(watchProfileName);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoProfile, out watchProfileName));
-            Assert.False(watchNoProfile);
-            Assert.Null(watchProfileName);
-
-            Assert.Empty(output.ToString());
+            var options = VerifyOptions([]);
+            Assert.Equal(["run"], options.LaunchProcessArguments);
         }
 
-        [Fact]
-        public void RunOptions_Run()
+        [Theory]
+        [InlineData("add")]
+        [InlineData("build")]
+        [InlineData("build-server")]
+        [InlineData("clean")]
+        [InlineData("format")]
+        [InlineData("help")]
+        [InlineData("list")]
+        [InlineData("msbuild")]
+        [InlineData("new")]
+        [InlineData("nuget")]
+        [InlineData("pack")]
+        [InlineData("publish")]
+        [InlineData("remove")]
+        [InlineData("restore")]
+        [InlineData("run")]
+        [InlineData("sdk")]
+        [InlineData("sln")]
+        [InlineData("store")]
+        [InlineData("test")]
+        [InlineData("tool")]
+        [InlineData("vstest")]
+        [InlineData("workload")]
+        public void ExplicitCommand(string command)
         {
-            StringWriter output = new();
-            var args = new[] { "--verbose", "run" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions([command]);
+            Assert.Equal(command, options.ExplicitCommand);
+            AssertEx.SequenceEqual([command], options.LaunchProcessArguments);
+        }
 
-            Assert.True(options.Verbose);
-            Assert.False(options.WatchNoLaunchProfile);
-            Assert.Null(options.WatchLaunchProfileName);
-            Assert.Empty(options.RemainingArguments);
-
-            Assert.False(options.CommandNoLaunchProfile);
-            Assert.Null(options.CommandLaunchProfileName);
-
-            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoProfile, out var watchProfileName));
-            Assert.False(watchNoProfile);
-            Assert.Null(watchProfileName);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoProfile, out watchProfileName));
-            Assert.False(watchNoProfile);
-            Assert.Null(watchProfileName);
-
-            Assert.Empty(output.ToString());
+        [Theory]
+        [CombinatorialData]
+        public void WatchOptions_NotPassedThrough_BeforeCommand(
+            [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
+            bool before)
+        {
+            var options = VerifyOptions(before ? [option, "test"] : ["test", option]);
+            Assert.Equal(["test"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RunOptions_LaunchProfile_Watch()
         {
-            StringWriter output = new();
-            var args = new[] { "-lp", "P", "run" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-
-            Assert.Equal("P", options.WatchLaunchProfileName);
-            Assert.Null(options.CommandLaunchProfileName);
-
-            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
-            Assert.Equal("P", watchProfileName);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
-            Assert.Equal("P", watchProfileName);
-
-            Assert.Empty(output.ToString());
+            var options = VerifyOptions(["-lp", "P", "run"]);
+            Assert.Equal("P", options.LaunchProfileName);
+            Assert.Equal(["run", "-lp", "P"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RunOptions_LaunchProfile_Run()
         {
-            StringWriter output = new();
-            var args = new[] { "run", "-lp", "P" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-
-            Assert.Null(options.WatchLaunchProfileName);
-            Assert.Equal("P", options.CommandLaunchProfileName);
-
-            Assert.Equal(new[] { "run", "--launch-profile", "P" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
-            Assert.Null(watchProfileName);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
-            Assert.Equal("P", watchProfileName);
-
-            Assert.Empty(output.ToString());
+            var options = VerifyOptions(["run", "-lp", "P"]);
+            Assert.Equal("P", options.LaunchProfileName);
+            Assert.Equal(["run", "-lp", "P"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RunOptions_LaunchProfile_Both()
         {
-            StringWriter output = new();
-            var args = new[] { "-lp", "P1", "run", "-lp", "P2" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-
-            Assert.Equal("P1", options.WatchLaunchProfileName);
-            Assert.Equal("P2", options.CommandLaunchProfileName);
-
-            Assert.Equal(new[] { "run", "--launch-profile", "P2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out var watchProfileName));
-            Assert.Equal("P1", watchProfileName);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out watchProfileName));
-            Assert.Equal("P1", watchProfileName);
-
-            Assert.Equal(new[] { "warn ⌚ Using launch profile name 'P1', ignoring 'P2'." }, _testReporter.Messages);
-            Assert.Empty(output.ToString());
+            VerifyErrors(["-lp", "P1", "run", "-lp", "P2"],
+                "error ❌ Option '-lp' expects a single argument but 2 were provided.");
         }
 
         [Fact]
         public void RunOptions_NoProfile_Watch()
         {
-            StringWriter output = new();
-            var args = new[] { "--no-launch-profile", "run" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(["--no-launch-profile", "run"]);
 
-            Assert.True(options.WatchNoLaunchProfile);
-            Assert.False(options.CommandNoLaunchProfile);
-
-            Assert.Equal(new[] { "run", }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
-            Assert.True(watchNoLaunchProfile);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
-            Assert.True(watchNoLaunchProfile);
-
-            Assert.Empty(output.ToString());
+            Assert.True(options.NoLaunchProfile);
+            Assert.Equal(["run", "--no-launch-profile"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RunOptions_NoProfile_Run()
         {
-            StringWriter output = new();
-            var args = new[] { "run", "--no-launch-profile" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(["run", "--no-launch-profile"]);
 
-            Assert.False(options.WatchNoLaunchProfile);
-            Assert.True(options.CommandNoLaunchProfile);
-
-            Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
-            Assert.False(watchNoLaunchProfile);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
-            Assert.True(watchNoLaunchProfile);
-
-            Assert.Empty(output.ToString());
+            Assert.True(options.NoLaunchProfile);
+            Assert.Equal(["run", "--no-launch-profile"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RunOptions_NoProfile_Both()
         {
-            StringWriter output = new();
-            var args = new[] { "--no-launch-profile", "run", "--no-launch-profile" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(["--no-launch-profile", "run", "--no-launch-profile"]);
 
-            Assert.True(options.WatchNoLaunchProfile);
-            Assert.True(options.CommandNoLaunchProfile);
-
-            Assert.Equal(new[] { "run", "--no-launch-profile" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out var watchNoLaunchProfile, out _));
-            Assert.True(watchNoLaunchProfile);
-
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out watchNoLaunchProfile, out _));
-            Assert.True(watchNoLaunchProfile);
-
-            Assert.Empty(output.ToString());
+            Assert.True(options.NoLaunchProfile);
+            Assert.Equal(["run", "--no-launch-profile"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RemainingOptions()
         {
-            StringWriter output = new();
-            var args = new[] { "-watchArg", "--verbose", "run", "-runArg" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-            //dotnet watch -- --verbose run
+            var options = VerifyOptions(["-watchArg", "--verbose", "run", "-runArg"]);
+            
             Assert.True(options.Verbose);
-            Assert.Equal(["-watchArg", "-runArg"], options.RemainingArguments);
+            Assert.Equal(["run", "-watchArg", "-runArg"], options.LaunchProcessArguments);
+        }
 
-            Assert.Equal(["run", "-watchArg", "-runArg"], options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
-            Assert.Equal(["-watchArg", "-runArg"], options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
+        [Fact]
+        public void UnknownOption()
+        {
+            var options = VerifyOptions(["--verbose", "--unknown", "x", "y", "run", "--project", "p"]);
 
-            Assert.Empty(output.ToString());
+            Assert.Equal("p", options.Project);
+            Assert.Equal(["run", "--project", "p", "--unknown", "x", "y"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RemainingOptionsDashDash()
         {
-            StringWriter output = new();
-            var args = new[] { "-watchArg", "--", "--verbose", "run", "-runArg" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(["-watchArg", "--", "--verbose", "run", "-runArg"]);
 
             Assert.False(options.Verbose);
-            Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.RemainingArguments);
-
-            Assert.Equal(new[] { "run", "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
-            Assert.Equal(new[] { "-watchArg", "--verbose", "run", "-runArg" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
-
-            Assert.Empty(output.ToString());
+            Assert.Equal(["run", "-watchArg", "--verbose", "run", "-runArg"], options.LaunchProcessArguments);
         }
 
         [Fact]
         public void RemainingOptionsDashDashRun()
         {
-            StringWriter output = new();
-            var args = new[] { "--", "run" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(["--", "run"]);
 
             Assert.False(options.Verbose);
-            Assert.Equal(new[] { "run" }, options.RemainingArguments);
-
-            Assert.Equal(new[] { "run", "run" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
-            Assert.Equal(new[] { "run" }, options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
-
-            Assert.Empty(output.ToString());
+            Assert.Equal(["run", "run"], options.LaunchProcessArguments);
         }
 
         [Theory]
         [CombinatorialData]
         public void OptionsSpecifiedBeforeOrAfterRun(bool afterRun)
         {
-            StringWriter output = new();
             var args = new[] { "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" };
             args = afterRun ? args.Prepend("run").ToArray() : args.Append("run").ToArray();
 
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(args);
 
             Assert.Equal("P", options.Project);
             Assert.Equal("F", options.TargetFramework);
-            Assert.Equal(new[] { ("P1", "V1"), ("P2", "V2") }, options.BuildProperties);
+            Assert.Equal([("P1", "V1"), ("P2", "V2")], options.BuildProperties);
 
-            Assert.Equal(new[] { "run", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" }, options.GetLaunchProcessArguments(hotReload: false, _testReporter, out _, out _));
-            Assert.Empty(options.GetLaunchProcessArguments(hotReload: true, _testReporter, out _, out _));
-
-            Assert.Empty(output.ToString());
+            Assert.Equal(["run", "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2"], options.LaunchProcessArguments);
         }
 
         public enum ArgPosition
@@ -302,7 +242,6 @@ namespace Microsoft.DotNet.Watcher.Tools
                 "--non-interactive")]
             string arg)
         {
-            StringWriter output = new();
             var args = new[] { arg };
 
             args = position switch
@@ -313,7 +252,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 _ => args,
             };
 
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
+            var options = VerifyOptions(args);
 
             Assert.True(arg switch
             {
@@ -324,118 +263,78 @@ namespace Microsoft.DotNet.Watcher.Tools
                 "--non-interactive" => options.NonInteractive,
                 _ => false
             });
-
-            Assert.Empty(output.ToString());
         }
 
-        [Theory]
-        [InlineData("--property", "P1=V1", "P2=V2")]
-        public void OptionDuplicates_Allowed_Strings(string argName, string argValue1, string argValue2)
+        [Fact]
+        public void MultiplePropertyValues()
         {
-            StringWriter output = new();
-            var args = new[] { argName, argValue1, "run", argName, argValue2 };
+            var options = VerifyOptions(["--property", "P1=V1", "run", "--property", "P2=V2"]);
+            AssertEx.SequenceEqual(["P1=V1", "P2=V2"], options.BuildProperties.Select(p => $"{p.name}={p.value}"));
 
-            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, output: output);
-
-            Assert.Equal(new[] { argValue1, argValue2 }, argName switch
-            {
-                "--property" => options.BuildProperties.Select(p => $"{p.name}={p.value}"),
-                _ => null,
-            });
-
-            Assert.Equal(0, errorCode);
-            Assert.Equal("", output.ToString());
+            // options must be repeated since --property does not support multiple args
+            AssertEx.SequenceEqual(["run", "--property", "P1=V1", "--property", "P2=V2"], options.LaunchProcessArguments);
         }
 
         [Theory]
-        [InlineData(new object[] { new[] { "--project", "abc" } })]
-        [InlineData(new object[] { new[] { "--framework", "abc" } })]
-        public void OptionDuplicates_NotAllowed(string[] args)
+        [InlineData("--project")]
+        [InlineData("--framework")]
+        public void OptionDuplicates_NotAllowed(string option)
         {
-            StringWriter output = new();
-            args = args.Concat(new[] { "run" }).Concat(args).ToArray();
-
-            var options = CommandLineOptions.Parse(args, _testReporter, out var errorCode, output: output);
-            Assert.Null(options);
-            Assert.Equal(1, errorCode);
-
-            // TODO: Re-enable this check when a new version of S.CL is released with this fix in it:
-            // https://github.com/dotnet/command-line-api/pull/2289
-            //Assert.Equal("", output.ToString());
+            VerifyErrors([option, "abc", "run", option, "xyz"],
+                $"error ❌ Option '{option}' expects a single argument but 2 were provided.");
         }
 
         [Theory]
-        [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" })]
-        [InlineData(new[] { "run" }, new string[0])]
-        [InlineData(new[] { "run", "--", "runarg" }, new[] { "runarg" })]
-        [InlineData(new[] { "-watcharg", "run", "runarg1", "-runarg2" }, new[] { "-watcharg", "runarg1", "-runarg2" })]
+        [InlineData(new[] { "--unrecognized-arg" }, new[] { "run", "--unrecognized-arg" })]
+        [InlineData(new[] { "run" }, new[] { "run" })]
+        [InlineData(new[] { "run", "--", "runarg" }, new[] { "run", "runarg" })]
+        [InlineData(new[] { "--verbose", "run", "runarg1", "-runarg2" }, new[] { "run", "runarg1", "-runarg2" })]
         // run is after -- and therefore not parsed as a command:
-        [InlineData(new[] { "-watcharg", "--", "run", "--", "runarg" }, new[] { "-watcharg", "run", "--", "runarg" })]
+        [InlineData(new[] { "--verbose", "--", "run", "--", "runarg" }, new[] { "run", "run", "--", "runarg" })]
         // run is before -- and therefore parsed as a command:
-        [InlineData(new[] { "-watcharg", "run", "--", "--", "runarg" }, new[] { "-watcharg" , "--", "runarg" })]
+        [InlineData(new[] { "--verbose", "run", "--", "--", "runarg" }, new[] { "run", "--", "runarg" })]
         public void ParsesRemainingArgs(string[] args, string[] expected)
         {
-            StringWriter output = new();
-            var options = CommandLineOptions.Parse(args, _testReporter, out _, output: output);
-
-            Assert.NotNull(options);
-
-            Assert.Equal(expected, options.RemainingArguments);
-            Assert.Empty(output.ToString());
+            var options = VerifyOptions(args);
+            Assert.Equal(expected, options.LaunchProcessArguments);
         }
 
         [Fact]
         public void CannotHaveQuietAndVerbose()
         {
-            StringWriter error = new();
-            var args = new[] { "--quiet", "--verbose" };
-            _ = CommandLineOptions.Parse(args, _testReporter, out _, error: error);
-
-            Assert.Contains(Resources.Error_QuietAndVerboseSpecified, error.ToString());
+            VerifyErrors(["--quiet", "--verbose"],
+                $"error ❌ {Resources.Error_QuietAndVerboseSpecified}");
         }
 
         [Fact]
         public void ShortFormForProjectArgumentPrintsWarning()
         {
-            var args = new[] { "-p", "MyProject.csproj" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _);
+            var options = VerifyOptions(["-p", "MyProject.csproj"],
+                expectedMessages: [$"warn ⌚ {Resources.Warning_ProjectAbbreviationDeprecated}"]);
 
-            Assert.Equal(new[] { $"warn ⌚ {Resources.Warning_ProjectAbbreviationDeprecated}" }, _testReporter.Messages);
-            Assert.NotNull(options);
             Assert.Equal("MyProject.csproj", options.Project);
         }
 
         [Fact]
         public void LongFormForProjectArgumentWorks()
         {
-            var args = new[] { "--project", "MyProject.csproj" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _);
-
-            Assert.Empty(_testReporter.Messages);
-            Assert.NotNull(options);
+            var options = VerifyOptions(["--project", "MyProject.csproj"]);
             Assert.Equal("MyProject.csproj", options.Project);
         }
 
         [Fact]
         public void LongFormForLaunchProfileArgumentWorks()
         {
-            var args = new[] { "--launch-profile", "CustomLaunchProfile" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _);
-
-            Assert.Empty(_testReporter.Messages);
+            var options = VerifyOptions(["--launch-profile", "CustomLaunchProfile"]);
             Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.WatchLaunchProfileName);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
 
         [Fact]
         public void ShortFormForLaunchProfileArgumentWorks()
         {
-            var args = new[] { "-lp", "CustomLaunchProfile" };
-            var options = CommandLineOptions.Parse(args, _testReporter, out _);
-
-            Assert.Empty(_testReporter.Messages);
-            Assert.NotNull(options);
-            Assert.Equal("CustomLaunchProfile", options.WatchLaunchProfileName);
+            var options = VerifyOptions(["-lp", "CustomLaunchProfile"]);
+            Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
     }
 }

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -1,12 +1,208 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
     internal static class AssertEx
     {
+        private class AssertEqualityComparer<T> : IEqualityComparer<T>
+        {
+            public static readonly IEqualityComparer<T> Instance = new AssertEqualityComparer<T>();
+
+            private static bool CanBeNull()
+            {
+                var type = typeof(T);
+                return !type.GetType().IsValueType ||
+                    (type.GetType().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+            }
+
+            public static bool IsNull(T @object)
+            {
+                if (!CanBeNull())
+                {
+                    return false;
+                }
+
+                return object.Equals(@object, default(T));
+            }
+
+            public static bool Equals(T left, T right)
+            {
+                return Instance.Equals(left, right);
+            }
+
+            bool IEqualityComparer<T>.Equals(T x, T y)
+            {
+                if (CanBeNull())
+                {
+                    if (object.Equals(x, default(T)))
+                    {
+                        return object.Equals(y, default(T));
+                    }
+
+                    if (object.Equals(y, default(T)))
+                    {
+                        return false;
+                    }
+                }
+
+                if (x.GetType() != y.GetType())
+                {
+                    return false;
+                }
+
+                if (x is IEquatable<T> equatable)
+                {
+                    return equatable.Equals(y);
+                }
+
+                if (x is IComparable<T> comparableT)
+                {
+                    return comparableT.CompareTo(y) == 0;
+                }
+
+                if (x is IComparable comparable)
+                {
+                    return comparable.CompareTo(y) == 0;
+                }
+
+                var enumerableX = x as IEnumerable;
+                var enumerableY = y as IEnumerable;
+
+                if (enumerableX != null && enumerableY != null)
+                {
+                    var enumeratorX = enumerableX.GetEnumerator();
+                    var enumeratorY = enumerableY.GetEnumerator();
+
+                    while (true)
+                    {
+                        bool hasNextX = enumeratorX.MoveNext();
+                        bool hasNextY = enumeratorY.MoveNext();
+
+                        if (!hasNextX || !hasNextY)
+                        {
+                            return hasNextX == hasNextY;
+                        }
+
+                        if (!Equals(enumeratorX.Current, enumeratorY.Current))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return object.Equals(x, y);
+            }
+
+            int IEqualityComparer<T>.GetHashCode(T obj)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public static void Equal<T>(T expected, T actual, IEqualityComparer<T> comparer = null, string message = null)
+        {
+            if (ReferenceEquals(expected, actual))
+            {
+                return;
+            }
+
+            if (expected == null)
+            {
+                Fail("expected was null, but actual wasn't" + Environment.NewLine + message);
+            }
+            else if (actual == null)
+            {
+                Fail("actual was null, but expected wasn't" + Environment.NewLine + message);
+            }
+            else if (!(comparer ?? AssertEqualityComparer<T>.Instance).Equals(expected, actual))
+            {
+                var expectedAndActual = $"""
+                    Expected:
+                    {expected}
+                    Actual:
+                    {actual}
+                    """;
+
+                Fail(message + Environment.NewLine + expectedAndActual);
+            }
+        }
+
+        public static void Equal<T>(
+            IEnumerable<T> expected,
+            IEnumerable<T> actual,
+            IEqualityComparer<T> comparer = null,
+            string message = null,
+            string itemSeparator = null,
+            Func<T, string> itemInspector = null)
+            => SequenceEqual(expected, actual, comparer, message, itemSeparator, itemInspector);
+
+        public static void SequenceEqual<T>(
+            IEnumerable<T> expected,
+            IEnumerable<T> actual,
+            IEqualityComparer<T> comparer = null,
+            string message = null,
+            string itemSeparator = null,
+            Func<T, string> itemInspector = null)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.NotNull(actual);
+            }
+
+            if (!expected.SequenceEqual(actual, comparer))
+            {
+                Fail(GetAssertMessage(expected, actual, message, itemInspector, itemSeparator));
+            }
+        }
+
+        private static string GetAssertMessage<T>(
+            IEnumerable<T> expected,
+            IEnumerable<T> actual,
+            string prefix = null,
+            Func<T, string> itemInspector = null,
+            string itemSeparator = null)
+        {
+            itemInspector ??= (typeof(T) == typeof(byte)) ? b => $"0x{b:X2}" : new Func<T, string>(obj => (obj != null) ? obj.ToString() : "<null>");
+            itemSeparator ??= (typeof(T) == typeof(byte)) ? ", " : "," + Environment.NewLine;
+
+            var expectedString = string.Join(itemSeparator, expected.Take(10).Select(itemInspector));
+            var actualString = string.Join(itemSeparator, actual.Select(itemInspector));
+
+            var message = new StringBuilder();
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                message.AppendLine(prefix);
+                message.AppendLine();
+            }
+
+            message.AppendLine("Expected:");
+            message.AppendLine(expectedString);
+            if (expected.Count() > 10)
+            {
+                message.AppendLine("... truncated ...");
+            }
+
+            message.AppendLine("Actual:");
+            message.AppendLine(actualString);
+
+            return message.ToString();
+        }
+
+        public static void Empty(string actual, string message = null)
+            => Equal("", actual, message: message);
+
+        public static void Fail(string message)
+            => throw new XunitException(message);
+
         public static void EqualFileList(string root, IEnumerable<string> expectedFiles, FileSet actualFiles)
             => EqualFileList(root, expectedFiles, actualFiles.Select(f => f.FilePath));
 

--- a/test/dotnet-watch.Tests/Utilities/TestOptions.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestOptions.cs
@@ -5,6 +5,6 @@ namespace Microsoft.DotNet.Watcher;
 
 internal static class TestOptions
 {
-    public static readonly CommandLineOptions CommandLine = new() { RemainingArguments = [] };
+    public static readonly CommandLineOptions CommandLine = new() { LaunchProcessArguments = [] };
     public static readonly EnvironmentOptions Environmental = new(WorkingDirectory: "", MuxerPath: "");
 }

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         [InlineData("P and Q and \"R\"", "argPQR")]
         public async Task ArgumentsFromLaunchSettings_Watch(string profileName, string expectedArgs)
         {
-            var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
+            var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings", identifier: profileName)
                 .WithSource();
 
             App.Start(testAsset, arguments: new[]
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         [InlineData("P and Q and \"R\"", "argPQR")]
         public async Task ArgumentsFromLaunchSettings_HotReload(string profileName, string expectedArgs)
         {
-            var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
+            var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings", identifier: profileName)
                 .WithSource();
 
             App.Start(testAsset, arguments: new[]

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Testing;
+using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tests
@@ -22,7 +23,7 @@ namespace Microsoft.DotNet.Watcher.Tests
                 .Path;
 
             var reporter = new ConsoleReporter(console, verbose: true, quiet: false, suppressEmojis: false);
-            var options = CommandLineOptions.Parse(["run"], reporter, out var _);
+            var options = CommandLineOptions.Parse(["run"], reporter, console.Out, out var _);
             var app = new Program(console, reporter, options, new EnvironmentOptions(WorkingDirectory: testAsset, MuxerPath: ""));
 
             var run = app.RunAsync();
@@ -48,7 +49,6 @@ namespace Microsoft.DotNet.Watcher.Tests
         [InlineData(new[] { "--", "test", "args" }, "test,args")]
         [InlineData(new[] { "--", "build", "args" }, "build,args")]
         [InlineData(new[] { "abc" }, "abc")]
-        [InlineData(new[] { "workload", "list" }, "workload,list")]
         public async Task Arguments(string[] arguments, string expectedApplicationArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: string.Join(",", arguments))
@@ -64,8 +64,8 @@ namespace Microsoft.DotNet.Watcher.Tests
         [InlineData(new[] { "--", "run", "args" }, "Argument Specified in Props,run,args")]
         // if arguments specified on command line the ones from launch profile are ignored
         [InlineData(new[] { "-lp", "P1", "--", "run", "args" },"Argument Specified in Props,run,args")]
-        // if no arguments specified on command line the ones from launch profile are added
-        [InlineData(new[] { "-lp", "P1" }, "Argument Specified in Props,Arg1 from launch profile,Arg2 from launch profile")]
+        // arguments specified in build file override arguments in launch profile
+        [InlineData(new[] { "-lp", "P1" }, "Argument Specified in Props")]
         public async Task Arguments_HostArguments(string[] arguments, string expectedApplicationArgs)
         {
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppCustomHost", identifier: string.Join(",", arguments))
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             App.Start(testAsset, arguments);
 
-            Assert.Equal(expectedApplicationArgs, await App.AssertOutputLineStartsWith("Arguments = "));
+            AssertEx.Equal(expectedApplicationArgs, await App.AssertOutputLineStartsWith("Arguments = "));
         }
 
         [Fact]
@@ -83,8 +83,8 @@ namespace Microsoft.DotNet.Watcher.Tests
                 .WithSource();
 
             App.DotnetWatchArgs.Clear();
-            App.Start(testAsset, arguments: new[]
-            {
+            App.Start(testAsset, arguments:
+            [
                 "--no-hot-reload",
                 "run",
                 "-f",         // dotnet watch does not recognize this arg -> dotnet run arg
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Watcher.Tests
                 "minimal",
                 "--",         // the following args are not dotnet run args
                 "-v",         // application arg
-            });
+            ]);
 
             Assert.Equal("-v", await App.AssertOutputLineStartsWith("Arguments = "));
             Assert.Equal("WatchHotReloadAppMultiTfm, Version=1.2.3.4, Culture=neutral, PublicKeyToken=null", await App.AssertOutputLineStartsWith("AssemblyName = "));
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             Assert.Contains(App.Process.Output, l => l.Contains("Determining projects to restore..."));
 
             // not expected to find verbose output of dotnet watch
-            Assert.DoesNotContain(App.Process.Output, l => l.Contains("Running dotnet with the following arguments"));
+            Assert.DoesNotContain(App.Process.Output, l => l.Contains("Working directory:"));
         }
 
         [Fact]
@@ -117,8 +117,9 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
                 .WithSource();
 
-            App.Start(testAsset, arguments: new[]
-            {
+            App.DotnetWatchArgs.Clear();
+            App.Start(testAsset, arguments:
+            [
                 "run",
                 "-f",         // dotnet watch does not recognize this arg -> dotnet run arg
                 "net6.0",
@@ -127,16 +128,16 @@ namespace Microsoft.DotNet.Watcher.Tests
                 "--property",
                 "AssemblyTitle= | A=B'\tC | ",
                 "--",         // the following args are not dotnet run args
-                "-v",         // application arg
-            });
+                "-v",         // dotnet build argument
+                "minimal"
+            ]);
 
-            Assert.Equal("-v", await App.AssertOutputLineStartsWith("Arguments = ", failure: s => s.Contains("MSBUILD")));
             Assert.Equal("WatchHotReloadAppMultiTfm, Version=1.2.3.4, Culture=neutral, PublicKeyToken=null", await App.AssertOutputLineStartsWith("AssemblyName = "));
             Assert.Equal("' | A=B'\tC | '", await App.AssertOutputLineStartsWith("AssemblyTitle = "));
             Assert.Equal(".NETCoreApp,Version=v6.0", await App.AssertOutputLineStartsWith("TFM = "));
 
             // not expected to find verbose output of dotnet watch
-            Assert.DoesNotContain(App.Process.Output, l => l.Contains("Running dotnet with the following arguments"));
+            Assert.DoesNotContain(App.Process.Output, l => l.Contains("Working directory:"));
 
             Assert.Contains(App.Process.Output, l => l.Contains("Hot reload enabled."));
         }

--- a/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Watcher.Tests
     {
         private const string StartedMessage = "Started";
         private const string ExitingMessage = "Exiting";
-        private const string WatchStartedMessage = "dotnet watch 🚀 Started";
+        private const string WatchStartedMessage = "dotnet watch ⌚ Started";
         private const string WatchExitedMessage = "dotnet watch ⌚ Exited";
         private const string WatchErrorOutputEmoji = "❌";
         private const string WaitingForFileChangeMessage = "dotnet watch ⏳ Waiting for a file to change";


### PR DESCRIPTION
Instead of launching process directly in Hot Reload with Hot Reload environment variables set on the process start info, we now launch `dotnet run` (or any other `dotnet` command) with Hot Reload variables set via environment directives (i.e. `dotnet [env:XYZ=...] run <remaining args>`). This allows us to avoid interpreting the subcommand and most of the command line options and arguments passed to `dotnet watch`. We can now easily support any existing `dotnet` subcommand. 

We have 3 kinds of options: 

1) dotnet-watch specific (such as `--verbose`)
These are consumed by dotnet-watch and not included in `<remaining args>`

2) options that dotnet-watch needs to understand but are passed through to the subcommand (e.g. --launch-profile)
We parse these and include them in `<remaining args>` (if they precede the subcommand they are moved after the subcommand).

3) other options
These are not interpreted, just included in `<remaining args>`.

Fixes https://github.com/dotnet/sdk/issues/39020
Fixes https://github.com/dotnet/aspnetcore/issues/52294
Fixes https://github.com/dotnet/sdk/issues/36611 
Fixes https://github.com/dotnet/sdk/issues/34055
Fixes https://github.com/dotnet/sdk/issues/29539
Fixes https://github.com/dotnet/sdk/issues/25612