### PR TITLE
Fix CONTAINER2005 error from all caps project name

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -279,7 +279,7 @@ public static class ContainerHelpers
 
             // normalize the name. a little more complex, but this does all of our checks in a single pass and doesn't require coming back
             // after the normalization to check if our invariants hold
-            var normalizedAllChars = true;
+            var invalidChars = 0;
             var normalizationOccurred = false;
             var builder = new StringBuilder(containerRepository);
             for (int i = 0; i < containerRepository.Length; i++)
@@ -288,7 +288,6 @@ public static class ContainerHelpers
                 if (IsLowerAlpha(current) || IsNumeric(current) || IsAllowedPunctuation(current))
                 {
                     // no need to set the builder's char here, since we preloaded
-                    normalizedAllChars = false;
                 }
                 else if (IsUpperAlpha(current))
                 {
@@ -299,12 +298,13 @@ public static class ContainerHelpers
                 {
                     builder[i] = '-';
                     normalizationOccurred = true;
+                    invalidChars++;
                 }
             }
             var normalizedImageName = builder.ToString();
 
             // check for normalization to useless name
-            if (normalizedAllChars)
+            if (invalidChars == builder.Length)
             {
                 // The name was normalized to all dashes, so there was nothing recoverable. We should throw.
                 var error = (nameof(Strings.InvalidImageName_EntireNameIsInvalidCharacters), new string[] { containerRepository });

--- a/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -78,6 +78,7 @@ public class ContainerHelpersTests
     [InlineData("Api", "api", "NormalizedContainerName", null)]
     [InlineData("API", "api", "NormalizedContainerName", null)]
     [InlineData("$runtime", null, null, "InvalidImageName_NonAlphanumericStartCharacter")]
+    [InlineData("-%", null, null, "InvalidImageName_NonAlphanumericStartCharacter")]
     public void IsValidRepositoryName(string containerRepository, string? expectedNormalized, string? expectedWarning, string? expectedError)
     {
         var actual = ContainerHelpers.NormalizeRepository(containerRepository);

--- a/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -52,6 +52,7 @@ public class ContainerHelpersTests
     [Theory]
     [InlineData("dotnet/runtime", true)]
     [InlineData("foo/bar", true)]
+    [InlineData("owner/API", true)]
     [InlineData("registry", true)]
     [InlineData("-foo/bar", false)]
     [InlineData(".foo/bar", false)]
@@ -59,9 +60,31 @@ public class ContainerHelpersTests
     [InlineData("foo/bar-", false)]
     [InlineData("foo/bar.", false)]
     [InlineData("foo/bar_", false)]
+    [InlineData("--------", false)]
     public void IsValidImageName(string imageName, bool expectedReturn)
     {
         Assert.Equal(expectedReturn, ContainerHelpers.IsValidImageName(imageName));
+    }
+
+    [Theory]
+    [InlineData("0aa", "0aa", null, null)]
+    [InlineData("9zz", "9zz", null, null)]
+    [InlineData("aa0", "aa0", null, null)]
+    [InlineData("zz9", "zz9", null, null)]
+    [InlineData("runtime", "runtime", null, null)]
+    [InlineData("dotnet_runtime", "dotnet_runtime", null, null)]
+    [InlineData("dotnet-runtime", "dotnet-runtime", null, null)]
+    [InlineData("dotnet/runtime", "dotnet/runtime", null, null)]
+    [InlineData("dotnet runtime", "dotnet-runtime", "NormalizedContainerName", null)]
+    [InlineData("Api", "api", "NormalizedContainerName", null)]
+    [InlineData("API", "api", "NormalizedContainerName", null)]
+    [InlineData("$runtime", null, null, "InvalidImageName_NonAlphanumericStartCharacter")]
+    public void IsValidRepositoryName(string containerRepository, string? expectedNormalized, string? expectedWarning, string? expectedError)
+    {
+        var actual = ContainerHelpers.NormalizeRepository(containerRepository);
+        Assert.Equal(expectedNormalized, actual.normalizedImageName);
+        Assert.Equal(expectedWarning, actual.normalizationWarning?.Item1);
+        Assert.Equal(expectedError, actual.normalizationError?.Item1);
     }
 
     [Theory]

--- a/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/ContainerHelpersTests.cs
@@ -52,7 +52,6 @@ public class ContainerHelpersTests
     [Theory]
     [InlineData("dotnet/runtime", true)]
     [InlineData("foo/bar", true)]
-    [InlineData("owner/API", true)]
     [InlineData("registry", true)]
     [InlineData("-foo/bar", false)]
     [InlineData(".foo/bar", false)]


### PR DESCRIPTION
Fix `CONTAINER2005` error being emitted if a project's name is all capitals but otherwise valid.

Resolves #40501.
