### PR TITLE
[release/8.0.1xx] Temporarily disabling Build_Components_WithDesktopMSBuild_Works test

### DIFF
--- a/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
+++ b/src/Tests/Microsoft.NET.Sdk.Razor.Tests/BuildWithComponentsIntegrationTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
         [CoreMSBuildOnlyFact]
         public void Build_Components_WithDotNetCoreMSBuild_Works() => Build_ComponentsWorks();
 
-        [RequiresMSBuildVersionFact("17.8.0.37606")]
+        [RequiresMSBuildVersionFact("17.8.0.37606", Skip = "https://github.com/dotnet/sdk/issues/39960")]
         public void Build_Components_WithDesktopMSBuild_Works() => Build_ComponentsWorks();
 
         [Fact]


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/issues/39960