### PR TITLE
Clean up PR artifacts publishing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,3 +1,5 @@
+# Pipeline: https://dev.azure.com/dnceng/internal/_build?definitionId=286
+
 trigger:
   batch: true
   branches:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -90,6 +90,8 @@ stages:
       platform:
         name: 'Managed'
         container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
+        # Publish not needed for PR builds
+        skipPublishValidation: true
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/build-pr.yml
       parameters:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -1,11 +1,6 @@
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-    - release/9.0.1xx-preview*
-    - internal/release/*
-    - exp/*
+# Pipeline: https://dev.azure.com/dnceng-public/public/_build?definitionId=101
+
+trigger: none
 
 pr:
   branches:
@@ -83,7 +78,7 @@ stages:
         matrix:
           Build_Release:
             _BuildConfig: Release
-            _PublishArgs: '-publish /p:DotNetPublishUsingPipelines=true'
+            _PublishArgs: ''
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: test
               _Test: -test

--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -184,7 +184,6 @@ jobs:
           Contents: |
             log/$(_BuildConfig)/**/*
             TestResults/$(_BuildConfig)/**/*
-            SymStore/$(_BuildConfig)/**/*
             tmp/$(_BuildConfig)/**/*.binlog
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
         continueOnError: true
@@ -318,7 +317,6 @@ jobs:
             Contents: |
               log/$(_BuildConfig)/**/*
               TestResults/$(_BuildConfig)/**/*
-              SymStore/$(_BuildConfig)/**/*
               tmp/$(_BuildConfig)/**/*.binlog
             TargetFolder: '$(Build.ArtifactStagingDirectory)'
           continueOnError: true
@@ -464,7 +462,6 @@ jobs:
           Contents: |
             log/$(_BuildConfig)/**/*
             TestResults/$(_BuildConfig)/**/*
-            SymStore/$(_BuildConfig)/**/*
             tmp/$(_BuildConfig)/**/*.binlog
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
         continueOnError: true


### PR DESCRIPTION
## Summary

We were publishing many outputs/artifacts to our PR builds. Generally, PR builds only require text logs, binlogs, test results, and other information helpful for debugging. Actual build assets should be acquired via our internal build pipeline.

## Highlights
- Added comments to pipeline yamls for links to pipelines
- Disabled CI trigger (post-merge build) for PR pipeline
- Disabled asset publishing for Windows_NT build
- Disabled SymStore (PDB) content copying for PR build