### PR TITLE
Disable CA2022 errors

### DIFF
--- a/src/RazorSdk/Tool/Client.cs
+++ b/src/RazorSdk/Tool/Client.cs
@@ -169,7 +169,9 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
+#pragma warning disable CA2022 // Avoid inexact read
                         await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
+#pragma warning restore CA2022
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }
                     catch (OperationCanceledException)

--- a/src/RazorSdk/Tool/ConnectionHost.cs
+++ b/src/RazorSdk/Tool/ConnectionHost.cs
@@ -107,7 +107,9 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
+#pragma warning disable CA2022 // Avoid inexact read
                         await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
+#pragma warning restore CA2022
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }
                     catch (OperationCanceledException)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/39893

Backport of a patch from: https://github.com/dotnet/installer/pull/19145