### PR TITLE
Accept it if the versions from different sets are equal

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -131,7 +131,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     if (!_manifests.TryAdd(readableManifest.ManifestId, (manifest, manifestInfo)))
                     {
                         var existingManifest = _manifests[readableManifest.ManifestId].manifest;
-                        throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, readableManifest.ManifestId, readableManifest.ManifestPath, existingManifest.ManifestPath);
+                        if (!existingManifest.Version.Equals(readableManifest.ManifestVersion))
+                        {
+                            throw new WorkloadManifestCompositionException(Strings.DuplicateManifestID, manifestProvider.GetType().FullName, readableManifest.ManifestId, readableManifest.ManifestPath, existingManifest.ManifestPath);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a partial fix for the issues discussed in https://github.com/dotnet/installer/pull/19222

Specifically, the resolver supports there being multiple workload sets, as long as they don't have overlapping manifests. If we find the same manifest, it currently errors. It should only do that if the two manifest versions are the same, we don't need to error.