### PR TITLE
Migrate to 1ES templates for internal builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -102,17 +102,21 @@ extends:
             helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             helixTargetQueue: Windows.Amd64.VS2022.Pre
-          strategy:
-            matrix:
-              Build_Release:
-                _BuildConfig: Release
-                _PublishArgs: '-publish /p:DotNetPublishUsingPipelines=true'
-                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                  _SignType: test
-                  _Test: -test
-                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                  _SignType: real
-                  _Test: ''
+          variables:
+          - name: _BuildConfig
+            value: Release
+          - name: _PublishArgs
+            value: '-publish /p:DotNetPublishUsingPipelines=true'
+          - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _SignType
+              value: test
+            - name: _Test
+              value: -test
+          - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            - name: _SignType
+              value: real
+            - name: _Test
+              value: ''
       - template: /eng/common/templates-official/job/source-build.yml@self
         parameters:
           platform:
@@ -136,13 +140,15 @@ extends:
               helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: Windows.Amd64.VS2022.Pre
-            strategy:
-              matrix:
-                Build_Debug:
-                  _BuildConfig: Debug
-                  _PublishArgs: ''
-                  _SignType: test
-                  _Test: -test
+            variables:
+            - name: _BuildConfig
+              value: Debug
+            - name: _PublishArgs
+              value: ''
+            - name: _SignType
+              value: test
+            - name: _Test
+              value: -test
 
         - template: /eng/build.yml@self
           parameters:
@@ -156,12 +162,13 @@ extends:
                 name: $(DncEngInternalBuildPool)
                 image: 1es-windows-2022
                 os: windows
-            strategy:
-              matrix:
-                Build_Debug:
-                  _BuildConfig: Debug
-                  _PublishArgs: ''
-                  _SignType: test
+            variables:
+            - name: _BuildConfig
+              value: Debug
+            - name: _PublishArgs
+              value: ''
+            - name: _SignType
+              value: test
 
         - template: /eng/build.yml@self
           parameters:
@@ -179,13 +186,15 @@ extends:
               helixTargetQueue: ubuntu.2204.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: Ubuntu.2204.Amd64
-            strategy:
-              matrix:
-                Build_Release:
-                  _BuildConfig: Release
-                  _PublishArgs: ''
-                  _SignType: test
-                  _Test: -test
+            variables:
+            - name: _BuildConfig
+              value: Release
+            - name: _PublishArgs
+              value: ''
+            - name: _SignType
+              value: test
+            - name: _Test
+              value: -test
 
         - template: /eng/build.yml@self
           parameters:
@@ -198,13 +207,15 @@ extends:
               helixTargetQueue: OSX.13.Amd64.Open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: OSX.13.Amd64
-            strategy:
-              matrix:
-                Build_Release:
-                  _BuildConfig: Release
-                  _PublishArgs: ''
-                  _SignType: test
-                  _Test: -test
+            variables:
+            - name: _BuildConfig
+              value: Release
+            - name: _PublishArgs
+              value: ''
+            - name: _SignType
+              value: test
+            - name: _Test
+              value: -test
 
       - template: /eng/template-engine.yml@self
       - template: /eng/dotnet-format/dotnet-format-integration.yml@self

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -291,7 +291,10 @@ extends:
             - name: _Test
               value: -test
 
+      # dotnet-format builds
       - template: /eng/dotnet-format/dotnet-format-integration.yml@self
+        parameters:
+          PublishTaskName: 1ES.PublishBuildArtifacts@1
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -64,8 +64,6 @@ extends:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
     stages:
     - stage: build
       displayName: Build
@@ -133,7 +131,6 @@ extends:
                 os: windows
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
-                # Should this be windows.vs2022preview.amd64?
                 image: 1es-windows-2022
                 os: windows
             ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -181,7 +181,7 @@ extends:
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
                 image: 1es-ubuntu-2204
-                os: windows
+                os: linux
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: ubuntu.2204.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -217,7 +217,80 @@ extends:
             - name: _Test
               value: -test
 
-      - template: /eng/template-engine.yml@self
+          # template-engine builds
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT_TemplateEngine
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngPublicBuildPool)
+                image: 1es-windows-2022-open
+                os: windows
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngInternalBuildPool)
+                image: 1es-windows-2022
+                os: windows
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Windows.Amd64.VS2022.Pre
+            variables:
+              - name: _BuildConfig
+                value: Release
+              - name: PublishArgs
+                value: '-publish /p:DotNetPublishUsingPipelines=true'
+              - name: _SignType
+                value: test
+              - name: _Test
+                value: -test
+
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Ubuntu_22_04_TemplateEngine
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngPublicBuildPool)
+                image: 1es-ubuntu-2204-open
+                os: linux
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngInternalBuildPool)
+                image: 1es-ubuntu-2204
+                os: linux
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Ubuntu.2204.Amd64
+            variables:
+              - name: _BuildConfig
+                value: Release
+              - name: _PublishArgs
+                value: ''
+              - name: _SignType
+                value: test
+              - name: _Test
+                value: -test
+
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Darwin_TemplateEngine
+            pool:
+              name: Azure Pipelines
+              image: macOS-latest
+              os: macOS
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: OSX.1100.Amd64.Open
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: OSX.1100.Amd64
+            variables:
+            - name: _BuildConfig
+              value: Release
+            - name: _PublishArgs
+              value: ''
+            - name: _SignType
+              value: test
+            - name: _Test
+              value: -test
+
       - template: /eng/dotnet-format/dotnet-format-integration.yml@self
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -176,11 +176,11 @@ extends:
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngPublicBuildPool)
-                image: 1es-ubunto-2204-open
+                image: 1es-ubuntu-2204-open
                 os: linux
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
-                image: 1es-ubunto-2204
+                image: 1es-ubuntu-2204
                 os: windows
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: ubuntu.2204.amd64.open

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,164 +47,199 @@ variables:
         /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64) 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-CLI-SDLValidation-Params
-  - template: /eng/common/templates/variables/pool-providers.yml
+  - template: /eng/common/templates-official/variables/pool-providers.yml
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - job: Publish_Build_Configuration
-    pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        vmImage: 'windows-2019'
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2019.amd64
-    steps:
-      - publish: $(Build.SourcesDirectory)\eng\BuildConfiguration
-        artifact: BuildConfiguration
-        displayName: Publish Build Config
-  - template: /eng/build.yml
-    parameters:
-      agentOs: Windows_NT
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        helixTargetQueue: Windows.Amd64.VS2022.Pre
-      strategy:
-        matrix:
-          Build_Release:
-            _BuildConfig: Release
-            _PublishArgs: '-publish /p:DotNetPublishUsingPipelines=true'
-            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              _SignType: test
-              _Test: -test
-            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              _SignType: real
-              _Test: ''
-  - template: /eng/common/templates/job/source-build.yml
-    parameters:
-      platform:
-        name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/build.yml
-      parameters:
-        agentOs: Windows_NT_FullFramework
+        image: 1es-windows-2022
+        os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build
+      jobs:
+      - job: Publish_Build_Configuration
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022-open
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            image: 1es-windows-2022-open
+            os: windows
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre
-        strategy:
-          matrix:
-            Build_Debug:
-              _BuildConfig: Debug
-              _PublishArgs: ''
-              _SignType: test
-              _Test: -test
-
-    - template: /eng/build.yml
-      parameters:
-        agentOs: Windows_NT_TestAsTools
-        pool:
+            image: 1es-windows-2022
+            os: windows
+        steps:
+          - task: 1ES.PublishPipelineArtifact@1
+            displayName: Publish Build Config
+            inputs:
+              targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
+              artifactName: buildConfiguration
+      - template: /eng/build.yml@self
+        parameters:
+          agentOs: Windows_NT
+          pool:
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              name: $(DncEngPublicBuildPool)
+              image: 1es-windows-2022-open
+              os: windows
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-windows-2022
+              os: windows
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022-open
+            helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022
-        strategy:
-          matrix:
-            Build_Debug:
-              _BuildConfig: Debug
-              _PublishArgs: ''
-              _SignType: test
+            helixTargetQueue: Windows.Amd64.VS2022.Pre
+          strategy:
+            matrix:
+              Build_Release:
+                _BuildConfig: Release
+                _PublishArgs: '-publish /p:DotNetPublishUsingPipelines=true'
+                ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                  _SignType: test
+                  _Test: -test
+                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                  _SignType: real
+                  _Test: ''
+      - template: /eng/common/templates-official/job/source-build.yml@self
+        parameters:
+          platform:
+            name: 'Managed'
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT_FullFramework
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngPublicBuildPool)
+                image: 1es-windows-2022-open
+                os: windows
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngInternalBuildPool)
+                # Should this be windows.vs2022preview.amd64?
+                image: 1es-windows-2022
+                os: windows
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Windows.Amd64.VS2022.Pre
+            strategy:
+              matrix:
+                Build_Debug:
+                  _BuildConfig: Debug
+                  _PublishArgs: ''
+                  _SignType: test
+                  _Test: -test
 
-    - template: /eng/build.yml
-      parameters:
-        agentOs: Ubuntu_22_04
-        pool:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: 'ubuntu-22.04'
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2204.amd64
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: ubuntu.2204.amd64.open
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Ubuntu.2204.Amd64
-        strategy:
-          matrix:
-            Build_Release:
-              _BuildConfig: Release
-              _PublishArgs: ''
-              _SignType: test
-              _Test: -test
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT_TestAsTools
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngPublicBuildPool)
+                image: 1es-windows-2022-open
+                os: windows
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngInternalBuildPool)
+                image: 1es-windows-2022
+                os: windows
+            strategy:
+              matrix:
+                Build_Debug:
+                  _BuildConfig: Debug
+                  _PublishArgs: ''
+                  _SignType: test
 
-    - template: /eng/build.yml
-      parameters:
-        agentOs: Darwin
-        pool:
-          vmImage: 'macOS-latest'
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.13.Amd64.Open
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: OSX.13.Amd64
-        strategy:
-          matrix:
-            Build_Release:
-              _BuildConfig: Release
-              _PublishArgs: ''
-              _SignType: test
-              _Test: -test
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Ubuntu_22_04
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngPublicBuildPool)
+                image: 1es-ubunto-2204-open
+                os: linux
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: $(DncEngInternalBuildPool)
+                image: 1es-ubunto-2204
+                os: windows
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: ubuntu.2204.amd64.open
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: Ubuntu.2204.Amd64
+            strategy:
+              matrix:
+                Build_Release:
+                  _BuildConfig: Release
+                  _PublishArgs: ''
+                  _SignType: test
+                  _Test: -test
 
-  - template: /eng/template-engine.yml
-  - template: /eng/dotnet-format/dotnet-format-integration.yml
+        - template: /eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            pool:
+              name: Azure Pipelines
+              image: macOS-latest
+              os: macOS
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: OSX.13.Amd64.Open
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              helixTargetQueue: OSX.13.Amd64
+            strategy:
+              matrix:
+                Build_Release:
+                  _BuildConfig: Release
+                  _PublishArgs: ''
+                  _SignType: test
+                  _Test: -test
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
-        dependsOn:
-          - Windows_NT
-          - Source_Build_Managed
-        pool:
-          name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishInstallersAndChecksums: true
-      publishAssetsImmediately: true
-      SDLValidationParameters:
-        enable: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "dotnet-sdk"
-        -TsaCodebaseName "dotnet-sdk"
-        -TsaPublish $True'
+      - template: /eng/template-engine.yml@self
+      - template: /eng/dotnet-format/dotnet-format-integration.yml@self
+
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            dependsOn:
+              - Windows_NT
+              - Source_Build_Managed
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-windows-2022
+              os: windows
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          publishingInfraVersion: 3
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          publishInstallersAndChecksums: true
+          publishAssetsImmediately: true
+          SDLValidationParameters:
+            enable: false
+            params: ' -SourceToolsList @("policheck","credscan")
+            -TsaInstanceURL $(_TsaInstanceURL)
+            -TsaProjectName $(_TsaProjectName)
+            -TsaNotificationEmail $(_TsaNotificationEmail)
+            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+            -TsaBugAreaPath $(_TsaBugAreaPath)
+            -TsaIterationPath $(_TsaIterationPath)
+            -TsaRepositoryName "dotnet-sdk"
+            -TsaCodebaseName "dotnet-sdk"
+            -TsaPublish $True'

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -64,7 +64,7 @@ stages:
       - publish: $(Build.SourcesDirectory)\eng\BuildConfiguration
         artifact: BuildConfiguration
         displayName: Publish Build Config
-  - template: /eng/build.yml
+  - template: /eng/build-pr.yml
     parameters:
       agentOs: Windows_NT
       pool:
@@ -95,7 +95,7 @@ stages:
         name: 'Managed'
         container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Windows_NT_FullFramework
         pool:
@@ -117,7 +117,7 @@ stages:
               _SignType: test
               _Test: -test
 
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Windows_NT_TestAsTools
         pool:
@@ -134,7 +134,7 @@ stages:
               _PublishArgs: ''
               _SignType: test
 
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Ubuntu_22_04
         pool:
@@ -155,7 +155,7 @@ stages:
               _SignType: test
               _Test: -test
 
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Darwin
         pool:

--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -16,7 +16,7 @@ parameters:
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0.3xx'), not(contains(parameters.agentOs, 'TemplateEngine'))) }}:
-  - template: /eng/common/templates-official/job/onelocbuild.yml@self
+  - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
       CreatePr: true
       LclSource: lclFilesfromPackage
@@ -25,7 +25,7 @@ jobs:
       MirrorRepo: sdk
 
 - ${{ if not(contains(parameters.agentOs, 'TemplateEngine')) }}:
-  - template: /eng/common/templates-official/job/job.yml@self
+  - template: /eng/common/templates/job/job.yml
     parameters:
       name: ${{ parameters.agentOs }}
       enableMicrobuild: true
@@ -206,7 +206,7 @@ jobs:
 
 # AoT Jobs
 - ${{ if and(in(parameters.agentOs, 'Windows_NT', 'Darwin'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:
-  - template: /eng/common/templates-official/job/job.yml@self
+  - template: /eng/common/templates/job/job.yml
     parameters:
       name: ${{ parameters.agentOs }}_AoT_Tests
       enableMicrobuild: true
@@ -338,7 +338,7 @@ jobs:
 
 # TemplateEngine Jobs
 - ${{ if contains(parameters.agentOs, 'TemplateEngine') }}:
-  - template: /eng/common/templates-official/job/job.yml@self
+  - template: /eng/common/templates/job/job.yml
     parameters:
       name: ${{ parameters.agentOs }}
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -40,22 +40,37 @@ jobs:
       workspace:
         clean: all
       variables:
-        - ${{ insert }}: ${{ parameters.variables }}
-        - _AgentOSName: ${{ parameters.agentOs }}
-        - _TeamName: DotNetCore
-        - _OfficialBuildIdArgs: ''
-        - _PublishArgs: ''
-        - _SignArgs: ''
-        - _HelixApiToken: ''
+        - ${{ each variable in parameters.variables }}:
+          - ${{ if ne(variable.name, '') }}:
+            - name: ${{ variable.name }}
+              value: ${{ variable.value }}
+        - name: _AgentOSName
+          value: ${{ parameters.agentOs }}
+        - name: _TeamName
+          value: DotNetCore
+        - name: _OfficialBuildIdArgs
+          value: ''
+        - name: _PublishArgs
+          value: ''
+        - name: _SignArgs
+          value: ''
+        - name: _HelixApiToken
+          value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - group: DotNet-HelixApi-Access
-          - _HelixApiToken: $(HelixApiAccessToken)
+          - name: group
+            value: DotNet-HelixApi-Access
+          - name: _HelixApiToken
+            value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - group: dotnet-benchview
-          - _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-          - _PerfIterations: 25
+          - name: group
+            value: dotnet-benchview
+          - name: _OfficialBuildIdArgs
+            value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _SignArgs
+            value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+          - name: _PerfIterations
+            value: 25
   
       steps:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -221,22 +236,37 @@ jobs:
       workspace:
         clean: all
       variables:
-        - ${{ insert }}: ${{ parameters.variables }}
-        - _AgentOSName: ${{ parameters.agentOs }}
-        - _TeamName: DotNetCore
-        - _OfficialBuildIdArgs: ''
-        - _PublishArgs: ''
-        - _SignArgs: ''
-        - _HelixApiToken: ''
+        - ${{ each variable in parameters.variables }}:
+          - ${{ if ne(variable.name, '') }}:
+            - name: ${{ variable.name }}
+              value: ${{ variable.value }}
+        - name: _AgentOSName
+          value: ${{ parameters.agentOs }}
+        - name: _TeamName
+          value: DotNetCore
+        - name: _OfficialBuildIdArgs
+          value: ''
+        - name: _PublishArgs
+          value: ''
+        - name: _SignArgs
+          value: ''
+        - name: _HelixApiToken
+          value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - group: DotNet-HelixApi-Access
-          - _HelixApiToken: $(HelixApiAccessToken)
+          - name: group
+            value: DotNet-HelixApi-Access
+          - name: _HelixApiToken
+            value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - group: dotnet-benchview
-          - _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-          - _PerfIterations: 25
+          - name: group
+            value: dotnet-benchview
+          - name: _OfficialBuildIdArgs
+            value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _SignArgs
+            value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+          - name: _PerfIterations
+            value: 25
 
       steps:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.agentOs, 'Windows_NT', 'Darwin')) }}:
@@ -353,22 +383,37 @@ jobs:
       workspace:
         clean: all
       variables:
-        - ${{ insert }}: ${{ parameters.variables }}
-        - _AgentOSName: ${{ parameters.agentOs }}
-        - _TeamName: DotNetCore
-        - _OfficialBuildIdArgs: ''
-        - _PublishArgs: ''
-        - _SignArgs: ''
-        - _HelixApiToken: ''
+        - ${{ each variable in parameters.variables }}:
+          - ${{ if ne(variable.name, '') }}:
+            - name: ${{ variable.name }}
+              value: ${{ variable.value }}
+        - name: _AgentOSName
+          value: ${{ parameters.agentOs }}
+        - name: _TeamName
+          value: DotNetCore
+        - name: _OfficialBuildIdArgs
+          value: ''
+        - name: _PublishArgs
+          value: ''
+        - name: _SignArgs
+          value: ''
+        - name: _HelixApiToken
+          value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - group: DotNet-HelixApi-Access
-          - _HelixApiToken: $(HelixApiAccessToken)
+          - name: group
+            value: DotNet-HelixApi-Access
+          - name: _HelixApiToken
+            value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - group: dotnet-benchview
-          - _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-          - _PerfIterations: 25
+          - name: group
+            value: dotnet-benchview
+          - name: _OfficialBuildIdArgs
+            value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _SignArgs
+            value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+          - name: _PerfIterations
+            value: 25
 
       steps:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -58,13 +58,11 @@ jobs:
           value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - name: group
-            value: DotNet-HelixApi-Access
+          - group: DotNet-HelixApi-Access
           - name: _HelixApiToken
             value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: group
-            value: dotnet-benchview
+          - group: dotnet-benchview
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           - name: _SignArgs
@@ -254,13 +252,11 @@ jobs:
           value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - name: group
-            value: DotNet-HelixApi-Access
+          - group: DotNet-HelixApi-Access
           - name: _HelixApiToken
             value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: group
-            value: dotnet-benchview
+          - group: dotnet-benchview
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           - name: _SignArgs
@@ -401,13 +397,11 @@ jobs:
           value: ''
         # Helix Testing requires a token when internally run
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - name: group
-            value: DotNet-HelixApi-Access
+          - group: DotNet-HelixApi-Access
           - name: _HelixApiToken
             value: $(HelixApiAccessToken)
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: group
-            value: dotnet-benchview
+          - group: dotnet-benchview
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           - name: _SignArgs

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -195,7 +195,7 @@ jobs:
         continueOnError: true	
         condition: always()
   
-      - task: PublishBuildArtifacts@1	
+      - task: 1ES.PublishBuildArtifacts@1	
         displayName: Publish Logs to VSTS	
         inputs:	
           PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
@@ -327,7 +327,7 @@ jobs:
           continueOnError: true	
           condition: always()
 
-        - task: PublishBuildArtifacts@1	
+        - task: 1ES.PublishBuildArtifacts@1	
           displayName: Publish Logs to VSTS	
           inputs:	
             PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
@@ -470,7 +470,7 @@ jobs:
         continueOnError: true	
         condition: always()
   
-      - task: PublishBuildArtifacts@1	
+      - task: 1ES.PublishBuildArtifacts@1	
         displayName: Publish Logs to VSTS	
         inputs:	
           PathtoPublish: '$(Build.ArtifactStagingDirectory)'	

--- a/eng/dotnet-format/dotnet-format-integration.yml
+++ b/eng/dotnet-format/dotnet-format-integration.yml
@@ -1,3 +1,59 @@
+parameters:
+  - name: PublishTaskName
+    default: PublishBuildArtifacts@1
+  - name: TestArguments
+    type: object
+    default:
+      - Name: Roslyn
+        _repo: "https://github.com/dotnet/roslyn"
+        _repoName: "dotnet/roslyn"
+        _targetSolution: "Compilers.slnf"
+        _branchName: "main"
+        _sha: "a3bb37003aeccad012a6e7dd220977599e8b8e65"
+        _useParentSdk: 0
+      - Name: sdk
+        _repo: "https://github.com/dotnet/sdk"
+        _repoName: "dotnet/sdk"
+        _targetSolution: "sdk.sln"
+        _branchName: "main"
+        _sha: "be25db95c376bffd508a023399ddd34392fe6458"
+        _useParentSdk: 0
+      - Name: project_system
+        _repo: "https://github.com/dotnet/project-system"
+        _repoName: "dotnet/project-system"
+        _targetSolution: "ProjectSystem.sln"
+        _branchName: "main"
+        _sha: "e660d54d6b3198751bd0502fe270e1657f32a913"
+        _useParentSdk: 1
+      - Name: msbuild
+        _repo: "https://github.com/dotnet/msbuild"
+        _repoName: "dotnet/msbuild"
+        _targetSolution: "MSBuild.sln"
+        _branchName: "main"
+        _sha: "f4fa6bde775a3f7cbb2bb90a349ee5fc759114f3"
+        _useParentSdk: 0
+      - Name: aspnetcore
+        _repo: "https://github.com/dotnet/aspnetcore"
+        _repoName: "dotnet/aspnetcore"
+        _targetSolution: "AspNetCore.sln"
+        _branchName: "main"
+        _sha: "d765d7ba4871a8c2cb38d4134553d3be9a7370d7"
+        _useParentSdk: 0
+      - Name: efcore
+        _repo: "https://github.com/dotnet/efcore"
+        _repoName: "dotnet/efcore"
+        _targetSolution: "All.sln"
+        _branchName: "main"
+        _sha: "1b2ff365399ab6736a9ea4c98ab1b60acda5d917"
+        _useParentSdk: 0
+      - Name: razor_tooling
+        _repo: "https://github.com/dotnet/razor"
+        _repoName: "dotnet/razor"
+        _targetSolution: "Razor.sln"
+        _branchName: "main"
+        _sha: "ecb4b595e3322a18c240f50a763868540f51eaaa"
+        _useParentSdk: 0
+
 jobs:
 - job: Formatting_Check
   pool:
@@ -10,7 +66,7 @@ jobs:
         .\artifacts\sdk-build-env.bat
          dotnet run --project .\src\BuiltInTools\dotnet-format\dotnet-format.csproj -c Release -- @eng\dotnet-format\validate.rsp
       displayName: Run dotnet-format
-    - task: PublishBuildArtifacts@1
+    - task: ${{ parameters.PublishTaskName }}
       displayName: Publish Logs
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
@@ -18,68 +74,17 @@ jobs:
       continueOnError: true
       condition: not(succeeded())
 
-- job: dotnet_format_integration_tests
-  pool:
-    vmImage: 'windows-latest'
-  strategy:
-    maxParallel: 8
-    matrix:
-      roslyn:
-        _repo: "https://github.com/dotnet/roslyn"
-        _repoName: "dotnet/roslyn"
-        _targetSolution: "Compilers.slnf"
-        _branchName: "main"
-        _sha: "a3bb37003aeccad012a6e7dd220977599e8b8e65"
-        _useParentSdk: 0
-      sdk:
-        _repo: "https://github.com/dotnet/sdk"
-        _repoName: "dotnet/sdk"
-        _targetSolution: "sdk.sln"
-        _branchName: "main"
-        _sha: "be25db95c376bffd508a023399ddd34392fe6458"
-        _useParentSdk: 0
-      project-system:
-        _repo: "https://github.com/dotnet/project-system"
-        _repoName: "dotnet/project-system"
-        _targetSolution: "ProjectSystem.sln"
-        _branchName: "main"
-        _sha: "e660d54d6b3198751bd0502fe270e1657f32a913"
-        _useParentSdk: 1
-      msbuild:
-        _repo: "https://github.com/dotnet/msbuild"
-        _repoName: "dotnet/msbuild"
-        _targetSolution: "MSBuild.sln"
-        _branchName: "main"
-        _sha: "f4fa6bde775a3f7cbb2bb90a349ee5fc759114f3"
-        _useParentSdk: 0
-      aspnetcore:
-        _repo: "https://github.com/dotnet/aspnetcore"
-        _repoName: "dotnet/aspnetcore"
-        _targetSolution: "AspNetCore.sln"
-        _branchName: "main"
-        _sha: "d765d7ba4871a8c2cb38d4134553d3be9a7370d7"
-        _useParentSdk: 0
-      efcore:
-        _repo: "https://github.com/dotnet/efcore"
-        _repoName: "dotnet/efcore"
-        _targetSolution: "All.sln"
-        _branchName: "main"
-        _sha: "1b2ff365399ab6736a9ea4c98ab1b60acda5d917"
-        _useParentSdk: 0
-      razor-tooling:
-        _repo: "https://github.com/dotnet/razor"
-        _repoName: "dotnet/razor"
-        _targetSolution: "Razor.sln"
-        _branchName: "main"
-        _sha: "ecb4b595e3322a18c240f50a763868540f51eaaa"
-        _useParentSdk: 0
-  timeoutInMinutes: 60
-  steps:
-    - script: eng\dotnet-format\integration-test.cmd -repo '$(_repo)' -branchName '$(_branchName)' -sha '$(_sha)' -targetSolution '$(_targetSolution)' -useParentSdk $(_useParentSdk) -testPath '$(Agent.TempDirectory)\temp' -stage 'prepare'
-      displayName: Prepare $(_repoName) for formatting
+- ${{ each testArgs in parameters.TestArguments }}:
+  - job: dotnet_format_integration_tests_${{ testArgs.Name }}
+    pool:
+      vmImage: 'windows-latest'
+    timeoutInMinutes: 60
+    steps:
+      - script: eng\dotnet-format\integration-test.cmd -repo '${{ testArgs._repo }}' -branchName '${{ testArgs._branchName }}' -sha '${{ testArgs._sha }}' -targetSolution '${{ testArgs._targetSolution }}' -useParentSdk ${{ testArgs._useParentSdk }} -testPath '$(Agent.TempDirectory)\temp' -stage 'prepare'
+        displayName: Prepare ${{ testArgs._repoName }} for formatting
 
-    - script: eng\dotnet-format\integration-test.cmd -repo '$(_repo)' -branchName '$(_branchName)' -sha '$(_sha)' -targetSolution '$(_targetSolution)' -useParentSdk $(_useParentSdk) -testPath '$(Agent.TempDirectory)\temp' -stage 'format-workspace'
-      displayName: Run dotnet-format on $(_repoName) $(_targetSolution)
+      - script: eng\dotnet-format\integration-test.cmd -repo '${{ testArgs._repo }}' -branchName '${{ testArgs._branchName }}' -sha '${{ testArgs._sha }}' -targetSolution '${{ testArgs._targetSolution }}' -useParentSdk ${{ testArgs._useParentSdk }} -testPath '$(Agent.TempDirectory)\temp' -stage 'format-workspace'
+        displayName: Run dotnet-format on ${{ testArgs._repoName }} ${{ testArgs._targetSolution }}
 
-    - script: eng\dotnet-format\integration-test.cmd -repo '$(_repo)' -branchName '$(_branchName)' -sha '$(_sha)' -targetSolution '$(_targetSolution)' -useParentSdk $(_useParentSdk) -testPath '$(Agent.TempDirectory)\temp' -stage 'format-folder'
-      displayName: Run dotnet-format on $(_repoName) repo folder
+      - script: eng\dotnet-format\integration-test.cmd -repo '${{ testArgs._repo }}' -branchName '${{ testArgs._branchName }}' -sha '${{ testArgs._sha }}' -targetSolution '${{ testArgs._targetSolution }}' -useParentSdk ${{ testArgs._useParentSdk }} -testPath '$(Agent.TempDirectory)\temp' -stage 'format-folder'
+        displayName: Run dotnet-format on ${{ testArgs._repoName }} repo folder

--- a/eng/dotnet-format/dotnet-format-integration.yml
+++ b/eng/dotnet-format/dotnet-format-integration.yml
@@ -59,8 +59,7 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: $(DncEngPublicBuildPool)
-      image: 1es-windows-2022-open
-      os: windows
+      demands: ImageOverride -equals 1es-windows-2022-open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022
@@ -86,8 +85,7 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: 1es-windows-2022-open
-        os: windows
+        demands: ImageOverride -equals 1es-windows-2022-open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022

--- a/eng/dotnet-format/dotnet-format-integration.yml
+++ b/eng/dotnet-format/dotnet-format-integration.yml
@@ -57,7 +57,14 @@ parameters:
 jobs:
 - job: Formatting_Check
   pool:
-    vmImage: 'windows-latest'
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: $(DncEngPublicBuildPool)
+      image: 1es-windows-2022-open
+      os: windows
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
   timeoutInMinutes: 60
   steps:
     - script: .\restore.cmd
@@ -77,7 +84,14 @@ jobs:
 - ${{ each testArgs in parameters.TestArguments }}:
   - job: dotnet_format_integration_tests_${{ testArgs.Name }}
     pool:
-      vmImage: 'windows-latest'
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: $(DncEngPublicBuildPool)
+        image: 1es-windows-2022-open
+        os: windows
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
     timeoutInMinutes: 60
     steps:
       - script: eng\dotnet-format\integration-test.cmd -repo '${{ testArgs._repo }}' -branchName '${{ testArgs._branchName }}' -sha '${{ testArgs._sha }}' -targetSolution '${{ testArgs._targetSolution }}' -useParentSdk ${{ testArgs._useParentSdk }} -testPath '$(Agent.TempDirectory)\temp' -stage 'prepare'

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -1,6 +1,6 @@
 jobs:
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Windows_NT_TemplateEngine
         pool:
@@ -22,7 +22,7 @@ jobs:
               _SignType: test
               _Test: -test
 
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Ubuntu_22_04_TemplateEngine
         pool:
@@ -44,7 +44,7 @@ jobs:
               _SignType: test
               _Test: -test
 
-    - template: /eng/build.yml
+    - template: /eng/build-pr.yml
       parameters:
         agentOs: Darwin_TemplateEngine
         pool:


### PR DESCRIPTION
Switch to 1ES pipeline templates for internal builds.

Internal PR with these changes to test the pipeline changes: https://dev.azure.com/dnceng/internal/_git/dotnet-sdk/pullrequest/38177

This PR follows the process outlined in this dotnet/installer PR: https://github.com/dotnet/installer/pull/19016

Additional notes:

- `matrix:` elements were replaced.  In most cases there weren't actually multiple value sets, so the matrix could just be removed.  For dotnet-format, the matrix of repos to test on was replaced with a template parameter with default values and an `each` preprocessor loop
- template parameter variables had to change syntax
- For template engine yaml, copied it directly into the internal .vsts-ci.yml file
- For dotnet-format, updated the yaml template to work for both internal and external builds to avoid having to duplicate it