### PR TITLE
Update warning message for containers package detection when building SDK-containerizable project types

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -211,7 +211,7 @@
 
     <PropertyGroup>
       <_ContainerPackageIsPresent>false</_ContainerPackageIsPresent>
-      <_ContainerPackageIsPresent Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)'))">true</_ContainerPackageIsPresent>
+      <_ContainerPackageIsPresent Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)'))">true</_ContainerPackageIsPresent>
       <_IsWebProject>false</_IsWebProject>
       <_IsWebProject Condition="'@(_WebCapability)' != ''">true</_IsWebProject>
       <_IsWorkerProject>false</_IsWorkerProject>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -195,27 +195,24 @@
 
   <Target Name="_CheckContainersPackage" AfterTargets="Build">
     <PropertyGroup>
+      <!-- facts to base on comparisons on -->
       <_ContainersPackageIdentity>Microsoft.NET.Build.Containers</_ContainersPackageIdentity>
       <_WebDefaultSdkVersion>7.0.300</_WebDefaultSdkVersion>
       <_WorkerDefaultSdkVersion>8.0.100</_WorkerDefaultSdkVersion>
       <_ConsoleDefaultSdkVersion>8.0.200</_ConsoleDefaultSdkVersion>
+
+      <!-- capability detection for the executing SDK -->
       <_SdkCanPublishWeb>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WebDefaultSdkVersion)'))</_SdkCanPublishWeb>
       <_SdkCanPublishWorker>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WorkerDefaultSdkVersion)'))</_SdkCanPublishWorker>
       <_SdkCanPublishConsole>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_ConsoleDefaultSdkVersion)'))</_SdkCanPublishConsole>
-    </PropertyGroup>
-    <ItemGroup>
-      <_ContainersPackage Include="@(PackageReference)" Condition="'%(Identity)' == '$(_ContainersPackageIdentity)'"/>
-      <_WebCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWeb'" />
-      <_WorkerCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWorker'" />
-    </ItemGroup>
 
-    <PropertyGroup>
+      <!-- capability detection for the executing project -->
       <_ContainerPackageIsPresent>false</_ContainerPackageIsPresent>
       <_ContainerPackageIsPresent Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)'))">true</_ContainerPackageIsPresent>
       <_IsWebProject>false</_IsWebProject>
-      <_IsWebProject Condition="'@(_WebCapability)' != ''">true</_IsWebProject>
+      <_IsWebProject Condition="@(ProjectCapability->AnyHaveMetadataValue('Identity', 'DotNetCoreWeb'))">true</_IsWebProject>
       <_IsWorkerProject>false</_IsWorkerProject>
-      <_IsWorkerProject Condition="'@(_WorkerCapability)' != ''">true</_IsWorkerProject>
+      <_IsWorkerProject Condition="@(ProjectCapability->AnyHaveMetadataValue('Identity', 'DotNetCoreWorker'))">true</_IsWorkerProject>
     </PropertyGroup>
 
     <Warning
@@ -225,7 +222,7 @@
           ($(_SdkCanPublishWorker) and $(_IsWorkerProject)) or
           ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true')
         )"
-      Text="The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers as it no longer needed." />
+      Text="The $(_ContainersPackageIdentity) NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to $(_ContainersPackageIdentity) as it no longer needed." />
 
     <PropertyGroup>
       <EnableSdkContainerSupport Condition="'@(ContainersPackage)' != ''">true</EnableSdkContainerSupport>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -199,24 +199,33 @@
       <_WebDefaultSdkVersion>7.0.300</_WebDefaultSdkVersion>
       <_WorkerDefaultSdkVersion>8.0.100</_WorkerDefaultSdkVersion>
       <_ConsoleDefaultSdkVersion>8.0.200</_ConsoleDefaultSdkVersion>
-      <_SdkCanPublishWeb Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WebDefaultSdkVersion)'))" >true</_SdkCanPublishWeb>
-      <_SdkCanPublishWorker Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WorkerDefaultSdkVersion)'))">true</_SdkCanPublishWorker>
-      <_SdkCanPublishConsole Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_ConsoleDefaultSdkVersion)'))">true</_SdkCanPublishConsole>
+      <_SdkCanPublishWeb>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WebDefaultSdkVersion)'))</_SdkCanPublishWeb>
+      <_SdkCanPublishWorker>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WorkerDefaultSdkVersion)'))</_SdkCanPublishWorker>
+      <_SdkCanPublishConsole>$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_ConsoleDefaultSdkVersion)'))</_SdkCanPublishConsole>
     </PropertyGroup>
     <ItemGroup>
-      <_ContainersPackage Include="@(PackageReference)" Condition="'%(Identity)' == '$(ContainersPackageIdentity)'"/>
+      <_ContainersPackage Include="@(PackageReference)" Condition="'%(Identity)' == '$(_ContainersPackageIdentity)'"/>
       <_WebCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWeb'" />
       <_WorkerCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWorker'" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_ContainerPackageIsPresent>false</_ContainerPackageIsPresent>
+      <_ContainerPackageIsPresent Condition="'@(_ContainersPackage)' != ''">true</_ContainerPackageIsPresent>
+      <_IsWebProject>false</_IsWebProject>
+      <_IsWebProject Condition="'@(_WebCapability)' != ''">true</_IsWebProject>
+      <_IsWorkerProject>false</_IsWorkerProject>
+      <_IsWorkerProject Condition="'@(_WorkerCapability)' != ''">true</_IsWorkerProject>
+    </PropertyGroup>
+
     <Warning
-      Condition="'@(_ContainersPackage)' != ''
+      Condition="$(_ContainerPackageIsPresent)
         and (
-          ($(_SdkCanPublishWeb) and '@(_WebCapability)' != '') or
-          ($(_SdkCanPublishWorker) and '@(_WorkerCapability)' != '') or
-          ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true'
+          ($(_SdkCanPublishWeb) and $(_IsWebProject)) or
+          ($(_SdkCanPublishWorker) and $(_IsWorkerProject)) or
+          ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true')
         )"
-      Text="Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers as it no longer needed." />
+      Text="The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers as it no longer needed." />
 
     <PropertyGroup>
       <EnableSdkContainerSupport Condition="'@(ContainersPackage)' != ''">true</EnableSdkContainerSupport>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -211,7 +211,7 @@
 
     <PropertyGroup>
       <_ContainerPackageIsPresent>false</_ContainerPackageIsPresent>
-      <_ContainerPackageIsPresent Condition="'@(_ContainersPackage)' != ''">true</_ContainerPackageIsPresent>
+      <_ContainerPackageIsPresent Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)')) != ''">true</_ContainerPackageIsPresent>
       <_IsWebProject>false</_IsWebProject>
       <_IsWebProject Condition="'@(_WebCapability)' != ''">true</_IsWebProject>
       <_IsWorkerProject>false</_IsWorkerProject>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -195,12 +195,29 @@
 
   <Target Name="_CheckContainersPackage" AfterTargets="Build">
     <PropertyGroup>
-      <ContainersPackageIdentity>Microsoft.NET.Build.Containers</ContainersPackageIdentity>
+      <_ContainersPackageIdentity>Microsoft.NET.Build.Containers</_ContainersPackageIdentity>
+      <_WebDefaultSdkVersion>7.0.300</_WebDefaultSdkVersion>
+      <_WorkerDefaultSdkVersion>8.0.100</_WorkerDefaultSdkVersion>
+      <_ConsoleDefaultSdkVersion>8.0.200</_ConsoleDefaultSdkVersion>
+      <_SdkCanPublishWeb Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WebDefaultSdkVersion)'))" >true</_SdkCanPublishWeb>
+      <_SdkCanPublishWorker Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_WorkerDefaultSdkVersion)'))">true</_SdkCanPublishWorker>
+      <_SdkCanPublishConsole Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '$(_ConsoleDefaultSdkVersion)'))">true</_SdkCanPublishConsole>
     </PropertyGroup>
     <ItemGroup>
-      <ContainersPackage Include="@(PackageReference)" Condition="'%(Identity)' == '$(ContainersPackageIdentity)'" />
+      <_ContainersPackage Include="@(PackageReference)" Condition="'%(Identity)' == '$(ContainersPackageIdentity)'"/>
+      <_WebCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWeb'" />
+      <_WorkerCapability Include="@(ProjectCapability)" Condition="'%(Identity)' == 'DotNetCoreWorker'" />
     </ItemGroup>
-    <Warning Text="Microsoft.NET.Build.Containers NuGet package is explicitly referenced. Consider removing the package reference to Microsoft.NET.Build.Containers as it is now part of .NET SDK." Condition="'@(ContainersPackage)' != ''" />
+
+    <Warning
+      Condition="'@(_ContainersPackage)' != ''
+        and (
+          ($(_SdkCanPublishWeb) and '@(_WebCapability)' != '') or
+          ($(_SdkCanPublishWorker) and '@(_WorkerCapability)' != '') or
+          ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true'
+        )"
+      Text="Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers as it no longer needed." />
+
     <PropertyGroup>
       <EnableSdkContainerSupport Condition="'@(ContainersPackage)' != ''">true</EnableSdkContainerSupport>
     </PropertyGroup>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -211,7 +211,7 @@
 
     <PropertyGroup>
       <_ContainerPackageIsPresent>false</_ContainerPackageIsPresent>
-      <_ContainerPackageIsPresent Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)')) != ''">true</_ContainerPackageIsPresent>
+      <_ContainerPackageIsPresent Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', '$(_ContainersPackageIdentity)'))">true</_ContainerPackageIsPresent>
       <_IsWebProject>false</_IsWebProject>
       <_IsWebProject Condition="'@(_WebCapability)' != ''">true</_IsWebProject>
       <_IsWorkerProject>false</_IsWorkerProject>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -222,7 +222,7 @@
           ($(_SdkCanPublishWorker) and $(_IsWorkerProject)) or
           ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true')
         )"
-      Text="The $(_ContainersPackageIdentity) NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to $(_ContainersPackageIdentity) as it no longer needed." />
+      Text="The $(_ContainersPackageIdentity) NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to $(_ContainersPackageIdentity) because it is no longer needed." />
 
     <PropertyGroup>
       <EnableSdkContainerSupport Condition="'@(ContainersPackage)' != ''">true</EnableSdkContainerSupport>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -518,7 +518,8 @@ public class EndToEndTests : IDisposable
             $"/p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageAspNet}",
             $"/p:ContainerRegistry={DockerRegistryManager.LocalRegistry}",
             $"/p:ContainerRepository={imageName}",
-            $"/p:ContainerImageTag={imageTag}")
+            $"/p:ContainerImageTag={imageTag}",
+            "/p:EnableSdkContainerSupport=true")
             .WithEnvironmentVariable("NUGET_PACKAGES", privateNuGetAssets.FullName)
             .WithWorkingDirectory(newProjectDir.FullName)
             .Execute()

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -369,7 +369,7 @@ public class EndToEndTests : IDisposable
 
         if (addPackageReference)
         {
-            commandResult.Should().HaveStdOutContaining("warning : Microsoft.NET.Build.Containers NuGet package is explicitly referenced. Consider removing the package reference to Microsoft.NET.Build.Containers as it is now part of .NET SDK.");
+            commandResult.Should().HaveStdOutContaining("warning : The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers because it is no longer needed.");
         }
         else
         {


### PR DESCRIPTION
## Description

We need to make the warning about removing the Microsoft.NET.Build.Containers NuGet package only fire when running in the context of an SDK that can actually package the kind of app being packaged (since this is still being pushed as a PackageReference as well as bundled into the SDK for certain project types).

Fixes #39931.

## Customer Impact

Customers only get a warning if the SDK they are building containers with is actually capable of natively containerizing the kind of project they are building - this means that 8.0.100 SDK users (e.g. Linux distro installs) will only see this error for Web and Worker projects, never console apps. This is valuable because those users will rarely have access to an SDK that _can_ natively target console apps during the 8 cycle, which is LTS.

## Regression

**Yes**, this warning should not have been triggering for different kinds of projects in the different SDK bands - we have been errantly throwing this in different ways since 7.0.400.

## Risk

**Low**, this makes a warning less likely to fire by removing the warning in situations where it is not applicable

## Testing

Automated tests cover these scenarios already.

We should backport this to 8.0.100 so that the LTS SDKs do not throw errant warnings.
