### PR TITLE
Show workload update notifications for workloads installed via Visual Studio

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
+using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using NuGet.Common;
@@ -220,6 +221,16 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         {
             try
             {
+#if !DOT_NET_BUILD_FROM_SOURCE
+                if (OperatingSystem.IsWindows())
+                {
+                    //  Also advertise updates for workloads installed by Visual Studio
+                    InstalledWorkloadsCollection installedVSWorkloads = new InstalledWorkloadsCollection();
+                    VisualStudioWorkloads.GetInstalledWorkloads(_workloadResolver, installedVSWorkloads, _sdkFeatureBand);
+                    installedWorkloads = installedWorkloads.Concat(installedVSWorkloads.AsEnumerable().Select(kvp => new WorkloadId(kvp.Key))).Distinct().ToList();
+                }
+#endif
+
                 var overlayProvider = new TempDirectoryWorkloadManifestProvider(Path.Combine(_userProfileDir, "sdk-advertising", _sdkFeatureBand.ToString()), _sdkFeatureBand.ToString());
                 var advertisingManifestResolver = _workloadResolver.CreateOverlayResolver(overlayProvider);
                 return _workloadResolver.GetUpdatedWorkloads(advertisingManifestResolver, installedWorkloads);

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMStateTree.cs
@@ -77,4 +77,41 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             return tree;
         }
     }
+
+    internal class VMState
+    {
+        public string DefaultRootState { get; set; }
+
+        public Dictionary<string, VMStateTree> VMStates { get; set; } = new Dictionary<string, VMStateTree>();
+
+        public SerializableVMState ToSerializable()
+        {
+            return new SerializableVMState()
+            {
+                DefaultRootState = DefaultRootState,
+                VMStates = VMStates.Values.Select(v => v.ToSerializeable()).ToList()
+            };
+        }
+
+        public VMStateTree GetRootState()
+        {
+            return VMStates[DefaultRootState];
+        }
+    }
+
+    internal class SerializableVMState
+    {
+        public string DefaultRootState { get; set; }
+
+        public List<SerializableVMStateTree> VMStates { get; set; }
+
+        public VMState ToVMState()
+        {
+            return new VMState()
+            {
+                DefaultRootState = DefaultRootState,
+                VMStates = VMStates.Select(s => s.ToVMStateTree()).ToDictionary(s => s.SnapshotName)
+            };
+        }
+    }
 }

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -94,14 +94,22 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 return;
             }
 
-            var installedSdkFolder = $@"c:\Program Files\dotnet\sdk\{SdkInstallerVersion}";
+            var result = VM.CreateRunCommand("dotnet", "--version")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            string existingVersionToOverwrite = result.StdOut;
+
+            var installedSdkFolder = $@"c:\Program Files\dotnet\sdk\{existingVersionToOverwrite}";
 
             Log.WriteLine($"Deploying SDK from {TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest} to {installedSdkFolder} on VM.");
 
             //  TODO: It would be nice if the description included the date/time of the SDK build, to distinguish different snapshots
             VM.CreateActionGroup("Deploy Stage 2 SDK",
                     VM.CopyFolder(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, installedSdkFolder),
-                    ChangeVersionFileContents(SdkInstallerVersion))
+                    ChangeVersionFileContents(existingVersionToOverwrite))
                 .Execute()
                 .Should()
                 .Pass();

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -179,5 +179,16 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
             return WorkloadSet.FromJson(filteredOutput, defaultFeatureBand: new SdkFeatureBand(SdkInstallerVersion));
         }
+
+        protected string GetWorkloadVersion()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "--version")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            return result.StdOut;
+        }
     }
 }

--- a/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -198,5 +198,14 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
             return result.StdOut;
         }
+
+        protected void AddNuGetSource(string source)
+        {
+            VM.CreateRunCommand("dotnet", "nuget", "add", "source", source)
+                .WithDescription($"Add {source} to NuGet.config")
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }

--- a/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             InstallSdk();
             InstallWorkload("wasm-tools");
             ApplyRC1Manifests();
-            
+
             TestWasmWorkload();
 
             //  Second time applying same rollback file shouldn't do anything
@@ -218,6 +218,33 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .Execute().Should().Pass();
 
             TestWasmWorkload();
+        }
+
+        [Fact]
+        public void InstallShouldNotUpdatePinnedRollback()
+        {
+            InstallSdk();
+            ApplyRC1Manifests();
+            var workloadVersion = GetWorkloadVersion();
+            
+            InstallWorkload("aspire");
+
+            GetWorkloadVersion().Should().Be(workloadVersion);
+        }
+
+        [Fact]
+        public void UpdateShouldUndoPinnedRollback()
+        {
+            InstallSdk();
+            ApplyRC1Manifests();
+            var workloadVersion = GetWorkloadVersion();
+
+            VM.CreateRunCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should().Pass();
+
+            GetWorkloadVersion().Should().NotBe(workloadVersion);
+
         }
 
         [Fact]

--- a/src/Tests/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.MsiInstallerTests.Framework;
+
+namespace Microsoft.DotNet.MsiInstallerTests
+{
+    public class VSWorkloadTests : VMTestBase
+    {
+        public VSWorkloadTests(ITestOutputHelper log) : base(log)
+        {
+            VM.SetCurrentState("Install VS 17.10 Preview 6");
+            DeployStage2Sdk();
+        }
+
+        [Fact]
+        public void WorkloadListShowsVSInstalledWorkloads()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "list")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().Pass();
+
+            result.Should().HaveStdOutContaining("aspire");
+        }
+
+        [Fact]
+        public void UpdatesAreAdvertisedForVSInstalledWorkloads()
+        {
+            AddNuGetSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json");
+
+            VM.CreateRunCommand("dotnet", "new", "classlib", "-o", "LibraryTest")
+                .WithWorkingDirectory(@"C:\SdkTesting")
+                .Execute()
+                .Should()
+                .Pass();
+
+            //  build (or any restoring) command should check for and notify of updates
+            VM.CreateRunCommand("dotnet", "build")
+                .WithWorkingDirectory(@"C:\SdkTesting\LibraryTest")
+                .Execute().Should().Pass()
+                .And.HaveStdOutContaining("Workload updates are available");
+
+            //  Workload list should list the specific workloads that have updates
+            VM.CreateRunCommand("dotnet", "workload", "list")
+                .WithIsReadOnly(true)
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Updates are available for the following workload(s): aspire");
+        }
+    }
+}

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -213,17 +213,6 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
 
-        string GetWorkloadVersion()
-        {
-            var result = VM.CreateRunCommand("dotnet", "workload", "--version")
-                .WithIsReadOnly(true)
-                .Execute();
-
-            result.Should().Pass();
-
-            return result.StdOut;
-        }
-
         string GetUpdateMode()
         {
             var result = VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode")

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -223,14 +223,5 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             return result.StdOut;
         }
-
-        void AddNuGetSource(string source)
-        {
-            VM.CreateRunCommand("dotnet", "nuget", "add", "source", source)
-                .WithDescription($"Add {source} to NuGet.config")
-                .Execute()
-                .Should()
-                .Pass();
-        }
     }
 }


### PR DESCRIPTION
Fix #40295

Also adds some more workload tests and the ability for VM tests to have different start states.