### PR TITLE
Use MicroBuildOutputFolderOverride to move the MicroBuild plugin install directory

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,6 +48,9 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-CLI-SDLValidation-Params
   - template: /eng/common/templates-official/variables/pool-providers.yml
+  # Set the MicroBuild plugin installation directory to the agent temp directory to avoid SDL tool scanning.
+  - name: MicroBuildOutputFolderOverride
+    value: $(Agent.TempDirectory)
 
 resources:
   repositories:


### PR DESCRIPTION
This should fix 1ES credscan issues.

See also https://github.com/dotnet/installer/pull/19179