### PR TITLE
fix dotnet/msbuild#10004 by making TL quiet on dotnet new's implicit restore

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-new/DotnetCommandCallbacks.cs
+++ b/src/Cli/dotnet/commands/dotnet-new/DotnetCommandCallbacks.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.Tools.New
         internal static bool RestoreProject(string pathToRestore)
         {
             PathUtility.EnsureAllPathsExist(new[] { pathToRestore }, CommonLocalizableStrings.FileNotFound, allowDirectories: true);
-            return RestoreCommand.Run(new string[] { pathToRestore }) == 0;
+            // for the implicit restore we do not want the terminal logger to emit any output unless there are errors
+            return RestoreCommand.Run([pathToRestore, "-tlp:verbosity=quiet"]) == 0;
         }
 
         internal static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string? solutionFolder, bool? inRoot)


### PR DESCRIPTION
Closes dotnet/msbuild#10004