### PR TITLE
Add RazorWarningLevel

### DIFF
--- a/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
+++ b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets
@@ -53,6 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <CompilerVisibleProperty Include="GenerateRazorMetadataSourceChecksumAttributes" />
       <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
       <CompilerVisibleProperty Include="_RazorSourceGeneratorDebug" />
+      <CompilerVisibleProperty Include="RazorWarningLevel" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
+++ b/src/RazorSdk/Targets/Sdk.Razor.CurrentVersion.targets
@@ -117,6 +117,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
+    <RazorWarningLevel Condition="'$(RazorWarningLevel)' == ''">$(WarningLevel)</RazorWarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!--
       The property IsRazorCompilerReferenced is defined by the 2.x Razor.Design package. We can use this as a best guess to determine if a project is targeting 2.x or earlier.
       This is useful to provide 3.0 or newer specific build warnings. However, since it's not very reliable, we should not use this to make build-altering decisions.


### PR DESCRIPTION
Adds support for RazorWarningLevel (similar to C# WarningLevel) - so the razor compiler can report new warnings on existing code and users will be able to turn those warnings off to avoid breaking their builds.
Related to https://github.com/dotnet/razor/pull/10346.

I plan to add a test once razor official builds work again so I can flow a razor build here to test it in CI.