### PR TITLE
Remove PublishTestResults task on Helix testing jobs

### DIFF
--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -172,16 +172,6 @@ jobs:
               HelixAccessToken: $(_HelixApiToken)
               RunAoTTests: 'false'
 
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        inputs:
-          testResultsFormat: xUnit
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
-          buildPlatform: '$(BuildPlatform)'
-          buildConfiguration: '$(_BuildConfig)'
-        condition: always()
-
       - task: CopyFiles@2
         displayName: Gather Logs
         inputs:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -183,16 +183,6 @@ jobs:
               HelixAccessToken: $(_HelixApiToken)
               RunAoTTests: 'false'
 
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        inputs:
-          testResultsFormat: xUnit
-          testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
-          testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
-          buildPlatform: '$(BuildPlatform)'
-          buildConfiguration: '$(_BuildConfig)'
-        condition: always()
-
       - task: CopyFiles@2
         displayName: Gather Logs
         inputs:


### PR DESCRIPTION
## Summary

We get this set of warnings in our PR build:

![image](https://github.com/dotnet/sdk/assets/17788297/ab1119c3-7bfa-4873-ac90-11f5ea53a7d9)

This happens because these jobs were converted to strictly run Helix tests. Helix has its own mechanism for handling test results. The `PublishTestResults` task is intended for locally running unit tests and getting the results .xml file, then publishing it to Azure Pipelines to show the results in the Tests tab for the build. Removing this task was simply missed when the tests were converted to Helix.