### PR TITLE
[release/7.0.4xx] Temporarily disabling Build_Components_WithDesktopMSBuild_Works test

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         [CoreMSBuildOnlyFact]
         public void Build_Components_WithDotNetCoreMSBuild_Works() => Build_ComponentsWorks();
 
-        [RequiresMSBuildVersionFact("17.7.0.25102")]
+        [RequiresMSBuildVersionFact("17.7.0.25102", Skip = "https://github.com/dotnet/sdk/issues/39960")]
         public void Build_Components_WithDesktopMSBuild_Works() => Build_ComponentsWorks();
 
         [Fact]


### PR DESCRIPTION
Related: #39960