### PR TITLE
Add bootstrapper validation to clickonce test

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -66,7 +66,7 @@ namespace Microsoft.NET.Publish.Tests
     {(publishSingleFile == true ? $"<RuntimeIdentifier>{rid}</RuntimeIdentifier>" : "")}
   </PropertyGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.8.1">
+    <BootstrapperPackage Include="".NETFramework,Version=v4.8.1"">
       <Install>true</Install>
       <ProductName>Microsoft .NET Framework 4.8.1 (x86 and x64)</ProductName>
     </BootstrapperPackage>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishToClickOnce.cs
@@ -65,13 +65,20 @@ namespace Microsoft.NET.Publish.Tests
     {(publishSingleFile.HasValue ? $"<PublishSingleFile>{publishSingleFile}</PublishSingleFile>" : "")}
     {(publishSingleFile == true ? $"<RuntimeIdentifier>{rid}</RuntimeIdentifier>" : "")}
   </PropertyGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8.1">
+      <Install>true</Install>
+      <ProductName>Microsoft .NET Framework 4.8.1 (x86 and x64)</ProductName>
+    </BootstrapperPackage>
+  </ItemGroup>
 </Project>
 ");
 
             command
                 .Execute("/p:PublishProfile=test")
                 .Should()
-                .Pass();
+                .Pass()
+                .And.NotHaveStdErrContaining("warning");
 
             outputDirectory.Should().HaveFiles(new[] {
                 $"setup.exe",


### PR DESCRIPTION
### Issue
ClickOnce validation does not include coverage for bootstrapper products included in the publish.

### Fix
Update ClickOnce profile pubxml to include a bootstrapper product for publishing. Any failure to publish it will produce a warning. Test has been updated to validate that there are no warnings in the publish.