### PR TITLE
Add workload config command

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -244,12 +244,6 @@ namespace Microsoft.DotNet.Workloads.Workload
 
     internal static class InstallingWorkloadCommandParser
     {
-        public static readonly CliOption<string> WorkloadSetMode = new("--mode")
-        {
-            Description = Strings.WorkloadSetMode,
-            Hidden = true
-        };
-
         public static readonly CliOption<string> WorkloadSetVersionOption = new("--version")
         {
             Description = Strings.WorkloadSetVersionOptionDescription

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -124,6 +124,7 @@ namespace Microsoft.DotNet.Cli
             command.Subcommands.Add(WorkloadRestoreCommandParser.GetCommand());
             command.Subcommands.Add(WorkloadCleanCommandParser.GetCommand());
             command.Subcommands.Add(WorkloadElevateCommandParser.GetCommand());
+            command.Subcommands.Add(WorkloadConfigCommandParser.GetCommand());
 
             command.Validators.Add(commandResult =>
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/config/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/LocalizableStrings.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandDescription" xml:space="preserve">
+    <value>Modify or display workload configuration values.</value>
+  </data>
+</root>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/LocalizableStrings.resx
@@ -118,6 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandDescription" xml:space="preserve">
-    <value>Modify or display workload configuration values.</value>
+    <value>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</value>
+  </data>
+  <data name="UpdateModeDescription" xml:space="preserve">
+    <value>Controls whether updates should look for workload sets or the latest version of each individual manifest.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
@@ -80,13 +80,13 @@ namespace Microsoft.DotNet.Workloads.Workload.Config
                 }
                 else
                 {
-                    Reporter.WriteLine($"Invalid update mode: {_updateMode}");
-                    return 1;
+                    //  This should not be hit, as parser sets the accepted values and should error before getting here if the value is not valid
+                    throw new InvalidOperationException($"Invalid update mode: {_updateMode}");
                 }
             }
             else
             {
-                Reporter.WriteLine("No update mode specified");
+                _parseResult.ShowHelp();
             }
 
             return 0;

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Workloads.Workload;
+using Microsoft.DotNet.Workloads.Workload.Install;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+#nullable enable
+
+namespace Microsoft.DotNet.Workloads.Workload.Config
+{
+    internal class WorkloadConfigCommand : WorkloadCommandBase
+    {
+        bool _hasUpdateMode;
+        string? _updateMode;
+        readonly IWorkloadResolverFactory _workloadResolverFactory;
+
+        private string? _dotnetPath;
+        private string _userProfileDir;
+        private readonly IWorkloadResolver _workloadResolver;
+        private readonly ReleaseVersion _sdkVersion;
+        private readonly SdkFeatureBand _sdkFeatureBand;
+
+        readonly IInstaller _workloadInstaller;
+
+        public WorkloadConfigCommand(
+            ParseResult parseResult,
+            IReporter? reporter = null,
+            IWorkloadResolverFactory? workloadResolverFactory = null
+        ) : base(parseResult, CommonOptions.HiddenVerbosityOption, reporter)
+        {
+            //  TODO: Is it possible to check the order of the options?  This would allow us to print the values out in the same order they are specified on the command line
+            _hasUpdateMode = parseResult.HasOption(WorkloadConfigCommandParser.UpdateMode);
+            _updateMode = parseResult.GetValue(WorkloadConfigCommandParser.UpdateMode);
+
+            _workloadResolverFactory = workloadResolverFactory ?? new WorkloadResolverFactory();
+
+            var creationResult = _workloadResolverFactory.Create();
+
+            _dotnetPath = creationResult.DotnetPath;
+            _userProfileDir = creationResult.UserProfileDir;
+            _workloadResolver = creationResult.WorkloadResolver;
+            _sdkVersion = creationResult.SdkVersion;
+
+            _sdkFeatureBand = new SdkFeatureBand(_sdkVersion);
+            _workloadInstaller = WorkloadInstallerFactory.GetWorkloadInstaller(Reporter, _sdkFeatureBand, creationResult.WorkloadResolver, Verbosity, creationResult.UserProfileDir, VerifySignatures, PackageDownloader, creationResult.DotnetPath);
+        }
+
+        public override int Execute()
+        {
+            if (_hasUpdateMode)
+            {
+                if (_updateMode == WorkloadConfigCommandParser.UpdateMode_WorkloadSet)
+                {
+                    _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, true);
+                }
+                else if (_updateMode == WorkloadConfigCommandParser.UpdateMode_Manifests)
+                {
+                    _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, false);
+                }
+                else if (string.IsNullOrEmpty(_updateMode))
+                {
+                    if (InstallingWorkloadCommand.ShouldUseWorkloadSetMode(_sdkFeatureBand, _dotnetPath))
+                    {
+                        Reporter.WriteLine(WorkloadConfigCommandParser.UpdateMode_WorkloadSet);
+                    }
+                    else
+                    {
+                        Reporter.WriteLine(WorkloadConfigCommandParser.UpdateMode_Manifests);
+                    }
+                }
+                else
+                {
+                    Reporter.WriteLine($"Invalid update mode: {_updateMode}");
+                    return 1;
+                }
+            }
+            else
+            {
+                Reporter.WriteLine("No update mode specified");
+            }
+
+            return 0;
+        }
+    }
+    
+}

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Config
 {
     internal class WorkloadConfigCommand : WorkloadCommandBase
     {
-        bool _hasUpdateMode;
-        string? _updateMode;
-        readonly IWorkloadResolverFactory _workloadResolverFactory;
+        private bool _hasUpdateMode;
+        private string? _updateMode;
+        private readonly IWorkloadResolverFactory _workloadResolverFactory;
 
         private string? _dotnetPath;
         private string _userProfileDir;
@@ -38,7 +38,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Config
             IWorkloadResolverFactory? workloadResolverFactory = null
         ) : base(parseResult, CommonOptions.HiddenVerbosityOption, reporter)
         {
-            //  TODO: Is it possible to check the order of the options?  This would allow us to print the values out in the same order they are specified on the command line
             _hasUpdateMode = parseResult.HasOption(WorkloadConfigCommandParser.UpdateMode);
             _updateMode = parseResult.GetValue(WorkloadConfigCommandParser.UpdateMode);
 
@@ -57,13 +56,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Config
 
         public override int Execute()
         {
+            //  When we support multiple configuration values, it would be nice if we could process and display them in the order they are passed.
+            //  It seems that the parser doesn't give us a good way to do that, however
             if (_hasUpdateMode)
             {
-                if (_updateMode == WorkloadConfigCommandParser.UpdateMode_WorkloadSet)
+                if (WorkloadConfigCommandParser.UpdateMode_WorkloadSet.Equals(_updateMode, StringComparison.InvariantCultureIgnoreCase))
                 {
                     _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, true);
                 }
-                else if (_updateMode == WorkloadConfigCommandParser.UpdateMode_Manifests)
+                else if (WorkloadConfigCommandParser.UpdateMode_Manifests.Equals(_updateMode, StringComparison.InvariantCultureIgnoreCase))
                 {
                     _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, false);
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Workloads.Workload.Config;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class WorkloadConfigCommandParser
+    {
+        //  dotnet workload config --update-mode workload-set
+
+        public static readonly string UpdateMode_WorkloadSet = "workload-set";
+        public static readonly string UpdateMode_Manifests = "manifests";
+
+        public static readonly CliOption<string> UpdateMode = new("--update-mode")
+        {
+            Description = "Set the update mode for the workload manifest",
+            //Hidden = true,
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        private static readonly CliCommand Command = ConstructCommand();
+
+        public static CliCommand GetCommand()
+        {
+            return Command;
+        }
+
+        private static CliCommand ConstructCommand()
+        {
+            UpdateMode.AcceptOnlyFromAmong(UpdateMode_WorkloadSet, UpdateMode_Manifests);
+
+            CliCommand command = new("config", LocalizableStrings.CommandDescription);
+            command.Options.Add(UpdateMode);
+
+            command.SetAction(parseResult =>
+            {
+                new WorkloadConfigCommand(parseResult).Execute();
+            });
+
+            return command;
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli
 
         public static readonly CliOption<string> UpdateMode = new("--update-mode")
         {
-            Description = "Set the update mode for the workload manifest",
+            Description = LocalizableStrings.UpdateModeDescription,
             //Hidden = true,
             Arity = ArgumentArity.ZeroOrOne
         };

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommandParser.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.Cli
         public static readonly CliOption<string> UpdateMode = new("--update-mode")
         {
             Description = LocalizableStrings.UpdateModeDescription,
-            //Hidden = true,
             Arity = ArgumentArity.ZeroOrOne
         };
 

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.cs.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.de.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.es.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.fr.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.it.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ja.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ko.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pl.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pt-BR.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.ru.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.tr.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hans.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hant.xlf
@@ -3,8 +3,15 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="CommandDescription">
-        <source>Modify or display workload configuration values.</source>
-        <target state="new">Modify or display workload configuration values.</target>
+        <source>Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</source>
+        <target state="new">Modify or display workload configuration values.
+To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet workload config --update-mode"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateModeDescription">
+        <source>Controls whether updates should look for workload sets or the latest version of each individual manifest.</source>
+        <target state="new">Controls whether updates should look for workload sets or the latest version of each individual manifest.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Modify or display workload configuration values.</source>
+        <target state="new">Modify or display workload configuration values.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -183,9 +183,6 @@
   <data name="PrintDownloadLinkOnlyDescription" xml:space="preserve">
     <value>Only print the list of links to download without downloading.</value>
   </data>
-  <data name="WorkloadSetMode" xml:space="preserve">
-    <value>Control whether future workload operations should use workload sets or loose manifests.</value>
-  </data>
   <data name="DownloadToCacheOptionDescription" xml:space="preserve">
     <value>Download packages needed to install a workload to a folder that can be used for offline installation.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -367,11 +367,6 @@
         <target state="translated">CESTA</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Určete, jestli by budoucí operace úloh měly používat sady úloh nebo volné manifesty.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -367,11 +367,6 @@
         <target state="translated">PFAD</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Hiermit wird gesteuert, ob zukünftige Workloadvorgänge Workloadsätze oder lose Manifeste verwenden sollen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -367,11 +367,6 @@
         <target state="translated">RUTA DE ACCESO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Controle si las operaciones de carga de trabajo futuras deben usar conjuntos de cargas de trabajo o manifiestos flexibles.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -367,11 +367,6 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Contrôlez si les futures opérations de charge de travail doivent utiliser des ensembles de charges de travail ou des manifestes lâches.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -367,11 +367,6 @@
         <target state="translated">PERCORSO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Controllare se le operazioni future del carico di lavoro devono usare set di carichi di lavoro o manifesti separati.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -367,11 +367,6 @@
         <target state="translated">パス</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">将来のワークロード操作でワークロード セットを使用するか、ルーズ マニフェストを使用するかを制御します。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -367,11 +367,6 @@
         <target state="translated">경로</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">향후 워크로드 작업에서 워크로드 집합을 사용할지, 매니페스트를 완화할지를 제어합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -367,11 +367,6 @@
         <target state="translated">ŚCIEŻKA</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Określ, czy przyszłe operacje związane z obciążeniami powinny wykorzystywać zestawy obciążeń, czy luźne manifesty.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -367,11 +367,6 @@
         <target state="translated">CAMINHO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Controle se as operações de carga de trabalho futuras devem usar conjuntos de carga de trabalho ou manifestos flexíveis.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -367,11 +367,6 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Укажите, должны ли будущие операции рабочей нагрузки использовать наборы рабочей нагрузки или свободные манифесты.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -367,11 +367,6 @@
         <target state="translated">YOL</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">Gelecekteki iş yükü işlemlerinin iş yükü kümelerini mi yoksa gevşek bildirimleri mi kullanması gerektiğini kontrol edin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -367,11 +367,6 @@
         <target state="translated">路径</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">控制未来的工作负载操作应该使用工作负载集还是松散清单。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -367,11 +367,6 @@
         <target state="translated">路徑</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetMode">
-        <source>Control whether future workload operations should use workload sets or loose manifests.</source>
-        <target state="translated">控制未來的工作負載作業應該使用工作負載集合還是鬆散資訊清單。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetUpgrade">
         <source>Updating workload version from {0} to {1}.</source>
         <target state="new">Updating workload version from {0} to {1}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -138,9 +138,6 @@
   <data name="WorkloadUpdateFailed" xml:space="preserve">
     <value>Workload update failed: {0}</value>
   </data>
-  <data name="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto" xml:space="preserve">
-    <value>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</value>
-  </data>
   <data name="FromPreviousSdkOptionDescription" xml:space="preserve">
     <value>Include workloads installed with earlier SDK versions in update.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
         private readonly bool _adManifestOnlyOption;
         private readonly bool _printRollbackDefinitionOnly;
         private readonly bool _fromPreviousSdk;
-        private readonly string _workloadSetMode;
-
         public WorkloadUpdateCommand(
             ParseResult parseResult,
             IReporter reporter = null,
@@ -41,7 +39,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             _fromPreviousSdk = parseResult.GetValue(WorkloadUpdateCommandParser.FromPreviousSdkOption);
             _adManifestOnlyOption = parseResult.GetValue(WorkloadUpdateCommandParser.AdManifestOnlyOption);
             _printRollbackDefinitionOnly = parseResult.GetValue(WorkloadUpdateCommandParser.PrintRollbackOption);
-            _workloadSetMode = parseResult.GetValue(InstallingWorkloadCommandParser.WorkloadSetMode);
 
             _workloadInstaller = _workloadInstallerFromConstructor ?? WorkloadInstallerFactory.GetWorkloadInstaller(Reporter,
                                 _sdkFeatureBand, _workloadResolver, Verbosity, _userProfileDir, VerifySignatures, PackageDownloader,
@@ -91,22 +88,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputStart==");
                 Reporter.WriteLine(workloadSet.ToJson());
                 Reporter.WriteLine("==workloadRollbackDefinitionJsonOutputEnd==");
-            }
-            else if (!string.IsNullOrWhiteSpace(_workloadSetMode))
-            {
-                if (_workloadSetMode.Equals("workloadset", StringComparison.OrdinalIgnoreCase))
-                {
-                    _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, true);
-                }
-                else if (_workloadSetMode.Equals("loosemanifest", StringComparison.OrdinalIgnoreCase) ||
-                         _workloadSetMode.Equals("auto", StringComparison.OrdinalIgnoreCase))
-                {
-                    _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, false);
-                }
-                else
-                {
-                    throw new GracefulException(string.Format(LocalizableStrings.WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto, _workloadSetMode), isUserError: true);
-                }
             }
             else
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommandParser.cs
@@ -48,7 +48,6 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.VerbosityOption);
             command.Options.Add(PrintRollbackOption);
             command.Options.Add(WorkloadInstallCommandParser.SkipSignCheckOption);
-            command.Options.Add(InstallingWorkloadCommandParser.WorkloadSetMode);
 
             command.SetAction((parseResult) => new WorkloadUpdateCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Nepovedlo se stáhnout balíčky aktualizace úlohy do mezipaměti: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Neplatný argument „{0}“ argumentu --mode pro aktualizaci úlohy dotnet. Jediné podporované režimy jsou workloadset, loosemanifest a auto.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Manifesty reklamy se úspěšně aktualizovaly.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Fehler beim Herunterladen von Paketen zur Workloadaktualisierung in den Cache: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Ungültiges Argument "{0}" zum Argument --mode für das Dotnet Workload-Update. Es werden nur die Modi "workloadset", "loosemanifest" und "auto" unterstützt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Werbemanifeste wurden erfolgreich aktualisiert.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -57,11 +57,6 @@
         <target state="translated">No se pudieron descargar los paquetes de actualización de la carga de trabajo en caché: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Argumento "{0}" no válido para el argumento --mode para la actualización de la carga de trabajo de dotnet. Solo los modos admitidos son "workloadset", "loosemanifest" y "auto".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Los manifiestos de publicidad se han actualizado correctamente.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Échec du téléchargement des packages de mise à jour de charge de travail dans le cache : {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Argument «{0}» non valide à l’argument --mode pour la mise à jour de charge de travail dotnet. Seuls les modes pris en charge sont « workloadset », « loosemanifest » et « auto ».</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Les manifestes de publicité ont été mis à jour.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Non è stato possibile scaricare i pacchetti di aggiornamento del carico di lavoro nella cache: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Argomento non valido "{0}" per l'argomento --mode per l'aggiornamento del carico di lavoro dotnet. Le uniche modalità supportate sono "workloadset", "loosemanifest" e "auto".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">I manifesti pubblicitari sono stati aggiornati.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -57,11 +57,6 @@
         <target state="translated">ワークロード更新パッケージをキャッシュにダウンロードできませんでした: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">.NET ワークロード更新の --mode 引数に対する引数 "{0}" が無効です。サポートされているモードは、"workloadset"、"loosemanifest"、および "auto" のみです。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">広告マニフェストを正常に更新しました。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -57,11 +57,6 @@
         <target state="translated">캐시할 워크로드 업데이트 패키지를 다운로드하지 못했습니다. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">dotnet 워크로드 업데이트의 --mode 인수에 대한 "{0}" 인수가 잘못되었습니다. "workloadset", "loosemanifest", "auto" 모드만 지원됩니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">알림 매니페스트를 업데이트했습니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Nie można pobrać pakietów aktualizacji pakietów roboczych do pamięci podręcznej: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Nieprawidłowy argument „{0}” argumentu --mode dla aktualizacji obciążenia dotnet. Obsługiwane tryby to „workloadset”, „loosemanifest” i „auto”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Pomyślnie zaktualizowano manifesty reklam.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Falha ao baixar pacotes de atualização de carga de trabalho para o cache: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Argumento "{0}" inválido para o argumento --mode para atualização de carga de trabalho dotnet. Os únicos modos com suporte são "workloadset", "loosemanifest" e "auto".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Manifestos de anúncio atualizados com êxito.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Не удалось скачать пакеты обновления рабочей нагрузки в кэш: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Недопустимый аргумент "{0}" для аргумента --mode для обновления рабочей нагрузки dotnet. Поддерживаются только режимы "workloadset", "loosemanifest" и "auto".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Манифесты рекламы успешно обновлены.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">İş yükü güncelleştirme paketleri önbelleğe yüklenemedi: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">Dotnet iş yükü güncelleştirmesi için --mod bağımsız değişkeninde geçersiz "{0}" bağımsız değişkeni. Yalnızca "workloadset", "loosemanifest" ve "auto" modları desteklenir.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">Reklam bildirimleri başarıyla güncelleştirildi.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,11 +57,6 @@
         <target state="translated">未能将工作负载更新程序包下载到缓存: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">dotnet 工作负载更新的 --mode 参数的参数“{0}”无效。仅支持“workloadset”、“loosemanifest”和“auto”模式。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">成功更新广告清单。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,11 +57,6 @@
         <target state="translated">無法將工作負載更新套件下載到快取: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetModeTakesWorkloadSetLooseManifestOrAuto">
-        <source>Invalid argument "{0}" to the --mode argument for dotnet workload update. Only supported modes are "workloadset", "loosemanifest", and "auto".</source>
-        <target state="translated">dotnet 工作負載更新的 --mode 引數之引數 "{0}" 無效。僅支援 "workloadset"、"loosemanifest" 和 "auto" 模式。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadUpdateAdManifestsSucceeded">
         <source>Successfully updated advertising manifests.</source>
         <target state="translated">已成功更新廣告資訊清單。</target>

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -74,6 +74,7 @@
     <EmbeddedResource Update="**\dotnet-workload\repair\*.resx" Namespace="Microsoft.DotNet.Workloads.Workload.Repair" />
     <EmbeddedResource Update="**\dotnet-workload\elevate\*.resx" Namespace="Microsoft.DotNet.Workloads.Workload.Elevate" />
     <EmbeddedResource Update="**\dotnet-workload\clean\*.resx" Namespace="Microsoft.DotNet.Workloads.Workload.Clean" />
+    <EmbeddedResource Update="**\dotnet-workload\config\*.resx" Namespace="Microsoft.DotNet.Workloads.Workload.Config" />
     <EmbeddedResource Update="Installer\Windows\*.resx" Namespace="Microsoft.DotNet.Installer.Windows" />
     <EmbeddedResource Update="ToolManifest\*.resx" Namespace="Microsoft.DotNet.ToolManifest" />
     <EmbeddedResource Update="NugetSearch\*.resx" Namespace="Microsoft.DotNet.NugetSearch" />
@@ -88,7 +89,7 @@
     <!-- override the Microsoft.TemplateEngine.Cli's dependency with the latest Microsoft.DotNet.TemplateLocator -->
     <ProjectReference Include="../../Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" />
     <ProjectReference Include="../../Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj" />
-    <ProjectReference Include="../../Microsoft.Win32.Msi/Microsoft.Win32.Msi.csproj"/>
+    <ProjectReference Include="../../Microsoft.Win32.Msi/Microsoft.Win32.Msi.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Cli\Microsoft.TemplateEngine.Cli.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -115,7 +116,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="SDDLTests"/>
+    <InternalsVisibleTo Include="SDDLTests" />
   </ItemGroup>
 
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -159,11 +159,6 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 return _workloadSet?.Version!;
             }
 
-            if (InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkRootPath), "default.json")).UseWorkloadSets == true)
-            {
-                return null;
-            }
-
             using (SHA256 sha256Hash = SHA256.Create())
             {
                 byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(string.Join(";",

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/RemoteDirectory.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/RemoteDirectory.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     abstract class RemoteDirectory
     {

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/RemoteFile.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/RemoteFile.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     abstract class RemoteFile
     {

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
@@ -124,6 +124,26 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
         }
     }
 
+    class VMMoveFolderAction : VMAction
+    {
+        public string SourcePath { get; set; }
+        public string TargetPath { get; set; }
+
+        public VMMoveFolderAction(VirtualMachine vm) : base(vm)
+        {
+        }
+
+        protected override SerializedVMAction SerializeDerivedProperties()
+        {
+            return new SerializedVMAction
+            {
+                Type = VMActionType.MoveFolderOnVM,
+                SourcePath = SourcePath,
+                TargetPath = TargetPath,
+            };
+        }
+    }
+
     class VMWriteFileAction : VMAction
     {
         public string TargetPath { get; set; }
@@ -168,6 +188,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
         RunCommand,
         CopyFileToVM,
         CopyFolderToVM,
+        MoveFolderOnVM,
         WriteFileToVM,
         GetRemoteDirectory,
         GetRemoteFile,
@@ -190,10 +211,10 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
         //  Applies to RunCommand
         public string WorkingDirectory { get; set; }
 
-        //  Applies to CopyFileToVM, CopyFolderToVM, WriteFileToVM, GetRemoteDirectory, GetRemoteFile
+        //  Applies to CopyFileToVM, CopyFolderToVM, MoveFolderOnVM, WriteFileToVM, GetRemoteDirectory, GetRemoteFile
         public string TargetPath { get; set; }
 
-        //  Applies to CopyFileToVM, CopyFolderToVM
+        //  Applies to CopyFileToVM, CopyFolderToVM, MoveFolderOnVM
         public string SourcePath { get; set; }
 
         //  Applies to CopyFileToVM, CopyFolderToVM
@@ -222,6 +243,8 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                     return $"Copy file to VM: {SourcePath} -> {TargetPath}";
                 case VMActionType.CopyFolderToVM:
                     return $"Copy folder to VM: {SourcePath} -> {TargetPath}";
+                case VMActionType.MoveFolderOnVM:
+                    return $"Move folder {SourcePath} -> {TargetPath}";
                 case VMActionType.WriteFileToVM:
                     return $"Write file to VM: {TargetPath}";
                 case VMActionType.GetRemoteDirectory:

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.Utils;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     abstract class VMAction
     {

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMControl.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMControl.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.Installer.Windows;
 using Microsoft.Management.Infrastructure;
 using Microsoft.Management.Infrastructure.Serialization;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     internal class VMControl : IDisposable
     {
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         {
             var remoteCommand = new RemoteCommand(Log, VMMachineName, _psExecPath, workingDirectory, args);
 
-            for (int i=0; i<3; i++)
+            for (int i = 0; i < 3; i++)
             {
                 var result = remoteCommand.Execute();
                 if (result.ExitCode != 6 && !result.StdErr.Contains("The handle is invalid"))
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         {
             VMEnabledState getCurrentState()
             {
-                var state = (VMEnabledState) (UInt16)VMInstance.CimInstanceProperties["EnabledState"].Value;
+                var state = (VMEnabledState)(ushort)VMInstance.CimInstanceProperties["EnabledState"].Value;
                 return state;
             }
 
@@ -219,7 +219,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var methodParameters = new CimMethodParametersCollection()
             {
-                CimMethodParameter.Create("RequestedState", (UInt16) targetState, CimFlags.In)
+                CimMethodParameter.Create("RequestedState", (ushort) targetState, CimFlags.In)
             };
 
 
@@ -245,13 +245,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
             {
                 CimInstance job = (CimInstance)result.OutParameters["Job"].Value;
                 job = _session.GetInstance(virtNamespace, job);
-                while (IsRunning((JobState)(UInt16)job.CimInstanceProperties["JobState"].Value))
+                while (IsRunning((JobState)(ushort)job.CimInstanceProperties["JobState"].Value))
                 {
                     await Task.Delay(100);
                     job = _session.GetInstance(job.CimSystemProperties.Namespace, job);
                 }
 
-                var jobState = (JobState)(UInt16)job.CimInstanceProperties["JobState"].Value;
+                var jobState = (JobState)(ushort)job.CimInstanceProperties["JobState"].Value;
                 if (jobState != JobState.Completed && jobState != JobState.CompletedWithWarnings)
                 {
                     Log.WriteLine("Job failed: " + jobState);
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             }
             else
             {
-                if (result.ReturnValue.Value is UInt32 returnValue)
+                if (result.ReturnValue.Value is uint returnValue)
                 {
                     if (returnValue != 0)
                     {
@@ -305,7 +305,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             CompletedWithWarnings = 32768
         }
 
-        enum VMEnabledState : UInt16
+        enum VMEnabledState : ushort
         {
             Unknown = 0,
             Other = 1,
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             ShuttingDown = 4,
             NotApplicable = 5,
             EnabledButOffline = 6,
-           
+
         }
 
         class RemoteCommand : TestCommand

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
@@ -1,11 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     internal class VMStateTree
     {
-        public string SnapshotId {  get; set; }
+        public string SnapshotId { get; set; }
         public string SnapshotName { get; set; }
 
         public Dictionary<SerializedVMAction, (VMActionResult actionResult, VMStateTree resultingState)> Actions { get; set; } = new();
@@ -18,7 +18,8 @@ namespace Microsoft.DotNet.MsiInstallerTests
             {
                 SnapshotId = SnapshotId,
                 SnapshotName = SnapshotName,
-                Actions = Actions.Select(a => new SerializableVMStateTree.Entry() {
+                Actions = Actions.Select(a => new SerializableVMStateTree.Entry()
+                {
                     Action = a.Key,
                     ActionResult = a.Value.actionResult,
                     ResultingState = a.Value.resultingState.ToSerializeable()

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
+{
+    public class VMTestBase : SdkTest, IDisposable
+    {
+        internal VirtualMachine VM { get; }
+
+        public VMTestBase(ITestOutputHelper log) : base(log)
+        {
+            VM = new VirtualMachine(Log);
+        }
+
+        public virtual void Dispose()
+        {
+            VM.Dispose();
+        }
+
+        protected string SdkInstallerVersion
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(VM.VMTestSettings.SdkInstallerVersion))
+                {
+                    return VM.VMTestSettings.SdkInstallerVersion;
+                }
+                else
+                {
+                    return "8.0.203";
+                }
+            }
+        }
+
+        protected string SdkInstallerFileName => $"dotnet-sdk-{SdkInstallerVersion}-win-x64.exe";
+
+        protected void InstallSdk(bool deployStage2 = true)
+        {
+            VM.CreateRunCommand("setx", "DOTNET_NOLOGO", "true")
+                .WithDescription("Disable .NET SDK first run message")
+                .Execute()
+                .Should()
+                .Pass();
+
+            VM.CreateRunCommand($@"c:\SdkTesting\{SdkInstallerFileName}", "/quiet")
+                .WithDescription($"Install SDK {SdkInstallerVersion}")
+                .Execute()
+                .Should()
+                .Pass();
+
+            if (deployStage2)
+            {
+                DeployStage2Sdk();
+            }
+        }
+
+        protected void UninstallSdk()
+        {
+            VM.CreateRunCommand($@"c:\SdkTesting\{SdkInstallerFileName}", "/quiet", "/uninstall")
+                .WithDescription($"Uninstall SDK {SdkInstallerVersion}")
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        protected void DeployStage2Sdk()
+        {
+            if (!VM.VMTestSettings.ShouldTestStage2)
+            {
+                return;
+            }
+
+            var installedSdkFolder = $@"c:\Program Files\dotnet\sdk\{SdkInstallerVersion}";
+
+            Log.WriteLine($"Deploying SDK from {TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest} to {installedSdkFolder} on VM.");
+
+            var vmVersionFilePath = Path.Combine(installedSdkFolder, ".version");
+
+            var existingVersionFileContents = VM.GetRemoteFile(vmVersionFilePath).ReadAllText().Split(Environment.NewLine);
+            var newVersionFileContents = File.ReadAllLines(Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, ".version"));
+            newVersionFileContents[1] = existingVersionFileContents[1];
+
+            //  TODO: It would be nice if the description included the date/time of the SDK build, to distinguish different snapshots
+            VM.CreateActionGroup("Deploy Stage 2 SDK",
+                    VM.CopyFolder(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, installedSdkFolder),
+                    VM.WriteFile(vmVersionFilePath, string.Join(Environment.NewLine, newVersionFileContents)))
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
+        protected string GetInstalledSdkVersion()
+        {
+            var command = VM.CreateRunCommand("dotnet", "--version");
+            command.IsReadOnly = true;
+            var result = command.Execute();
+            result.Should().Pass();
+            return result.StdOut;
+        }
+
+        protected WorkloadSet GetRollback()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "update", "--print-rollback")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            return ParseRollbackOutput(result.StdOut);
+        }
+
+        protected WorkloadSet ParseRollbackOutput(string output)
+        {
+            var filteredOutput = string.Join(Environment.NewLine,
+                output.Split(Environment.NewLine)
+                .Except(["==workloadRollbackDefinitionJsonOutputStart==", "==workloadRollbackDefinitionJsonOutputEnd=="]));
+
+            return WorkloadSet.FromJson(filteredOutput, defaultFeatureBand: new SdkFeatureBand(SdkInstallerVersion));
+        }
+    }
+}

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestSettings.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestSettings.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     internal class VMTestSettings
     {

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
@@ -299,6 +299,14 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
                 return VMActionResult.Success();
             }
+            else if (action.Type == VMActionType.MoveFolderOnVM)
+            {
+                var sourceSharePath = VMPathToSharePath(action.SourcePath);
+                var targetSharePath = VMPathToSharePath(action.TargetPath);
+                Directory.Move(sourceSharePath, targetSharePath);
+
+                return VMActionResult.Success();
+            }
             else if (action.Type == VMActionType.WriteFileToVM)
             {
                 var targetSharePath = VMPathToSharePath(action.TargetPath);

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.DotNet.MsiInstallerTests
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
     class VirtualMachine : IDisposable
     {
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                     Log.WriteLine($"Removing missing snapshot from tree: {nodeToRemove.Value.resultingState.SnapshotName}");
                     node.Actions.Remove(nodeToRemove.Key);
                 }
-                
+
                 foreach (var result in node.Actions.Select(a => a.Value.resultingState))
                 {
                     Recurse(result);
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             }
             else if (action.Type == VMActionType.ActionGroup && result.GroupedResults != null)
             {
-                for (int i=0; i<result.GroupedResults.Count; i++)
+                for (int i = 0; i < result.GroupedResults.Count; i++)
                 {
                     LogActionResult(action.Actions[i], result.GroupedResults[i]);
                 }

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -17,26 +17,6 @@ namespace Microsoft.DotNet.MsiInstallerTests
         {
         }
 
-        //  dotnet nuget add source c:\SdkTesting\WorkloadSets
-        //  dotnet workload update --mode workloadset
-
-        //  Show workload mode in dotnet workload --info
-
-
-        //  dotnet workload update-mode set workload-set
-
-        //  dotnet workload config --update-mode workload-set
-
-        //  dotnet workload config update-mode
-        //  dotnet workload config update-mode workload-set
-        //  dotnet workload config update-mode manifests
-
-        //  dotnet workload config update-band [default|release|preview|daily]
-
-        //  dotnet config workload.update-mode workload-set
-
-        //  dotnet setconfig --workload-update-mode workload-set
-
         [Fact]
         public void DoesNotUseWorkloadSetsByDefault()
         {

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.MsiInstallerTests.Framework;
+
+namespace Microsoft.DotNet.MsiInstallerTests
+{
+    public class WorkloadSetTests : VMTestBase
+    {
+        public WorkloadSetTests(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        //  dotnet nuget add source c:\SdkTesting\WorkloadSets
+        //  dotnet workload update --mode workloadset
+
+        //  Show workload mode in dotnet workload --info
+
+
+        //  dotnet workload update-mode set workload-set
+
+        //  dotnet workload config --update-mode workload-set
+
+        //  dotnet workload config update-mode
+        //  dotnet workload config update-mode workload-set
+        //  dotnet workload config update-mode manifests
+
+        //  dotnet workload config update-band [default|release|preview|daily]
+
+        //  dotnet config workload.update-mode workload-set
+
+        //  dotnet setconfig --workload-update-mode workload-set
+
+        [Fact]
+        public void DoesNotUseWorkloadSetsByDefault()
+        {
+            InstallSdk();
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var originalRollback = GetRollback();
+
+            VM.CreateRunCommand("dotnet", "nuget", "add", "source", @"c:\SdkTesting\WorkloadSets")
+                .WithDescription("Add WorkloadSets to NuGet.config")
+                .Execute()
+                .Should()
+                .Pass();
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var newRollback = GetRollback();
+
+            newRollback.ManifestVersions.Should().BeEquivalentTo(originalRollback.ManifestVersions);
+
+        }
+
+        [Fact]
+        public void UpdateWithWorkloadSets()
+        {
+            InstallSdk();
+
+            var originalWorkloadVersion = GetWorkloadVersion();
+            originalWorkloadVersion.Should().StartWith("8.0.200-manifests.");
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var originalRollback = GetRollback();
+            var updatedWorkloadVersion = GetWorkloadVersion();
+            updatedWorkloadVersion.Should().StartWith("8.0.200-manifests.");
+            updatedWorkloadVersion.Should().NotBe(originalWorkloadVersion);
+
+            VM.CreateRunCommand("dotnet", "nuget", "add", "source", @"c:\SdkTesting\WorkloadSets")
+                .WithDescription("Add WorkloadSets to NuGet.config")
+                .Execute()
+                .Should()
+                .Pass();
+
+            GetUpdateMode().Should().Be("manifests");
+
+            VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode", "workload-set")
+                .WithDescription("Switch mode to workload-set")
+                .Execute()
+                .Should()
+                .Pass();
+
+            GetWorkloadVersion().Should().Be(updatedWorkloadVersion);
+
+            GetUpdateMode().Should().Be("workload-set");
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var newRollback = GetRollback();
+
+            newRollback.ManifestVersions.Should().NotBeEquivalentTo(originalRollback.ManifestVersions);
+
+            GetWorkloadVersion().Should().Be("8.0.201");
+
+        }
+
+        string GetWorkloadVersion()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "--version")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            return result.StdOut;
+        }
+
+        string GetUpdateMode()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            return result.StdOut;
+        }
+    }
+}


### PR DESCRIPTION
- Add `dotnet workload config` command to set the workload update mode
- Fix displaying the workload version in `dotnet --info` and `dotnet workload --version` when in workload set mode but no workload set is installed
- Add some initial workload set MSI installation tests

Here's the how the new `dotnet workload config` command works:

- `dotnet workload config --update-mode` - Prints the current workload update mode
- `dotnet workload config --update-mode workload-set` - Switches to workload set update mode
- `dotnet workload config --update-mode manifests` - Switches to loose manifest update mode

Here's the command-line help:

```
C:\Users\User>dotnet workload config --help
Description:
  Modify or display workload configuration values.
  To display a value, specify the corresponding command-line option without providing a value.  For example: "dotnet
  workload config --update-mode"

Usage:
  dotnet workload config [options]

Options:
  --update-mode <manifests|workload-set>  Controls whether updates should look for workload sets or the latest version
                                          of each individual manifest.
  -?, -h, --help                          Show command line help.
```

This replaces the previous syntax, which was `dotnet workload update --mode workloadset` and `dotnet workload update --mode loosemanifest`.  Note that the previous option was hidden from command-line help, where currently the `dotnet workload config` command is not hidden.
