### PR TITLE
Refactor workload set and workload install/update logic

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Tools.Common
         /// and continues to its parent until it fails. Returns whether it succeeded
         /// in deleting the file it was intended to delete.
         /// </summary>
-        public static bool DeleteFileAndEmptyParents(string path)
+        public static bool DeleteFileAndEmptyParents(string path, int maxDirectoriesToDelete = int.MaxValue)
         {
             if (!File.Exists(path))
             {
@@ -112,9 +112,13 @@ namespace Microsoft.DotNet.Tools.Common
             File.Delete(path);
             var dir = Path.GetDirectoryName(path);
 
-            while (!Directory.EnumerateFileSystemEntries(dir).Any())
+            int directoriesDeleted = 0;
+
+            while (!Directory.EnumerateFileSystemEntries(dir).Any() &&
+                directoriesDeleted < maxDirectoriesToDelete)
             {
                 Directory.Delete(dir);
+                directoriesDeleted++;
                 dir = Path.GetDirectoryName(dir);
             }
 

--- a/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <param name="sdkFeatureBand">The SDK feature band of the install state file to write</param>
         /// <param name="newMode">Whether to use workload sets or not</param>
         /// <returns></returns>
-        public InstallResponseMessage SendUpdateWorkloadModeRequest(SdkFeatureBand sdkFeatureBand, bool newMode)
+        public InstallResponseMessage SendUpdateWorkloadModeRequest(SdkFeatureBand sdkFeatureBand, bool? newMode)
         {
             return Send(new InstallRequestMessage
             {

--- a/src/Cli/dotnet/Installer/Windows/InstallRequestMessage.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallRequestMessage.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// The new mode to use: workloadset or loosemanifests
         /// </summary>
-        public bool UseWorkloadSets
+        public bool? UseWorkloadSets
         {
             get; set;
         }

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                 {
                     foreach (var manifestUpdate in manifestsToUpdate)
                     {
-                        _workloadInstaller.InstallWorkloadManifest(manifestUpdate, context, offlineCache, UseRollback);
+                        _workloadInstaller.InstallWorkloadManifest(manifestUpdate, context, offlineCache);
                     }
 
                     if (!SpecifiedWorkloadSetVersionInGlobalJson)

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Workloads.Workload
             }
 
             string resolvedWorkloadSetVersion = _workloadSetVersionFromGlobalJson ??_workloadSetVersionFromCommandLine;
-            if (string.IsNullOrWhiteSpace(resolvedWorkloadSetVersion) && !UseRollback /* TODO && !specifiedWorkloadManifestsInInstallState */)
+            if (string.IsNullOrWhiteSpace(resolvedWorkloadSetVersion) && !UseRollback)
             {
                 _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, updateUsingWorkloadSets, offlineCache).Wait();
                 if (updateUsingWorkloadSets)
@@ -207,15 +207,17 @@ namespace Microsoft.DotNet.Workloads.Workload
                         {
                             _workloadInstaller.SaveInstallStateManifestVersions(_sdkFeatureBand, GetInstallStateContents(manifestsToUpdate));
                         }
+                        else if (SpecifiedWorkloadSetVersionOnCommandLine)
+                        {
+                            _workloadInstaller.AdjustWorkloadSetInInstallState(_sdkFeatureBand, resolvedWorkloadSetVersion);
+                        }
                         else if (this is WorkloadUpdateCommand)
                         {
-                            //  For workload updates, if you don't specify a rollback file, then we should update to a new version of the manifests or workload set, and
+                            //  For workload updates, if you don't specify a rollback file, or a workload version then we should update to a new version of the manifests or workload set, and
                             //  should remove the install state that pins to the other version
-                            //  TODO: Do we need to do something similar if the workload set version is pinned in the install state?
                             _workloadInstaller.RemoveManifestsFromInstallState(_sdkFeatureBand);
+                            _workloadInstaller.AdjustWorkloadSetInInstallState(_sdkFeatureBand, null);
                         }
-
-                        _workloadInstaller.AdjustWorkloadSetInInstallState(_sdkFeatureBand, resolvedWorkloadSetVersion);
                     }
 
                     _workloadResolver.RefreshWorkloadManifests();

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         protected readonly ReleaseVersion _targetSdkVersion;
         protected readonly string _fromRollbackDefinition;
         protected string _workloadSetVersionFromCommandLine;
+        protected string _globalJsonPath;
         protected string _workloadSetVersionFromGlobalJson;
         protected readonly PackageSourceLocation _packageSourceLocation;
         protected readonly IWorkloadResolverFactory _workloadResolverFactory;
@@ -99,12 +100,12 @@ namespace Microsoft.DotNet.Workloads.Workload
             _workloadInstallerFromConstructor = workloadInstaller;
             _workloadManifestUpdaterFromConstructor = workloadManifestUpdater;
 
-            var globaljsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
-            _workloadSetVersionFromGlobalJson = SdkDirectoryWorkloadManifestProvider.GlobalJsonReader.GetWorkloadVersionFromGlobalJson(globaljsonPath);
+            _globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
+            _workloadSetVersionFromGlobalJson = SdkDirectoryWorkloadManifestProvider.GlobalJsonReader.GetWorkloadVersionFromGlobalJson(_globalJsonPath);
 
             if (SpecifiedWorkloadSetVersionInGlobalJson && (SpecifiedWorkloadSetVersionOnCommandLine || UseRollback))
             {
-                throw new GracefulException(string.Format(Strings.CannotSpecifyVersionOnCommandLineAndInGlobalJson, globaljsonPath), isUserError: true);
+                throw new GracefulException(string.Format(Strings.CannotSpecifyVersionOnCommandLineAndInGlobalJson, _globalJsonPath), isUserError: true);
             }
 
             if (SpecifiedWorkloadSetVersionOnCommandLine && UseRollback)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         public WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null)
         {
             SdkFeatureBand workloadSetFeatureBand;
-            string workloadSetPackageVersion = WorkloadManifestUpdater.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
+            string workloadSetPackageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
             var workloadSetPackageId = GetManifestPackageId(new ManifestId("Microsoft.NET.Workloads"), workloadSetFeatureBand);
 
             var workloadSetPath = Path.Combine(_dotnetDir, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadSetVersion);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             return manifestInstallDir;
         }
 
-        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
         {
             var newManifestPath = Path.Combine(GetManifestInstallDirForFeatureBand(manifestUpdate.NewFeatureBand), manifestUpdate.ManifestId.ToString(), manifestUpdate.NewVersion.ToString());
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -107,11 +107,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         RemoveWorkloadSetInstallationRecord(workloadSetVersion, workloadSetFeatureBand, _sdkFeatureBand);
                     });
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                //  TODO: Add workload set specific message
-                throw;
-                //throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
+                throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadSet, workloadSetVersion, ex.Message), ex);
             }
 
             return WorkloadSet.FromWorkloadSetFolder(workloadSetPath, workloadSetVersion, _sdkFeatureBand);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -509,14 +509,16 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             File.WriteAllText(path, installStateContents.ToString());
         }
 
-        public void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool newMode)
+        public void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool? newMode)
         {
             string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, _dotnetDir), "default.json");
             Directory.CreateDirectory(Path.GetDirectoryName(path));
             var installStateContents = InstallStateContents.FromPath(path);
             installStateContents.UseWorkloadSets = newMode;
             File.WriteAllText(path, installStateContents.ToString());
-            _reporter.WriteLine(string.Format(LocalizableStrings.UpdatedWorkloadMode, newMode ? WorkloadConfigCommandParser.UpdateMode_WorkloadSet : WorkloadConfigCommandParser.UpdateMode_Manifests));
+
+            var newModeString = newMode == null ? "<null>" : (newMode.Value ? WorkloadConfigCommandParser.UpdateMode_WorkloadSet : WorkloadConfigCommandParser.UpdateMode_Manifests);
+            _reporter.WriteLine(string.Format(LocalizableStrings.UpdatedWorkloadMode, newModeString));
         }
 
         /// <summary>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         private readonly string _workloadMetadataDir;
         private const string InstalledPacksDir = "InstalledPacks";
         private const string InstalledManifestsDir = "InstalledManifests";
+        private const string InstalledWorkloadSetsDir = "InstalledWorkloadSets";
         protected readonly string _dotnetDir;
         protected readonly string _userProfileDir;
         protected readonly DirectoryPath _tempPackagesDir;
@@ -85,29 +86,35 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             return packs;
         }
 
-        public string InstallWorkloadSet(ITransactionContext context, string advertisingPackagePath)
+        public WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null)
         {
-            var workloadVersion = File.ReadAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName));
-            var workloadSetPath = Path.Combine(_dotnetDir, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadVersion);
-            context.Run(
-                action: () =>
-                {
-                    Directory.CreateDirectory(workloadSetPath);
+            SdkFeatureBand workloadSetFeatureBand;
+            string workloadSetPackageVersion = WorkloadManifestUpdater.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
+            var workloadSetPackageId = GetManifestPackageId(new ManifestId("Microsoft.NET.Workloads"), workloadSetFeatureBand);
 
-                    foreach (var file in Directory.EnumerateFiles(advertisingPackagePath))
-                    {
-                        File.Copy(file, Path.Combine(workloadSetPath, Path.GetFileName(file)), overwrite: true);
-                    }
-                },
-                rollback: () =>
-                {
-                    foreach (var file in Directory.EnumerateFiles(workloadSetPath))
-                    {
-                        PathUtility.DeleteFileAndEmptyParents(file);
-                    }
-                });
+            var workloadSetPath = Path.Combine(_dotnetDir, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadSetVersion);
 
-            return workloadSetPath;
+            try
+            {
+                InstallPackage(workloadSetPackageId, workloadSetPackageVersion, workloadSetPath, context, offlineCache);
+                context.Run(
+                    action: () =>
+                    {
+                        WriteWorkloadSetInstallationRecord(workloadSetVersion, workloadSetFeatureBand, _sdkFeatureBand);
+                    },
+                    rollback: () =>
+                    {
+                        RemoveWorkloadSetInstallationRecord(workloadSetVersion, workloadSetFeatureBand, _sdkFeatureBand);
+                    });
+            }
+            catch (Exception)
+            {
+                //  TODO: Add workload set specific message
+                throw;
+                //throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
+            }
+
+            return WorkloadSet.FromWorkloadSetFolder(workloadSetPath, workloadSetVersion, _sdkFeatureBand);
         }
 
         public void InstallWorkloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
@@ -228,84 +235,99 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false)
         {
-            string packagePath = null;
-            string tempBackupDir = null;
-
             var newManifestPath = Path.Combine(GetManifestInstallDirForFeatureBand(manifestUpdate.NewFeatureBand), manifestUpdate.ManifestId.ToString(), manifestUpdate.NewVersion.ToString());
 
             _reporter.WriteLine(string.Format(LocalizableStrings.InstallingWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion));
 
             try
             {
+                var newManifestPackageId = GetManifestPackageId(manifestUpdate.ManifestId, new SdkFeatureBand(manifestUpdate.NewFeatureBand));
+
+                InstallPackage(newManifestPackageId, manifestUpdate.NewVersion.ToString(), newManifestPath, transactionContext, offlineCache);
+
                 transactionContext.Run(
                     action: () =>
                     {
-                        var newManifestPackageId = GetManifestPackageId(manifestUpdate.ManifestId, new SdkFeatureBand(manifestUpdate.NewFeatureBand));
-                        if (offlineCache == null || !offlineCache.HasValue)
-                        {
-                            packagePath = _nugetPackageDownloader.DownloadPackageAsync(newManifestPackageId,
-                                new NuGetVersion(manifestUpdate.NewVersion.ToString()), _packageSourceLocation).GetAwaiter().GetResult();
-                        }
-                        else
-                        {
-                            packagePath = Path.Combine(offlineCache.Value.Value, $"{newManifestPackageId}.{manifestUpdate.NewVersion}.nupkg");
-                            if (!File.Exists(packagePath))
-                            {
-                                throw new Exception(string.Format(LocalizableStrings.CacheMissingPackage, newManifestPackageId, manifestUpdate.NewVersion, offlineCache));
-                            }
-                        }
-
-                        //  If target directory already exists, back it up in case we roll back
-                        if (Directory.Exists(newManifestPath) && Directory.GetFileSystemEntries(newManifestPath).Any())
-                        {
-                            tempBackupDir = Path.Combine(_tempPackagesDir.Value, $"{manifestUpdate.ManifestId}-{manifestUpdate.ExistingVersion}-backup");
-                            if (Directory.Exists(tempBackupDir))
-                            {
-                                Directory.Delete(tempBackupDir, true);
-                            }
-                            FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(newManifestPath, tempBackupDir));
-                        }
-
-                        ExtractManifestAsync(packagePath, newManifestPath).GetAwaiter().GetResult();
-
                         WriteManifestInstallationRecord(manifestUpdate.ManifestId, manifestUpdate.NewVersion, new SdkFeatureBand(manifestUpdate.NewFeatureBand), _sdkFeatureBand);
                     },
                     rollback: () =>
                     {
-                        if (!string.IsNullOrEmpty(tempBackupDir) && Directory.Exists(tempBackupDir))
-                        {
-                            FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(tempBackupDir, newManifestPath));
-                        }
-                    },
-                    cleanup: () =>
-                    {
-                        // Delete leftover dirs and files
-                        if (!string.IsNullOrEmpty(packagePath) && File.Exists(packagePath) && (offlineCache == null || !offlineCache.HasValue))
-                        {
-                            File.Delete(packagePath);
-                        }
-
-                        var versionDir = Path.GetDirectoryName(packagePath);
-                        if (Directory.Exists(versionDir) && !Directory.GetFileSystemEntries(versionDir).Any())
-                        {
-                            Directory.Delete(versionDir);
-                            var idDir = Path.GetDirectoryName(versionDir);
-                            if (Directory.Exists(idDir) && !Directory.GetFileSystemEntries(idDir).Any())
-                            {
-                                Directory.Delete(idDir);
-                            }
-                        }
-
-                        if (!string.IsNullOrEmpty(tempBackupDir) && Directory.Exists(tempBackupDir))
-                        {
-                            Directory.Delete(tempBackupDir, true);
-                        }
+                        RemoveManifestInstallationRecord(manifestUpdate.ManifestId, manifestUpdate.NewVersion, new SdkFeatureBand(manifestUpdate.NewFeatureBand), _sdkFeatureBand);
                     });
             }
             catch (Exception e)
             {
                 throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
             }
+        }
+
+        void InstallPackage(PackageId packageId, string packageVersion, string targetFolder, ITransactionContext transactionContext, DirectoryPath? offlineCache)
+        {
+            string packagePath = null;
+            string tempBackupDir = null;
+
+            transactionContext.Run(
+                action: () =>
+                {
+                    if (offlineCache == null || !offlineCache.HasValue)
+                    {
+                        packagePath = _nugetPackageDownloader.DownloadPackageAsync(packageId,
+                            new NuGetVersion(packageVersion), _packageSourceLocation).GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        packagePath = Path.Combine(offlineCache.Value.Value, $"{packageId}.{packageVersion}.nupkg");
+                        if (!File.Exists(packagePath))
+                        {
+                            throw new Exception(string.Format(LocalizableStrings.CacheMissingPackage, packageId, packageVersion, offlineCache));
+                        }
+                    }
+
+                    //  If target directory already exists, back it up in case we roll back
+                    if (Directory.Exists(targetFolder) && Directory.GetFileSystemEntries(targetFolder).Any())
+                    {
+                        tempBackupDir = Path.Combine(_tempPackagesDir.Value, $"{packageId} - {packageVersion}-backup");
+                        if (Directory.Exists(tempBackupDir))
+                        {
+                            Directory.Delete(tempBackupDir, true);
+                        }
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(targetFolder, tempBackupDir));
+                    }
+
+                    ExtractManifestAsync(packagePath, targetFolder).GetAwaiter().GetResult();
+
+                },
+                rollback: () =>
+                {
+                    if (!string.IsNullOrEmpty(tempBackupDir) && Directory.Exists(tempBackupDir))
+                    {
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(tempBackupDir, targetFolder));
+                    }
+                },
+                cleanup: () =>
+                {
+                    // Delete leftover dirs and files
+                    if (!string.IsNullOrEmpty(packagePath) && File.Exists(packagePath) && (offlineCache == null || !offlineCache.HasValue))
+                    {
+                        File.Delete(packagePath);
+                    }
+
+                    var versionDir = Path.GetDirectoryName(packagePath);
+                    if (Directory.Exists(versionDir) && !Directory.GetFileSystemEntries(versionDir).Any())
+                    {
+                        Directory.Delete(versionDir);
+                        var idDir = Path.GetDirectoryName(versionDir);
+                        if (Directory.Exists(idDir) && !Directory.GetFileSystemEntries(idDir).Any())
+                        {
+                            Directory.Delete(idDir);
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(tempBackupDir) && Directory.Exists(tempBackupDir))
+                    {
+                        Directory.Delete(tempBackupDir, true);
+                    }
+                });
         }
 
         public IEnumerable<WorkloadDownload> GetDownloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, bool includeInstalledItems)
@@ -376,37 +398,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     }
                 }
 
-                string installationRecordPath = null;
                 foreach (var featureBandToRemove in featureBandsToRemove)
                 {
-                    installationRecordPath = GetManifestInstallRecordPath(manifestId, manifestVersion, manifestFeatureBand, featureBandToRemove);
-                    File.Delete(installationRecordPath);
+                    RemoveManifestInstallationRecord(manifestId, manifestVersion, manifestFeatureBand, featureBandToRemove);
                 }
 
-                if (installationRecordPath != null)
+                if (featureBandsToRemove.Count == manifestInstallRecords[(manifestId, manifestVersion, manifestFeatureBand)].Count)
                 {
-                    var installationRecordDirectory = Path.GetDirectoryName(installationRecordPath);
-                    if (!Directory.GetFileSystemEntries(installationRecordDirectory).Any())
-                    {
-                        //  There are no installation records for the workload manifest anymore, so we can delete the manifest
-                        _reporter.WriteLine(string.Format(LocalizableStrings.DeletingWorkloadManifest, manifestId, $"{manifestVersion}/{manifestFeatureBand}"));
-                        var manifestPath = Path.Combine(GetManifestInstallDirForFeatureBand(manifestFeatureBand.ToString()), manifestId.ToString(), manifestVersion.ToString());
-                        Directory.Delete(manifestPath, true);
-
-                        //  Delete empty manifest installation record directory, and walk up tree deleting empty directories to clean up
-                        Directory.Delete(installationRecordDirectory);
-
-                        var manifestVersionDirectory = Path.GetDirectoryName(installationRecordDirectory);
-                        if (!Directory.GetFileSystemEntries(manifestVersionDirectory).Any())
-                        {
-                            Directory.Delete(manifestVersionDirectory);
-                            var manifestIdDirectory = Path.GetDirectoryName(manifestVersionDirectory);
-                            if (!Directory.GetFileSystemEntries(manifestIdDirectory).Any())
-                            {
-                                Directory.Delete(manifestIdDirectory);
-                            }
-                        }
-                    }
+                    //  All installation records for the manifest were removed, so we can delete the manifest
+                    _reporter.WriteLine(string.Format(LocalizableStrings.DeletingWorkloadManifest, manifestId, $"{manifestVersion}/{manifestFeatureBand}"));
+                    var manifestPath = Path.Combine(GetManifestInstallDirForFeatureBand(manifestFeatureBand.ToString()), manifestId.ToString(), manifestVersion.ToString());
+                    Directory.Delete(manifestPath, true);
                 }
             }
 
@@ -616,8 +618,25 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         }
 
 
-        //  Workload manifests have a feature band which is essentially part of their version, and may be installed by a later feature band of the SDK.  So there are two potentially different
-        //  Feature bands as part of the installation record
+        //  Workload sets and workload manifests have a feature band which is essentially part of their version, and may be installed by a later feature band of the SDK.
+        //  So there are two potentially different feature bands as part of the installation record
+        string GetWorkloadSetInstallRecordPath(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand, SdkFeatureBand referencingFeatureBand) =>
+            Path.Combine(_workloadMetadataDir, InstalledWorkloadSetsDir, "v1", workloadSetVersion, workloadSetFeatureBand.ToString(), referencingFeatureBand.ToString());
+
+        void WriteWorkloadSetInstallationRecord(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand, SdkFeatureBand referencingFeatureBand)
+        {
+            var path = GetWorkloadSetInstallRecordPath(workloadSetVersion, workloadSetFeatureBand, referencingFeatureBand);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+            using var _ = File.Create(path);
+        }
+
+        void RemoveWorkloadSetInstallationRecord(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand, SdkFeatureBand referencingFeatureBand)
+        {
+            var path = GetWorkloadSetInstallRecordPath(workloadSetVersion, workloadSetFeatureBand, referencingFeatureBand);
+            PathUtility.DeleteFileAndEmptyParents(path, maxDirectoriesToDelete: 2);
+        }
+
         private string GetManifestInstallRecordPath(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand featureBand, SdkFeatureBand referencingFeatureBand) =>
             Path.Combine(_workloadMetadataDir, InstalledManifestsDir, "v1", manifestId.ToString(), manifestVersion.ToString(), featureBand.ToString(), referencingFeatureBand.ToString());
 
@@ -627,6 +646,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             using var _ = File.Create(path);
+        }
+
+        void RemoveManifestInstallationRecord(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand featureBand, SdkFeatureBand referencingFeatureBand)
+        {
+            var installationRecordPath = GetManifestInstallRecordPath(manifestId, manifestVersion, featureBand, referencingFeatureBand);
+            PathUtility.DeleteFileAndEmptyParents(installationRecordPath, maxDirectoriesToDelete: 3);
         }
 
         private Dictionary<(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand manifestFeatureBand), List<SdkFeatureBand>> GetAllManifestInstallRecords()

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -13,14 +13,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
     {
         int ExitCode { get; }
 
-        string InstallWorkloadSet(ITransactionContext context, string advertisingPackagePath);
-
         void InstallWorkloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, DirectoryPath? offlineCache = null);
 
         void RepairWorkloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null);
 
         void GarbageCollect(Func<string, IWorkloadResolver> getResolverForWorkloadSet, DirectoryPath? offlineCache = null, bool cleanAllPacks = false);
 
+        WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null);
+
+        //  TODO: isRollback parameter seems unused / unnecessary
         void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false);
 
         IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository();

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         /// <param name="manifestContents">The JSON contents describing the install state.</param>
         void SaveInstallStateManifestVersions(SdkFeatureBand sdkFeatureBand, Dictionary<string, string> manifestContents);
 
-        void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool newMode);
+        void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool? newMode);
     }
 
     // Interface to pass to workload manifest updater

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IInstaller.cs
@@ -21,8 +21,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null);
 
-        //  TODO: isRollback parameter seems unused / unnecessary
-        void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false);
+        void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null);
 
         IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository();
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/IWorkloadManifestUpdater.cs
@@ -14,16 +14,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         IEnumerable<ManifestUpdateWithWorkloads> CalculateManifestUpdates();
 
+        string GetAdvertisedWorkloadSetVersion();
         IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(string rollbackDefinitionFilePath);
-        IEnumerable<ManifestVersionUpdate> ParseRollbackDefinitionFiles(IEnumerable<string> files);
+        IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet);
 
         Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand providedSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand);
 
         IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads);
 
         void DeleteUpdatableWorkloadsFile();
-
-        void DownloadWorkloadSet(string version, DirectoryPath? offlineCache);
     }
 
     internal record ManifestUpdateWithWorkloads(ManifestVersionUpdate ManifestUpdate, WorkloadCollection Workloads);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -355,4 +355,7 @@
   <data name="UpdatedWorkloadMode" xml:space="preserve">
     <value>Successfully updated workload install mode to use {0}.</value>
   </data>
+  <data name="FailedToInstallWorkloadSet" xml:space="preserve">
+    <value>Failed to install workload set version {0}: {1}</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -329,7 +329,7 @@
     <value>Skip signature verification of workload packages and installers.</value>
   </data>
   <data name="CheckForUpdatedWorkloadManifests" xml:space="preserve">
-    <value>Checking for updated workload manifests.</value>
+    <value>Checking for updated workload version.</value>
   </data>
   <data name="InvalidVersionForWorkload" xml:space="preserve">
     <value>Error parsing version '{1}' for workload manifest ID '{0}'</value>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -237,9 +237,6 @@
   <data name="AdManifestPackageDoesNotExist" xml:space="preserve">
     <value>Advertising manifest not updated. Manifest package for {0} doesn't exist.</value>
   </data>
-  <data name="ManifestDoesNotExist" xml:space="preserve">
-    <value>No manifest with ID {0} exists.</value>
-  </data>
   <data name="FailedToInstallWorkloadManifest" xml:space="preserve">
     <value>Failed to install manifest {0} version {1}: {2}.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -322,6 +322,13 @@
   <data name="CannotCombineSkipManifestAndRollback" xml:space="preserve">
     <value>Cannot use the {0} and {1} options together. If installing from a rollback file, remove {0}. Otherwise, remove {1}</value>
   </data>
+  <data name="CannotCombineSkipManifestAndVersion" xml:space="preserve">
+    <value>Cannot use the {0} and {1} options together.  Remove one of the options.</value>
+  </data>
+  <data name="CannotUseSkipManifestWithGlobalJsonWorkloadVersion" xml:space="preserve">
+    <value>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</value>
+    <comment>"workloadVersion" is a literal value and should not be translated.</comment>
+  </data>
   <data name="SkipSignCheckOptionDescription" xml:space="preserve">
     <value>Skip signature verification of workload packages and installers.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -327,7 +327,7 @@
   </data>
   <data name="CannotUseSkipManifestWithGlobalJsonWorkloadVersion" xml:space="preserve">
     <value>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</value>
-    <comment>"workloadVersion" is a literal value and should not be translated.</comment>
+    <comment>"workloadVersion" and "global.json" are literal values and should not be translated.</comment>
   </data>
   <data name="SkipSignCheckOptionDescription" xml:space="preserve">
     <value>Skip signature verification of workload packages and installers.</value>
@@ -360,6 +360,6 @@
     <value>Successfully updated workload install mode to use {0}.</value>
   </data>
   <data name="FailedToInstallWorkloadSet" xml:space="preserve">
-    <value>Failed to install workload set version {0}: {1}</value>
+    <value>Failed to install workload version {0}: {1}</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/MsiInstallerBase.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <param name="logFile">Full path of the log file</param>
         /// <returns>Error code indicating the result of the operation</returns>
         /// <exception cref="InvalidOperationException"></exception>
-        protected void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool newMode)
+        protected void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool? newMode)
         {
             string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, DotNetHome), "default.json");
             var installStateContents = InstallStateContents.FromPath(path);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1083,10 +1083,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        void IInstaller.UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool newMode)
+        void IInstaller.UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool? newMode)
         {
             UpdateInstallMode(sdkFeatureBand, newMode);
-            Reporter.WriteLine(string.Format(LocalizableStrings.UpdatedWorkloadMode, newMode ? WorkloadConfigCommandParser.UpdateMode_WorkloadSet : WorkloadConfigCommandParser.UpdateMode_Manifests));
+            string newModeString = newMode == null ? "<null>" : newMode.Value ? WorkloadConfigCommandParser.UpdateMode_WorkloadSet : WorkloadConfigCommandParser.UpdateMode_Manifests;
+            Reporter.WriteLine(string.Format(LocalizableStrings.UpdatedWorkloadMode, newModeString));
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             ReportPendingReboot();
 
             SdkFeatureBand workloadSetFeatureBand;
-            string msiPackageVersion = WorkloadManifestUpdater.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
+            string msiPackageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
             string msiPackageId = GetManifestPackageId(new ManifestId("Microsoft.NET.Workloads"), workloadSetFeatureBand).ToString();
 
             Log?.LogMessage($"Resolving Microsoft.NET.Workloads ({workloadSetVersion}) to {msiPackageId} ({msiPackageVersion}).");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -464,18 +464,18 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository() => RecordRepository;
 
-        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
         {
             try
             {
                 transactionContext.Run(
                     action: () =>
                     {
-                        InstallWorkloadManifestImplementation(manifestUpdate, offlineCache, isRollback);
+                        InstallWorkloadManifestImplementation(manifestUpdate, offlineCache);
                     },
                     rollback: () =>
                     {
-                        InstallWorkloadManifestImplementation(manifestUpdate, offlineCache: null, isRollback: true, action: InstallAction.Uninstall);
+                        InstallWorkloadManifestImplementation(manifestUpdate, offlineCache: null, action: InstallAction.Uninstall);
                     });
             }
             catch (Exception e)
@@ -485,14 +485,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        void InstallWorkloadManifestImplementation(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, bool isRollback = false, InstallAction action = InstallAction.Install)
+        void InstallWorkloadManifestImplementation(ManifestVersionUpdate manifestUpdate, DirectoryPath? offlineCache = null, InstallAction action = InstallAction.Install)
         {
             ReportPendingReboot();
 
             // Rolling back a manifest update after a successful install is essentially a downgrade, which is blocked so we have to
             // treat it as a special case and is different from the install failing and rolling that back, though depending where the install
             // failed, it may have removed the old product already.
-            Log?.LogMessage($"Installing manifest: Id: {manifestUpdate.ManifestId}, version: {manifestUpdate.NewVersion}, feature band: {manifestUpdate.NewFeatureBand}, rollback: {isRollback}.");
+            Log?.LogMessage($"Installing manifest: Id: {manifestUpdate.ManifestId}, version: {manifestUpdate.NewVersion}, feature band: {manifestUpdate.NewFeatureBand}.");
 
             // Resolve the package ID for the manifest payload package
             string msiPackageId = GetManifestPackageId(manifestUpdate.ManifestId, new SdkFeatureBand(manifestUpdate.NewFeatureBand)).ToString();

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -267,13 +267,13 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             context.Run(
                 action: () =>
                 {
-                    Elevate();
-
                     DetectState state = DetectPackage(msi.ProductCode, out Version installedVersion);
                     InstallAction plannedAction = PlanPackage(msi, state, InstallAction.Install, installedVersion);
 
                     if (plannedAction == InstallAction.Install)
                     {
+                        Elevate();
+
                         ExecutePackage(msi, plannedAction, msiPackageId);
 
                         // Update the reference count against the MSI.
@@ -316,7 +316,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             //  Unwrap AggregateException caused by switch from async to sync
             catch (Exception ex) when (ex is NuGetPackageNotFoundException || ex.InnerException is NuGetPackageNotFoundException)
             {
-                throw new GracefulException(string.Format(Update.LocalizableStrings.WorkloadVersionRequestedNotFound, workloadSetVersion), ex);
+                throw new GracefulException(string.Format(Update.LocalizableStrings.WorkloadVersionRequestedNotFound, workloadSetVersion), ex is NuGetPackageNotFoundException ? ex : ex.InnerException);
             }
             VerifyPackage(msi);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerServer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                         case InstallRequestType.AdjustWorkloadMode:
                             UpdateInstallMode(new SdkFeatureBand(request.SdkFeatureBand), request.UseWorkloadSets);
-                            string newMode = request.UseWorkloadSets ? "workload sets" : "loose manifests";
+                            string newMode = request.UseWorkloadSets == null ? "<null>" : request.UseWorkloadSets.Value ? "workload sets" : "loose manifests";
                             Dispatcher.ReplySuccess($"Updated install mode to use {newMode}.");
                             break;
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadGarbageCollector.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadGarbageCollector.cs
@@ -77,6 +77,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             foreach (var set in installedWorkloadSets.Keys)
             {
                 WorkloadSetsToKeep.Add(set);
+                _verboseReporter.WriteLine($"GC: Keeping workload set version {set} because workload set GC isn't implemented yet.");
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetDir), "default.json");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -156,18 +156,14 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     {
                         var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
                         if (string.IsNullOrWhiteSpace(_fromRollbackDefinition) &&
-                            File.Exists(installStateFilePath) &&
-                            InstallStateContents.FromString(File.ReadAllText(installStateFilePath)) is InstallStateContents installState &&
+                            InstallStateContents.FromPath(installStateFilePath) is InstallStateContents installState &&
                             (installState.Manifests != null || installState.WorkloadVersion != null))
                         {
-                            //  If there is a rollback state file, then we don't want to automatically update workloads when a workload is installed
+                            //  If the workload version is pinned in the install state, then we don't want to automatically update workloads when a workload is installed
                             //  To update to a new version, the user would need to run "dotnet workload update"
-                            //  TODO: We should also skip the update if a workload set version is pinned in install state or in global.json
                             _skipManifestUpdate = true;
                         }
                     }
-
-                    //  TODO: Should we still install a workload specified in global.json even if we are skipping updates?
 
                     RunInNewTransaction(context =>
                     {
@@ -175,7 +171,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                        {
                             if (Verbosity != VerbosityOptions.quiet && Verbosity != VerbosityOptions.q)
                             {
-                                //  TODO: Change this message to account for workload set wording
                                 Reporter.WriteLine(LocalizableStrings.CheckForUpdatedWorkloadManifests);
                             }
                             UpdateWorkloadManifests(context, offlineCache);
@@ -203,9 +198,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                         TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, workloadSetVersion => _workloadResolverFactory.CreateForWorkloadSet(_dotnetPath, _sdkVersion.ToString(), _userProfileDir, workloadSetVersion), offlineCache);
 
-                        //  TODO: Update this to only print the newly installed workload IDs?
                         Reporter.WriteLine();
-                        Reporter.WriteLine(string.Format(LocalizableStrings.InstallationSucceeded, string.Join(" ", workloadIds)));
+                        Reporter.WriteLine(string.Format(LocalizableStrings.InstallationSucceeded, string.Join(" ", newWorkloadInstallRecords)));
                         Reporter.WriteLine();
 
                     });

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 {
     internal class WorkloadInstallCommand : InstallingWorkloadCommand
     {
-        private readonly bool _skipManifestUpdate;
+        private bool _skipManifestUpdate;
         private readonly IReadOnlyCollection<string> _workloadIds;
 
         public WorkloadInstallCommand(
@@ -112,56 +112,98 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             {
                 var globaljsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
                 _workloadSetVersionFromGlobalJson = SdkDirectoryWorkloadManifestProvider.GlobalJsonReader.GetWorkloadVersionFromGlobalJson(globaljsonPath);
+                ErrorIfGlobalJsonAndCommandLineMismatch(globaljsonPath);
+
+                //  Normally we want to validate that the workload IDs specified were valid.  However, if there is a global.json file with a workload
+                //  set version specified, and we might update the workload version, then we don't do that check here, because we might not have the right
+                //  workload set installed yet, and trying to list the available workloads would throw an error
+                if (_skipManifestUpdate || string.IsNullOrEmpty(_workloadSetVersionFromGlobalJson))
+                {
+                    ValidateWorkloadIdsInput();
+                }
+
+                if (string.IsNullOrWhiteSpace(_workloadSetVersion) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
+                {
+                    var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
+                    if (File.Exists(installStateFilePath))
+                    {
+                        var installStateContents = InstallStateContents.FromPath(installStateFilePath);
+                        _workloadSetVersion = installStateContents.WorkloadVersion;
+                    }
+                }
 
                 try
                 {
-                    ErrorIfGlobalJsonAndCommandLineMismatch(globaljsonPath);
-
-                    //  Normally we want to validate that the workload IDs specified were valid.  However, if there is a global.json file with a workload
-                    //  set version specified, and we might update the workload version, then we don't do that check here, because we might not have the right
-                    //  workload set installed yet, and trying to list the available workloads would throw an error
-                    if (_skipManifestUpdate || string.IsNullOrEmpty(_workloadSetVersionFromGlobalJson))
-                    {
-                        ValidateWorkloadIdsInput();
-                    }
-
-                    if (string.IsNullOrWhiteSpace(_workloadSetVersion) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
-                    {
-                        var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
-                        if (File.Exists(installStateFilePath))
-                        {
-                            var installStateContents = InstallStateContents.FromPath(installStateFilePath);
-                            _workloadSetVersion = installStateContents.WorkloadVersion;
-                        }
-                    }
+                    Reporter.WriteLine();
 
                     DirectoryPath? offlineCache = string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption);
                     var workloadIds = _workloadIds.Select(id => new WorkloadId(id));
-                    if (string.IsNullOrWhiteSpace(_workloadSetVersion) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
+
+                    // Add workload Ids that already exist to our collection to later trigger an update in those installed workloads
+                    var installedWorkloads = _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(_sdkFeatureBand);
+                    var previouslyInstalledWorkloads = installedWorkloads.Intersect(workloadIds);
+                    if (previouslyInstalledWorkloads.Any())
                     {
-                        InstallWorkloads(
-                            workloadIds,
-                            _skipManifestUpdate,
-                            _includePreviews,
-                            offlineCache);
+                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadAlreadyInstalled, string.Join(" ", previouslyInstalledWorkloads)).Yellow());
                     }
-                    else
+                    workloadIds = workloadIds.Concat(installedWorkloads).Distinct();
+                    workloadIds = WriteSDKInstallRecordsForVSWorkloads(workloadIds);
+
+                    if (!_skipManifestUpdate)
                     {
-                        RunInNewTransaction(context =>
+                        var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
+                        if (string.IsNullOrWhiteSpace(_fromRollbackDefinition) && File.Exists(installStateFilePath) && InstallStateContents.FromString(File.ReadAllText(installStateFilePath)).Manifests is not null)
                         {
-                            if (!TryHandleWorkloadUpdateFromVersion(context, offlineCache, out var manifests))
+                            //  If there is a rollback state file, then we don't want to automatically update workloads when a workload is installed
+                            //  To update to a new version, the user would need to run "dotnet workload update"
+                            //  TODO: We should also skip the update if a workload set version is pinned in install state or in global.json
+                            _skipManifestUpdate = true;
+                        }
+                    }
+
+                    RunInNewTransaction(context =>
+                    {
+                        if (_skipManifestUpdate)
+                        {
+                            _workloadInstaller.InstallWorkloads(workloadIds, _sdkFeatureBand, context, offlineCache);
+                        }
+                        else
+                        {
+                            if (Verbosity != VerbosityOptions.quiet && Verbosity != VerbosityOptions.q)
                             {
-                                return;
+                                //  TODO: Change this message to account for workload set wording
+                                Reporter.WriteLine(LocalizableStrings.CheckForUpdatedWorkloadManifests);
                             }
-                            InstallWorkloadsWithInstallRecord(context, _workloadInstaller, workloadIds, _sdkFeatureBand, manifests, offlineCache, false);
-                        });
+                            UpdateWorkloads(context, workloadIds, offlineCache);
+                        }
+
+                        //  Write workload installation records
+                        var recordRepo = _workloadInstaller.GetWorkloadInstallationRecordRepository();
+                        var newWorkloadInstallRecords = workloadIds.Except(recordRepo.GetInstalledWorkloads(_sdkFeatureBand));
+                        context.Run(
+                            action: () =>
+                            {
+                                foreach (var workloadId in newWorkloadInstallRecords)
+                                {
+                                    recordRepo.WriteWorkloadInstallationRecord(workloadId, _sdkFeatureBand);
+                                }
+                            },
+                            rollback: () =>
+                            {
+                                foreach (var workloadId in newWorkloadInstallRecords)
+                                {
+                                    recordRepo.DeleteWorkloadInstallationRecord(workloadId, _sdkFeatureBand);
+                                }
+                            });
 
                         TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, workloadSetVersion => _workloadResolverFactory.CreateForWorkloadSet(_dotnetPath, _sdkVersion.ToString(), _userProfileDir, workloadSetVersion), offlineCache);
 
+                        //  TODO: Update this to only print the newly installed workload IDs?
                         Reporter.WriteLine();
                         Reporter.WriteLine(string.Format(LocalizableStrings.InstallationSucceeded, string.Join(" ", workloadIds)));
                         Reporter.WriteLine();
-                    }
+
+                    });
                 }
                 catch (Exception e)
                 {
@@ -172,74 +214,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             _workloadInstaller.Shutdown();
             return _workloadInstaller.ExitCode;
-        }
-
-        public void InstallWorkloads(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate = false, bool includePreviews = false, DirectoryPath? offlineCache = null)
-        {
-            Reporter.WriteLine();
-
-            var manifestsToUpdate = Enumerable.Empty<ManifestVersionUpdate>();
-            var useRollback = false;
-
-            WriteSDKInstallRecordsForVSWorkloads();
-
-            if (!skipManifestUpdate)
-            {
-                var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
-                var installState = InstallStateContents.FromPath(installStateFilePath);
-                if (string.IsNullOrWhiteSpace(_fromRollbackDefinition) && string.IsNullOrWhiteSpace(_workloadSetVersion) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson) &&
-                    (installState?.Manifests is not null || installState?.WorkloadVersion is not null))
-                {
-                    //  If there is a rollback state file, then we don't want to automatically update workloads when a workload is installed
-                    //  To update to a new version, the user would need to run "dotnet workload update"
-                    skipManifestUpdate = true;
-                }
-            }
-
-            RunInNewTransaction(context =>
-            {
-                if (!skipManifestUpdate)
-                {
-                    if (Verbosity != VerbosityOptions.quiet && Verbosity != VerbosityOptions.q)
-                    {
-                        Reporter.WriteLine(LocalizableStrings.CheckForUpdatedWorkloadManifests);
-                    }
-                    // Add workload Ids that already exist to our collection to later trigger an update in those installed workloads
-                    var installedWorkloads = _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(_sdkFeatureBand);
-                    var previouslyInstalledWorkloads = installedWorkloads.Intersect(workloadIds);
-                    if (previouslyInstalledWorkloads.Any())
-                    {
-                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadAlreadyInstalled, string.Join(" ", previouslyInstalledWorkloads)).Yellow());
-                    }
-                    workloadIds = workloadIds.Concat(installedWorkloads).Distinct();
-
-                    var useWorkloadSets = ShouldUseWorkloadSetMode(_sdkFeatureBand, _dotnetPath);
-                    useRollback = !string.IsNullOrWhiteSpace(_fromRollbackDefinition);
-
-                    _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews, useWorkloadSets, offlineCache).Wait();
-
-                    if (useWorkloadSets)
-                    {
-                        if (!TryInstallWorkloadSet(context, out manifestsToUpdate))
-                        {
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        manifestsToUpdate = useRollback ? _workloadManifestUpdater.CalculateManifestRollbacks(_fromRollbackDefinition) :
-                            _workloadManifestUpdater.CalculateManifestUpdates().Select(m => m.ManifestUpdate);
-                    }
-                }
-
-                InstallWorkloadsWithInstallRecord(context, _workloadInstaller, workloadIds, _sdkFeatureBand, manifestsToUpdate, offlineCache, useRollback);
-            });
-
-            TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, workloadSetVersion => _workloadResolverFactory.CreateForWorkloadSet(_dotnetPath, _sdkVersion.ToString(), _userProfileDir, workloadSetVersion), offlineCache);
-
-            Reporter.WriteLine();
-            Reporter.WriteLine(string.Format(LocalizableStrings.InstallationSucceeded, string.Join(" ", workloadIds)));
-            Reporter.WriteLine();
         }
 
         internal static void TryRunGarbageCollection(IInstaller workloadInstaller, IReporter reporter, VerbosityOptions verbosity, Func<string, IWorkloadResolver> getResolverForWorkloadSet, DirectoryPath? offlineCache = null)
@@ -254,76 +228,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 reporter.WriteLine(string.Format(LocalizableStrings.GarbageCollectionFailed,
                     verbosity.IsDetailedOrDiagnostic() ? e.ToString() : e.Message).Yellow());
             }
-        }
-
-        private void WriteSDKInstallRecordsForVSWorkloads()
-        {
-#if !DOT_NET_BUILD_FROM_SOURCE
-            if (OperatingSystem.IsWindows())
-            {
-                // The 'workload restore' command relies on this happening through the existing chain of logic, if this is massively refactored please ensure this is called.
-                VisualStudioWorkloads.WriteSDKInstallRecordsForVSWorkloads(_workloadInstaller, _workloadResolver, GetInstalledWorkloads(false), Reporter);
-            }
-#endif
-        }
-
-        private void InstallWorkloadsWithInstallRecord(
-            ITransactionContext context,
-            IInstaller installer,
-            IEnumerable<WorkloadId> workloadIds,
-            SdkFeatureBand sdkFeatureBand,
-            IEnumerable<ManifestVersionUpdate> manifestsToUpdate,
-            DirectoryPath? offlineCache,
-            bool usingRollback)
-        {
-            IEnumerable<PackInfo> workloadPackToInstall = new List<PackInfo>();
-            IEnumerable<WorkloadId> newWorkloadInstallRecords = new List<WorkloadId>();
-
-            context.Run(
-                action: () =>
-                {
-                    bool rollback = !string.IsNullOrWhiteSpace(_fromRollbackDefinition);
-
-                    foreach (var manifestUpdate in manifestsToUpdate)
-                    {
-                        installer.InstallWorkloadManifest(manifestUpdate, context, offlineCache, rollback);
-                    }
-
-                    if (usingRollback)
-                    {
-                        installer.SaveInstallStateManifestVersions(sdkFeatureBand, GetInstallStateContents(manifestsToUpdate));
-                    }
-
-                    if (string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
-                    {
-                        installer.AdjustWorkloadSetInInstallState(sdkFeatureBand, string.IsNullOrWhiteSpace(_workloadSetVersion) ? null : _workloadSetVersion);
-                    }
-
-                    _workloadResolver.RefreshWorkloadManifests();
-
-                    installer.InstallWorkloads(workloadIds, sdkFeatureBand, context, offlineCache);
-
-                    var recordRepo = installer.GetWorkloadInstallationRecordRepository();
-                    newWorkloadInstallRecords = workloadIds.Except(recordRepo.GetInstalledWorkloads(sdkFeatureBand));
-                    foreach (var workloadId in newWorkloadInstallRecords)
-                    {
-                        recordRepo.WriteWorkloadInstallationRecord(workloadId, sdkFeatureBand);
-                    }
-                },
-                rollback: () =>
-                {
-                    //  InstallWorkloadManifest and InstallWorkloadPacks already handle rolling back their actions, so here we only
-                    //  need to delete the installation records
-                    foreach (var workloadId in newWorkloadInstallRecords)
-                    {
-                        installer.GetWorkloadInstallationRecordRepository()
-                            .DeleteWorkloadInstallationRecord(workloadId, sdkFeatureBand);
-                    }
-
-                    //  Refresh the workload manifests to make sure that the resolver has the updated state after the rollback
-                    _workloadResolver.RefreshWorkloadManifests();
-                });
-
         }
 
         private async Task<IEnumerable<string>> GetPackageDownloadUrlsAsync(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -125,15 +125,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     if (string.IsNullOrWhiteSpace(_workloadSetVersionFromCommandLine) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
                     {
                         var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
-                        if (File.Exists(installStateFilePath))
+                        var installStateContents = InstallStateContents.FromPath(installStateFilePath);
+                        //  If install state has pinned workload set or manifest versions, then don't update workloads
+                        if (!string.IsNullOrEmpty(installStateContents.WorkloadVersion) || installStateContents.Manifests != null)
                         {
-                            var installStateContents = InstallStateContents.FromPath(installStateFilePath);
-                            //  If install state has pinned workload set or manifest versions, then don't update workloads
-                            if (!string.IsNullOrEmpty(installStateContents.WorkloadVersion) || installStateContents.Manifests != null)
-                            {
-                                //  TODO: respect shouldUpdateWorkloads, or figure out update / install manifest difference in InstallingWorkloadCommand
-                                shouldUpdateWorkloads = false;
-                            }
+                            //  TODO: respect shouldUpdateWorkloads, or figure out update / install manifest difference in InstallingWorkloadCommand
+                            shouldUpdateWorkloads = false;
                         }
                     }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -112,31 +112,31 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             {
                 bool shouldUpdateWorkloads = !_skipManifestUpdate;
 
-                //  Normally we want to validate that the workload IDs specified were valid.  However, if there is a global.json file with a workload
-                //  set version specified, and we might update the workload version, then we don't do that check here, because we might not have the right
-                //  workload set installed yet, and trying to list the available workloads would throw an error
-                if (!shouldUpdateWorkloads || string.IsNullOrEmpty(_workloadSetVersionFromGlobalJson))
-                {
-                    ValidateWorkloadIdsInput();
-                }
-
-                if (string.IsNullOrWhiteSpace(_workloadSetVersionFromCommandLine) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
-                {
-                    var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
-                    if (File.Exists(installStateFilePath))
-                    {
-                        var installStateContents = InstallStateContents.FromPath(installStateFilePath);
-                        //  If install state has pinned workload set or manifest versions, then don't update workloads
-                        if (!string.IsNullOrEmpty(installStateContents.WorkloadVersion) || installStateContents.Manifests != null)
-                        {
-                            //  TODO: respect shouldUpdateWorkloads, or figure out update / install manifest difference in InstallingWorkloadCommand
-                            shouldUpdateWorkloads = false;
-                        }
-                    }
-                }
-
                 try
                 {
+                    //  Normally we want to validate that the workload IDs specified were valid.  However, if there is a global.json file with a workload
+                    //  set version specified, and we might update the workload version, then we don't do that check here, because we might not have the right
+                    //  workload set installed yet, and trying to list the available workloads would throw an error
+                    if (!shouldUpdateWorkloads || string.IsNullOrEmpty(_workloadSetVersionFromGlobalJson))
+                    {
+                        ValidateWorkloadIdsInput();
+                    }
+
+                    if (string.IsNullOrWhiteSpace(_workloadSetVersionFromCommandLine) && string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
+                    {
+                        var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
+                        if (File.Exists(installStateFilePath))
+                        {
+                            var installStateContents = InstallStateContents.FromPath(installStateFilePath);
+                            //  If install state has pinned workload set or manifest versions, then don't update workloads
+                            if (!string.IsNullOrEmpty(installStateContents.WorkloadVersion) || installStateContents.Manifests != null)
+                            {
+                                //  TODO: respect shouldUpdateWorkloads, or figure out update / install manifest difference in InstallingWorkloadCommand
+                                shouldUpdateWorkloads = false;
+                            }
+                        }
+                    }
+
                     Reporter.WriteLine();
 
                     DirectoryPath? offlineCache = string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -147,6 +147,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     {
                         var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
                         if (string.IsNullOrWhiteSpace(_fromRollbackDefinition) &&
+                            !SpecifiedWorkloadSetVersionOnCommandLine &&
+                            !SpecifiedWorkloadSetVersionInGlobalJson &&
                             InstallStateContents.FromPath(installStateFilePath) is InstallStateContents installState &&
                             (installState.Manifests != null || installState.WorkloadVersion != null))
                         {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 var (id, (version, band)) = manifest;
                 var (installedVersion, installedBand) = GetInstalledManifestVersion(id);
                 return new ManifestVersionUpdate(id, installedVersion, installedBand.ToString(), version, band.ToString());
-            });
+            }).ToList();    //  Call ToList() so that GetInstalledManifestVersion call isn't delayed until the result is iterated over
         }
 
         public async Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand providedSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -181,6 +181,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
             }
 
+            if (preReleaseOrBuild != null)
+            {
+                packageVersion += '-' + preReleaseOrBuild;
+            }
+
             return packageVersion;
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -152,43 +152,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        public static string WorkloadSetVersionToWorkloadSetPackageVersion(string setVersion, out SdkFeatureBand sdkFeatureBand)
-        {
-            string[] sections = setVersion.Split(new char[] { '-', '+' }, 2);
-            string versionCore = sections[0];
-            string preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
-
-            string[] coreComponents = versionCore.Split('.');
-            string major = coreComponents[0];
-            string minor = coreComponents[1];
-            string patch = coreComponents[2];
-
-            string packageVersion = $"{major}.{patch}.";
-            if (coreComponents.Length == 3)
-            {
-                //  No workload set patch version
-                packageVersion += "0";
-
-                //  Use preview specifier (if any) from workload set version as part of SDK feature band
-                sdkFeatureBand = new SdkFeatureBand(setVersion);
-            }
-            else
-            {
-                //  Workload set version has workload patch version (ie 4 components)
-                packageVersion += coreComponents[3];
-
-                //  Don't include any preview specifiers in SDK feature band
-                sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
-            }
-
-            if (preReleaseOrBuild != null)
-            {
-                packageVersion += '-' + preReleaseOrBuild;
-            }
-
-            return packageVersion;
-        }
-
+        //  Corresponding method for opposite direction is in WorkloadSet class.  This version is kept here as implementation
+        //  depends on NuGetVersion
         public static string WorkloadSetPackageVersionToWorkloadSetVersion(SdkFeatureBand sdkFeatureBand, string packageVersion)
         {
             var nugetVersion = new NuGetVersion(packageVersion);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -520,6 +520,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet)
         {
+            //  TODO: Don't look up previous manifest versions (since we may be in the mode where there's a global.json with a workload set
+            //  that's not installed, and trying to get the current manifests will throw an exception)
             return CalculateManifestRollbacks(workloadSet.ManifestVersions.Select(kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand))));
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -485,8 +485,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet)
         {
-            //  TODO: Don't look up previous manifest versions (since we may be in the mode where there's a global.json with a workload set
-            //  that's not installed, and trying to get the current manifests will throw an exception)
             return CalculateManifestRollbacks(workloadSet.ManifestVersions.Select(kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand))));
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Nepodařilo se nainstalovat manifest {0} verze {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">ADRESÁŘ</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Kontrolují se aktualizované manifesty úloh.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Kontrolují se aktualizované manifesty úloh.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Cílová architektura, pro kterou se má úloha nainstalovat</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Neexistuje žádný manifest s ID {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">Instalační služba MSI manifestu se nenašla v balíčku NuGet {0}.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Možnosti {0} a {1} nelze použít společně. Při instalaci ze souboru vráceného zpět odeberte {0}. V opačném případě odeberte {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Na příkazovém řádku nelze pomocí možnosti --version nebo --from-history zadat konkrétní verzi úlohy, pokud je již verze zadána v souboru global.json {0}. Pokud chcete aktualizovat globálně nainstalovanou verzi úlohy, spusťte příkaz mimo cestu obsahující daný soubor global.json nebo aktualizujte verzi uvedenou v souboru global.json a spusťte příkaz dotnet workload update.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Fehler beim Installieren des Manifests "{0}", Version {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">VERZEICHNIS</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Es wird nach aktualisierten Workloadmanifesten gesucht.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Es wird nach aktualisierten Workloadmanifesten gesucht.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Das Zielframework, für das die Workload installiert wird.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Es ist kein Manifest mit der ID {0} vorhanden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">Manifest-MSI wurde im NuGet-Paket {0} nicht gefunden.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Die Optionen {0} und {1} können nicht zusammen verwendet werden. Entfernen Sie bei der Installation aus einer Rollbackdatei {0}. Entfernen Sie andernfalls {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Eine bestimmte Workload-Version kann in der Befehlszeile nicht über „--version“ oder „--from-history“ angegeben werden, wenn bereits eine Version in der global.json-Datei „{0}“ angegeben ist. Um die global installierte Workload-Version zu aktualisieren, führen Sie den Befehl außerhalb des Pfads aus, der diese global.json-Datei enthält, oder aktualisieren Sie die in der global.json Datei angegebene Version, und führen Sie „dotnet workload update“ aus.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">No se pudo instalar el manifiesto {0}, versión {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">DIRECTORIO</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Comprobando si hay manifiestos de carga de trabajo actualizados.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Comprobando si hay manifiestos de carga de trabajo actualizados.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -22,10 +22,20 @@
         <target state="translated">No se pueden usar las opciones {0} y {1} juntas. Si se instala desde un archivo de reversión, quite {0}. De lo contrario, quite {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">No se puede especificar una versión de carga de trabajo determinada en la línea de comandos mediante --version o --from-history cuando ya hay una versión especificada en el archivo global.json {0}. Para actualizar la versión de carga de trabajo instalada globalmente, ejecute el comando fuera de la ruta de acceso que contiene ese archivo global.json o actualice la versión especificada en el archivo global.json y ejecute "dotnet workload update".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -162,11 +162,6 @@
         <target state="translated">La plataforma de destino para la que se instala la carga de trabajo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">No existe ningún manifiesto con id. {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">No se encontró el MSI del manifiesto en el paquete NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Impossible d'installer la {0} version de manifeste {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">RÉPERTOIRE</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Recherche de manifestes de charge de travail mis à jour</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Recherche de manifestes de charge de travail mis à jour</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Framework cible pour lequel la charge de travail doit être installée.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Aucun manifeste ayant l’ID {0} existe.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">MSI de manifeste introuvable dans le package NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Impossible d’utiliser les options {0} et {1} ensemble. Si vous installez à partir d’un fichier de restauration, supprimez {0}. Sinon, supprimez {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Impossible de spécifier une version de charge de travail particulière sur la ligne de commande via --version ou --from-history lorsqu’une version est déjà spécifiée dans global.json fichier {0}. Pour mettre à jour la version de la charge de travail installée globalement, exécutez la commande en dehors du chemin contenant ce fichier global.json ou mettez à jour la version spécifiée dans le fichier global.json et exécutez « dotnet workload update »</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Verifica della disponibilità di manifesti del carico di lavoro aggiornati.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Verifica della disponibilità di manifesti del carico di lavoro aggiornati.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Non è stato possibile installare il manifesto {0}, versione {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">DIRECTORY</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Impossibile utilizzare contemporaneamente le opzioni {0} e {1}. Se si esegue l'installazione da un file di rollback, rimuovere {0}. In caso contrario, rimuovere {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Impossibile specificare una determinata versione del carico di lavoro nella riga di comando tramite --version o --from-history quando è già specificata una versione nel file global.json {0}. Per aggiornare la versione del carico di lavoro installata a livello globale, eseguire il comando all'esterno del percorso contenente tale file global.json o aggiornare la versione specificata nel file di global.json ed eseguire "dotnet workload update".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Framework di destinazione per cui installare il carico di lavoro.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Non esiste alcun manifesto con ID {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">L'identità del servizio gestita del manifesto non è stata trovata nel pacchetto NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">マニフェスト {0} のバージョン {1} をインストールできませんでした: {2}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">ディレクトリ</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">更新されたワークロード マニフェストを確認しています。</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">更新されたワークロード マニフェストを確認しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -162,11 +162,6 @@
         <target state="translated">ワークロードをインストールするターゲット フレームワーク。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">ID を持つ {0} マニフェストが存在しません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">NuGet パッケージ {0} にマニフェスト MSI が見つかりません</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -22,10 +22,20 @@
         <target state="translated">{0} オプションと {1} オプションを併用することはできません。ロールバック ファイルからインストールする場合、{0} を削除してください。その他の場合には、{1} を削除します</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">global.json ファイル {0} に既にバージョンが指定されている場合は、コマンド ラインで --version または --from-history を使用して特定のワークロード バージョンを指定することはできません。グローバルにインストールされたワークロード バージョンを更新するには、その global.json ファイルを含むパスの外部でコマンドを実行するか、global.json ファイルで指定されたバージョンを更新して、"dotnet workload update" を実行します。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">매니페스트 {0} 버전 {1}: {2}을 설치하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">디렉터리</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">업데이트된 워크로드 매니페스트를 확인하는 중입니다.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">업데이트된 워크로드 매니페스트를 확인하는 중입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -162,11 +162,6 @@
         <target state="translated">워크로드를 설치할 대상 프레임워크입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">ID가 {0}인 매니페스트가 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">NuGet 패키지 {0}에서 매니페스트 MSI를 찾을 수 없습니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -22,10 +22,20 @@
         <target state="translated">{0} 및 {1} 옵션을 함께 사용할 수 없습니다. 롤백 파일에서 설치하는 경우 {0}을(를) 제거합니다. 그렇지 않으면 {1}을(를) 제거합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">global.json 파일 {0}에 지정된 버전이 이미 있는 경우 --version 또는 --from-history를 통해 명령줄에서 특정 워크로드 버전을 지정할 수 없습니다. 전역으로 설치된 워크로드 버전을 업데이트하려면 해당 global.json 파일이 포함된 경로 외부에서 명령을 실행하거나 global.json 파일에 지정된 버전을 업데이트하고 "dotnet 워크로드 업데이트"를 실행합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Sprawdzanie zaktualizowanych manifestów obciążenia.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Sprawdzanie zaktualizowanych manifestów obciążenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Instalowanie manifestu {0} w wersji {1} nie powiodło się: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">KATALOG</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Docelowa platforma, dla której ma zostać zainstalowane obciążenie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Nie istnieje żaden manifest o identyfikatorze {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">Nie znaleziono pliku MSI manifestu w pakiecie NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Nie można jednocześnie używać poleceń {0} i {1}. W przypadku instalowania z pliku wycofywania usuń polecenie {0}. W przeciwnym razie usuń polecenie {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Nie można określić określonej wersji obciążenia w wierszu polecenia za pomocą opcji --version lub --from-history, jeśli istnieje już wersja określona w pliku global.json {0}. Aby zaktualizować wersję obciążenia zainstalowaną globalnie, uruchom polecenie poza ścieżką zawierającą ten plik global.json lub zaktualizuj wersję określoną w pliku global.json i uruchom polecenie „dotnet workload update”.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Verificando manifestos de carga de trabalho atualizados.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Verificando manifestos de carga de trabalho atualizados.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Falha ao instalar o manifesto {0} versão {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">DIRETÓRIO</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -162,11 +162,6 @@
         <target state="translated">A estrutura de destino para a qual a carga de trabalho será instalada.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Não existe nenhum manifesto com ID {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">MSI do manifesto não encontrado no pacote NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Não é possível usar as opções {0} e {1} juntas. Se estiver instalando a partir de um arquivo de reversão, remova {0}. Caso contrário, remova {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Não é possível especificar uma versão específica da carga de trabalho na linha de comando por meio de --version ou --from-history quando já existe uma versão especificada no arquivo global.json {0}. Para atualizar a versão da carga de trabalho instalada globalmente, execute o comando fora do caminho que contém o arquivo global.json ou atualize a versão especificada no arquivo global.json e execute "dotnet workload update".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Проверка обновленных манифестов рабочей нагрузки.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Проверка обновленных манифестов рабочей нагрузки.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Не удалось установить манифест {0} версии {1}: {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">КАТАЛОГ</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -162,11 +162,6 @@
         <target state="translated">Целевая платформа для установки рабочей нагрузки.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">Манифест с идентификатором {0} не существует.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">MSI манифеста не найден в пакете NuGet {0}</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -22,10 +22,20 @@
         <target state="translated">Невозможно использовать параметры {0} и {1} одновременно. При установке из файла отката удалите {0}, в противном случае удалите {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">Невозможно указать конкретную версию рабочей нагрузки в командной строке с помощью --version или --from-history, если в файле global.json уже указана версия {0}. Чтобы обновить глобально установленную версию рабочей нагрузки, выполните команду вне пути, содержащего этот файл global.json, либо измените версию в файле global.json и выполните команду "dotnet workload update".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">Güncelleştirilmiş iş yükü bildirimleri denetleniyor.</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">Güncelleştirilmiş iş yükü bildirimleri denetleniyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">{0} bildirimi sürüm {1} yüklenemedi:{2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">DİZİN</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -22,10 +22,20 @@
         <target state="translated">{0} ve {1} seçenekleri birlikte kullanılamıyor. Bir geri alma dosyasından yükleniyorsa {0} seçeneğini kaldırın. Aksi takdirde, {1} seçeneğini kaldırın</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">{0} global.json dosyasında zaten belirtilen bir sürüm varsa, “--version” veya “--from-history” aracılığıyla komut satırında belirli bir iş yükü sürümü belirtilemez. Genel olarak yüklenen iş yükü sürümünü güncelleştirmek için, komutu global.json dosyasını içeren yolun dışında çalıştırın veya global.json dosyasında belirtilen sürümü güncelleştirin ve “dotnet workload update” komutunu çalıştırın.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -162,11 +162,6 @@
         <target state="translated">İş yükünün yükleneceği hedef çerçeve.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">{0} kimliğine sahip bildirim yok.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">{0} NuGet paketinde bildirim MSI'sı bulunamadı</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">未能安装清单 {0} 版本 {1}: {2}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">目录</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">正在检查更新的工作负载清单。</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">正在检查更新的工作负载清单。</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -22,10 +22,20 @@
         <target state="translated">不能同时使用 {0} 和 {1} 选项。如果从回滚文件安装，请删除 {0}。否则，请删除 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">当 global.json 文件 {0} 中已指定版本时，无法在命令行上通过 --version 或 --from-history 指定特定工作负载版本。若要更新全局安装的工作负载版本，请在包含该 global.json 文件的路径外部运行命令，或者更新 global.json 文件中指定的版本，然后运行 "dotnet workload update"。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -162,11 +162,6 @@
         <target state="translated">要为其安装工作负载的目标框架。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">不存在 ID 为 {0} 的清单。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">在 NuGet 包 {0} 中找不到清单 MSI</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
-        <source>Checking for updated workload manifests.</source>
-        <target state="translated">正在檢查更新的工作負載資訊清單。</target>
+        <source>Checking for updated workload version.</source>
+        <target state="needs-review-translation">正在檢查更新的工作負載資訊清單。</target>
         <note />
       </trans-unit>
       <trans-unit id="DeletingWorkloadManifest">

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">無法安裝資訊清單 {0} 版本 {1}: {2}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToInstallWorkloadSet">
+        <source>Failed to install workload set version {0}: {1}</source>
+        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">
         <source>DIRECTORY</source>
         <target state="translated">目錄</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -162,11 +162,6 @@
         <target state="translated">要為工作負載安裝的目標 Framework。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestDoesNotExist">
-        <source>No manifest with ID {0} exists.</source>
-        <target state="translated">沒有識別碼為 {0} 的資訊清單。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestMsiNotFoundInNuGetPackage">
         <source>Manifest MSI not found in NuGet package {0}</source>
         <target state="translated">在 NuGet 套件 {0} 中找不到資訊清單 MSI</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -22,10 +22,20 @@
         <target state="translated">無法同時使用 {0} 與 {1} 選項。如果從復原檔案安裝，請移除 {0}。否則，請移除 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineSkipManifestAndVersion">
+        <source>Cannot use the {0} and {1} options together.  Remove one of the options.</source>
+        <target state="new">Cannot use the {0} and {1} options together.  Remove one of the options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotSpecifyVersionOnCommandLineAndInGlobalJson">
         <source>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</source>
         <target state="translated">當 global.json 檔案 {0} 中已指定版本時，無法在命令列上透過 --version 或 --from-history 指定特定工作負載版本。若要更新全域安裝的工作負載版本，請在包含該 global.json 檔案的路徑外執行命令，或更新 global.json 檔案中指定的版本，然後執行 "dotnet workload update"。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
+        <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
+        <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
+        <note>"workloadVersion" is a literal value and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="CannotUseSkipManifestWithGlobalJsonWorkloadVersion">
         <source>Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</source>
         <target state="new">Cannot use the {0} option when workload version is specified in global.json.  Remove the {0} option, or remove the 'workloadVersion' element from {1}.</target>
-        <note>"workloadVersion" is a literal value and should not be translated.</note>
+        <note>"workloadVersion" and "global.json" are literal values and should not be translated.</note>
       </trans-unit>
       <trans-unit id="CheckForUpdatedWorkloadManifests">
         <source>Checking for updated workload version.</source>
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallWorkloadSet">
-        <source>Failed to install workload set version {0}: {1}</source>
-        <target state="new">Failed to install workload set version {0}: {1}</target>
+        <source>Failed to install workload version {0}: {1}</source>
+        <target state="new">Failed to install workload version {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FromCacheOptionArgumentName">

--- a/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
@@ -127,11 +127,12 @@ namespace Microsoft.DotNet.Workloads.Workload
         /// This is to fix a bug where updating the manifests in the CLI will cause VS to also be told to use these newer workloads via the workload resolver.
         /// ...  but these workloads don't have their corresponding packs installed as VS doesn't update its workloads as the CLI does.
         /// </summary>
-        internal static void WriteSDKInstallRecordsForVSWorkloads(IInstaller workloadInstaller, IWorkloadResolver workloadResolver,
+        /// <returns>Updated list of workloads including any that may have had new install records written</returns>
+        internal static IEnumerable<WorkloadId> WriteSDKInstallRecordsForVSWorkloads(IInstaller workloadInstaller, IWorkloadResolver workloadResolver,
             IEnumerable<WorkloadId> workloadsWithExistingInstallRecords, IReporter reporter)
         {
             // Do this check to avoid adding an unused & unnecessary method to FileBasedInstallers
-            if (OperatingSystem.IsWindows() && typeof(NetSdkMsiInstallerClient) == workloadInstaller.GetType())
+            if (OperatingSystem.IsWindows() && workloadInstaller is NetSdkMsiInstallerClient)
             {
                 InstalledWorkloadsCollection vsWorkloads = new();
                 GetInstalledWorkloads(workloadResolver, vsWorkloads);
@@ -146,10 +147,15 @@ namespace Microsoft.DotNet.Workloads.Workload
                         string.Format(LocalizableStrings.WriteCLIRecordForVisualStudioWorkloadMessage,
                         string.Join(", ", workloadsToWriteRecordsFor.Select(w => w.ToString()).ToArray()))
                     );
-                }
 
-                ((NetSdkMsiInstallerClient)workloadInstaller).WriteWorkloadInstallRecords(workloadsToWriteRecordsFor);
+                    ((NetSdkMsiInstallerClient)workloadInstaller).WriteWorkloadInstallRecords(workloadsToWriteRecordsFor);
+
+                    return workloadsWithExistingInstallRecords.Concat(workloadsToWriteRecordsFor).ToList();
+                }
             }
+
+            return workloadsWithExistingInstallRecords;
+
         }
 
         /// <summary>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -150,7 +150,9 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 {
                     if (installedList.Contains(workloadId))
                     {
-                        yield return new UpdateAvailableEntry(manifestUpdate.ExistingVersion.ToString(),
+                        var existingVersion = _workloadListHelper.WorkloadResolver.GetManifestVersion(manifestUpdate.ManifestId.ToString());
+
+                        yield return new UpdateAvailableEntry(existingVersion,
                             manifestUpdate.NewVersion.ToString(),
                             workloadDefinition.Description, workloadId.ToString());
                     }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -156,6 +156,9 @@
   <data name="UpdateFromRollbackSwitchesModeToLooseManifests" xml:space="preserve">
     <value>Updating to a rollback file is not compatible with workload sets. Install and Update will now use loose manifests. To update to a specific workload version, use --version.</value>
   </data>
+  <data name="CannotCombineOptions" xml:space="preserve">
+    <value>Cannot use the {0} and {1} options together.</value>
+  </data>
   <data name="NoWorkloadUpdateFound" xml:space="preserve">
     <value>No workload update found.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -100,7 +100,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
 
                     RunInNewTransaction(context =>
                     {
-                        InstallWorkloads(context, workloadIds, shouldUpdateManifests: true, offlineCache);
+                        UpdateWorkloadManifests(context, offlineCache);
+                        _workloadInstaller.InstallWorkloads(workloadIds, _sdkFeatureBand, context, offlineCache);
                     });
 
                     WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, workloadSetVersion => _workloadResolverFactory.CreateForWorkloadSet(_dotnetPath, _sdkVersion.ToString(), _userProfileDir, workloadSetVersion), offlineCache);

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                   tempDirPath: tempDirPath)
 
         {
-            _workloadSetVersion = parseResult.GetValue(InstallingWorkloadCommandParser.WorkloadSetVersionOption);
+            
             _fromPreviousSdk = parseResult.GetValue(WorkloadUpdateCommandParser.FromPreviousSdkOption);
             _adManifestOnlyOption = parseResult.GetValue(WorkloadUpdateCommandParser.AdManifestOnlyOption);
             _printRollbackDefinitionOnly = parseResult.GetValue(WorkloadUpdateCommandParser.PrintRollbackOption);
@@ -91,23 +91,21 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             }
             else
             {
-                var globaljsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
-                _workloadSetVersionFromGlobalJson = SdkDirectoryWorkloadManifestProvider.GlobalJsonReader.GetWorkloadVersionFromGlobalJson(globaljsonPath);
-
+                Reporter.WriteLine();
                 try
                 {
-                    ErrorIfGlobalJsonAndCommandLineMismatch(globaljsonPath);
                     var workloadIds = WriteSDKInstallRecordsForVSWorkloads(GetUpdatableWorkloads());
 
                     DirectoryPath? offlineCache = string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption);
 
                     RunInNewTransaction(context =>
                     {
-                        UpdateWorkloads(context, workloadIds, offlineCache);
+                        InstallWorkloads(context, workloadIds, shouldUpdateManifests: true, offlineCache);
                     });
 
                     WorkloadInstallCommand.TryRunGarbageCollection(_workloadInstaller, Reporter, Verbosity, workloadSetVersion => _workloadResolverFactory.CreateForWorkloadSet(_dotnetPath, _sdkVersion.ToString(), _userProfileDir, workloadSetVersion), offlineCache);
 
+                    //  TODO: potentially only do this in some cases (ie not if global.json specifies workload set)
                     _workloadManifestUpdater.DeleteUpdatableWorkloadsFile();
 
                     Reporter.WriteLine();

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aktualizujte jenom manifesty reklamy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Aktualizace všech nainstalovaných úloh.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aktualisieren Sie nur Werbemanifeste.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Aktualisieren Sie alle installierten Workloads.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Actualizar solo los manifiestos de publicidad.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Actualice todas las cargas de trabajo instaladas.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Mettre à jour uniquement les manifestes de publicité</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Mettez à jour toutes les charges de travail installées.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aggiornare solo i manifesti pubblicitari.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Aggiornare tutti i carichi di lavoro installati.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">広告マニフェストのみを更新します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">インストールされたすべてのワークロードを更新します。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">광고 매니페스트만 업데이트합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">설치된 모든 워크로드를 업데이트합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aktualizuj tylko manifesty reklam.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Aktualizuj wszystkie zainstalowane obciążenia.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Atualizar somente manifestos de anúncio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Atualizar todas as cargas de trabalho instaladas.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Обновляются только манифесты рекламы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Обновление всех установленных рабочих нагрузок.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Yalnızca reklam bildirimlerini güncelleştirin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">Tüm yüklü iş yüklerini güncelleştirin.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">仅更新广告清单。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">更新所有已安装的工作负载。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">只更新廣告資訊清單。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotCombineOptions">
+        <source>Cannot use the {0} and {1} options together.</source>
+        <target state="new">Cannot use the {0} and {1} options together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Update all installed workloads.</source>
         <target state="translated">更新所有已安裝的工作負載。</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -17,6 +17,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         IEnumerable<WorkloadResolver.WorkloadInfo> GetAvailableWorkloads();
         bool IsPlatformIncompatibleWorkload(WorkloadId workloadId);
         string GetManifestVersion(string manifestId);
+        string GetManifestFeatureBand(string manifestId);
         IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
         string? GetWorkloadVersion();

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
+    //  TODO: Do we need this class, or the existing version information anymore now that workload manifest are side by side?
     public class ManifestVersionUpdate : IEquatable<ManifestVersionUpdate>, IComparable<ManifestVersionUpdate>
     {
         public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? existingVersion, string? existingFeatureBand, ManifestVersion? newVersion, string? newFeatureBand)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/ManifestVersionUpdate.cs
@@ -6,42 +6,21 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     //  TODO: Do we need this class, or the existing version information anymore now that workload manifest are side by side?
     public class ManifestVersionUpdate : IEquatable<ManifestVersionUpdate>, IComparable<ManifestVersionUpdate>
     {
-        public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? existingVersion, string? existingFeatureBand, ManifestVersion? newVersion, string? newFeatureBand)
+        public ManifestVersionUpdate(ManifestId manifestId, ManifestVersion? newVersion, string? newFeatureBand)
         {
             ManifestId = manifestId;
-            ExistingVersion = existingVersion;
-            ExistingFeatureBand = existingFeatureBand;
             NewVersion = newVersion;
             NewFeatureBand = newFeatureBand;
         }
 
         public ManifestId ManifestId { get; }
-        public ManifestVersion? ExistingVersion { get; }
-        public string? ExistingFeatureBand { get; }
         public ManifestVersion? NewVersion { get; }
         public string? NewFeatureBand { get; }
-
-        //  Returns an object representing an undo of this manifest update
-        public ManifestVersionUpdate Reverse()
-        {
-            return new ManifestVersionUpdate(ManifestId, NewVersion, NewFeatureBand, ExistingVersion, ExistingFeatureBand);
-        }
 
         public int CompareTo(ManifestVersionUpdate? other)
         {
             if (other == null) return 1;
             int ret = ManifestId.CompareTo(other.ManifestId);
-            if (ret != 0) return ret;
-            
-            if (ExistingVersion == null && other.ExistingVersion != null) return -1;
-            if (ExistingVersion != null && other.ExistingVersion == null) return 1;
-            if (ExistingVersion != null)
-            {
-                ret = ExistingVersion.CompareTo(other.ExistingVersion);
-                if (ret != 0) return ret;
-            }
-
-            ret = string.Compare(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal);
             if (ret != 0) return ret;
 
             if (NewVersion == null && other.NewVersion != null) return -1;
@@ -59,8 +38,6 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         {
             if (other == null) return false;
             return EqualityComparer<ManifestId>.Default.Equals(ManifestId, other.ManifestId) &&
-                EqualityComparer<ManifestVersion?>.Default.Equals(ExistingVersion, other.ExistingVersion) &&
-                string.Equals(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal) &&
                 EqualityComparer<ManifestVersion?>.Default.Equals(NewVersion, other.NewVersion) &&
                 string.Equals(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
         }
@@ -73,12 +50,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public override int GetHashCode()
         {
 #if NETCOREAPP3_1_OR_GREATER
-            return HashCode.Combine(ManifestId, ExistingVersion, ExistingFeatureBand, NewVersion, NewFeatureBand);
+            return HashCode.Combine(ManifestId, NewVersion, NewFeatureBand);
 #else
             int hashCode = 1601069575;
             hashCode = hashCode * -1521134295 + ManifestId.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(ExistingVersion);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(ExistingFeatureBand);
             hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(NewVersion);
             hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(NewFeatureBand);
             return hashCode;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -479,33 +479,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 {
                     foreach (var workloadSetDirectory in Directory.GetDirectories(workloadSetsRoot))
                     {
-                        WorkloadSet? workloadSet = null;
-                        foreach (var jsonFile in Directory.GetFiles(workloadSetDirectory, "*.workloadset.json"))
-                        {
-                            var newWorkloadSet = WorkloadSet.FromJson(File.ReadAllText(jsonFile), _sdkVersionBand);
-                            if (workloadSet == null)
-                            {
-                                workloadSet = newWorkloadSet;
-                            }
-                            else
-                            {
-                                //  If there are multiple workloadset.json files, merge them
-                                foreach (var kvp in newWorkloadSet.ManifestVersions)
-                                {
-                                    workloadSet.ManifestVersions.Add(kvp.Key, kvp.Value);
-                                }
-                            }
-                        }
-                        if (workloadSet != null)
-                        {
-                            if (File.Exists(Path.Combine(workloadSetDirectory, "baseline.workloadset.json")))
-                            {
-                                workloadSet.IsBaselineWorkloadSet = true;
-                            }
-
-                            workloadSet.Version = Path.GetFileName(workloadSetDirectory);
-                            availableWorkloadSets[workloadSet.Version] = workloadSet;
-                        }
+                        var workloadSetVersion = Path.GetFileName(workloadSetDirectory);
+                        var workloadSet = WorkloadSet.FromWorkloadSetFolder(workloadSetDirectory, workloadSetVersion, _sdkVersionBand);
+                        availableWorkloadSets[workloadSet.Version!] = workloadSet;
                     }
                 }
             }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -501,7 +501,6 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             foreach (var manifestRoot in _manifestRoots.Reverse())
             {
-                //  We don't automatically fall back to a previous band
                 var workloadSetsRoot = Path.Combine(manifestRoot, workloadSetFeatureBand.ToString(), WorkloadSetsFolderName);
                 if (Directory.Exists(workloadSetsRoot))
                 {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -210,4 +210,8 @@
   <data name="InvalidVersionForWorkload" xml:space="preserve">
     <value>Error parsing version '{1}' for workload manifest ID '{0}'</value>
   </data>
+  <data name="ManifestDoesNotExist" xml:space="preserve">
+    <value>No manifest with ID {0} exists.</value>
+  </data>
+
 </root>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -749,9 +749,21 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             InitializeManifests();
             if (_manifests.TryGetValue(manifestId, out var value))
             {
-                return value.manifest.Version;
+                return value.info.Version;
             }
-            throw new Exception($"Manifest with id {manifestId} does not exist.");
+            
+            throw new Exception(string.Format(Strings.ManifestDoesNotExist, manifestId));
+        }
+
+        public string GetManifestFeatureBand(string manifestId)
+        {
+            InitializeManifests();
+            if (_manifests.TryGetValue(manifestId, out var value))
+            {
+                return value.info.ManifestFeatureBand;
+            }
+
+            throw new Exception(string.Format(Strings.ManifestDoesNotExist, manifestId));
         }
             
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests()

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -136,5 +136,43 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             return json;
         }
 
+        //  Corresponding method for opposite direction is in WorkloadManifestUpdater, as its implementation depends on NuGetVersion,
+        //  which we'd like to avoid adding as a dependency here.
+        public static string WorkloadSetVersionToWorkloadSetPackageVersion(string setVersion, out SdkFeatureBand sdkFeatureBand)
+        {
+            string[] sections = setVersion.Split(new char[] { '-', '+' }, 2);
+            string versionCore = sections[0];
+            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
+
+            string[] coreComponents = versionCore.Split('.');
+            string major = coreComponents[0];
+            string minor = coreComponents[1];
+            string patch = coreComponents[2];
+
+            string packageVersion = $"{major}.{patch}.";
+            if (coreComponents.Length == 3)
+            {
+                //  No workload set patch version
+                packageVersion += "0";
+
+                //  Use preview specifier (if any) from workload set version as part of SDK feature band
+                sdkFeatureBand = new SdkFeatureBand(setVersion);
+            }
+            else
+            {
+                //  Workload set version has workload patch version (ie 4 components)
+                packageVersion += coreComponents[3];
+
+                //  Don't include any preview specifiers in SDK feature band
+                sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
+            }
+
+            if (preReleaseOrBuild != null)
+            {
+                packageVersion += '-' + preReleaseOrBuild;
+            }
+
+            return packageVersion;
+        }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -169,7 +169,9 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (preReleaseOrBuild != null)
             {
-                packageVersion += '-' + preReleaseOrBuild;
+                //  Figure out if we split on a '-' or '+'
+                char separator = setVersion[sections[0].Length];
+                packageVersion += separator + preReleaseOrBuild;
             }
 
             return packageVersion;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Závislost manifestu úlohy {0} verze {1} je nižší než verze {2} požadovaná manifestem {3} [{4}].</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Manifest úlohy {0}, který byl určen v {1}, nebyl nalezen. Tento problém může vyřešit spuštění „dotnet workload repair“.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Die Workloadmanifestabhängigkeit „{0}“, Version „{1}“, ist niedriger als die Version „{2}“, die vom Manifest „{3}“ [{4}] benötigt wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Das Arbeitsauslastungsmanifest {0}, das in {1} angegeben wurde, wurde nicht gefunden. Die Ausführung von "dotnet workload repair" kann dies beheben.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">La dependencia del manifiesto de carga de trabajo '{0}' versión '{1}' es inferior a la versión '{2}' requerida por el manifiesto '{3}' [{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">No se ha encontrado el manifiesto de carga de trabajo {0}, que se especificó en {1}. La ejecución de "dotnet workload repair" puede resolverlo.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">La version {0}' de la dépendance du manifeste de charge de travail est inférieure à la version '{1}' requise par {2}le manifeste '{3}' [{4}].</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Le manifeste de charge de travail {0}, spécifié dans {1}, est introuvable. L’exécution "dotnet workload repair" pourrait résoudre ce problème.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">La dipendenza del manifesto del carico di lavoro '{0}' versione '{1}' è inferiore alla versione '{2}' richiesta dal manifesto '{3}' [{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Il manifesto del carico di lavoro {0}, specificato in {1}, non è stato trovato. L'esecuzione della "dotnet workload repair" può risolvere questo errore.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">ワークロード マニフェストの依存関係 '{0}' のバージョン '{1}' は、マニフェスト '{3}' [{4}] で必要とされるバージョン '{2}' 以前のものです</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">{1} で指定されたワークロード マニフェスト {0} が見つかりませんでした。"dotnet workload repair" を実行すると、これを解決できる場合があります。</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">워크로드 매니페스트 종속성 '{0}' 버전 '{1}'이(가) '{3}' [{4}]에 필요한 버전 '{2}'보다 낮습니다</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">{1}에 지정된 워크로드 매니페스트 {0}을(를) 찾을 수 없습니다. "dotnet workload repair"를 실행하면 이 문제를 해결할 수 있습니다.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Zależność manifestu obciążenia „{0}” w wersji „{1}” jest niższa niż w wersji "{2}" wymaganej przez manifest „{3}”[{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Nie znaleziono manifestu obciążenia {0}, który został określony w: {1}. Uruchomienie polecenia "dotnet workload repair" może rozwiązać ten problem.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">A dependência do manifesto de carga de trabalho '{0}' versão '{1}' é inferior à versão '{2}' exigida pelo manifesto '{3}' [{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">O manifesto {0} de carga de trabalho, que foi especificado em {1}, não foi encontrado. Executar "dotnet workload repair" pode resolver isso.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Зависимость манифеста рабочей нагрузки "{0}" версии "{1}" ниже версии "{2}", необходимой для манифеста "{3}" [{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">Не найден манифест рабочей нагрузки {0}, указанный в {1}. Выполнение команды "dotnet workload repair" может устранить эту проблему.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">'{0}' iş yükü bildirimi bağımlılığının '{1}' sürümü, '{3}' [{4}] bildirimi için gereken '{2}' sürümünden düşük</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">{1} içinde belirtilen iş yükü bildirimi {0} bulunamadı. Çalışan "dotnet workload repair" bu sorunu çözebilir.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">工作负荷清单依赖项“{0}”版本“{1}”低于清单“{2}”所需的版本“{3}”[{4}]</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">找不到 {1} 中指定的工作负载清单 {0}。运行 "dotnet workload repair" 可能会解决此问题。</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">工作負載資訊清單相依性 '{0}' 版本 ' {1} ' 低於資訊清單 '{3}' [{4}] 所需的版本 '{2}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestDoesNotExist">
+        <source>No manifest with ID {0} exists.</source>
+        <target state="new">No manifest with ID {0} exists.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManifestFromInstallStateNotFound">
         <source>Workload manifest {0}, which was specified in {1}, was not found. Running "dotnet workload repair" may resolve this.</source>
         <target state="translated">找不到 {1} 中指定的工作負載資訊清單 {0}。執行 "dotnet workload repair" 可能會解決這個問題。</target>

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -468,7 +468,7 @@ namespace ManifestReaderTests
                 }
                 """);
 
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
                 new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "8.0.200", userProfileDir: null, globalJsonPath: null));
         }
 

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMControl.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMControl.cs
@@ -94,7 +94,8 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
         private IEnumerable<CimInstance> GetSnapshotInstances()
         {
-            var snapshots = _session.QueryInstances(virtNamespace, "WQL", $"SELECT * FROM Msvm_VirtualSystemSettingData WHERE VirtualSystemIdentifier='{VMInstance.CimInstanceProperties["Name"].Value}' And IsSaved='True'").ToList();
+            //  Note: Not querying for IsSaved='True' here, as this value was false for snapshots in at least one case
+            var snapshots = _session.QueryInstances(virtNamespace, "WQL", $"SELECT * FROM Msvm_VirtualSystemSettingData WHERE VirtualSystemIdentifier='{VMInstance.CimInstanceProperties["Name"].Value}'").ToList();
 
             return snapshots;
         }

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
     {
         public string DefaultRootState { get; set; }
 
-        public List<SerializableVMStateTree> VMStates { get; set; }
+        public List<SerializableVMStateTree> VMStates { get; set; } = new();
 
         public VMState ToVMState()
         {

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -157,9 +157,15 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             return result.StdOut;
         }
 
-        protected CommandResult InstallWorkload(string workloadName)
+        protected CommandResult InstallWorkload(string workloadName, bool skipManifestUpdate)
         {
-            var result = VM.CreateRunCommand("dotnet", "workload", "install", workloadName, "--skip-manifest-update")
+            string [] args = { "dotnet", "workload", "install", workloadName};
+            if (skipManifestUpdate)
+            {
+                args = [.. args, "--skip-manifest-update"];
+            }
+
+            var result = VM.CreateRunCommand(args)
                     .WithDescription($"Install {workloadName} workload")
                     .Execute();
 

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VirtualMachine.cs
@@ -360,7 +360,9 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             {
                 var targetSharePath = VMPathToSharePath(action.TargetPath);
 
-                CopyDirectory(action.SourcePath, targetSharePath);
+                var result = new RunExeCommand(Log, "robocopy", action.SourcePath, targetSharePath, "/mir")
+                    .Execute()
+                    .ExitCode.Should().BeLessThan(8);   //  Robocopy error exit codes are 8 or higher
 
                 return VMActionResult.Success();
             }
@@ -469,24 +471,6 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             ProcessDirectory(info, path);
 
             return sb.ToString();
-        }
-
-        static void CopyDirectory(string sourcePath, string destPath)
-        {
-            if (!Directory.Exists(destPath))
-            {
-                Directory.CreateDirectory(destPath);
-            }
-
-            foreach (var dir in Directory.GetDirectories(sourcePath))
-            {
-                CopyDirectory(dir, Path.Combine(destPath, Path.GetFileName(dir)));
-            }
-
-            foreach (var file in Directory.GetFiles(sourcePath))
-            {
-                new FileInfo(file).CopyTo(Path.Combine(destPath, Path.GetFileName(file)), true);
-            }
         }
 
         string VMPathToSharePath(string vmPath)

--- a/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             ApplyRC1Manifests();
 
-            InstallWorkload("wasm-tools");
+            InstallWorkload("wasm-tools", skipManifestUpdate: true);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             ApplyRC1Manifests();
 
-            InstallWorkload("android");
+            InstallWorkload("android", skipManifestUpdate: true);
         }
 
         [Fact]
@@ -95,9 +95,9 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             ApplyRC1Manifests();
 
-            InstallWorkload("android");
+            InstallWorkload("android", skipManifestUpdate: true);
 
-            InstallWorkload("wasm-tools");
+            InstallWorkload("wasm-tools", skipManifestUpdate: true);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var originalManifests = GetRollback();
 
-            InstallWorkload("wasm-tools");
+            InstallWorkload("wasm-tools", skipManifestUpdate: true);
 
             ListWorkloads().Should().Contain("wasm-tools");
 
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         public void InstallStateShouldBeRemovedOnSdkUninstall()
         {
             InstallSdk();
-            InstallWorkload("wasm-tools");
+            InstallWorkload("wasm-tools", skipManifestUpdate: true);
             ApplyRC1Manifests();
             var featureBand = new SdkFeatureBand(SdkInstallerVersion);
             var installStatePath = $@"c:\ProgramData\dotnet\workloads\x64\{featureBand}\InstallState\default.json";
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         public void UpdateWithRollback()
         {
             InstallSdk();
-            InstallWorkload("wasm-tools");
+            InstallWorkload("wasm-tools", skipManifestUpdate: true);
             ApplyRC1Manifests();
 
             TestWasmWorkload();
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             ApplyRC1Manifests();
             var workloadVersion = GetWorkloadVersion();
             
-            InstallWorkload("aspire");
+            InstallWorkload("aspire", skipManifestUpdate: false);
 
             GetWorkloadVersion().Should().Be(workloadVersion);
         }
@@ -270,7 +270,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             //VM.CreateRunCommand("powershell", "-Command", "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }")
             //    .Execute().Should().Pass();
 
-            InstallWorkload("aspire");
+            InstallWorkload("aspire", skipManifestUpdate: true);
 
             VM.CreateRunCommand("dotnet", "new", "aspire-starter", "-o", "Aspire-StarterApp01")
                 .WithWorkingDirectory(@"c:\SdkTesting")

--- a/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -259,6 +259,26 @@ namespace Microsoft.DotNet.MsiInstallerTests
             throw new NotImplementedException();
         }
 
+        [Fact]
+        public void TestAspire()
+        {
+            InstallSdk();
+
+            //AddNuGetSource("https://pkgs.dev.azure.com/dnceng/internal/_packaging/8.0.300-rtm.24224.15-shipping/nuget/v3/index.json");
+            //AddNuGetSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-d215c528/nuget/v3/index.json");
+
+            //VM.CreateRunCommand("powershell", "-Command", "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }")
+            //    .Execute().Should().Pass();
+
+            InstallWorkload("aspire");
+
+            VM.CreateRunCommand("dotnet", "new", "aspire-starter", "-o", "Aspire-StarterApp01")
+                .WithWorkingDirectory(@"c:\SdkTesting")
+                .Execute()
+                .Should()
+                .Pass();
+        }
+
 
         void TestWasmWorkload()
         {

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -137,9 +137,16 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(versionToInstall);
 
             //  Installing a workload shouldn't update workload version
-            InstallWorkload("aspire");
+            InstallWorkload("aspire", skipManifestUpdate: false);
 
             GetWorkloadVersion().Should().Be(versionToInstall);
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .Pass();
+
+            GetWorkloadVersion().Should().Be("8.0.300-preview.0.24217.2");
         }
 
         [Fact]
@@ -155,8 +162,8 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .Execute()
                 .Should()
                 .Fail()
-                .And
-                .HaveStdErrContaining(unavailableWorkloadSetVersion);
+                .And.HaveStdErrContaining(unavailableWorkloadSetVersion)
+                .And.NotHaveStdOutContaining("Installation rollback failed");
 
             VM.CreateRunCommand("dotnet", "workload", "search")
                 .WithIsReadOnly(true)

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -189,8 +189,8 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--source", @"c:\SdkTesting\workloadsets")
                 .Execute()
                 .Should()
-                .Fail();
-
+                .Pass()
+                .And.HaveStdOutContaining("No workload update found");
 
             VM.CreateRunCommand("dotnet", "workload", "search")
                 .WithIsReadOnly(true)

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -257,6 +257,22 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             return result.StdOut;
         }
+		
+        [Fact]
+        public void WorkloadSetInstallationRecordIsWrittenCorrectly()
+        {
+            //  Should the workload set version or the package version be used in the registry?
+            throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void TurnOffWorkloadSetUpdateMode()
+        {
+            //  If you have a workload set installed and then turn off workload set update mode, what should happen?
+            //  - Update should update individual manifests
+            //  - Resolver should ignore workload sets that are installed
+            throw new NotImplementedException();
+        }
 
         string GetUpdateMode()
         {

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -262,7 +262,8 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             return result.StdOut;
         }
-		
+
+        [Fact]
         public void UpdateShouldNotPinWorkloadSet()
         {
             InstallSdk();

--- a/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenDotnetWorkloadInstall.cs
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestsToUpdate =
                 new ManifestUpdateWithWorkloads[]
                     {
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), featureBand.ToString(), new ManifestVersion("2.0.0"), featureBand.ToString()), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("2.0.0"), featureBand.ToString()), null),
                     };
             (_, var installManager, var installer, _, _, _) =
                 GetTestInstallers(parseResult, userLocal, sdkVersion, manifestUpdates: manifestsToUpdate, installedFeatureBand: sdkVersion);
@@ -237,7 +237,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestsToUpdate =
                 new ManifestUpdateWithWorkloads[]
                     {
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), featureBand.ToString(), new ManifestVersion("2.0.0"), featureBand.ToString()), null)
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("2.0.0"), featureBand.ToString()), null)
                     };
             var cachePath = Path.Combine(_testAssetsManager.CreateTestDirectory(identifier: AppendForUserLocal("mockCache_", userLocal) + sdkVersion).Path,
                 "mockCachePath");
@@ -598,7 +598,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestsToUpdate =
                 new ManifestUpdateWithWorkloads[]
                     {
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), sdkFeatureBand, new ManifestVersion("2.0.0"), sdkFeatureBand), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("2.0.0"), sdkFeatureBand), null),
                     };
             (_, var installManager, _, _, _, _) =
                 GetTestInstallers(parseResult, true, sdkFeatureBand, manifestUpdates: manifestsToUpdate);

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -324,7 +324,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestId = new ManifestId("test-manifest-1");
             var manifestVersion = new ManifestVersion("5.0.0");
 
-            var manifestUpdate = new ManifestVersionUpdate(manifestId, null, null, manifestVersion, featureBand.ToString());
+            var manifestUpdate = new ManifestVersionUpdate(manifestId, manifestVersion, featureBand.ToString());
 
             CliTransaction.RunNew(context => installer.InstallWorkloadManifest(manifestUpdate, context));
 

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestUpdater = new WorkloadManifestUpdater(_reporter, workloadResolver, nugetDownloader, userProfileDir: Path.Combine(testDir, ".dotnet"), installationRepo, new MockPackWorkloadInstaller(dotnetRoot));
 
             var manifestUpdates = manifestUpdater.CalculateManifestUpdates().Select(m => m.ManifestUpdate);
-            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates);
+            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates.Select(u => u.ToManifestVersionUpdate()));
         }
 
 
@@ -194,7 +194,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestUpdater = new WorkloadManifestUpdater(_reporter, workloadResolver, nugetDownloader, userProfileDir: Path.Combine(testDir, ".dotnet"), installationRepo, new MockPackWorkloadInstaller(dotnetRoot));
 
             var manifestUpdates = manifestUpdater.CalculateManifestUpdates().Select(m => m.ManifestUpdate);
-            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates);
+            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates.Select(u => u.ToManifestVersionUpdate()));
         }
 
         [Theory]
@@ -443,7 +443,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestUpdater = new WorkloadManifestUpdater(_reporter, workloadResolver, nugetDownloader, testDir, installationRepo, new MockPackWorkloadInstaller(dotnetRoot));
 
             var manifestUpdates = manifestUpdater.CalculateManifestRollbacks(rollbackDefPath);
-            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates);
+            manifestUpdates.Should().BeEquivalentTo(expectedManifestUpdates.Select(u => u.ToManifestVersionUpdate()));
         }
 
         [Fact]

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -91,9 +91,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var featureBand = "6.0.100";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new ManifestVersionUpdate[] {
-                new ManifestVersionUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), featureBand, new ManifestVersion("7.0.0"), featureBand),
-                new ManifestVersionUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), featureBand, new ManifestVersion("4.0.0"), featureBand) };
+            var expectedManifestUpdates = new TestManifestUpdate[] {
+                new TestManifestUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), featureBand, new ManifestVersion("7.0.0"), featureBand),
+                new TestManifestUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), featureBand, new ManifestVersion("4.0.0"), featureBand) };
             var expectedManifestNotUpdated = new ManifestId[] { new ManifestId("test-manifest-3"), new ManifestId("test-manifest-4") };
 
             // Write mock manifests
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var adManifestDir = Path.Combine(testDir, ".dotnet", "sdk-advertising", featureBand);
             Directory.CreateDirectory(installedManifestDir);
             Directory.CreateDirectory(adManifestDir);
-            foreach (ManifestVersionUpdate manifestUpdate in expectedManifestUpdates)
+            foreach (var manifestUpdate in expectedManifestUpdates)
             {
                 Directory.CreateDirectory(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString()));
                 File.WriteAllText(Path.Combine(installedManifestDir, manifestUpdate.ManifestId.ToString(), _manifestFileName), GetManifestContent(manifestUpdate.ExistingVersion));
@@ -137,16 +137,16 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var currentFeatureBand = "6.0.300";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new ManifestVersionUpdate[] {
-                new ManifestVersionUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), "6.0.100", new ManifestVersion("7.0.0"), "6.0.100"),
-                new ManifestVersionUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), "6.0.100", new ManifestVersion("4.0.0"), "6.0.300"),
-                new ManifestVersionUpdate(new ManifestId("test-manifest-3"), new ManifestVersion("3.0.0"), "6.0.300", new ManifestVersion("4.0.0"), "6.0.300")};
+            var expectedManifestUpdates = new TestManifestUpdate[] {
+                new TestManifestUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), "6.0.100", new ManifestVersion("7.0.0"), "6.0.100"),
+                new TestManifestUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), "6.0.100", new ManifestVersion("4.0.0"), "6.0.300"),
+                new TestManifestUpdate(new ManifestId("test-manifest-3"), new ManifestVersion("3.0.0"), "6.0.300", new ManifestVersion("4.0.0"), "6.0.300")};
             var expectedManifestNotUpdated = new ManifestId[] { new ManifestId("test-manifest-4") };
 
             // Write mock manifests
             var adManifestDir = Path.Combine(testDir, ".dotnet", "sdk-advertising", currentFeatureBand);
             Directory.CreateDirectory(adManifestDir);
-            foreach (ManifestVersionUpdate manifestUpdate in expectedManifestUpdates)
+            foreach (var manifestUpdate in expectedManifestUpdates)
             {
                 var installedManifestDir = Path.Combine(testDir, "dotnet", "sdk-manifests", manifestUpdate.ExistingFeatureBand);
                 if (!Directory.Exists(installedManifestDir))
@@ -414,9 +414,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testDir = _testAssetsManager.CreateTestDirectory().Path;
             var currentFeatureBand = "6.0.100";
             var dotnetRoot = Path.Combine(testDir, "dotnet");
-            var expectedManifestUpdates = new ManifestVersionUpdate[] {
-                new ManifestVersionUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), currentFeatureBand, new ManifestVersion("4.0.0"), currentFeatureBand),
-                new ManifestVersionUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), currentFeatureBand, new ManifestVersion("2.0.0"), currentFeatureBand) };
+            var expectedManifestUpdates = new TestManifestUpdate[] {
+                new TestManifestUpdate(new ManifestId("test-manifest-1"), new ManifestVersion("5.0.0"), currentFeatureBand, new ManifestVersion("4.0.0"), currentFeatureBand),
+                new TestManifestUpdate(new ManifestId("test-manifest-2"), new ManifestVersion("3.0.0"), currentFeatureBand, new ManifestVersion("2.0.0"), currentFeatureBand) };
 
             // Write mock manifests
             var installedManifestDir = Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand);

--- a/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -181,9 +181,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             }
 
             var manifestInfo = expectedManifestUpdates.Select(
-                    manifest => (manifest.ManifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", manifest.ExistingFeatureBand, manifest.ManifestId.ToString(), "WorkloadManifest.json"), manifest.ExistingFeatureBand))
+                    manifest => (manifest.ManifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", manifest.ExistingFeatureBand, manifest.ManifestId.ToString(), "WorkloadManifest.json"), manifest.ExistingVersion.ToString(), manifest.ExistingFeatureBand))
                 .Concat(expectedManifestNotUpdated.Select(
-                    manifestId => (manifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand, manifestId.ToString(), "WorkloadManifest.json"), currentFeatureBand)))
+                    manifestId => (manifestId.ToString(), Path.Combine(testDir, "dotnet", "sdk-manifests", currentFeatureBand, manifestId.ToString(), "WorkloadManifest.json"), "2.0.0", currentFeatureBand)))
                 .ToArray();
 
             var workloadManifestProvider = new MockManifestProvider(manifestInfo);
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
             string manifestPath = Path.Combine(installedManifestDir6_0_200, testManifestName, _manifestFileName);
 
-            var workloadManifestProvider = new MockManifestProvider((testManifestName, manifestPath, "6.0.200"))
+            var workloadManifestProvider = new MockManifestProvider((testManifestName, manifestPath, "1.0.0", "6.0.200"))
             {
                 SdkFeatureBand = new SdkFeatureBand(sdkFeatureBand)
             };
@@ -302,7 +302,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             Directory.CreateDirectory(Path.Combine(emptyInstalledManifestsDir, testManifestName));
             File.WriteAllText(Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName), GetManifestContent(new ManifestVersion("1.0.0")));
 
-            var workloadManifestProvider = new MockManifestProvider((testManifestName, Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName), "6.0.200")) 
+            var workloadManifestProvider = new MockManifestProvider((testManifestName, Path.Combine(emptyInstalledManifestsDir, testManifestName, _manifestFileName), "1.0.0", "6.0.200")) 
             {
                 SdkFeatureBand = new SdkFeatureBand(sdkFeatureBand)
             };        

--- a/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -7,19 +7,19 @@ namespace ManifestReaderTests
 {
     internal class MockManifestProvider : IWorkloadManifestProvider
     {
-        readonly (string name, string path, string featureBand)[] _manifests;
+        readonly (string name, string path, string manifestVersion, string featureBand)[] _manifests;
 
         public MockManifestProvider(params string[] manifestPaths)
         {
             _manifests = Array.ConvertAll(manifestPaths, mp =>
             {
                 string manifestId = Path.GetFileNameWithoutExtension(Path.GetDirectoryName(mp));
-                return (manifestId, mp, (string)null);
+                return (manifestId, mp, (string)null, (string)null);
             });
             SdkFeatureBand = new SdkFeatureBand("6.0.100");
         }
 
-        public MockManifestProvider(params (string name, string path, string featureBand)[] manifests)
+        public MockManifestProvider(params (string name, string path, string manifestVersion, string featureBand)[] manifests)
         {
             _manifests = manifests;
             SdkFeatureBand = new SdkFeatureBand("6.0.100");
@@ -33,14 +33,14 @@ namespace ManifestReaderTests
 
         public IEnumerable<ReadableWorkloadManifest> GetManifests()
             {
-                foreach ((var id, var path, var featureBand) in _manifests)
+                foreach ((var id, var path, var manifestVersion, var featureBand) in _manifests)
                 {
                     yield return new(
                         id,
                         Path.GetDirectoryName(path),
                         path,
                         featureBand ?? SdkFeatureBand.ToString(),
-                        string.Empty,
+                        manifestVersion,
                         () => File.OpenRead(path),
                         () => WorkloadManifestReader.TryOpenLocalizationCatalogForManifest(path)
                     );

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             return InstallationRecordRepository;
         }
 
-        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null, bool isRollback = false)
+        public void InstallWorkloadManifest(ManifestVersionUpdate manifestUpdate, ITransactionContext transactionContext, DirectoryPath? offlineCache = null)
         {
             InstalledManifests.Add((manifestUpdate, offlineCache));
         }

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             new List<(ManifestVersionUpdate manifestUpdate, DirectoryPath?)>();
         public string CachePath;
         public bool GarbageCollectionCalled = false;
+        public bool InstallWorkloadSetCalled = false;
         public MockInstallationRecordRepository InstallationRecordRepository;
         public bool FailingRollback;
         public bool FailingGarbageCollection;
@@ -105,12 +106,12 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             });
         }
 
-        public string InstallWorkloadSet(ITransactionContext context, string advertisingPackagePath)
+        public WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null)
         {
-            var version = Path.GetFileName(Path.GetDirectoryName(advertisingPackagePath ?? string.Empty));
-            Directory.CreateDirectory(advertisingPackagePath);
-            File.WriteAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName), version);
-            return Path.GetDirectoryName(advertisingPackagePath ?? string.Empty);
+            InstallWorkloadSetCalled = true;
+            var workloadSet = WorkloadSet.FromJson(workloadSetContents, new SdkFeatureBand("6.0.100"));
+            workloadSet.Version = workloadSetVersion;
+            return workloadSet;
         }
 
         public void RepairWorkloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, DirectoryPath? offlineCache = null) => throw new NotImplementedException();

--- a/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockPackWorkloadInstaller.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             }
         }
 
-        public void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool newMode)
+        public void UpdateInstallMode(SdkFeatureBand sdkFeatureBand, bool? newMode)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
+++ b/src/Tests/dotnet-workload-install.Tests/MockWorkloadManifestUpdater.cs
@@ -14,11 +14,13 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public int GetManifestPackageDownloadsCallCount = 0;
         private readonly IEnumerable<ManifestUpdateWithWorkloads> _manifestUpdates;
         private bool _fromWorkloadSet;
+        private string _workloadSetVersion;
 
-        public MockWorkloadManifestUpdater(IEnumerable<ManifestUpdateWithWorkloads> manifestUpdates = null, bool fromWorkloadSet = false)
+        public MockWorkloadManifestUpdater(IEnumerable<ManifestUpdateWithWorkloads> manifestUpdates = null, bool fromWorkloadSet = false, string workloadSetVersion = null)
         {
             _manifestUpdates = manifestUpdates ?? new List<ManifestUpdateWithWorkloads>();
             _fromWorkloadSet = fromWorkloadSet;
+            _workloadSetVersion = workloadSetVersion;
         }
 
         public Task UpdateAdvertisingManifestsAsync(bool includePreview, bool useWorkloadSets = false, DirectoryPath? cachePath = null)
@@ -56,7 +58,9 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         public void DeleteUpdatableWorkloadsFile() { }
 
-        public void DownloadWorkloadSet(string version, DirectoryPath? offlineCache) => throw new NotImplementedException();
-        public IEnumerable<ManifestVersionUpdate> ParseRollbackDefinitionFiles(IEnumerable<string> files) => _manifestUpdates.Select(t => t.ManifestUpdate);
+        public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet) => _manifestUpdates.Select(t => t.ManifestUpdate);
+
+        public string GetAdvertisedWorkloadSetVersion() => _workloadSetVersion;
+        
     }
 }

--- a/src/Tests/dotnet-workload-install.Tests/TestManifestUpdate.cs
+++ b/src/Tests/dotnet-workload-install.Tests/TestManifestUpdate.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using FluentAssertions.Extensions;
+using ManifestReaderTests;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.DotNet.Workloads.Workload.Install;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Workload.Install.Tests
+{
+    public class TestManifestUpdate
+    {
+        public TestManifestUpdate(ManifestId manifestId, ManifestVersion existingVersion, string existingFeatureBand, ManifestVersion newVersion, string newFeatureBand)
+        {
+            ManifestId = manifestId;
+            ExistingVersion = existingVersion;
+            ExistingFeatureBand = existingFeatureBand;
+            NewVersion = newVersion;
+            NewFeatureBand = newFeatureBand;
+        }
+
+        public ManifestId ManifestId { get; }
+        public ManifestVersion ExistingVersion { get; }
+        public string ExistingFeatureBand { get; }
+        public ManifestVersion NewVersion { get; }
+        public string NewFeatureBand { get; }
+
+        //  Returns an object representing an undo of this manifest update
+        //public TestManifestUpdate Reverse()
+        //{
+        //    return new TestManifestUpdate(ManifestId, NewVersion, NewFeatureBand, ExistingVersion, ExistingFeatureBand);
+        //}
+
+        public int CompareTo(TestManifestUpdate other)
+        {
+            if (other == null) return 1;
+            int ret = ManifestId.CompareTo(other.ManifestId);
+            if (ret != 0) return ret;
+
+            if (ExistingVersion == null && other.ExistingVersion != null) return -1;
+            if (ExistingVersion != null && other.ExistingVersion == null) return 1;
+            if (ExistingVersion != null)
+            {
+                ret = ExistingVersion.CompareTo(other.ExistingVersion);
+                if (ret != 0) return ret;
+            }
+
+            ret = string.Compare(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal);
+            if (ret != 0) return ret;
+
+            if (NewVersion == null && other.NewVersion != null) return -1;
+            if (NewVersion != null && other.NewVersion == null) return 1;
+            if (NewVersion != null)
+            {
+                ret = NewVersion.CompareTo(other.NewVersion);
+                if (ret != 0) return ret;
+            }
+
+            ret = string.Compare(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
+            return ret;
+        }
+        public bool Equals(TestManifestUpdate other)
+        {
+            if (other == null) return false;
+            return EqualityComparer<ManifestId>.Default.Equals(ManifestId, other.ManifestId) &&
+                EqualityComparer<ManifestVersion>.Default.Equals(ExistingVersion, other.ExistingVersion) &&
+                string.Equals(ExistingFeatureBand, other.ExistingFeatureBand, StringComparison.Ordinal) &&
+                EqualityComparer<ManifestVersion>.Default.Equals(NewVersion, other.NewVersion) &&
+                string.Equals(NewFeatureBand, other.NewFeatureBand, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is TestManifestUpdate id && Equals(id);
+        }
+
+        public override int GetHashCode()
+        {
+#if NETCOREAPP3_1_OR_GREATER
+            return HashCode.Combine(ManifestId, ExistingVersion, ExistingFeatureBand, NewVersion, NewFeatureBand);
+#else
+            int hashCode = 1601069575;
+            hashCode = hashCode * -1521134295 + ManifestId.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(ExistingVersion);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(ExistingFeatureBand);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ManifestVersion?>.Default.GetHashCode(NewVersion);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(NewFeatureBand);
+            return hashCode;
+#endif
+        }
+
+        public ManifestVersionUpdate ToManifestVersionUpdate()
+        {
+            return new(ManifestId, NewVersion, NewFeatureBand);
+        }
+
+    }
+}

--- a/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Workload.List.Tests
             _reporter.Clear();
             var expectedWorkloads = new List<WorkloadId>() { new WorkloadId("mock-workload-1"), new WorkloadId("mock-workload-2"), new WorkloadId("mock-workload-3") };
             var workloadInstaller = new MockWorkloadRecordRepo(expectedWorkloads);
-            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(("SampleManifest", _manifestPath, "6.0.100")), Directory.GetCurrentDirectory());
+            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(("SampleManifest", _manifestPath, "5.0.0", "6.0.100")), Directory.GetCurrentDirectory());
             var command = new WorkloadListCommand(_parseResult, _reporter, workloadInstaller, "6.0.100", workloadResolver: workloadResolver);
             command.Execute();
 

--- a/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Runtime.CompilerServices;
+using ManifestReaderTests;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Workload.Install.Tests;
@@ -23,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         private WorkloadListCommand _workloadListCommand;
         private string _testDirectory;
 
-        private List<ManifestUpdateWithWorkloads> _mockManifestUpdates;
+        private List<(TestManifestUpdate update, WorkloadCollection workloads)> _mockManifestUpdates;
 
         private MockNuGetPackageDownloader _nugetDownloader;
         private string _dotnetRoot;
@@ -32,7 +34,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         {
         }
 
-        private void Setup(string identifier)
+        private IEnumerable<ManifestUpdateWithWorkloads> GetManifestUpdatesForMock()
+        {
+            return _mockManifestUpdates.Select(u => new ManifestUpdateWithWorkloads(u.update.ToManifestVersionUpdate(), u.workloads));
+        }
+
+        private void Setup([CallerMemberName] string identifier = "")
         {
             _testDirectory = _testAssetsManager.CreateTestDirectory(identifier: identifier).Path;
             _dotnetRoot = Path.Combine(_testDirectory, "dotnet");
@@ -42,8 +49,10 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             _mockManifestUpdates = new()
             {
                 new(
-                    new ManifestVersionUpdate(
+                    new TestManifestUpdate(
                         new ManifestId("manifest1"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion(UpdateAvailableVersion),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection
@@ -56,8 +65,10 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                             WorkloadDefinitionKind.Dev, null, null, null)
                     }),
                 new(
-                    new ManifestVersionUpdate(
+                    new TestManifestUpdate(
                         new ManifestId("manifest-other"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion("7.0.101"),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection
@@ -68,8 +79,10 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                             WorkloadDefinitionKind.Dev, null, null, null)
                     }),
                 new(
-                    new ManifestVersionUpdate(
+                    new TestManifestUpdate(
                         new ManifestId("manifest-older-version"),
+                        new ManifestVersion(CurrentSdkVersion),
+                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion("6.0.100"),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection
@@ -86,21 +99,31 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 "dotnet", "workload", "list", "--machine-readable", InstallingWorkloadCommandParser.VersionOption.Name, "7.0.100"
             });
 
+
+            var manifestProvider = new MockManifestProvider(_mockManifestUpdates.Select(u =>
+            {
+                string manifestFile = Path.Combine(_testDirectory, u.update.ManifestId.ToString() + ".json");
+                File.WriteAllText(manifestFile, GivenWorkloadManifestUpdater.GetManifestContent(u.update.ExistingVersion));
+                return (u.update.ManifestId.ToString(), manifestFile, u.update.ExistingVersion.ToString(), u.update.ExistingFeatureBand.ToString());
+            }).ToArray());
+            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, _dotnetRoot);
+
             _workloadListCommand = new WorkloadListCommand(
                 listParseResult,
                 _reporter,
                 nugetPackageDownloader: _nugetDownloader,
-                workloadManifestUpdater: new MockWorkloadManifestUpdater(_mockManifestUpdates),
+                workloadManifestUpdater: new MockWorkloadManifestUpdater(GetManifestUpdatesForMock()),
                 userProfileDir: _testDirectory,
                 currentSdkVersion: CurrentSdkVersion,
                 dotnetDir: _dotnetRoot,
-                workloadRecordRepo: new MockMatchingFeatureBandInstallationRecordRepository());
+                workloadRecordRepo: new MockMatchingFeatureBandInstallationRecordRepository(),
+                workloadResolver: workloadResolver);
         }
 
         [Fact]
         public void ItShouldGetAvailableUpdate()
         {
-            Setup(nameof(ItShouldGetAvailableUpdate));
+            Setup();
             WorkloadListCommand.UpdateAvailableEntry[] result =
                 _workloadListCommand.GetUpdateAvailable(new List<WorkloadId> { new("xamarin-android") }).ToArray();
 
@@ -114,7 +137,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         [Fact]
         public void ItShouldGetListOfWorkloadWithCurrentSdkVersionBand()
         {
-            Setup(nameof(ItShouldGetListOfWorkloadWithCurrentSdkVersionBand));
+            Setup();
             _workloadListCommand.Execute();
             _reporter.Lines.Should().Contain(c => c.Contains("\"installed\":[\"xamarin-android\"]"));
         }
@@ -129,7 +152,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 }),
                 _reporter,
                 nugetPackageDownloader: _nugetDownloader,
-                workloadManifestUpdater: new MockWorkloadManifestUpdater(_mockManifestUpdates),
+                workloadManifestUpdater: new MockWorkloadManifestUpdater(null),
                 userProfileDir: _testDirectory,
                 currentSdkVersion: CurrentSdkVersion,
                 dotnetDir: _dotnetRoot,
@@ -149,7 +172,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 }),
                 _reporter,
                 nugetPackageDownloader: _nugetDownloader,
-                workloadManifestUpdater: new MockWorkloadManifestUpdater(_mockManifestUpdates),
+                workloadManifestUpdater: new MockWorkloadManifestUpdater(null),
                 userProfileDir: _testDirectory,
                 currentSdkVersion: "6.0.101",
                 dotnetDir: _dotnetRoot,

--- a/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
+++ b/src/Tests/dotnet-workload-list.Tests/GivenWorkloadInstallerAndWorkloadsInstalled.cs
@@ -44,8 +44,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 new(
                     new ManifestVersionUpdate(
                         new ManifestId("manifest1"),
-                        new ManifestVersion(CurrentSdkVersion),
-                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion(UpdateAvailableVersion),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection
@@ -60,8 +58,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 new(
                     new ManifestVersionUpdate(
                         new ManifestId("manifest-other"),
-                        new ManifestVersion(CurrentSdkVersion),
-                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion("7.0.101"),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection
@@ -74,8 +70,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 new(
                     new ManifestVersionUpdate(
                         new ManifestId("manifest-older-version"),
-                        new ManifestVersion(CurrentSdkVersion),
-                        currentSdkFeatureBand.ToString(),
                         new ManifestVersion("6.0.100"),
                         currentSdkFeatureBand.ToString()),
                     new WorkloadCollection

--- a/src/Tests/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/src/Tests/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public WorkloadResolver.PackInfo TryGetPackInfo(WorkloadPackId packId) => throw new NotImplementedException();
         public bool IsPlatformIncompatibleWorkload(WorkloadId workloadId) => throw new NotImplementedException();
         public string GetManifestVersion(string manifestId) => throw new NotImplementedException();
+        public string GetManifestFeatureBand(string manifestId) => throw new NotImplementedException();
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -219,7 +219,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var oldVersion = upgrade ? "2.3.2" : "2.3.6";
             var workloadManifestUpdater = new MockWorkloadManifestUpdater(
                 manifestUpdates: new ManifestUpdateWithWorkloads[] {
-                    new ManifestUpdateWithWorkloads(new ManifestVersionUpdate(new ManifestId("android"), new ManifestVersion(oldVersion), "8.0.200", new ManifestVersion("2.3.4"), "8.0.200"), Enumerable.Empty<KeyValuePair<WorkloadId, WorkloadDefinition>>().ToDictionary())
+                    new ManifestUpdateWithWorkloads(new ManifestVersionUpdate(new ManifestId("android"), new ManifestVersion("2.3.4"), "8.0.200"), Enumerable.Empty<KeyValuePair<WorkloadId, WorkloadDefinition>>().ToDictionary())
                 },
                 fromWorkloadSet: true, workloadSetVersion: workloadSetVersion);
             var resolverFactory = new MockWorkloadResolverFactory(dotnetDir, sdkVersion, workloadResolver, userProfileDir);
@@ -375,7 +375,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var manifestsToUpdate =
                 new ManifestUpdateWithWorkloads[]
                     {
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("1.0.0"), existingSdkFeatureBand, new ManifestVersion("2.0.0"), newSdkFeatureBand), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest"), new ManifestVersion("2.0.0"), newSdkFeatureBand), null),
                     };
             (var dotnetPath, var updateCommand, var packInstaller, _, _, _) = GetTestInstallers(parseResult, manifestUpdates: manifestsToUpdate, sdkVersion: "6.0.300", identifier: existingSdkFeatureBand + newSdkFeatureBand, installedFeatureBand: existingSdkFeatureBand);
 
@@ -385,8 +385,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             packInstaller.InstalledManifests[0].manifestUpdate.ManifestId.Should().Be(manifestsToUpdate[0].ManifestUpdate.ManifestId);
             packInstaller.InstalledManifests[0].manifestUpdate.NewVersion.Should().Be(manifestsToUpdate[0].ManifestUpdate.NewVersion);
             packInstaller.InstalledManifests[0].manifestUpdate.NewFeatureBand.Should().Be(manifestsToUpdate[0].ManifestUpdate.NewFeatureBand);
-            packInstaller.InstalledManifests[0].manifestUpdate.ExistingVersion.Should().Be(manifestsToUpdate[0].ManifestUpdate.ExistingVersion);
-            packInstaller.InstalledManifests[0].manifestUpdate.ExistingFeatureBand.Should().Be(manifestsToUpdate[0].ManifestUpdate.ExistingFeatureBand);
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
 
             var defaultJsonPath = Path.Combine(dotnetPath, "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), "6.0.300", "InstallState", "default.json");
@@ -404,9 +402,9 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var manifestsToUpdate =
                 new ManifestUpdateWithWorkloads[]
                     {
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-1"), new ManifestVersion("1.0.0"), "6.0.300", new ManifestVersion("2.0.0"), "6.0.100"), null),
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-2"), new ManifestVersion("1.0.0"), "6.0.100", new ManifestVersion("2.0.0"), "6.0.300"), null),
-                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-3"), new ManifestVersion("1.0.0"), "5.0.100", new ManifestVersion("2.0.0"), "6.0.100"), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-1"), new ManifestVersion("2.0.0"), "6.0.100"), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-2"), new ManifestVersion("2.0.0"), "6.0.300"), null),
+                        new(new ManifestVersionUpdate(new ManifestId("mock-manifest-3"), new ManifestVersion("2.0.0"), "6.0.100"), null),
                     };
             (_, var updateCommand, var packInstaller, _, _, _) = GetTestInstallers(parseResult, manifestUpdates: manifestsToUpdate, sdkVersion: "6.0.300", installedFeatureBand: "6.0.300");
 
@@ -418,9 +416,6 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             packInstaller.InstalledManifests[0].manifestUpdate.NewFeatureBand.Should().Be("6.0.100");
             packInstaller.InstalledManifests[1].manifestUpdate.NewFeatureBand.Should().Be("6.0.300");
             packInstaller.InstalledManifests[2].manifestUpdate.NewFeatureBand.Should().Be("6.0.100");
-            packInstaller.InstalledManifests[0].manifestUpdate.ExistingFeatureBand.Should().Be("6.0.300");
-            packInstaller.InstalledManifests[1].manifestUpdate.ExistingFeatureBand.Should().Be("6.0.100");
-            packInstaller.InstalledManifests[2].manifestUpdate.ExistingFeatureBand.Should().Be("5.0.100");
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
         }
 


### PR DESCRIPTION
- Fix file not found error updating in workload set mode if no workload sets for feature band were found
- Add workload set installation records when installing workload sets in file based installer
- Refactor workload set install / update logic to pass around workload set version instead of using a file in the advertising manifest path to pass the version
- Refactor workload update and install commands to share update logic
- Refactor workload set installation logic in file based installer to share logic with workload manifest installation
- Update logic mapping from workload set version to feature band, to resolve ambiguity that previously existed.  Now the preview part of the workload set version will be used for the feature band if the workload set version doesn't have a fourth version number part.
- Unify logic to read workload set json files into `WorkloadSet.FromWorkloadSetFolder`