### PR TITLE
Update the help text for dotnet tool run and dotnet tool local install

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -224,7 +224,7 @@ For more reasons, including package naming enforcement, visit https://aka.ms/fai
   </data>
   <data name="NoManifestGuide" xml:space="preserve">
     <value>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</value>
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</value>
   </data>
   <data name="InvalidRuntimeIdentifier" xml:space="preserve">
     <value>The runtime identifier {0} is invalid. Valid runtime identifiers are: {1}.</value>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -58,8 +58,8 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Pokud jste chtěli nainstalovat globální nástroj, přijdete k příkazu možnost --global.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Pokud jste chtěli nainstalovat globální nástroj, přijdete k příkazu možnost --global.
 Pokud chcete vytvořit manifest, použijte příkaz dotnet new tool-manifest, obvykle v kořenovém adresáři úložiště.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -58,8 +58,8 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Wenn Sie ein globales Tool installieren möchten, fügen Sie dem Befehl "--global" hinzu.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Wenn Sie ein globales Tool installieren möchten, fügen Sie dem Befehl "--global" hinzu.
 Wenn Sie ein Manifest erstellen möchten, verwenden Sie "dotnet new tool-manifest", in der Regel im Stammverzeichnis des Repositorys.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -58,8 +58,8 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Si pretendía instalar una herramienta global, agregue "--global" al comando.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Si pretendía instalar una herramienta global, agregue "--global" al comando.
 Si desea crear un manifiesto, utilice "dotnet new tool-manifest", normalmente en el directorio raíz del repositorio.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -58,8 +58,8 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Si vous avez l'intention d'installer un outil global, ajoutez '--global' à la commande.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Si vous avez l'intention d'installer un outil global, ajoutez '--global' à la commande.
 Si vous souhaitez créer un manifeste, utilisez 'dotnet new tool-manifest', généralement dans le répertoire racine de dépôt.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -58,8 +58,8 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Se si intendeva installare uno strumento globale, aggiungere `--global` al comando.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Se si intendeva installare uno strumento globale, aggiungere `--global` al comando.
 Se si vuole creare un manifesto, usare `dotnet new tool-manifest`, in genere nella directory radice del repository.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">グローバル ツールをインストールする場合、コマンドに `--global` を追加します。
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">グローバル ツールをインストールする場合、コマンドに `--global` を追加します。
 マニフェストを作成する場合、通常はリポジトリのルート ディレクトリで `dotnet new tool-manifest` を使用します。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">전역 도구를 설치하려고 한 경우 명령에 `--global`을 추가하세요.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">전역 도구를 설치하려고 한 경우 명령에 `--global`을 추가하세요.
 매니페스트를 만들려면 일반적으로 리포지토리 루트 디렉터리에서 `dotnet new tool-manifest`를 사용하세요.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -58,8 +58,8 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Jeśli chcesz zainstalować narzędzie globalne, dodaj opcję „--global” do polecenia.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Jeśli chcesz zainstalować narzędzie globalne, dodaj opcję „--global” do polecenia.
 Jeśli chcesz utworzyć manifest, użyj polecenia „dotnet new tool-manifest” (zwykle w katalogu głównym repozytorium).</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,8 +58,8 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Se você pretende instalar uma ferramenta global, adicione `--global` ao comando.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Se você pretende instalar uma ferramenta global, adicione `--global` ao comando.
 Se quiser criar um manifesto, use `dotnet new tool-manifest`, normalmente no diretório raiz do repositório.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Если вы хотели установить глобальное средство, добавьте в команду параметр "--global".
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Если вы хотели установить глобальное средство, добавьте в команду параметр "--global".
 Если вы хотите создать манифест, используйте команду "dotnet new tool-manifest", которая обычно выполняется в корневом каталоге репозитория.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">Genel bir aracı yüklemeyi amaçlıyorsanız komuta '--global' ifadesini ekleyin.
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Genel bir aracı yüklemeyi amaçlıyorsanız komuta '--global' ifadesini ekleyin.
 Bir bildirim oluşturmak istiyorsanız 'dotnet new tool-manifest' ifadesini kullanın. Bu ifade genelde depo kök dizinine eklenir.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">如果你打算安装全局工具，请在命令中添加 `--global`。
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">如果你打算安装全局工具，请在命令中添加 `--global`。
 如果你想要创建一个清单，请使用 `dotnet new tool-manifest`，通常位于存储库的根目录中。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,8 +58,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
-        <target state="translated">若預計要安裝全域工具，請為命令新增 '--global'。
+If you would like to create a manifest, use the `--create-manifest-if-needed` flag with the `dotnet tool install` command, or use `dotnet new tool-manifest`, usually in the repo root directory.</source>
+        <target state="needs-review-translation">若預計要安裝全域工具，請為命令新增 '--global'。
 若希望建立資訊清單，請使用 'dotnet new tool-manifest'，通常位於存放庫根目錄中。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/LocalizableStrings.resx
@@ -121,7 +121,7 @@
     <value>Cannot find a tool in the manifest file that has a command named '{0}'.</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
-    <value>Run local tool. Note that this command cannot be used to run a global tool. </value>
+    <value>Run a local tool. Note that this command cannot be used to run a global tool. </value>
   </data>
   <data name="CommandNameArgumentDescription" xml:space="preserve">
     <value>The command name of the tool to run.</value>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/LocalizableStrings.resx
@@ -121,7 +121,7 @@
     <value>Cannot find a tool in the manifest file that has a command named '{0}'.</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
-    <value>Run local tool.</value>
+    <value>Run local tool. Note that this command cannot be used to run a global tool. </value>
   </data>
   <data name="CommandNameArgumentDescription" xml:space="preserve">
     <value>The command name of the tool to run.</value>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Spustí místní nástroj.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Spustí místní nástroj.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.cs.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Spustí místní nástroj.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Hiermit wird das lokale Tool ausgeführt.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Hiermit wird das lokale Tool ausgeführt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.de.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Hiermit wird das lokale Tool ausgeführt.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.es.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Ejecutar la herramienta local.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Ejecutar la herramienta local.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Ejecutar la herramienta local.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.fr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Exécute l'outil local.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Exécute l'outil local.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Exécute l'outil local.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.it.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Esegue lo strumento locale.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Esegue lo strumento locale.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Esegue lo strumento locale.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">ローカル ツールを実行します。</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">ローカル ツールを実行します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ja.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">ローカル ツールを実行します。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ko.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">로컬 도구를 실행합니다.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">로컬 도구를 실행합니다.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">로컬 도구를 실행합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pl.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Uruchom narzędzie lokalne.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Uruchom narzędzie lokalne.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Uruchom narzędzie lokalne.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Execute a ferramenta local.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Execute a ferramenta local.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Execute a ferramenta local.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Запуск локального средства.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Запуск локального средства.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.ru.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Запуск локального средства.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.tr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">Yerel aracı çalıştırın.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">Yerel aracı çalıştırın.</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">Yerel aracı çalıştırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">运行本地工具。</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">运行本地工具。</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">运行本地工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool.</source>
-        <target state="translated">執行本機工具。</target>
+        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <target state="needs-review-translation">執行本機工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandNameArgumentDescription">

--- a/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Run local tool. Note that this command cannot be used to run a global tool. </source>
+        <source>Run a local tool. Note that this command cannot be used to run a global tool. </source>
         <target state="needs-review-translation">執行本機工具。</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
resolve #39329, #33030

- Update the help text for dotnet tool run is limited to only locally installed tools.
- Update the error message for `NoManifestGuide` to prompt user to use the `--create-manifest-if-needed` flag for local tool installation.
