### PR TITLE
More workload set fixes

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -134,8 +134,8 @@ namespace Microsoft.DotNet.Workloads.Workload
             {
                 // This file isn't created in tests.
                 var version = File.ReadAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName));
-                PrintWorkloadSetTransition(version);
-                if (!version.Equals(_workloadSetVersion) && !version.Equals(_workloadSetVersionFromGlobalJson))
+                if ((_workloadSetVersion != null && !version.Equals(_workloadSetVersion)) ||
+                    (_workloadSetVersionFromGlobalJson != null && !version.Equals(_workloadSetVersionFromGlobalJson)))
                 {
                     // NuGet found a partial match. Reject in favor of a full match.
                     Reporter.WriteLine(
@@ -143,6 +143,8 @@ namespace Microsoft.DotNet.Workloads.Workload
                     updates = null;
                     return false;
                 }
+
+                PrintWorkloadSetTransition(version);
             }
             else if (_workloadInstaller is FileBasedInstaller || _workloadInstaller is NetSdkMsiInstallerClient)
             {

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -124,10 +124,10 @@ namespace Microsoft.DotNet.Workloads.Workload
             }
 
             _workloadManifestUpdater.DownloadWorkloadSet(_workloadSetVersionFromGlobalJson ?? _workloadSetVersion, offlineCache);
-            return TryInstallWorkloadSet(context, out updates);
+            return TryInstallWorkloadSet(context, out updates, throwOnFailure: true);
         }
 
-        public bool TryInstallWorkloadSet(ITransactionContext context, out IEnumerable<ManifestVersionUpdate> updates)
+        public bool TryInstallWorkloadSet(ITransactionContext context, out IEnumerable<ManifestVersionUpdate> updates, bool throwOnFailure = false)
         {
             var advertisingPackagePath = Path.Combine(_userProfileDir, "sdk-advertising", _sdkFeatureBand.ToString(), "microsoft.net.workloads");
             if (File.Exists(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName)))
@@ -139,7 +139,14 @@ namespace Microsoft.DotNet.Workloads.Workload
             else if (_workloadInstaller is FileBasedInstaller || _workloadInstaller is NetSdkMsiInstallerClient)
             {
                 // No workload sets found
-                Reporter.WriteLine(Update.LocalizableStrings.NoWorkloadUpdateFound);
+                if (throwOnFailure)
+                {
+                    throw new NuGetPackageNotFoundException(string.Format(Update.LocalizableStrings.WorkloadVersionRequestedNotFound, _workloadSetVersionFromGlobalJson ?? _workloadSetVersion));
+                }
+                else
+                {
+                    Reporter.WriteLine(Update.LocalizableStrings.NoWorkloadUpdateFound);
+                }
                 updates = null;
                 return false;
             }

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -134,16 +134,6 @@ namespace Microsoft.DotNet.Workloads.Workload
             {
                 // This file isn't created in tests.
                 var version = File.ReadAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName));
-                if ((_workloadSetVersion != null && !version.Equals(_workloadSetVersion)) ||
-                    (_workloadSetVersionFromGlobalJson != null && !version.Equals(_workloadSetVersionFromGlobalJson)))
-                {
-                    // NuGet found a partial match. Reject in favor of a full match.
-                    Reporter.WriteLine(
-                        string.Format(Update.LocalizableStrings.WrongWorkloadSetVersion, _workloadSetVersionFromGlobalJson ?? _workloadSetVersion, version));
-                    updates = null;
-                    return false;
-                }
-
                 PrintWorkloadSetTransition(version);
             }
             else if (_workloadInstaller is FileBasedInstaller || _workloadInstaller is NetSdkMsiInstallerClient)

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -160,15 +160,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
         private void PrintWorkloadSetTransition(string newVersion)
         {
-            var currentVersion = _workloadResolver.GetWorkloadVersion();
-            if (currentVersion == null || !string.IsNullOrWhiteSpace(_workloadSetVersionFromGlobalJson))
-            {
-                Reporter.WriteLine(string.Format(Strings.NewWorkloadSet, newVersion));
-            }
-            else
-            {
-                Reporter.WriteLine(string.Format(Strings.WorkloadSetUpgrade, currentVersion, newVersion));
-            }
+            Reporter.WriteLine(string.Format(Strings.NewWorkloadSet, newVersion));
         }
 
         protected async Task<List<WorkloadDownload>> GetDownloads(IEnumerable<WorkloadId> workloadIds, bool skipManifestUpdate, bool includePreview, string downloadFolder = null)

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -133,7 +133,16 @@ namespace Microsoft.DotNet.Workloads.Workload
             if (File.Exists(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName)))
             {
                 // This file isn't created in tests.
-                PrintWorkloadSetTransition(File.ReadAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName)));
+                var version = File.ReadAllText(Path.Combine(advertisingPackagePath, Constants.workloadSetVersionFileName));
+                PrintWorkloadSetTransition(version);
+                if (!version.Equals(_workloadSetVersion) && !version.Equals(_workloadSetVersionFromGlobalJson))
+                {
+                    // NuGet found a partial match. Reject in favor of a full match.
+                    Reporter.WriteLine(
+                        string.Format(Update.LocalizableStrings.WrongWorkloadSetVersion, _workloadSetVersionFromGlobalJson ?? _workloadSetVersion, version));
+                    updates = null;
+                    return false;
+                }
             }
             else if (_workloadInstaller is FileBasedInstaller || _workloadInstaller is NetSdkMsiInstallerClient)
             {

--- a/src/Cli/dotnet/commands/dotnet-workload/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/LocalizableStrings.resx
@@ -138,7 +138,7 @@
   <data name="WorkloadInstallTypeColumn" xml:space="preserve">
     <value>Install Type</value>
   </data>
-  <data name="WorkloadManfiestVersionColumn" xml:space="preserve">
+  <data name="WorkloadManifestVersionColumn" xml:space="preserve">
     <value>Manifest Version</value>
   </data>
   <data name="WorkloadManifestPathColumn" xml:space="preserve">

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -60,6 +61,10 @@ namespace Microsoft.DotNet.Cli
                 reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion()}");
             }
 
+            var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.DotnetPath), "default.json")).UseWorkloadSets;
+            var workloadSetsString = useWorkloadSets == true ? "workload sets" : "loose manifests";
+            reporter.WriteLine($"Configured to use {workloadSetsString} when installing new manifests.");
+
             if (installedWorkloads.Count == 0)
             {
                 reporter.WriteLine(CommonStrings.NoWorkloadsInstalledInfoWarning);
@@ -81,7 +86,7 @@ namespace Microsoft.DotNet.Cli
                 reporter.Write($"{separator}{CommonStrings.WorkloadSourceColumn}:");
                 reporter.WriteLine($" {workload.Value,align}");
 
-                reporter.Write($"{separator}{CommonStrings.WorkloadManfiestVersionColumn}:");
+                reporter.Write($"{separator}{CommonStrings.WorkloadManifestVersionColumn}:");
                 reporter.WriteLine($"    {workloadManifest.Version + '/' + workloadFeatureBand,align}");
 
                 reporter.Write($"{separator}{CommonStrings.WorkloadManifestPathColumn}:");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/LocalizableStrings.resx
@@ -349,9 +349,6 @@
   <data name="NewWorkloadSet" xml:space="preserve">
     <value>Installing workload version {0}.</value>
   </data>
-  <data name="WorkloadSetUpgrade" xml:space="preserve">
-    <value>Updating workload version from {0} to {1}.</value>
-  </data>
   <data name="CannotSpecifyVersionOnCommandLineAndInGlobalJson" xml:space="preserve">
     <value>Cannot specify a particular workload version on the command line via --version or --from-history when there is already a version specified in global.json file {0}. To update the globally installed workload version, run the command outside of the path containing that global.json file or update the version specified in the global.json file and run "dotnet workload update."</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -294,19 +294,23 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
             InstallAction plannedAction = PlanPackage(msi, state, requestedAction, installedVersion);
 
-            if (plannedAction != InstallAction.None)
+            if (plannedAction == InstallAction.Uninstall)
+            {
+                Elevate();
+
+                // Update the reference count against the MSI.
+                UpdateDependent(InstallRequestType.RemoveDependent, msi.Manifest.ProviderKeyName, _dependent);
+
+                ExecutePackage(msi, plannedAction, msiPackageId);
+            }
+            else if (plannedAction != InstallAction.None)
             {
                 Elevate();
 
                 ExecutePackage(msi, plannedAction, msiPackageId);
 
                 // Update the reference count against the MSI.
-                UpdateDependent(
-                    plannedAction == InstallAction.Uninstall ?
-                        InstallRequestType.RemoveDependent :
-                        InstallRequestType.AddDependent,
-                    msi.Manifest.ProviderKeyName,
-                    _dependent);
+                UpdateDependent(InstallRequestType.AddDependent, msi.Manifest.ProviderKeyName, _dependent);
             }
 
             return Path.Combine(DotNetHome, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadSetVersion);

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -342,7 +342,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     var downloadedPackageVersion = packageReader.NuspecReader.GetVersion();
                     if (packageVersion != null && !downloadedPackageVersion.Equals(packageVersion))
                     {
-                        throw new Exception(string.Format(Update.LocalizableStrings.WorkloadVersionNotFound, packageVersion));
+                        throw new NuGetPackageNotFoundException($"Requested workload version {packageVersion} of {id} but found version {downloadedPackageVersion} instead.");
                     }
 
                     var workloadSetVersion = WorkloadSetPackageVersionToWorkloadSetVersion(band, downloadedPackageVersion.ToString());

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -340,6 +340,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     // Create version file later used as part of installing the workload set in the file-based installer and in the msi-based installer
                     using PackageArchiveReader packageReader = new(packagePath);
                     var downloadedPackageVersion = packageReader.NuspecReader.GetVersion();
+                    if (packageVersion != null && !downloadedPackageVersion.Equals(packageVersion))
+                    {
+                        throw new Exception(string.Format(Update.LocalizableStrings.WorkloadVersionNotFound, packageVersion));
+                    }
+
                     var workloadSetVersion = WorkloadSetPackageVersionToWorkloadSetVersion(band, downloadedPackageVersion.ToString());
                     File.WriteAllText(Path.Combine(adManifestPath, Constants.workloadSetVersionFileName), workloadSetVersion);
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -340,7 +340,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     // Create version file later used as part of installing the workload set in the file-based installer and in the msi-based installer
                     using PackageArchiveReader packageReader = new(packagePath);
                     var downloadedPackageVersion = packageReader.NuspecReader.GetVersion();
-                    var workloadSetVersion = WorkloadSetPackageVersionToWorkloadSetVersion(_sdkFeatureBand, downloadedPackageVersion.ToString());
+                    var workloadSetVersion = WorkloadSetPackageVersionToWorkloadSetVersion(band, downloadedPackageVersion.ToString());
                     File.WriteAllText(Path.Combine(adManifestPath, Constants.workloadSetVersionFileName), workloadSetVersion);
                 }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.cs.xlf
@@ -377,11 +377,6 @@
         <target state="translated">CESTA</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Aktualizuje se verze úlohy z {0} na {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Aktualizuje verzi na zadanou verzi úlohy.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.de.xlf
@@ -377,11 +377,6 @@
         <target state="translated">PFAD</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Die Workloadversion wird von {0} auf {1} aktualisiert.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Aktualisieren Sie auf die angegebene Workloadversion.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.es.xlf
@@ -377,11 +377,6 @@
         <target state="translated">RUTA DE ACCESO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Actualizando la versión de carga de trabajo de {0} a {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Actualice a la versión de carga de trabajo especificada.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.fr.xlf
@@ -377,11 +377,6 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Mise à jour de la version de la charge de travail de {0} à {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Mettre à jour vers la version de charge de travail spécifiée.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.it.xlf
@@ -377,11 +377,6 @@
         <target state="translated">PERCORSO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Aggiornamento della versione del carico di lavoro da {0} a {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Eseguire l'aggiornamento alla versione del carico di lavoro specificata.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ja.xlf
@@ -377,11 +377,6 @@
         <target state="translated">パス</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">ワークロードのバージョンを {0} から {1} に更新しています。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">指定されたワークロード バージョンに更新します。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ko.xlf
@@ -377,11 +377,6 @@
         <target state="translated">경로</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">워크로드 버전을 {0}에서 {1}(으)로 업데이트하는 중입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">지정된 워크로드 버전으로 업데이트합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pl.xlf
@@ -377,11 +377,6 @@
         <target state="translated">ŚCIEŻKA</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Aktualizowanie wersji obciążenia z {0} do {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Zaktualizuj do określonej wersji obciążenia.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -377,11 +377,6 @@
         <target state="translated">CAMINHO</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Atualizando a versão da carga de trabalho {0} para {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Atualize para a versão de carga de trabalho especificada.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.ru.xlf
@@ -377,11 +377,6 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">Обновление версии рабочей нагрузки с {0} до {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Обновление до указанной версии рабочей нагрузки.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.tr.xlf
@@ -377,11 +377,6 @@
         <target state="translated">YOL</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">İş yükü {0} sürümünden {1} sürümüne güncelleştiriliyor.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">Belirtilen iş yükü sürümünde güncelleştirme var.</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -377,11 +377,6 @@
         <target state="translated">路径</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">正在将工作负载版本从 {0} 更新为 {1}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">更新到指定的工作负载版本。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -377,11 +377,6 @@
         <target state="translated">路徑</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadSetUpgrade">
-        <source>Updating workload version from {0} to {1}.</source>
-        <target state="translated">正在將工作負載版本從 {0} 更新為 {1}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WorkloadSetVersionOptionDescription">
         <source>Update to the specified workload version.</source>
         <target state="translated">更新至指定的工作負載版本。</target>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
             else
             {
                 var globalJsonInformation = _workloadListHelper.ManifestProvider.GetGlobalJsonInformation();
-
+                Reporter.WriteLine();
                 var shouldPrintTable = globalJsonInformation?.WorkloadVersionInstalled != false;
                 var shouldShowWorkloadSetVersion = globalJsonInformation is not null ||
                     InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(_workloadListHelper._currentSdkFeatureBand, _workloadListHelper.DotnetPath), "default.json")).UseWorkloadSets == true;

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -159,4 +159,7 @@
   <data name="NoWorkloadUpdateFound" xml:space="preserve">
     <value>No workload update found.</value>
   </data>
+  <data name="WrongWorkloadSetVersion" xml:space="preserve">
+    <value>Workload version {0} could not be found. Approximate best match of version {1} was found.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -159,7 +159,4 @@
   <data name="NoWorkloadUpdateFound" xml:space="preserve">
     <value>No workload update found.</value>
   </data>
-  <data name="WorkloadVersionNotFound" xml:space="preserve">
-    <value>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</value>
-  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -159,7 +159,7 @@
   <data name="NoWorkloadUpdateFound" xml:space="preserve">
     <value>No workload update found.</value>
   </data>
-  <data name="WrongWorkloadSetVersion" xml:space="preserve">
-    <value>Workload version {0} could not be found. Approximate best match of version {1} was found.</value>
+  <data name="WorkloadVersionNotFound" xml:space="preserve">
+    <value>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -159,4 +159,7 @@
   <data name="NoWorkloadUpdateFound" xml:space="preserve">
     <value>No workload update found.</value>
   </data>
+  <data name="WorkloadVersionRequestedNotFound" xml:space="preserve">
+    <value>Workload version {0} not found.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Aktualizace úlohy se nepovedla: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aktualizace úlohy se nepovedla: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aktualizace úlohy se nepovedla: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Aktualizace úlohy se nepovedla: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Fehler bei der Workloadaktualisierung: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Fehler bei der Workloadaktualisierung: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Fehler bei der Workloadaktualisierung: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Fehler bei der Workloadaktualisierung: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -72,9 +72,9 @@
         <target state="translated">No se pudo actualizar la carga de trabajo: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">No se pudo actualizar la carga de trabajo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">No se pudo actualizar la carga de trabajo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -72,11 +72,6 @@
         <target state="translated">No se pudo actualizar la carga de trabajo: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Échec de la mise à jour du chargement vers le serveur : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Échec de la mise à jour du chargement vers le serveur : {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Échec de la mise à jour du chargement vers le serveur : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Échec de la mise à jour du chargement vers le serveur : {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Aggiornamento del carico di lavoro non riuscito: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Aggiornamento del carico di lavoro non riuscito: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aggiornamento del carico di lavoro non riuscito: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aggiornamento del carico di lavoro non riuscito: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">ワークロードの更新に失敗しました: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -72,9 +72,9 @@
         <target state="translated">ワークロードの更新に失敗しました: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -72,11 +72,6 @@
         <target state="translated">ワークロードの更新に失敗しました: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">ワークロードの更新に失敗しました: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">워크로드 업데이트 실패: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">워크로드 업데이트 실패: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -72,11 +72,6 @@
         <target state="translated">워크로드 업데이트 실패: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -72,9 +72,9 @@
         <target state="translated">워크로드 업데이트 실패: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aktualizacja pakietu roboczego nie powiodła się: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Aktualizacja pakietu roboczego nie powiodła się: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Aktualizacja pakietu roboczego nie powiodła się: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Aktualizacja pakietu roboczego nie powiodła się: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">A atualização da carga de trabalho falhou: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">A atualização da carga de trabalho falhou: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -72,9 +72,9 @@
         <target state="translated">A atualização da carga de trabalho falhou: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -72,11 +72,6 @@
         <target state="translated">A atualização da carga de trabalho falhou: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Сбой обновления рабочей нагрузки: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -72,9 +72,9 @@
         <target state="translated">Сбой обновления рабочей нагрузки: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Сбой обновления рабочей нагрузки: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Сбой обновления рабочей нагрузки: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -72,9 +72,9 @@
         <target state="translated">İş yükü güncelleştirmesi başarısız oldu: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">İş yükü güncelleştirmesi başarısız oldu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">İş yükü güncelleştirmesi başarısız oldu: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">İş yükü güncelleştirmesi başarısız oldu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">工作负载更新失败: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -72,11 +72,6 @@
         <target state="translated">工作负载更新失败: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">工作负载更新失败: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -72,9 +72,9 @@
         <target state="translated">工作负载更新失败: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -72,9 +72,9 @@
         <target state="translated">工作負載更新失敗: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WrongWorkloadSetVersion">
-        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
-        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+      <trans-unit id="WorkloadVersionNotFound">
+        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
+        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -72,11 +72,6 @@
         <target state="translated">工作負載更新失敗: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="WorkloadVersionNotFound">
-        <source>Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</source>
-        <target state="new">Could not find workload version {0}. Does it exist in a NuGet feed in your NuGet.config?</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">工作負載更新失敗: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WrongWorkloadSetVersion">
+        <source>Workload version {0} could not be found. Approximate best match of version {1} was found.</source>
+        <target state="new">Workload version {0} could not be found. Approximate best match of version {1} was found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">工作負載更新失敗: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkloadVersionRequestedNotFound">
+        <source>Workload version {0} not found.</source>
+        <target state="new">Workload version {0} not found.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.cs.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Při ověřování úloh došlo k problému. Další informace získáte spuštěním příkazu „dotnet workload update“.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Verze manifestu</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.de.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Problem beim Verifizieren der Workloads. Führen Sie "dotnet workload update" aus, um weitere Informationen zu erhalten.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Manifestversion</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.es.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Se encontró un problema al comprobar las cargas de trabajo. Para obtener más información, ejecute "dotnet workload update".</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Versión del manifiesto</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.fr.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Un problème s’est produit lors de la vérification des charges de travail. Pour plus d’informations, exécutez « dotnet workload update ».</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Version de manifeste</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.it.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Si è verificato un problema nella verifica dei carichi di lavoro. Per altre informazioni, eseguire "dotnet workload update".</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Versioni del manifesto</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ja.xlf
@@ -57,7 +57,7 @@
         <target state="translated">ワークロードの検証中に問題が発生しました。詳細については、"dotnet workload update" を実行してください。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">マニフェストのバージョン</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ko.xlf
@@ -57,7 +57,7 @@
         <target state="translated">워크로드를 확인하는 동안 문제가 발생했습니다. 자세한 내용을 확인하려면 "dotnet workload update"를 실행하세요.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">매니페스트 버전</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.pl.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Napotkano problem podczas weryfikowania obciążeń. Aby uzyskać więcej informacji, uruchom polecenie „dotnet workload update”.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Wersja manifestu</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,7 +57,7 @@
         <target state="translated">Foi encontrado um problema ao verificar as cargas de trabalho. Para obter mais informações, execute "dotnet workload update".</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Versão do Manifesto</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.ru.xlf
@@ -57,7 +57,7 @@
         <target state="translated">При проверке рабочих нагрузок возникла проблема. Для получения дополнительных сведений выполните команду "dotnet workload update".</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Версия манифеста</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.tr.xlf
@@ -57,7 +57,7 @@
         <target state="translated">İş yükleri doğrulanırken bir sorunla karşılaşıldı. Daha fazla bilgi için "dotnet workload update" komutunu çalıştırın.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">Bildirim Sürümü</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,7 +57,7 @@
         <target state="translated">验证工作负载时遇到问题。有关详细信息，请运行 "dotnet workload update"。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">清单版本</target>
         <note />

--- a/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,7 +57,7 @@
         <target state="translated">驗證工作負載時發生問題。如需詳細資訊，請執行 "dotnet workload update"。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
-      <trans-unit id="WorkloadManfiestVersionColumn">
+      <trans-unit id="WorkloadManifestVersionColumn">
         <source>Manifest Version</source>
         <target state="translated">資訊清單版本</target>
         <note />

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -121,12 +121,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _workloadSet = null;
             _manifestsFromInstallState = null;
             _installStateFilePath = null;
-            _useManifestsFromInstallState = false;
+            _useManifestsFromInstallState = true;
             var availableWorkloadSets = GetAvailableWorkloadSets();
 
             if (_workloadSetVersionFromConstructor != null)
             {
-                _useManifestsFromInstallState = true;
+                _useManifestsFromInstallState = false;
                 if (!availableWorkloadSets.TryGetValue(_workloadSetVersionFromConstructor, out _workloadSet))
                 {
                     throw new FileNotFoundException(string.Format(Strings.WorkloadVersionNotFound, _workloadSetVersionFromConstructor));
@@ -138,7 +138,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 _globalJsonWorkloadSetVersion = GlobalJsonReader.GetWorkloadVersionFromGlobalJson(_globalJsonPathFromConstructor);
                 if (_globalJsonWorkloadSetVersion != null)
                 {
-                    _useManifestsFromInstallState = true;
+                    _useManifestsFromInstallState = false;
                     if (!availableWorkloadSets.TryGetValue(_globalJsonWorkloadSetVersion, out _workloadSet))
                     {
                         _exceptionToThrow = new FileNotFoundException(string.Format(Strings.WorkloadVersionFromGlobalJsonNotFound, _globalJsonWorkloadSetVersion, _globalJsonPathFromConstructor));

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private WorkloadSet? _workloadSet;
         private WorkloadSet? _manifestsFromInstallState;
         private string? _installStateFilePath;
-        private bool _workloadSetDominatesInstallState = true;
+        private bool _workloadSetDominatesInstallState = false;
 
         //  This will be non-null if there is an error loading manifests that should be thrown when they need to be accessed.
         //  We delay throwing the error so that in the case where global.json specifies a workload set that isn't installed,
@@ -121,7 +121,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _workloadSet = null;
             _manifestsFromInstallState = null;
             _installStateFilePath = null;
-            _workloadSetDominatesInstallState = true;
+            _workloadSetDominatesInstallState = false;
             var availableWorkloadSets = GetAvailableWorkloadSets();
 
             if (_workloadSetVersionFromConstructor != null)
@@ -137,6 +137,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 _globalJsonWorkloadSetVersion = GlobalJsonReader.GetWorkloadVersionFromGlobalJson(_globalJsonPathFromConstructor);
                 if (_globalJsonWorkloadSetVersion != null)
                 {
+                    _workloadSetDominatesInstallState = true;
                     if (!availableWorkloadSets.TryGetValue(_globalJsonWorkloadSetVersion, out _workloadSet))
                     {
                         _exceptionToThrow = new FileNotFoundException(string.Format(Strings.WorkloadVersionFromGlobalJsonNotFound, _globalJsonWorkloadSetVersion, _globalJsonPathFromConstructor));
@@ -168,7 +169,6 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet == null && availableWorkloadSets.Any())
             {
-                _workloadSetDominatesInstallState = false;
                 var maxWorkloadSetVersion = availableWorkloadSets.Keys.Select(k => new ReleaseVersion(k)).Max()!;
                 _workloadSet = availableWorkloadSets[maxWorkloadSetVersion.ToString()];
             }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadInstallType.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadInstallType.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
     /// <summary>
@@ -41,14 +43,15 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public static string GetInstallStateFolder(SdkFeatureBand sdkFeatureBand, string dotnetDir)
         {
             var installType = GetWorkloadInstallType(sdkFeatureBand, dotnetDir);
+            var architecture = RuntimeInformation.ProcessArchitecture.ToString();
 
             if (installType == InstallType.FileBased)
             {
-                return Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand.ToString(), "InstallState");
+                return Path.Combine(dotnetDir, "metadata", "workloads", architecture, sdkFeatureBand.ToString(), "InstallState");
             }
             else if (installType == InstallType.Msi)
             {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "dotnet", "workloads", sdkFeatureBand.ToString(), "InstallState");
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "dotnet", "workloads", architecture, sdkFeatureBand.ToString(), "InstallState");
             }
             else
             {

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -1276,7 +1276,7 @@ Microsoft.Net.Workload.Emscripten.net7"
 
         private string CreateMockInstallState(string featureBand, string installStateContents)
         {
-            var installStateFolder = Path.Combine(_fakeDotnetRootDirectory!, "metadata", "workloads", featureBand, "InstallState");
+            var installStateFolder = Path.Combine(_fakeDotnetRootDirectory!, "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), featureBand, "InstallState");
             Directory.CreateDirectory(installStateFolder);
 
             string installStatePath = Path.Combine(installStateFolder, "default.json");

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining(unavailableWorkloadSetVersion);
+                .HaveStdErrContaining(unavailableWorkloadSetVersion);
 
             VM.CreateRunCommand("dotnet", "workload", "search")
                 .WithIsReadOnly(true)

--- a/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/src/Tests/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             (string dotnetRoot, FileBasedInstaller installer, _, _) = GetTestInstaller();
             var stringFeatureBand = "6.0.300"; // This is hard-coded in the test installer, so if that changes, update this, too.
             var sdkFeatureBand = new SdkFeatureBand(stringFeatureBand);
-            var path = Path.Combine(dotnetRoot, "metadata", "workloads", stringFeatureBand, "InstallState", "default.json");
+            var path = Path.Combine(dotnetRoot, "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), stringFeatureBand, "InstallState", "default.json");
 
             installer.UpdateInstallMode(sdkFeatureBand, true);
             var installState = InstallStateContents.FromString(File.ReadAllText(path));

--- a/src/Tests/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
+++ b/src/Tests/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
@@ -343,7 +343,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 
         private void CreateInstallState(string featureBand, string installStateContents)
         {
-            var installStateFolder = Path.Combine(_dotnetRoot!, "metadata", "workloads", featureBand, "InstallState");
+            var installStateFolder = Path.Combine(_dotnetRoot!, "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), featureBand, "InstallState");
             Directory.CreateDirectory(installStateFolder);
 
             string installStatePath = Path.Combine(installStateFolder, "default.json");

--- a/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/src/Tests/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var resolverFactory = new MockWorkloadResolverFactory(Path.Combine(Path.GetTempPath(), "dotnetTestPath"), versionNumber, workloadResolver, "userProfileDir");
             var updateCommand = new WorkloadUpdateCommand(Parser.Instance.Parse("dotnet workload update"), Reporter.Output, resolverFactory, workloadInstaller, nugetPackageDownloader, workloadManifestUpdater);
 
-            var installStatePath = Path.Combine(Path.GetTempPath(), "dotnetTestPath", "metadata", "workloads", versionNumber, "InstallState", "default.json");
+            var installStatePath = Path.Combine(Path.GetTempPath(), "dotnetTestPath", "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), versionNumber, "InstallState", "default.json");
             var contents = new InstallStateContents();
             contents.UseWorkloadSets = true;
             var versionFile = Path.Combine("userProfileDir", "sdk-advertising", "8.0.0", "microsoft.net.workloads", Constants.workloadSetVersionFileName);
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             packInstaller.InstalledManifests[0].manifestUpdate.ExistingFeatureBand.Should().Be(manifestsToUpdate[0].ManifestUpdate.ExistingFeatureBand);
             packInstaller.InstalledManifests[0].offlineCache.Should().Be(null);
 
-            var defaultJsonPath = Path.Combine(dotnetPath, "metadata", "workloads", "6.0.300", "InstallState", "default.json");
+            var defaultJsonPath = Path.Combine(dotnetPath, "metadata", "workloads", RuntimeInformation.ProcessArchitecture.ToString(), "6.0.300", "InstallState", "default.json");
             File.Exists(defaultJsonPath).Should().BeTrue();
             var json = JsonDocument.Parse(new FileStream(defaultJsonPath, FileMode.Open, FileAccess.Read), new JsonDocumentOptions() { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
             json.RootElement.Should().NotBeNull();


### PR DESCRIPTION
This aims to resolve #40005 and #37828 as well as one other bug I'd found. More specifically, it:
1. Makes it an error if we resolve a workload set version when you asked for a different one.
2. Adds a message to dotnet workload --info to indicate whether we're trying to use workload sets or not.
3. Removes the version from individual workload manifests if we're configured to use a workload set.
4. Fixes a typo (Manfiest --> Manifest)
5. Ensures that if we have a workload set and some manifests specified in the install state file, that the workload set wins if it came from a global.json or the install state file but loses if it was just the highest-numbered workload set available when we're finding which manifests to use.