### PR TITLE
Fix reporter encoding

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs
@@ -26,7 +26,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (
                 !CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("en", StringComparison.InvariantCultureIgnoreCase) &&
+#if NET
+                OperatingSystemSupportsUtf8()
+#else
                 CurrentPlatformIsWindowsAndOfficiallySupportsUTF8Encoding()
+#endif
                 )
             {
                 Console.OutputEncoding = DefaultMultilingualEncoding;
@@ -34,6 +38,17 @@ namespace Microsoft.DotNet.Cli.Utils
                 // If the InputEncoding is not set, the encoding will work in CMD but not in Powershell, as the raw CHCP page won't be changed.
             }
         }
+
+#if NET
+        public static bool OperatingSystemSupportsUtf8()
+        {
+            return !OperatingSystem.IsIOS() &&
+                !OperatingSystem.IsAndroid() &&
+                !OperatingSystem.IsTvOS() &&
+                !OperatingSystem.IsBrowser() &&
+                (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 18363));
+        }
+#endif
 
         private static void ApplyOverrideToCurrentProcess(CultureInfo language)
         {

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -24,11 +24,7 @@ namespace Microsoft.DotNet.Cli
             using AutomaticEncodingRestorer _ = new();
 
             // Setting output encoding is not available on those platforms
-            if (!OperatingSystem.IsIOS() &&
-                !OperatingSystem.IsAndroid() &&
-                !OperatingSystem.IsTvOS() &&
-                !OperatingSystem.IsBrowser() &&
-                (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 18363)))
+            if (UILanguageOverride.OperatingSystemSupportsUtf8())
             {
                 Console.OutputEncoding = Encoding.UTF8;
             }

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -24,14 +24,13 @@ namespace Microsoft.DotNet.Cli
             using AutomaticEncodingRestorer _ = new();
 
             // Setting output encoding is not available on those platforms
-            if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsBrowser())
+            if (!OperatingSystem.IsIOS() &&
+                !OperatingSystem.IsAndroid() &&
+                !OperatingSystem.IsTvOS() &&
+                !OperatingSystem.IsBrowser() &&
+                (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 18363)))
             {
-                //if output is redirected, force encoding to utf-8;
-                //otherwise the caller may not decode it correctly
-                if (Console.IsOutputRedirected)
-                {
-                    Console.OutputEncoding = Encoding.UTF8;
-                }
+                Console.OutputEncoding = Encoding.UTF8;
             }
 
             DebugHelper.HandleDebugSwitch(ref args);


### PR DESCRIPTION
Our reporter uses Console.Out and defaults it to the default code page (437). This changes it to use UTF8 encoding, which made the output look more like this:
<img width="592" alt="image" src="https://github.com/dotnet/sdk/assets/12969783/d0bcdf85-f00e-42f3-9e80-610104418201">

instead of:
<img width="691" alt="image" src="https://github.com/dotnet/sdk/assets/12969783/4892ed5a-96c5-42f5-94b7-62b24f7b68e5">


Fixes AB#2036256