### PR TITLE
Have --no-restore imply -restore:false to override any response file command-line arguments

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -107,10 +107,10 @@ namespace Microsoft.DotNet.Cli
             return arg;
         }
 
-        public static CliOption<bool> NoRestoreOption = new("--no-restore")
+        public static CliOption<bool> NoRestoreOption = new ForwardedOption<bool>("--no-restore")
         {
             Description = CommonLocalizableStrings.NoRestoreDescription
-        };
+        }.ForwardAs("-restore:false");
 
         public static CliOption<bool> InteractiveMsBuildForwardOption =
             new ForwardedOption<bool>("--interactive")

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -94,6 +94,24 @@ namespace Microsoft.DotNet.Cli.Build.Tests
         }
 
         [Fact]
+        public void ItDoesNotImplicitlyRestoreFromResponseFileWithTheNoRestoreOption()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                .WithSource();
+
+            string responseFilePath = Path.Combine(testInstance.Path, "Directory.Build.rsp");
+
+            File.WriteAllText(responseFilePath, @"-restore");
+
+            new DotnetBuildCommand(Log)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("--no-restore")
+                .Should().Fail()
+                .And.HaveStdOutContaining("project.assets.json");
+        }
+
+        [Fact]
         public void ItRunsWhenRestoringToSpecificPackageDir()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("TestAppSimple")


### PR DESCRIPTION
This updates the `--no-restore` to be a forwarded argument of `-restore:false` to override any argument that may come from a response file.

Fixes #39821

I also verified manually with the locally built assemblies:
![image](https://github.com/dotnet/sdk/assets/17556515/61175675-2fdf-44b7-83aa-d3e193e986f7)
