### PR TITLE
GitHub workflow for actions/stale to label and close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,9 @@ on:
       daysBeforeClose:
         required: true
         default: "30"
+      operationsPerRun:
+        required: true
+        default: "500"
 
 permissions:
   issues: write
@@ -32,3 +35,4 @@ jobs:
           days-before-close: ${{ fromJson(inputs.daysBeforeClose || 30  ) }} # Default to 30 days if not specified as input
           days-before-pr-stale: -1 # Do not label PRs as 'stale'
           days-before-pr-close: -1 # Do not close PRs labeled as 'stale'
+          operations-per-run: ${{ fromJson(inputs.operationsPerRun || 500 )}}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/stale@v9 # https://github.com/actions/stale/blob/v9/README.md
         with:
+          ascending: true # Process the oldest issues first
           stale-issue-label: 'stale'
           stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'stale'. It will be closed if no further activity occurs within 30 more days. Any new comment will remove the label."
           close-issue-message: "This issue will now be closed since it has been labeled 'stale' without activity for 30 days."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: 'Stale: Label and Close Issues'
+on:
+  schedule:
+    - cron: '19 * * * *' # Hourly at 19 minutes after the hour (random/uncommon time)
+
+  workflow_dispatch:
+    # Manual triggering through the GitHub UI, API, or CLI
+    inputs:
+      daysBeforeStale:
+        required: true
+        default: "2192"
+      daysBeforeClose:
+        required: true
+        default: "30"
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    if: github.repository_owner == 'dotnet' # Do not run on forks
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9 # https://github.com/actions/stale/blob/v9/README.md
+        with:
+          stale-issue-label: 'stale'
+          stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'stale'. It will be closed if no further activity occurs within 30 more days. Any new comment will remove the label."
+          close-issue-message: "This issue will now be closed since it has been labeled 'stale' without activity for 30 days."
+          days-before-stale: ${{ fromJson(inputs.daysBeforeStale || 2192) }} # Default to 6 years if not specified as input
+          days-before-close: ${{ fromJson(inputs.daysBeforeClose || 30  ) }} # Default to 30 days if not specified as input
+          days-before-pr-stale: -1 # Do not label PRs as 'stale'
+          days-before-pr-close: -1 # Do not close PRs labeled as 'stale'


### PR DESCRIPTION
This adopts [actions/stale](https://github.com/actions/stale) into a new workflow to label and close stale issues, with a configuration achieving the following behavior:

* Applies only to issues, and not PRs
* Labels issues as https://github.com/dotnet/sdk/labels/stale after `2192` days (6 years), and leaves a comment when doing so
* Removes the label if an issue is updated or commented
    * This is the default behavior for [`remove-stale-when-updated`](https://github.com/actions/stale?tab=readme-ov-file#remove-stale-when-updated)
    * This does not happen immediately, but will be picked up during a subsequent run of the workflow
* Closes stale issues after `30` more days of inactivity, and leaves a comment when doing so
* Runs the workflow every hour, with a limit of `500` operations per run (up from the default of `30` but low enough to avoid hitting the rate limit)
* Provides a `workflow_dispatch` to allow the workflow to be run interactively in the GitHub UI with input
* Only run on the dotnet org (not forks)

For this to successfully run, the following [GitHub Actions settings](https://github.com/dotnet/sdk/settings/actions) must be enabled:

1. Allow enterprise, and select non-enterprise, actions and reusable workflows
2. Allow actions created by GitHub

This replaces [Add repository policy to label and close stale issues (#40226)](https://github.com/dotnet/sdk/pull/40226).