### PR TITLE
feat: Add support for updatedTypes in metadata updates

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -8,7 +8,7 @@ export async function receiveHotReloadAsync() {
     const deltas = await response.json();
     if (deltas) {
       try {
-        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta));
+        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.updatedTypes));
       } catch (error) {
         console.warn(error);
         return;

--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -8,7 +8,7 @@ export async function receiveHotReloadAsync() {
     const deltas = await response.json();
     if (deltas) {
       try {
-        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.updatedTypes));
+        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta, d.updatedTypes));
       } catch (error) {
         console.warn(error);
         return;

--- a/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
@@ -132,6 +132,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             public string ModuleId { get; set; } = default!;
             public string MetadataDelta { get; set; } = default!;
             public string ILDelta { get; set; } = default!;
+            public int[]? UpdatedTypes { get; set; } = default!;
         }
     }
 }

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -147,7 +147,7 @@ setTimeout(async function () {
       // to be a failure. These deltas will get applied later, when Blazor completes initialization.
       deltas.forEach(d => {
         try {
-          window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta)
+          window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta, d.updatedTypes)
         } catch (error) {
           console.warn(error);
           applyError = error;

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -30,6 +31,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             context.Request.Body = GetJson(deltas);
@@ -56,6 +58,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -63,6 +66,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             var context = new DefaultHttpContext();
@@ -97,6 +101,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -104,6 +109,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             var context = new DefaultHttpContext();
@@ -124,6 +130,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta3",
                     MetadataDelta = "MetadataDelta3",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -131,6 +138,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta4",
                     MetadataDelta = "MetadataDelta4",
+                    UpdatedTypes = [42],
                 },
                     new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -138,6 +146,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta5",
                     MetadataDelta = "MetadataDelta5",
+                    UpdatedTypes = [42],
                 },
             };
 
@@ -184,6 +193,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -191,6 +201,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             middleware.Deltas.AddRange(deltas);
@@ -221,6 +232,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -228,6 +240,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             middleware.Deltas.AddRange(deltas);
@@ -262,6 +275,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta1",
                     MetadataDelta = "MetadataDelta1",
+                    UpdatedTypes = [42],
                 },
                 new BlazorWasmHotReloadMiddleware.UpdateDelta
                 {
@@ -269,6 +283,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     ModuleId = Guid.NewGuid().ToString(),
                     ILDelta = "ILDelta2",
                     MetadataDelta = "MetadataDelta2",
+                    UpdatedTypes = [42],
                 }
             };
             middleware.Deltas.AddRange(deltas);
@@ -284,6 +299,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 ModuleId = Guid.NewGuid().ToString(),
                 ILDelta = "ILDelta3",
                 MetadataDelta = "MetadataDelta3",
+                UpdatedTypes = [42],
             };
             deltas.Add(update);
             middleware.Deltas.Add(update);
@@ -313,6 +329,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 Assert.Equal(expected[i].MetadataDelta, actual[i].MetadataDelta);
                 Assert.Equal(expected[i].ModuleId, actual[i].ModuleId);
                 Assert.Equal(expected[i].SequenceId, actual[i].SequenceId);
+                Assert.Equal(expected[i].UpdatedTypes, actual[i].UpdatedTypes);
             }
         }
 


### PR DESCRIPTION
Related https://github.com/dotnet/aspnetcore/issues/52937, corresponding PR in blazor: https://github.com/dotnet/aspnetcore/pull/55347

This PR passes the updatedType parameter in order by the hot reload agent to properly invoke MetadatatUpdateHandler types.