### PR TITLE
Sync the VMR from sdk into dotnet/dotnet main

### DIFF
--- a/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/3019_133595567453787401/values.xml
+++ b/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/3019_133595567453787401/values.xml
@@ -1,0 +1,3 @@
+﻿<values>
+  <value name="StillAlive" type="qword">133595570560309553</value>
+</values>

--- a/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/3019_133595567453787401/values.xml
+++ b/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/3019_133595567453787401/values.xml
@@ -1,3 +1,0 @@
-﻿<values>
-  <value name="StillAlive" type="qword">133595570560309553</value>
-</values>

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -165,8 +165,7 @@ jobs:
     - template: ../steps/vmr-prepare.yml@self
       parameters:
         ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-          # TODO: Set back to vmrBranch: $(System.PullRequest.TargetBranch)
-          vmrBranch: main-sdk
+          vmrBranch: $(System.PullRequest.TargetBranch)
         ${{ else }}:
           vmrBranch: ${{ parameters.vmrBranch }}
 

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -63,8 +63,7 @@ jobs:
 
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
     # Push main and release branches to the public VMR
-    # TODO: Remove main-sdk when sdk becomes the VMR's origin
-    - ${{ if or(eq(parameters.vmrBranch, 'main'), eq(parameters.vmrBranch, 'main-sdk'), startsWith(parameters.vmrBranch, 'release/')) }}:
+    - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
       - script: >
           ./.dotnet/dotnet darc vmr push
           --vmr '$(vmrPath)'

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -24,8 +24,7 @@ parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
   type: string
-  # TODO: Change back to ' ' when sdk becomes the VMR's origin
-  default: main-sdk
+  default: ' '
 
 - name: disableBuild
   displayName: Skip the VMR Build stage
@@ -52,8 +51,7 @@ resources:
     type: github
     name: dotnet/dotnet
     endpoint: dotnet
-    # TODO: Change back to ${{ variables.VmrBranch }}
-    ref: main-sdk
+    ref: ${{ variables.VmrBranch }}
 
 stages:
 # You can temporarily disable the VMR Build stage by setting the disableBuild variable

--- a/eng/pipelines/vmr-sync-internal.yml
+++ b/eng/pipelines/vmr-sync-internal.yml
@@ -15,8 +15,7 @@ resources:
   - repository: vmr
     type: git
     name: dotnet-dotnet
-    # TODO: Change back to '$(Build.SourceBranch)' when sdk becomes the VMR's origin
-    ref: main-sdk
+    ref: $(Build.SourceBranch)
 
   - repository: 1ESPipelineTemplates
     type: git
@@ -27,7 +26,7 @@ parameters:
 - name: vmrBranch
   displayName: dotnet-dotnet branch to push to
   type: string
-  default: 'main-sdk'
+  default: ' '
 
 variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -17,8 +17,7 @@ resources:
     type: github
     name: dotnet/dotnet
     endpoint: dotnet
-    # TODO: Change back to '$(Build.SourceBranch)' when sdk becomes the VMR's origin
-    ref: main-sdk
+    ref: $(Build.SourceBranch)
 
   - repository: 1ESPipelineTemplates
     type: git
@@ -29,7 +28,7 @@ parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
   type: string
-  default: 'main-sdk'
+  default: ' '
 
 variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -1,33 +1,33 @@
-# This yml is used by these pipelines and triggers: 
+# This yml is used by these pipelines and triggers:
 # NOTE: the triggers are defined in the Azure DevOps UI as they are too complex
 #
 # - dotnet-source-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=240
 #   - PR: ultralite build
-#   - CI: release/* and main-sdk only, every batched commit, full build
+#   - CI: release/*, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-unified-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=278
 #   - PR: lite build
-#   - CI: release/* and main-sdk only, every batched commit, full build
+#   - CI: release/* only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-source-build (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1219
 #   - PR: ultralite build
-#   - CI: release/*, internal/release/*, and main-sdk only, every batched commit, full build
+#   - CI: release/* and internal/release/* only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-source-build-lite (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1299
-#   - PR: release/*, main, and main-sdk only, lite build, on-demand trigger
+#   - PR: release/* and main only, lite build, on-demand trigger
 #   - CI: main only, every batched commit, lite build
 #
 # - dotnet-unified-build (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1330
 #   - PR: lite build
-#   - CI: release/*, internal/release/*, main, and main-sdk, every batched commit, full build
+#   - CI: release/*, internal/release/* and main only, every batched commit, full build
 
 variables:
 # enable source-only build for pipelines that contain the -source-build string

--- a/src/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/pr.yml
@@ -4,13 +4,13 @@
 # - dotnet-source-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=240
 #   - PR: ultralite build
-#   - CI: release/* and main-sdk only, every batched commit, full build
+#   - CI: release/* only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 # - dotnet-unified-build (public)
 #   https://dev.azure.com/dnceng-public/public/_build?definitionId=278
 #   - PR: lite build
-#   - CI: release/* and main-sdk only, every batched commit, full build
+#   - CI: release/* only, every batched commit, full build
 #   - Schedule: main only, full build
 #
 

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -4,8 +4,6 @@ schedules:
   branches:
     include:
     - main
-    # TODO: Remove 'main-sdk' when sdk becomes the VMR's origin
-    - main-sdk
 
 # Relies on dotnet-source-build being in the same repo as this pipeline
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-considerations

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -6,8 +6,6 @@ schedules:
   branches:
     include:
     - main
-    # TODO: Remove 'main-sdk' when sdk becomes the VMR's origin
-    - main-sdk
     - release/*.0.1xx*
     - internal/release/*.0.1xx*
 


### PR DESCRIPTION
Needs the "main-sdk" branch force pushed into the "main" branch in both dotnet/dotnet and dotnet-dotnet (internal) first.