### PR TITLE
Fix missing files from container images when directory name starts with dot

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -119,6 +119,7 @@ internal class Layer
                                 },
                                 options: new EnumerationOptions()
                                 {
+                                    AttributesToSkip = FileAttributes.System, // Include hidden files
                                     RecurseSubdirectories = true
                                 });
                     foreach (var item in fileList)


### PR DESCRIPTION
Include hidden files when creating tar layers for container publishing.

Fixes #40511.
