### PR TITLE
[Blazor] Correct ETag and Content-Length computation, add more precision to quality definition

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -98,7 +98,7 @@ public class ApplyCompressionNegotiation : Task
                     {
                         Name = "Content-Encoding",
                         Value = compressedAsset.AssetTraitValue,
-                        Quality = Math.Round(1.0 / (length + 1), 6).ToString("F6")
+                        Quality = Math.Round(1.0 / (length + 1), 12).ToString("F12")
                     };
                     Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
                     var endpointCopy = new StaticWebAssetEndpoint
@@ -230,7 +230,7 @@ public class ApplyCompressionNegotiation : Task
                 headers.Add(new StaticWebAssetEndpointResponseHeader
                 {
                     Name = "ETag",
-                    Value = $"W/\"{header.Value}\""
+                    Value = $"W/{header.Value}"
                 });
             }
             else if (string.Equals(header.Name, "Content-Type", StringComparison.Ordinal))

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
@@ -50,12 +50,12 @@ public class ApplyCompressionNegotiationTest
                 CreateCandidateEndpoint(
                     "candidate.js",
                     Path.Combine("wwwroot", "candidate.js"),
-                    CreateHeaders("text/javascript")),
+                    CreateHeaders("text/javascript", [("Content-Length", "20")])),
 
                 CreateCandidateEndpoint(
                     "candidate.js.gz",
                     Path.Combine("compressed", "candidate.js.gz"),
-                    CreateHeaders("text/javascript"))
+                    CreateHeaders("text/javascript", [("Content-Length", "9")]))
             ],
             TestResolveFileLength = value => value switch
             {
@@ -79,11 +79,12 @@ public class ApplyCompressionNegotiationTest
                 ResponseHeaders =
                 [
                     new () { Name = "Content-Encoding", Value = "gzip" },
+                    new () { Name = "Content-Length", Value = "9" },
                     new () { Name = "Content-Type", Value = "text/javascript" },
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new ()
             {
@@ -91,7 +92,8 @@ public class ApplyCompressionNegotiationTest
                 AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
                 ResponseHeaders =
                 [
-                    new () { Name = "Content-Type", Value = "text/javascript" }
+                    new () { Name = "Content-Length", Value = "20" },
+                    new () { Name = "Content-Type", Value = "text/javascript" },
                 ],
                 EndpointProperties = [],
                 Selectors = [],
@@ -103,6 +105,7 @@ public class ApplyCompressionNegotiationTest
                 ResponseHeaders =
                 [
                     new () { Name = "Content-Encoding", Value = "gzip" },
+                    new () { Name = "Content-Length", Value = "9" },
                     new () { Name = "Content-Type", Value = "text/javascript" },
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
@@ -188,7 +191,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new ()
             {
@@ -212,7 +215,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new ()
             {
@@ -288,7 +291,7 @@ public class ApplyCompressionNegotiationTest
                         new (){ Name = "Vary", Value = "Content-Encoding" }
                     ],
                     EndpointProperties = [],
-                    Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                    Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
                 new() {
                     Route = "candidate.js",
@@ -310,7 +313,7 @@ public class ApplyCompressionNegotiationTest
                         new (){ Name = "Vary", Value = "Content-Encoding" }
                     ],
                     EndpointProperties = [],
-                    Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                    Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
                 new() {
                     Route = "candidate.fingerprint.js",
@@ -361,7 +364,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -385,7 +388,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -473,7 +476,7 @@ public class ApplyCompressionNegotiationTest
                         new (){ Name = "Vary", Value = "Content-Encoding" }
                     ],
                     EndpointProperties = [],
-                    Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                    Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
                 new() {
                     Route = "candidate.js",
@@ -495,7 +498,7 @@ public class ApplyCompressionNegotiationTest
                         new (){ Name = "Vary", Value = "Content-Encoding" }
                     ],
                     EndpointProperties = [],
-                    Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                    Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
                 new() {
                     Route = "candidate.fingerprint.js",
@@ -557,7 +560,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -570,7 +573,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "br", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "br", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -594,7 +597,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -607,7 +610,7 @@ public class ApplyCompressionNegotiationTest
                     new () { Name = "Vary", Value = "Content-Encoding" }
                 ],
                 EndpointProperties = [],
-                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "br", Quality = "0.100000" } ],
+                Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "br", Quality = "0.100000000000" } ],
             },
             new StaticWebAssetEndpoint
             {
@@ -657,7 +660,7 @@ public class ApplyCompressionNegotiationTest
             {
                 Name = name,
                 Value = value,
-                Quality = "0.100000"
+                Quality = "0.100000000000"
             }
         ];
     }

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
@@ -64,7 +64,7 @@ public class DefineStaticWebAssetEndpointsTest
                 new StaticWebAssetEndpointResponseHeader
                 {
                     Name = "ETag",
-                    Value = "integrity"
+                    Value = "\"integrity\""
                 },
                 new StaticWebAssetEndpointResponseHeader
                 {
@@ -73,37 +73,6 @@ public class DefineStaticWebAssetEndpointsTest
                 }
             ]);
     }
-
-    //[Theory]
-    //[InlineData(StaticWebAsset.SourceTypes.Project)]
-    //[InlineData(StaticWebAsset.SourceTypes.Package)]
-    //public void DoesNotDefineEndpointsForProjectOrPackageAssets(string sourceType)
-    //{
-    //    var errorMessages = new List<string>();
-    //    var buildEngine = new Mock<IBuildEngine>();
-    //    buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
-    //        .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
-
-    //    var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
-
-    //    var task = new DefineStaticWebAssetEndpoints
-    //    {
-    //        BuildEngine = buildEngine.Object,
-    //        CandidateAssets = [CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", sourceType, "candidate.js", "All", "All")],
-    //        ExistingEndpoints = [],
-    //        ContentTypeMappings = [CreateContentMapping("**/*.js", "text/javascript")],
-    //        TestLengthResolver = asset => asset.EndsWith("candidate.js") ? 10 : throw new InvalidOperationException(),
-    //        TestLastWriteResolver = asset => asset.EndsWith("candidate.js") ? lastWrite : throw new InvalidOperationException(),
-    //    };
-
-    //    // Act
-    //    var result = task.Execute();
-
-    //    // Assert
-    //    result.Should().Be(true);
-    //    var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
-    //    endpoints.Should().BeEmpty();
-    //}
 
     [Fact]
     public void DoesNotDefineNewEndpointsWhenAnExistingEndpointAlreadyExists()


### PR DESCRIPTION
* The ETag value needs to be quoted in all cases.
* The length for some files was incorrectly computed using the original item spec, which pointed to the source file (in the case of compressed files).
* The Quality parameter for Content-Negotiation has more precision now (12 digits, which covers files up to 1TB)