### PR TITLE
Add nuget-team as CODEOWNER for dotnet-list-package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,8 @@
 /test/dotnet-add-package.Tests @dotnet/nuget-team
 /src/Cli/dotnet/commands/dotnet-nuget @dotnet/nuget-team
 /test/dotnet-nuget.UnitTests @dotnet/nuget-team
+/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package @dotnet/nuget-team
+/test/dotnet-list-package.Tests @dotnet/nuget-team
 
 # Area-FSharp
 /src/Cli/dotnet/commands/dotnet-fsi @dotnet/fsharp


### PR DESCRIPTION
A new NuGet command was added to dotnet, so we'd like to list NuGet team as the code owner for the source and tests.