### PR TITLE
Mark UseWindowsThreadPool as feature switch

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -665,7 +665,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.UseWindowsThreadPool"
                                     Condition="'$(UseWindowsThreadPool)' != ''"
-                                    Value="$(UseWindowsThreadPool)" />
+                                    Value="$(UseWindowsThreadPool)"
+                                    Trim="true" />
 
     <RuntimeHostConfigurationOption Include="System.Xml.XmlResolver.IsNetworkingEnabledByDefault"
                                     Condition="'$(XmlResolverIsNetworkingEnabledByDefault)' != ''"


### PR DESCRIPTION
Saves 30 kB on a PublishTrimmed Hello World app that uses Windows thread pool (and ~10 kB if using the portable thread pool).

This is a feature switch that trimming can optimize, but we weren't optimizing it because the `RuntimeHostConfigurationOption` wasn't manifested as a feature switch (this was just setting the `AppContext` value).

I would have noticed this on native AOT because I monitor hello world size pretty closely, but it looks like native AOT special cased it to treat it as a feature switch here: https://github.com/dotnet/runtime/blob/7bb7e74d6b1f22e69654f038b06d7688a6ac45de/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L293. The optimization was only missing for PublishTrimmed as a result. The line in native AOT targets should be deleted once we ingest the new SDK with this fix.

Noticed this because this resulted in some conflicts within the https://github.com/dotnet/runtime/blob/7bb7e74d6b1f22e69654f038b06d7688a6ac45de/src/libraries/System.Runtime/tests/System.Runtime.Tests/TrimmingTests/UseWindowsThreadPoolFalse.cs test as I'm in the process of bringing those up with native AOT.

Cc @eduardo-vp @kouvel @eerhardt @dotnet/illink-contrib 