### PR TITLE
Reference latest MSBuild for netcore MSBuild stuff

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -115,11 +115,14 @@
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)"/>
   </ItemGroup>
 
-  <!-- Use different versions of Microsoft.Build.* depending on whether we are building in source-only
-       modes or normal modes. In normal modes we use MicrosoftBuildMinimumVersion, otherwise
-       we use MicrosoftBuildVersion. Note: This is not abstracted in Versions.props because source-only
+  <!-- Use different versions of Microsoft.Build.* depending on whether the output will be used in
+       .NET Framework (VS) or only in the .NET SDK.
+
+       Note: This is not abstracted in Versions.props because source-only
        modes will import a version override file after Versions.props. -->
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' or '$(TargetFramework)' != 'net472'">
+    <!-- MSBuild-y stuff that runs in the CLI can always reference the latest MSBuild since
+         that is what will be packaged with the .NET SDK. -->
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <!-- Localization is the same between source-only and regular modes. Always taken from latest. Duplicated between the itemgroups for clarity. -->
@@ -130,7 +133,9 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="$(MicrosoftBuildVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'">
+    <!-- MSBuild-y stuff that runs in VS/MSBuild.exe should reference the lagging minimum version so
+         it works in that slightly-older Visual Studio. -->
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildMinimumVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildMinimumVersion)" />
     <!-- Localization is the same between source-only and regular modes. Always taken from latest. Duplicated between the itemgroups for clarity. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -102,7 +102,7 @@
          These should be used in places where we always want to target the latest. This includes source-only modes (always use the latest)
          as well as some additional cases like the msbuild that is redistributed in the SDK.
 
-         In non-source-only modes, some tasks and the resolver will need to run in an MSBuild that is older
+         Some .NET Framework tasks and the resolver will need to run in a VS/MSBuild that is older
          than the very latest, based on what we want the SDK to support. So use a version that matches the version
          in minimumMSBuildVersion. In these cases, we don't want to use MicrosoftBuildVersion and other
          associated properties that are updated by the VMR infrastructure. So, we read this version

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CapturingLogger.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CapturingLogger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests;
 public class CapturingLogger : ILogger
 {
     public LoggerVerbosity Verbosity { get => LoggerVerbosity.Diagnostic; set { } }
-    public string Parameters { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public string? Parameters { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     private List<BuildMessageEventArgs> _messages = new();
     public IReadOnlyList<BuildMessageEventArgs> Messages { get { return _messages; } }


### PR DESCRIPTION
MSBuild references were changed in #38506 to use
MSBuildMinimumVersion in all non-source-build scenarios, but
that's not necessary: the SDK will deliver the latest .NET MSBuild
and use it for all CLI-driven builds.

Using the old version broke some tests because of a mismatch
between newer targets and the old engine that was being used
to execute tests.

Instead, split the reference based on the TF of the project that is
building: for `net472`, use the minimum version if available, but
for `$(SdkTargetFramework)` always use the latest.
