### PR TITLE
Fix PR builds ran manually or against release branches

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,7 +17,8 @@ pr:
 variables:
   - name: _CIBuild
     value: -restore -build -sign -pack -ci
-  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+  # Disable post-build signing for internal release-branch builds or internal manual builds.
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
     - name: PostBuildSign
       value: false
   - ${{ else }}:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -23,7 +23,8 @@ variables:
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCore
-  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+  # Disable post-build signing for internal release-branch builds or internal manual builds.
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
     - name: PostBuildSign
       value: false
   - ${{ else }}:

--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -56,7 +56,7 @@ jobs:
           - _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           - _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
           - _PerfIterations: 25
-  
+
       steps:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - task: PowerShell@2
@@ -98,7 +98,7 @@ jobs:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
               RunAoTTests: 'false'
-  
+
       - ${{ if eq(parameters.agentOs, 'Windows_NT_FullFramework') }}:
         - powershell: eng\common\build.ps1
                     $(_CIBuild)
@@ -130,7 +130,7 @@ jobs:
               TestFullMSBuild: 'true'
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
-  
+
       - ${{ if eq(parameters.agentOs, 'Windows_NT_TestAsTools') }}:
         - powershell: eng\common\build.ps1
                     $(_CIBuild)
@@ -142,7 +142,7 @@ jobs:
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)
-  
+
       - ${{ if notIn(parameters.agentOs, 'Windows_NT', 'Windows_NT_FullFramework', 'Windows_NT_TestAsTools') }}:
         - script: eng/common/build.sh
                     $(_CIBuild)
@@ -173,35 +173,35 @@ jobs:
               RunAoTTests: 'false'
 
       - task: PublishTestResults@2
-        displayName: Publish Test Results	
-        inputs:	
-          testResultsFormat: xUnit	
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-          buildPlatform: '$(BuildPlatform)'	
-          buildConfiguration: '$(_BuildConfig)'	
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: xUnit
+          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
+          buildPlatform: '$(BuildPlatform)'
+          buildConfiguration: '$(_BuildConfig)'
         condition: always()
 
-      - task: CopyFiles@2	
-        displayName: Gather Logs	
-        inputs:	
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-          Contents: |	
-           log/$(_BuildConfig)/**/*	
-           TestResults/$(_BuildConfig)/**/*	
-           SymStore/$(_BuildConfig)/**/*
-           tmp/$(_BuildConfig)/**/*.binlog
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-        continueOnError: true	
+      - task: CopyFiles@2
+        displayName: Gather Logs
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+          Contents: |
+            log/$(_BuildConfig)/**/*
+            TestResults/$(_BuildConfig)/**/*
+            SymStore/$(_BuildConfig)/**/*
+            tmp/$(_BuildConfig)/**/*.binlog
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        continueOnError: true
         condition: always()
-  
-      - task: PublishBuildArtifacts@1	
-        displayName: Publish Logs to VSTS	
-        inputs:	
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-          publishLocation: Container	
-        continueOnError: true	
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
         condition: always()
 
 # AoT Jobs
@@ -314,26 +314,26 @@ jobs:
               RunAoTTests: 'true'
 
       - ${{ if in(parameters.agentOs, 'Windows_NT', 'Darwin') }}:
-        - task: CopyFiles@2	
-          displayName: Gather Logs	
-          inputs:	
-            SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-            Contents: |	
-              log/$(_BuildConfig)/**/*	
-              TestResults/$(_BuildConfig)/**/*	
+        - task: CopyFiles@2
+          displayName: Gather Logs
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+            Contents: |
+              log/$(_BuildConfig)/**/*
+              TestResults/$(_BuildConfig)/**/*
               SymStore/$(_BuildConfig)/**/*
               tmp/$(_BuildConfig)/**/*.binlog
-            TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-          continueOnError: true	
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
+          continueOnError: true
           condition: always()
 
-        - task: PublishBuildArtifacts@1	
-          displayName: Publish Logs to VSTS	
-          inputs:	
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-            ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-            publishLocation: Container	
-          continueOnError: true	
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Logs to VSTS
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+            publishLocation: Container
+          continueOnError: true
           condition: always()
 
 # TemplateEngine Jobs
@@ -446,35 +446,35 @@ jobs:
                 /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/dotnet-new.IntegrationTests.binlog
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run dotnet new Integration Tests
-  
+
       - task: PublishTestResults@2
-        displayName: Publish Test Results	
-        inputs:	
-          testResultsFormat: xUnit	
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-          buildPlatform: '$(BuildPlatform)'	
-          buildConfiguration: '$(_BuildConfig)'	
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: xUnit
+          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
+          buildPlatform: '$(BuildPlatform)'
+          buildConfiguration: '$(_BuildConfig)'
         condition: always()
-  
-      - task: CopyFiles@2	
-        displayName: Gather Logs	
-        inputs:	
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-          Contents: |	
-           log/$(_BuildConfig)/**/*	
-           TestResults/$(_BuildConfig)/**/*	
-           SymStore/$(_BuildConfig)/**/*
-           tmp/$(_BuildConfig)/**/*.binlog
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-        continueOnError: true	
+
+      - task: CopyFiles@2
+        displayName: Gather Logs
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+          Contents: |
+            log/$(_BuildConfig)/**/*
+            TestResults/$(_BuildConfig)/**/*
+            SymStore/$(_BuildConfig)/**/*
+            tmp/$(_BuildConfig)/**/*.binlog
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        continueOnError: true
         condition: always()
-  
-      - task: PublishBuildArtifacts@1	
-        displayName: Publish Logs to VSTS	
-        inputs:	
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-          publishLocation: Container	
-        continueOnError: true	
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
         condition: always()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -67,7 +67,7 @@ jobs:
             value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
           - name: _PerfIterations
             value: 25
-  
+
       steps:
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - task: PowerShell@2
@@ -109,7 +109,7 @@ jobs:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
               RunAoTTests: 'false'
-  
+
       - ${{ if eq(parameters.agentOs, 'Windows_NT_FullFramework') }}:
         - powershell: eng\common\build.ps1
                     $(_CIBuild)
@@ -141,7 +141,7 @@ jobs:
               TestFullMSBuild: 'true'
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
-  
+
       - ${{ if eq(parameters.agentOs, 'Windows_NT_TestAsTools') }}:
         - powershell: eng\common\build.ps1
                     $(_CIBuild)
@@ -153,7 +153,7 @@ jobs:
           displayName: Build
           env:
             BuildConfig: $(_BuildConfig)
-  
+
       - ${{ if notIn(parameters.agentOs, 'Windows_NT', 'Windows_NT_FullFramework', 'Windows_NT_TestAsTools') }}:
         - script: eng/common/build.sh
                     $(_CIBuild)
@@ -184,35 +184,35 @@ jobs:
               RunAoTTests: 'false'
 
       - task: PublishTestResults@2
-        displayName: Publish Test Results	
-        inputs:	
-          testResultsFormat: xUnit	
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-          buildPlatform: '$(BuildPlatform)'	
-          buildConfiguration: '$(_BuildConfig)'	
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: xUnit
+          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
+          buildPlatform: '$(BuildPlatform)'
+          buildConfiguration: '$(_BuildConfig)'
         condition: always()
 
-      - task: CopyFiles@2	
-        displayName: Gather Logs	
-        inputs:	
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-          Contents: |	
-           log/$(_BuildConfig)/**/*	
-           TestResults/$(_BuildConfig)/**/*	
-           SymStore/$(_BuildConfig)/**/*
-           tmp/$(_BuildConfig)/**/*.binlog
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-        continueOnError: true	
+      - task: CopyFiles@2
+        displayName: Gather Logs
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+          Contents: |
+            log/$(_BuildConfig)/**/*
+            TestResults/$(_BuildConfig)/**/*
+            SymStore/$(_BuildConfig)/**/*
+            tmp/$(_BuildConfig)/**/*.binlog
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        continueOnError: true
         condition: always()
-  
-      - task: 1ES.PublishBuildArtifacts@1	
-        displayName: Publish Logs to VSTS	
-        inputs:	
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-          publishLocation: Container	
-        continueOnError: true	
+
+      - task: 1ES.PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
         condition: always()
 
 # AoT Jobs
@@ -338,26 +338,26 @@ jobs:
               RunAoTTests: 'true'
 
       - ${{ if in(parameters.agentOs, 'Windows_NT', 'Darwin') }}:
-        - task: CopyFiles@2	
-          displayName: Gather Logs	
-          inputs:	
-            SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-            Contents: |	
-              log/$(_BuildConfig)/**/*	
-              TestResults/$(_BuildConfig)/**/*	
+        - task: CopyFiles@2
+          displayName: Gather Logs
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+            Contents: |
+              log/$(_BuildConfig)/**/*
+              TestResults/$(_BuildConfig)/**/*
               SymStore/$(_BuildConfig)/**/*
               tmp/$(_BuildConfig)/**/*.binlog
-            TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-          continueOnError: true	
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
+          continueOnError: true
           condition: always()
 
-        - task: 1ES.PublishBuildArtifacts@1	
-          displayName: Publish Logs to VSTS	
-          inputs:	
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-            ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-            publishLocation: Container	
-          continueOnError: true	
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: Publish Logs to VSTS
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+            publishLocation: Container
+          continueOnError: true
           condition: always()
 
 # TemplateEngine Jobs
@@ -483,35 +483,35 @@ jobs:
                 /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/dotnet-new.IntegrationTests.binlog
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run dotnet new Integration Tests
-  
+
       - task: PublishTestResults@2
-        displayName: Publish Test Results	
-        inputs:	
-          testResultsFormat: xUnit	
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-          buildPlatform: '$(BuildPlatform)'	
-          buildConfiguration: '$(_BuildConfig)'	
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: xUnit
+          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
+          buildPlatform: '$(BuildPlatform)'
+          buildConfiguration: '$(_BuildConfig)'
         condition: always()
-  
-      - task: CopyFiles@2	
-        displayName: Gather Logs	
-        inputs:	
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-          Contents: |	
-           log/$(_BuildConfig)/**/*	
-           TestResults/$(_BuildConfig)/**/*	
-           SymStore/$(_BuildConfig)/**/*
-           tmp/$(_BuildConfig)/**/*.binlog
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-        continueOnError: true	
+
+      - task: CopyFiles@2
+        displayName: Gather Logs
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+          Contents: |
+            log/$(_BuildConfig)/**/*
+            TestResults/$(_BuildConfig)/**/*
+            SymStore/$(_BuildConfig)/**/*
+            tmp/$(_BuildConfig)/**/*.binlog
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        continueOnError: true
         condition: always()
-  
-      - task: 1ES.PublishBuildArtifacts@1	
-        displayName: Publish Logs to VSTS	
-        inputs:	
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-          publishLocation: Container	
-        continueOnError: true	
+
+      - task: 1ES.PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+          publishLocation: Container
+        continueOnError: true
         condition: always()


### PR DESCRIPTION
## Summary

Currently, if you manually go and run a PR build [in our PR pipeline](https://dev.azure.com/dnceng-public/public/_build?definitionId=101), it will fail. Why? Because the information provided for signing won't function for Ubuntu and Darwin builds. The build is incorrectly setting PostBuildSign to `false` for these builds. This also applies to builds when `release` branches are merged. Those also fail for the same reason.

To fix this, I believe the intent of this logic was only supposed to apply for `internal` builds. Thus, I've added this to the condition. Now, PostBuildSign will only be `false` if it is both an internal build (not this pipeline) *AND* it is either a `release` branch or if the pipeline is ran manually. Lastly, I did some whitespace cleanup too.

## Failure Examples

![image](https://github.com/dotnet/sdk/assets/17788297/087bfd10-ba29-4625-ae4a-cbd65b4fa6c9)

- Failure on manual build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=640222
- Failure on `release` branch build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=643153

## Test Build
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=644329
