### PR TITLE
Revert "[release/7.0.4xx] Update dependencies from dotnet/templating"

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,7 +13,7 @@
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-templating -->
-    <add key="darc-pub-dotnet-templating-580301b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-templating-580301bf/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-templating-afb365f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-templating-afb365fb/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-templating -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
     <!--  End: Package sources from dotnet-windowsdesktop -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.409">
+    <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="7.0.408">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>580301bf0a6cadc49c2271c1d44a6be9ad686f8c</Sha>
+      <Sha>afb365fbd7c08fa9fcdb2899725adb3cca6c387d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Mocks" Version="7.0.409-servicing.24203.5">
+    <Dependency Name="Microsoft.TemplateEngine.Mocks" Version="7.0.408-servicing.true.24164.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>580301bf0a6cadc49c2271c1d44a6be9ad686f8c</Sha>
+      <Sha>afb365fbd7c08fa9fcdb2899725adb3cca6c387d</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.17">
@@ -313,9 +313,9 @@
       <Sha>740189d758fb3bbdc118c5b6171ef1a7351a8c44</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.TestHelper" Version="7.0.409-servicing.24203.5">
+    <Dependency Name="Microsoft.TemplateEngine.TestHelper" Version="7.0.408-servicing.true.24164.3">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>580301bf0a6cadc49c2271c1d44a6be9ad686f8c</Sha>
+      <Sha>afb365fbd7c08fa9fcdb2899725adb3cca6c387d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,14 +128,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.409</MicrosoftTemplateEngineAbstractionsPackageVersion>
+    <MicrosoftTemplateEngineAbstractionsPackageVersion>7.0.408</MicrosoftTemplateEngineAbstractionsPackageVersion>
     <MicrosoftTemplateEngineEdgePackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineEdgePackageVersion>
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>
     <MicrosoftTemplateSearchCommonPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateSearchCommonPackageVersion>
     <!-- test dependencies -->
-    <MicrosoftTemplateEngineMocksPackageVersion>7.0.409-servicing.24203.5</MicrosoftTemplateEngineMocksPackageVersion>
-    <MicrosoftTemplateEngineTestHelperPackageVersion>7.0.409-servicing.24203.5</MicrosoftTemplateEngineTestHelperPackageVersion>
+    <MicrosoftTemplateEngineMocksPackageVersion>7.0.408-servicing.true.24164.3</MicrosoftTemplateEngineMocksPackageVersion>
+    <MicrosoftTemplateEngineTestHelperPackageVersion>7.0.408-servicing.true.24164.3</MicrosoftTemplateEngineTestHelperPackageVersion>
     <MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/sdk#39705

## Summary
I believe this change caused [this issue](https://github.com/dotnet/sdk/issues/40073) and want to see if this build passes with this... revert-ion? That's not a word. Whatever.