### PR TITLE
Identify loongarch64 as valid arch

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -234,6 +234,7 @@ internal sealed class Registry
             "ppc64le" => "ppc64le",
             "s390x" => "s390x",
             "riscv64" => "riscv64",
+            "loongarch64" => "loongarch64",
             _ => null
         };
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -43,6 +43,7 @@ namespace Microsoft.NET.Build.Tasks
                                       RuntimeIdentifier.EndsWith("-arm") || RuntimeIdentifier.Contains("-arm-") ? Architecture.Arm :
 #if !NETFRAMEWORK
                                       RuntimeIdentifier.EndsWith("-riscv64") || RuntimeIdentifier.Contains("-riscv64-") ? Architecture.RiscV64 :
+                                      RuntimeIdentifier.EndsWith("-loongarch64") || RuntimeIdentifier.Contains("-loongarch64-") ? Architecture.LoongArch64 :
 #endif
                                       throw new ArgumentException(nameof(RuntimeIdentifier));
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -261,6 +261,9 @@ namespace Microsoft.NET.Build.Tasks
                 case "riscv64":
                     architecture = Architecture.RiscV64;
                     break;
+                case "loongarch64":
+                    architecture = Architecture.LoongArch64;
+                    break;
 #endif
                 case "x64":
                     architecture = Architecture.X64;
@@ -431,6 +434,7 @@ namespace Microsoft.NET.Build.Tasks
                 Architecture.Arm64 => "arm64",
 #if !NETFRAMEWORK
                 Architecture.RiscV64 => "riscv64",
+                Architecture.LoongArch64 => "loongarch64",
 #endif
                 _ => null
             };


### PR DESCRIPTION
Similar to #18247, LoongArch64 is a valid architecture supporting R2R compilation.

cc @akoeplinger, @shushanhf