### PR TITLE
Make pipeline ymls work with the SDK repo

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.dotnet.darc": {
+      "version": "1.1.0-beta.24210.2",
+      "commands": [
+        "darc"
+      ]
+    }
+  }
+}

--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
+
+# See latest release at https://github.com/nexB/scancode-toolkit/releases
+SCANCODE_VERSION="32.1.0"
+
+pyEnvPath="/tmp/scancode-env"
+python3 -m venv $pyEnvPath
+source $pyEnvPath/bin/activate
+pip install scancode-toolkit==$SCANCODE_VERSION
+deactivate
+
+# Setup a script which executes scancode in the virtual environment
+cat > /usr/local/bin/scancode << EOF
+#!/bin/bash
+set -euo pipefail
+source $pyEnvPath/bin/activate
+scancode "\$@"
+deactivate
+EOF
+
+chmod +x /usr/local/bin/scancode

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -1,5 +1,5 @@
 ### This job builds https://github.com/dotnet/dotnet with given parameters
-### If run in an installer PR, new changes are applied to a local copy of the VMR, then it is built and tested
+### If run in an sdk PR, new changes are applied to a local copy of the VMR, then it is built and tested
 
 parameters:
 - name: architecture
@@ -86,7 +86,7 @@ parameters:
   type: boolean
   default: false
 
-#### INSTALLER parameters ####
+#### sdk parameters ####
 
 - name: isBuiltFromVmr
   displayName: True when build is running from dotnet/dotnet directly
@@ -175,7 +175,7 @@ jobs:
         parameters:
           vmrPath: $(vmrPath)
           vmrBranch: ${{ parameters.vmrBranch }}
-          targetRef: $(Build.SourceVersion) # Synchronize the current installer commit
+          targetRef: $(Build.SourceVersion) # Synchronize the current sdk commit
 
   - ${{ if parameters.buildFromArchive }}:
     - script: |

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -3,7 +3,7 @@
 
 parameters:
 - name: targetRef
-  displayName: Target revision of dotnet/installer to synchronize
+  displayName: Target revision of dotnet/sdk to synchronize
   type: string
   default: $(Build.SourceVersion)
 
@@ -73,7 +73,7 @@ jobs:
           --github-pat '$(BotAccount-dotnet-bot-repo-PAT)'
           --verbose
         displayName: Push changes to dotnet/dotnet (public)
-        workingDirectory: $(Agent.BuildDirectory)/installer
+        workingDirectory: $(Agent.BuildDirectory)/sdk
   
     # Push internal/release branches to the internal VMR
     - ${{ if startsWith(parameters.vmrBranch, 'internal/release/') }}:
@@ -86,4 +86,4 @@ jobs:
           --azdev-pat '$(dn-bot-dnceng-build-rw-code-rw)'
           --verbose
         displayName: Push changes to dotnet-dotnet (internal)
-        workingDirectory: $(Agent.BuildDirectory)/installer
+        workingDirectory: $(Agent.BuildDirectory)/sdk

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -8,7 +8,7 @@ parameters:
   type: string
 
 - name: targetRef
-  displayName: Target revision in dotnet/installer to synchronize
+  displayName: Target revision in dotnet/sdk to synchronize
   type: string
   default: $(Build.SourceVersion)
 
@@ -19,16 +19,16 @@ parameters:
 
 steps:
 - checkout: self
-  displayName: Clone dotnet/installer
-  path: installer
+  displayName: Clone dotnet/sdk
+  path: sdk
 
 # This step is needed so that when we get a detached HEAD / shallow clone,
-# we still pull the commit into the temporary installer clone to use it during the sync.
+# we still pull the commit into the temporary sdk clone to use it during the sync.
 - script: |
-    git branch installer-head
+    git branch sdk-head
     git rev-parse HEAD
   displayName: Label PR commit
-  workingDirectory: $(Agent.BuildDirectory)/installer
+  workingDirectory: $(Agent.BuildDirectory)/sdk
 
 - script: |
     git checkout -B ${{ parameters.vmrBranch }}
@@ -54,17 +54,17 @@ steps:
     --tmp $(Agent.TempDirectory)
     --azdev-pat '$(dn-bot-all-orgs-code-r)'
     --branch ${{ parameters.vmrBranch }}
-    --repository "installer:${{ parameters.targetRef }}"
+    --repository "sdk:${{ parameters.targetRef }}"
     --recursive
-    --remote "installer:$(Agent.BuildDirectory)/installer"
-    --component-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md
-    --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
+    --remote "sdk:$(Agent.BuildDirectory)/sdk"
+    --component-template $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/Component.template.md
+    --tpn-template $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
     --debug
     ||
     (echo "##vso[task.logissue type=error]Failed to synchronize the VMR" && exit 1)
   displayName: Synchronize dotnet/dotnet (Unix)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/installer
+  workingDirectory: $(Agent.BuildDirectory)/sdk
 
 - script: git config --global diff.astextplain.textconv echo
   displayName: Disable astextplain in git diff (Windows)
@@ -76,12 +76,12 @@ steps:
     -tmp $(Agent.TempDirectory) `
     -azdevPat '$(dn-bot-all-orgs-code-r)' `
     -branch ${{ parameters.vmrBranch }} `
-    -repository "installer:${{ parameters.targetRef }}" `
+    -repository "sdk:${{ parameters.targetRef }}" `
     -recursive `
     # passing remote fails for some reason, but it is the default anyway
-    # -remote "installer:$(Agent.BuildDirectory)/installer"
-    -componentTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md `
-    -tpnTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt `
+    # -remote "sdk:$(Agent.BuildDirectory)/sdk"
+    -componentTemplate $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/Component.template.md `
+    -tpnTemplate $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt `
     -debugOutput
 
     if ($LASTEXITCODE -ne 0) {
@@ -90,7 +90,7 @@ steps:
     }
   displayName: Synchronize dotnet/dotnet (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/installer
+  workingDirectory: $(Agent.BuildDirectory)/sdk
 
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - publish: $(Agent.TempDirectory)

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -6,6 +6,8 @@
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=___
 # - sdk-unified-build-full
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=___
+# - dotnet-sdk-source-build-internal
+#   https://dev.azure.com/dnceng-public/public/_build?definitionId=1378
 
 trigger: none
 pr:

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -1,11 +1,11 @@
 # This YAML is used by these PR pipelines:
 #
-# - installer-source-build
-#   https://dev.azure.com/dnceng-public/public/_build?definitionId=233
-# - installer-unified-build
-#   https://dev.azure.com/dnceng-public/public/_build?definitionId=277
-# - installer-unified-build-full
-#   https://dev.azure.com/dnceng-public/public/_build?definitionId=279
+# - sdk-source-build
+#   https://dev.azure.com/dnceng-public/public/_build?definitionId=___
+# - sdk-unified-build
+#   https://dev.azure.com/dnceng-public/public/_build?definitionId=___
+# - sdk-unified-build-full
+#   https://dev.azure.com/dnceng-public/public/_build?definitionId=___
 
 trigger: none
 pr:

--- a/src/Installer/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/ci.yml
@@ -4,30 +4,30 @@
 # - dotnet-source-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=240
 #   - PR: ultralite build
-#   - CI: release/* only, every batched commit, full build
+#   - CI: release/* and main-sdk only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-unified-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=278
 #   - PR: lite build
-#   - CI: release/* only, every batched commit, full build
+#   - CI: release/* and main-sdk only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-source-build (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1219
 #   - PR: ultralite build
-#   - CI: release/* and internal/release/* only, every batched commit, full build
+#   - CI: release/*, internal/release/*, and main-sdk only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-source-build-lite (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1299
-#   - PR: release/* and main, lite build, on-demand trigger
+#   - PR: release/*, main, and main-sdk only, lite build, on-demand trigger
 #   - CI: main only, every batched commit, lite build
 #
 # - dotnet-unified-build (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1330
 #   - PR: lite build
-#   - CI: release/*, internal/release/* and main, every batched commit, full build
+#   - CI: release/*, internal/release/*, main, and main-sdk, every batched commit, full build
 
 variables:
 # enable source-only build for pipelines that contain the -source-build string
@@ -75,7 +75,7 @@ extends:
     - ${{ if and(ne(variables.isPRTrigger, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
       - template: /eng/pipelines/templates/stages/vmr-scan.yml@self
 
-    - template: /src/installer/eng/pipelines/templates/stages/vmr-build.yml@self
+    - template: /src/sdk/eng/pipelines/templates/stages/vmr-build.yml@self
       parameters:
         isBuiltFromVmr: true
         isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}

--- a/src/Installer/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/pr.yml
@@ -3,19 +3,19 @@
 #
 # - dotnet-source-build (public)
 #   - PR: ultralite build
-#   - CI: release/* only, every batched commit, full build
+#   - CI: release/* and main-sdk only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-unified-build (public)
 #   - PR: lite build
-#   - CI: release/* only, every batched commit, full build
+#   - CI: release/* and main-sdk only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-source-build (internal)
 #   - PR: ultralite build
 #
 # - dotnet-source-build-lite (internal)
-#   - PR: release/* and main, lite build, on-demand trigger
+#   - PR: release/*, main, and main-sdk, lite build, on-demand trigger
 #
 # - dotnet-unified-build (internal)
 #   - PR: lite build
@@ -37,7 +37,7 @@ variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 
 stages:
-- template: /src/installer/eng/pipelines/templates/stages/vmr-build.yml
+- template: /src/sdk/eng/pipelines/templates/stages/vmr-build.yml
   parameters:
     isBuiltFromVmr: true
     isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}

--- a/src/Installer/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -4,6 +4,7 @@ schedules:
   branches:
     include:
     - main
+    - main-sdk
 
 # Relies on dotnet-source-build being in the same repo as this pipeline
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-considerations

--- a/src/Installer/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -38,17 +38,17 @@ jobs:
       
       echo "Dotnet-dotnet build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$dotnet_dotnet_build&view=results"
 
-      installer_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --query "[?contains(@, 'installer')]" --output tsv | sed "s,installer ,,g")
-      installer_build=$(az pipelines runs list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --pipeline-ids '$(INSTALLER_OFFICIAL_CI_PIPELINE_ID)' --query "[?sourceVersion == '$installer_sha'].id" --output tsv)
-      if [[ -z "$installer_build" ]]; then
-        echo "Could not find a build of installer for commit '$installer_sha'"
+      sdk_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --query "[?contains(@, 'sdk')]" --output tsv | sed "s,sdk ,,g")
+      sdk_build=$(az pipelines runs list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --pipeline-ids '$(SDK_OFFICIAL_CI_PIPELINE_ID)' --query "[?sourceVersion == '$sdk_sha'].id" --output tsv)
+      if [[ -z "$sdk_build" ]]; then
+        echo "Could not find a build of sdk for commit '$sdk_sha'"
         exit 1
       fi
 
-      echo "Installer build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$installer_build&view=results"
+      echo "Sdk build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$sdk_build&view=results"
 
-      echo "##vso[build.addbuildtag]installer-$installer_sha"
-      echo "##vso[task.setvariable variable=InstallerBuildId]$installer_build"
+      echo "##vso[build.addbuildtag]sdk-$sdk_sha"
+      echo "##vso[task.setvariable variable=SdkBuildId]$sdk_build"
       echo "##vso[task.setvariable variable=DotnetDotnetBuildId]$dotnet_dotnet_build"
     displayName: Find associated builds
     name: Get_Build_Ids
@@ -86,7 +86,7 @@ jobs:
       msft_sdk_tarball_name=$(find "$(Pipeline.Workspace)/Artifacts" -name "dotnet-sdk-*-$platform-${{ parameters.architecture }}.tar.gz" -exec basename {} \;)
 
       if [[ -z "$msft_sdk_tarball_name" ]]; then
-        echo "Microsoft SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build https://dev.azure.com/dnceng/internal/_build/results?buildId=$(InstallerBuildId) might have failed."
+        echo "Microsoft SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build https://dev.azure.com/dnceng/internal/_build/results?buildId=$(SdkBuildId) might have failed."
         exit 1
       fi
 

--- a/src/Installer/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -18,14 +18,14 @@ stages:
         InitializeDotNetCli true
         ./.dotnet/dotnet tool restore
       displayName: Initialize tooling
-      workingDirectory: $(Build.SourcesDirectory)/src/installer
+      workingDirectory: $(Build.SourcesDirectory)/src/sdk
 
     - script: |
         set -e
-        sha=`./.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" installer`
+        sha=`./.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" sdk`
         echo "##vso[build.addbuildtag]$sha"
       displayName: Tag the build
-      workingDirectory: $(Build.SourcesDirectory)/src/installer
+      workingDirectory: $(Build.SourcesDirectory)/src/sdk
 
     - script: |
         ./eng/detect-binaries.sh
@@ -39,5 +39,5 @@ stages:
         --tmp "$(Agent.TempDirectory)"
         || (echo '##[error]Found cloaked files in the VMR' && exit 1)
       displayName: Scan for cloaked files
-      workingDirectory: $(Build.SourcesDirectory)/src/installer
+      workingDirectory: $(Build.SourcesDirectory)/src/sdk
       continueOnError: true

--- a/src/Installer/SourceBuild/content/eng/pipelines/templates/steps/download-pipeline-artifact.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/templates/steps/download-pipeline-artifact.yml
@@ -1,11 +1,11 @@
 parameters:
 - name: pipeline
   type: string
-  default: $(INSTALLER_OFFICIAL_CI_PIPELINE_ID)
+  default: $(SDK_OFFICIAL_CI_PIPELINE_ID)
 
 - name: buildId
   type: string
-  default: $(InstallerBuildId)
+  default: $(SdkBuildId)
 
 - name: artifact
   type: string

--- a/src/Installer/SourceBuild/content/eng/pipelines/templates/variables/pipelines.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/templates/variables/pipelines.yml
@@ -3,9 +3,7 @@ variables:
   value: internal
 - name: AZDO_ORG
   value: https://dev.azure.com/dnceng/
-- name: INSTALLER_OFFICIAL_CI_PIPELINE_ID
-  value: 286
-- name: INSTALLER_TARBALL_BUILD_CI_PIPELINE_ID
-  value: 1011
+- name: SDK_OFFICIAL_CI_PIPELINE_ID
+  value: 140
 - name: DOTNET_DOTNET_CI_PIPELINE_ID
   value: 1219

--- a/src/Installer/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/Installer/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -6,6 +6,7 @@ schedules:
   branches:
     include:
     - main
+    - main-sdk
     - release/*.0.1xx*
     - internal/release/*.0.1xx*
 
@@ -20,7 +21,7 @@ parameters:
   default: " " # Set it to an empty string to allow it be an optional parameter
 
 variables:
-  installerRoot: '$(Build.SourcesDirectory)/src/installer'
+  sdkRoot: '$(Build.SourcesDirectory)/src/sdk'
 
 jobs:
 - job: Setup
@@ -80,7 +81,7 @@ jobs:
       artifactFeeds: public/dotnet-public-pypi
       onlyAddExtraIndex: false
 
-  - script: $(installerRoot)/eng/install-scancode.sh
+  - script: $(sdkRoot)/eng/install-scancode.sh
     displayName: Install Scancode
 
   - script: >


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4357

Changes all pipeline references from `installer` to `sdk`. Also adds necessary files to sdk that are required for pipeline steps such as `dotnet-tools.json` (used for darc), and `install-scancode.sh` (used by the license scan pipeline).

Will resolve conflicts and rebase against main after updates to and merge of the feature branch into main.