### PR TITLE
skip CanSortByDownloadCountAndThenByName because it's blocking

### DIFF
--- a/test/dotnet-new.Tests/DotnetNewSearchTests.cs
+++ b/test/dotnet-new.Tests/DotnetNewSearchTests.cs
@@ -436,7 +436,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
 
-        [Theory]
+#pragma warning disable xUnit1004
+        [Theory(Skip = "https://github.com/dotnet/sdk/issues/39772")]
+#pragma warning restore xUnit1004
         [InlineData("console --search")]
         [InlineData("--search console")]
         [InlineData("search console")]


### PR DESCRIPTION
We'll want to backport this to all the other branches that are blocked once merged.