### PR TITLE
Fix loading of rollback installed workloads in Visual Studio

### DIFF
--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -58,8 +58,11 @@
     <EmbeddedResource Include="..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Sdk.Localization"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Text.Json"  VersionOverride="8.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Condition="'$(UseSystemTextJson)'=='True'"/>
     <PackageReference Include="Newtonsoft.Json" Condition="'$(UseSystemTextJson)'!='True'"/>
   </ItemGroup>
 </Project>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -91,6 +91,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Text.Json"  VersionOverride="8.0.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" ExcludeAssets="Runtime" />


### PR DESCRIPTION
## Description
With PR #37681 , we introduced a new code path that will load System.Text.Json in framework and core versions of the .NET SDK. This code path triggers when installing SDK workloads using rollback files. While this scenario is not broadly documented, it is the default for all dogfooders of Aspire workloads as a script is used to install specific versions of the workloads.

We don't reference S.T.J in the framework version of the msbuildsdkresolver. However, it transitively pulls in a 7.0 version of that package through another dependency. Because of transitive pinning, this gets hoisted to version 8.0.2 which VS does not have. 

This is fine in the .net core SDK but breaks VS.

## Customer Impact 

Any customer installing workloads from a rollback file will have their workload templates be broken and get errors when doing file new on any project.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2013426


## Regression
**Yes,** 

## Risk
Low - we have similar pinned package versions in other framework assemblies for this specific reason.

## Testing
Jose tested manually copying the newly built files over the old ones that he was unblocked with no errors and valid templates showing up.