### PR TITLE
Fix matcher null which results in ArgumentNullException

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                     {
                         var candidateMatchPath = GetDiscoveryCandidateMatchPath(candidate);
                         relativePathCandidate = candidateMatchPath;
-                        if (string.IsNullOrEmpty(candidate.GetMetadata("RelativePath")))
+                        if (matcher != null && string.IsNullOrEmpty(candidate.GetMetadata("RelativePath")))
                         {
                             var match = matcher.Match(candidateMatchPath);
                             if (!match.HasMatches)


### PR DESCRIPTION
System.ArgumentNullException: Value cannot be null. (Parameter 'matcher')
   at System.ThrowHelper.Throw(String paramName)
   at System.ThrowHelper.ThrowIfNull(Object argument, String paramName)
   at Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.Match(Matcher matcher, String rootDir, IEnumerable`1 files)
   at Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.Match(Matcher matcher, String file)
   at Microsoft.AspNetCore.StaticWebAssets.Tasks.DefineStaticWebAssets.Execute()

See more details in https://github.com/dotnet/installer/pull/19145