### PR TITLE
Fix dotnet fsi does not support DOTNET_CLI_UI_LANGUAGE

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <returns>The custom language that was set by the user.
         /// DOTNET_CLI_UI_LANGUAGE > VSLANG. Returns null if none are set.</returns>
-        private static CultureInfo GetOverriddenUILanguage()
+        public static CultureInfo GetOverriddenUILanguage()
         {
             // DOTNET_CLI_UI_LANGUAGE=<culture name> is the main way for users to customize the CLI's UI language.
             string dotnetCliLanguage = Environment.GetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE);

--- a/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/commands/dotnet-fsi/FsiForwardingApp.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using Microsoft.DotNet.Cli.Utils;
+
 namespace Microsoft.DotNet.Cli
 {
     public class FsiForwardingApp : ForwardingApp
@@ -8,7 +11,19 @@ namespace Microsoft.DotNet.Cli
         private const string FsiDllName = @"FSharp/fsi.dll";
         private const string FsiExeName = @"FSharp/fsi.exe";
 
-        public FsiForwardingApp(string[] arguments) : base(GetFsiAppPath(), arguments)
+        static string[] processArguments(string[] args)
+        {
+            var lang = UILanguageOverride.GetOverriddenUILanguage();
+            if (lang == null)
+            {
+                return args;
+            }
+            else
+            {
+                return args.Append($"--preferreduilang:{lang.Name}").ToArray();
+            }
+        }
+        public FsiForwardingApp(string[] arguments) : base(GetFsiAppPath(), processArguments(arguments))
         {
         }
 


### PR DESCRIPTION
This fixes https://github.com/dotnet/sdk/issues/40301
and fixes https://github.com/dotnet/fsharp/issues/16146

This gets the SDK overridden language version and uses it to specify the fsi --preferreduilang command line argument, which is how fsi knows to do this.
````
--preferreduilang:<string>               Specify the preferred output language culture name (e.g. es-ES, ja-JP)
````
