### PR TITLE
Request silent restore for all separate restore steps

### DIFF
--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -61,11 +61,8 @@ namespace Microsoft.DotNet.Tools
             }
 
             IEnumerable<string> restoreArguments = ["-target:Restore"];
-            if (arguments != null)
-            {
-                (var newArgumentsToAdd, var existingArgumentsToForward) = ProcessForwardedArgumentsForSeparateRestore(arguments);
-                restoreArguments = [.. restoreArguments, .. newArgumentsToAdd, .. existingArgumentsToForward];
-            }
+            (var newArgumentsToAdd, var existingArgumentsToForward) = ProcessForwardedArgumentsForSeparateRestore(arguments);
+            restoreArguments = [.. restoreArguments, .. newArgumentsToAdd, .. existingArgumentsToForward];
 
             return new RestoreCommand(restoreArguments, msbuildPath);
         }
@@ -121,7 +118,7 @@ namespace Microsoft.DotNet.Tools
             HashSet<string> newArgumentsToAdd = new() { "-tlp:verbosity=quiet" };
             List<string> existingArgumentsToForward = new();
 
-            foreach (var argument in forwardedArguments)
+            foreach (var argument in forwardedArguments ?? Enumerable.Empty<string>)
             {
                 if (!IsExcludedFromSeparateRestore(argument) && !IsExcludedFromRestore(argument))
                 {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools
             HashSet<string> newArgumentsToAdd = new() { "-tlp:verbosity=quiet" };
             List<string> existingArgumentsToForward = new();
 
-            foreach (var argument in forwardedArguments ?? Enumerable.Empty<string>)
+            foreach (var argument in forwardedArguments ?? Enumerable.Empty<string>())
             {
                 if (!IsExcludedFromSeparateRestore(argument) && !IsExcludedFromRestore(argument))
                 {

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools
         private static (string[] newArgumentsToAdd, string[] existingArgumentsToForward) ProcessForwardedArgumentsForSeparateRestore(IEnumerable<string> forwardedArguments)
         {
             // Separate restore should be silent in terminal logger - regardless of actual scenario
-            HashSet<string> newArgumentsToAdd = new() { "-nologo", "-tlp:verbosity=quiet" };
+            HashSet<string> newArgumentsToAdd = new() { "-tlp:verbosity=quiet" };
             List<string> existingArgumentsToForward = new();
 
             foreach (var argument in forwardedArguments)
@@ -130,6 +130,7 @@ namespace Microsoft.DotNet.Tools
 
                 if (TriggersSilentSeparateRestore(argument))
                 {
+                    newArgumentsToAdd.Add("-nologo");
                     newArgumentsToAdd.Add("-verbosity:quiet");
                 }
             }

--- a/src/Cli/dotnet/commands/RestoringCommand.cs
+++ b/src/Cli/dotnet/commands/RestoringCommand.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Tools
         [
             "getProperty",
             "getItem",
-            "getTargetResult"
+            "getTargetResult",
             "t",
             "target",
             "consoleloggerparameters",

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -56,15 +56,15 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm -t:Run")]
-        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm /t:Run")]
+        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore -tlp:verbosity=quiet", "-property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore -tlp:verbosity=quiet", "-property:TargetFramework=tfm -t:Run")]
+        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore -tlp:verbosity=quiet", "-property:TargetFramework=tfm /t:Run")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-target:Restore -nologo -tlp:verbosity=quiet -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
+                                  "-target:Restore -tlp:verbosity=quiet -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
                                   "-property:TargetFramework=tfm -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild")]
-        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -nologo -tlp:verbosity=quiet -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
+        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -tlp:verbosity=quiet -nologo -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args,
             string expectedAdditionalArgsForRestore,

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -56,13 +56,13 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm -t:Run")]
-        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm /t:Run")]
+        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore -nologo -verbosity:quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore -nologo -verbosity:quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm -t:Run")]
+        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm /t:Run")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-target:Restore -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
+                                  "-target:Restore -nologo -verbosity:quiet -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
                                   "-property:TargetFramework=tfm -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild")]
         [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetBuildInvocation.cs
@@ -56,15 +56,15 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore -nologo -verbosity:quiet", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore -nologo -verbosity:quiet", "--property:TargetFramework=tfm")]
-        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm -t:Run")]
-        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm /t:Run")]
+        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-p:TargetFramework=tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "/p:TargetFramework=tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "--property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-t:Run", "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm -t:Run")]
+        [InlineData(new string[] { "/t:Run", "-f", "tfm" }, "-target:Restore -nologo -tlp:verbosity=quiet", "-property:TargetFramework=tfm /t:Run")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-target:Restore -nologo -verbosity:quiet -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
+                                  "-target:Restore -nologo -tlp:verbosity=quiet -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild",
                                   "-property:TargetFramework=tfm -verbosity:diag -property:OutputPath=<cwd>myoutput -property:_CommandLineDefinedOutputPath=true /ArbitrarySwitchForMSBuild")]
-        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -nologo -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
+        [InlineData(new string[] { "-f", "tfm", "-getItem:Compile", "-getProperty:TargetFramework", "-getTargetResult:Build" }, "-target:Restore -nologo -tlp:verbosity=quiet -verbosity:quiet", "-property:TargetFramework=tfm -getItem:Compile -getProperty:TargetFramework -getTargetResult:Build")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args,
             string expectedAdditionalArgsForRestore,

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             command.SeparateRestoreCommand
                    .GetArgumentsToMSBuild()
                    .Should()
-                   .Be($"{ExpectedPrefix} -target:Restore -nologo -tlp:verbosity=quiet {ExpectedProperties}");
+                   .Be($"{ExpectedPrefix} -target:Restore -tlp:verbosity=quiet {ExpectedProperties}");
 
             command.GetArgumentsToMSBuild()
                    .Should()

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             command.SeparateRestoreCommand
                    .GetArgumentsToMSBuild()
                    .Should()
-                   .Be($"{ExpectedPrefix} -target:Restore -nologo -verbosity:quiet {ExpectedProperties}");
+                   .Be($"{ExpectedPrefix} -target:Restore -nologo -tlp:verbosity=quiet {ExpectedProperties}");
 
             command.GetArgumentsToMSBuild()
                    .Should()

--- a/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/dotnet-msbuild/GivenDotnetPublishInvocation.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             command.SeparateRestoreCommand
                    .GetArgumentsToMSBuild()
                    .Should()
-                   .Be($"{ExpectedPrefix} -target:Restore {ExpectedProperties}");
+                   .Be($"{ExpectedPrefix} -target:Restore -nologo -verbosity:quiet {ExpectedProperties}");
 
             command.GetArgumentsToMSBuild()
                    .Should()


### PR DESCRIPTION
### Context

Separate execution of restore for some of the invoked msbuild commands lead to suboptimal experience with terminal logger feature. Example: https://github.com/dotnet/msbuild/issues/9614

### Changes made

This PR is proposing:
 * Each case of additionl restore step should be invoked in quiet mode for terminal logger (`-tlp:verbosity=quiet`)
 * The `Get<X>` commands still lead to quiet verbosity for all loggers (`-verbosity:quiet`) 
 * Workloads advertising is OK - unless user didn't issue msbuild `get<X>` commands (this stays untouched from current main behavior)
 * If user explicitly specifies verbosity, the quietness of the separate restore step is not forced (this is debatable, but less risky for now)

### Testing

Existing unit tests + manual testing of the case from the user filed issue