### PR TITLE
Update build.yml

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -104,7 +104,7 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
+          condition: succeeded()
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)


### PR DESCRIPTION
Don't run tests in CI when the repo build failed. This caused weird issues in https://github.com/dotnet/sdk/pull/39842. Also not submitting tests to Helix when the build step failed reduces machine allocation.