### PR TITLE
Reduced frequency of GitHub stale action; add action write permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Stale: Label and Close Issues'
 on:
   schedule:
-    - cron: '19 * * * *' # Hourly at 19 minutes after the hour (random/uncommon time)
+    - cron: '19 4,16 * * *' # Twice daily at 19 minutes after the hour (random/uncommon time)
 
   workflow_dispatch:
     # Manual triggering through the GitHub UI, API, or CLI
@@ -14,9 +14,10 @@ on:
         default: "30"
       operationsPerRun:
         required: true
-        default: "500"
+        default: "4000"
 
 permissions:
+  actions: write # For managing the operation state cache
   issues: write
 
 jobs:
@@ -35,4 +36,4 @@ jobs:
           days-before-close: ${{ fromJson(inputs.daysBeforeClose || 30  ) }} # Default to 30 days if not specified as input
           days-before-pr-stale: -1 # Do not label PRs as 'stale'
           days-before-pr-close: -1 # Do not close PRs labeled as 'stale'
-          operations-per-run: ${{ fromJson(inputs.operationsPerRun || 500 )}}
+          operations-per-run: ${{ fromJson(inputs.operationsPerRun || 4000 )}}


### PR DESCRIPTION
The action has been producing a warning of:
> Error delete _state: [403] Resource not accessible by integration

That error has been reported as [Error delete _state: [403] Resource not accessible by integration (actions/stale#1133)](https://github.com/actions/stale/issues/1133#issuecomment-2079373371), and adding the `actions: write` permission should address it, allowing the action to write data for managing the cache and managing the action runs.

Also, based on reviewing the runs so far, we have API rate limit room to increase the operations per run and reduce the run frequency. Reducing the frequency will reduce the noise this workflow puts into the https://github.com/dotnet/sdk/actions list.