### PR TITLE
Add --format to dotnet sln list

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -177,4 +177,7 @@
   <data name="SolutionFolderHeader" xml:space="preserve">
     <value>Solution Folder(s)</value>
   </data>
+  <data name="CmdFormatDescription" xml:space="preserve">
+    <value>The desired output format of the command</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -56,22 +56,19 @@ namespace Microsoft.DotNet.Tools.Sln.List
             {
                 Array.Sort(paths);
 
-                if (_outputFormat == SlnListReportOutputFormat.console_with_header)
-                {
-                    string header = _displaySolutionFolders ? LocalizableStrings.SolutionFolderHeader : LocalizableStrings.ProjectsHeader;
-                    Reporter.Output.WriteLine($"{header}");
-                    Reporter.Output.WriteLine(new string('-', header.Length));
-                }
-
                 switch (_outputFormat)
                 {
-                    case SlnListReportOutputFormat.console:
-                    case SlnListReportOutputFormat.console_with_header:
+                    case SlnListReportOutputFormat.text:
+                        string header = _displaySolutionFolders ? LocalizableStrings.SolutionFolderHeader : LocalizableStrings.ProjectsHeader;
+                        Reporter.Output.WriteLine($"{header}");
+                        Reporter.Output.WriteLine(new string('-', header.Length));
+
                         foreach (string slnProject in paths)
                         {
                             Reporter.Output.WriteLine(slnProject);
                         }
                         break;
+
                     case SlnListReportOutputFormat.json:
                         var jsonArray = JsonSerializer.Serialize(paths, s_noEscapeJsonSerializerOptions);
                         Reporter.Output.WriteLine(jsonArray);

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -2,23 +2,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Sln.Internal;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Common;
+using Microsoft.DotNet.Tools.Tool.List;
 
 namespace Microsoft.DotNet.Tools.Sln.List
 {
     internal class ListProjectsInSolutionCommand : CommandBase
     {
+        private readonly static JsonSerializerOptions s_noEscapeJsonSerializerOptions = new() { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
         private readonly string _fileOrDirectory;
         private readonly bool _displaySolutionFolders;
+        private readonly SlnListReportOutputFormat _outputFormat;
 
         public ListProjectsInSolutionCommand(
             ParseResult parseResult) : base(parseResult)
         {
             _fileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
             _displaySolutionFolders = parseResult.GetValue(SlnListParser.SolutionFolderOption);
+            _outputFormat = parseResult.GetValue(SlnListParser.OutputFormatOption);
         }
 
         public override int Execute()
@@ -50,12 +56,26 @@ namespace Microsoft.DotNet.Tools.Sln.List
             {
                 Array.Sort(paths);
 
-                string header = _displaySolutionFolders ? LocalizableStrings.SolutionFolderHeader : LocalizableStrings.ProjectsHeader;
-                Reporter.Output.WriteLine($"{header}");
-                Reporter.Output.WriteLine(new string('-', header.Length));
-                foreach (string slnProject in paths)
+                if (_outputFormat == SlnListReportOutputFormat.console_with_header)
                 {
-                    Reporter.Output.WriteLine(slnProject);
+                    string header = _displaySolutionFolders ? LocalizableStrings.SolutionFolderHeader : LocalizableStrings.ProjectsHeader;
+                    Reporter.Output.WriteLine($"{header}");
+                    Reporter.Output.WriteLine(new string('-', header.Length));
+                }
+
+                switch (_outputFormat)
+                {
+                    case SlnListReportOutputFormat.console:
+                    case SlnListReportOutputFormat.console_with_header:
+                        foreach (string slnProject in paths)
+                        {
+                            Reporter.Output.WriteLine(slnProject);
+                        }
+                        break;
+                    case SlnListReportOutputFormat.json:
+                        var jsonArray = JsonSerializer.Serialize(paths, s_noEscapeJsonSerializerOptions);
+                        Reporter.Output.WriteLine(jsonArray);
+                        break;
                 }
             }
             return 0;

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
@@ -7,9 +7,11 @@ using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
 {
-    public static class SlnListParser
+    internal static class SlnListParser
     {
         public static readonly CliOption<bool> SolutionFolderOption = new("--solution-folders") { Description = LocalizableStrings.ListSolutionFoldersArgumentDescription };
+
+        public static readonly CliOption<SlnListReportOutputFormat> OutputFormatOption = new("--format") { Description = LocalizableStrings.CmdFormatDescription };
 
         private static readonly CliCommand Command = ConstructCommand();
 
@@ -23,6 +25,7 @@ namespace Microsoft.DotNet.Cli
             CliCommand command = new("list", LocalizableStrings.ListAppFullName);
 
             command.Options.Add(SolutionFolderOption);
+            command.Options.Add(OutputFormatOption);
             command.SetAction((parseResult) => new ListProjectsInSolutionCommand(parseResult).Execute());
 
             return command;

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListReportOutputFormat.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListReportOutputFormat.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Sln.List
+{
+    internal enum SlnListReportOutputFormat
+    {
+        console_with_header = 0,
+        console = 1,
+        json = 2,
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListReportOutputFormat.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListReportOutputFormat.cs
@@ -5,8 +5,7 @@ namespace Microsoft.DotNet.Tools.Sln.List
 {
     internal enum SlnListReportOutputFormat
     {
-        console_with_header = 0,
-        console = 1,
-        json = 2,
+        text = 0,
+        json = 1,
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Přidá do souboru řešení jeden nebo více projektů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umístěte projekt do kořene řešení, není potřeba vytvářet složku řešení.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Fügt einer Projektmappendatei ein oder mehrere Projekte hinzu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Platzieren Sie das Projekt im Stamm der Projektmappe, statt einen Projektmappenordner zu erstellen.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Agrega uno o varios proyectos a un archivo de solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque el proyecto en la raíz de la solución, en lugar de crear una carpeta de soluciones.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ajoutez un ou plusieurs projets à un fichier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Place le projet à la racine de la solution, au lieu de créer un dossier solution.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Consente di aggiungere uno o più progetti a un file di soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Inserisce il progetto nella radice della soluzione invece di creare una cartella soluzione.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">1 つ以上のプロジェクトをソリューション ファイルに追加します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">ソリューション フォルダーを作成するのではなく、プロジェクトをソリューションのルートに配置します。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">솔루션 파일에 하나 이상의 프로젝트를 추가합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">솔루션 폴더를 만드는 대신, 솔루션의 루트에 프로젝트를 배치하세요.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Dodaj co najmniej jeden projekt do pliku rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umieść projekt w katalogu głównym rozwiązania zamiast tworzyć folder rozwiązania.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Adicionar um ou mais projetos em um arquivo de solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque o projeto na raiz da solução, em vez de criar uma pasta da solução.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Добавление проектов в файл решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Поместите проект в корень решения вместо создания папки решения.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Bir çözüm dosyasına bir veya daha fazla proje ekler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Bir çözüm klasörü oluşturmak yerine projeyi çözümün köküne yerleştirin.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">将一个或多个项目添加到解决方案文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">将项目放在解决方案的根目录下，而不是创建解决方案文件夹。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">為解決方案檔新增一或多個專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdFormatDescription">
+        <source>The desired output format of the command</source>
+        <target state="new">The desired output format of the command</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">請將專案放置在解決方案的根目錄中，而非放置於建立解決方案的資料夾中。</target>

--- a/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
@@ -20,8 +20,9 @@ Arguments:
   <SLN_FILE>    The solution file to operate on. If not specified, the command will search the current directory for one. [default: {PathUtility.EnsureTrailingSlash(defaultVal)}]
 
 Options:
-  --solution-folders  Display solution folder paths.
-  -?, -h, --help    Show command line help.";
+  --solution-folders                           Display solution folder paths.
+  --format <console|console_with_header|json>  The desired output format of the command
+  -?, -h, --help                               Show command line help";
 
 
         public GivenDotnetSlnList(ITestOutputHelper log) : base(log)


### PR DESCRIPTION
Add a `--format` option to `dotnet sln list`.

Closes #26303

Unresolved questions:
- [x] What should I do with the untranslated translation entries?
- [x] Is there a specific policy that says "don't have options with underscores", and if so, what should I replace `console_with_header` with, or are there better names for this?
- [x] Is there a good way to indicate that `console_with_header` is the default value?
- [ ] Add tests that validate the output