### PR TITLE
fix: Don't fail metadata updates on missing assemblies

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -82,24 +82,36 @@ namespace Microsoft.Extensions.HotReload
             var handlerActions = new UpdateHandlerActions();
             foreach (var assembly in sortedAssemblies)
             {
-                foreach (var attr in assembly.GetCustomAttributesData())
+                try
                 {
-                    // Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
-                    // define their own copy without having to cross-compile.
-                    if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+                    foreach (var attr in assembly.GetCustomAttributesData())
                     {
-                        continue;
-                    }
+                        // Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
+                        // define their own copy without having to cross-compile.
+                        if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+                        {
+                            continue;
+                        }
 
-                    IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
-                    if (ctorArgs.Count != 1 ||
-                        ctorArgs[0].Value is not Type handlerType)
-                    {
-                        _log($"'{attr}' found with invalid arguments.");
-                        continue;
-                    }
+                        IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
+                        if (ctorArgs.Count != 1 ||
+                            ctorArgs[0].Value is not Type handlerType)
+                        {
+                            _log($"'{attr}' found with invalid arguments.");
+                            continue;
+                        }
 
-                    GetHandlerActions(handlerActions, handlerType);
+                        GetHandlerActions(handlerActions, handlerType);
+                    }
+                }
+                catch (Exception e)
+                {
+                    // In cross-platform scenarios, such as debugging in VS through WSL, Roslyn
+                    // runs on Windows, and the agent runs on Linux. Assemblies accessible to Windows
+                    // may not be available or loaded on linux (such as WPF's assemblies).
+                    // In such case, we can ignore the assemblies and continue enumerating handlers for
+                    // the rest of the assemblies of current domain.
+                    _log($"'{assembly.FullName}' is not loaded ({e.Message})");
                 }
             }
 

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/App.csproj
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/App.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dep\Dep.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Program.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+using System.Reflection.Metadata;
+
+[assembly: MetadataUpdateHandler(typeof(UpdateHandler))]
+
+// delete the dependency dll to cause load failure of DepSubType
+var depPath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location!)!, "Dep.dll");
+File.Delete(depPath);
+Console.WriteLine($"File deleted: {depPath}");
+
+while (true)
+{
+    lock (UpdateHandler.Guard)
+    {
+        Printer.Print();
+    }
+
+    Thread.Sleep(100);
+}
+
+static class UpdateHandler
+{
+    // Lock to avoid the updated Print method executing concurrently with the update handler.
+    public static object Guard = new object();
+
+    public static void UpdateApplication(Type[] types)
+    {
+        lock (Guard)
+        {
+            Console.WriteLine($"Updated types: {(types == null ? "<null>" : types.Length == 0 ? "<empty>" : string.Join(",", types.Select(t => t.Name)))}");
+        }
+    }
+}

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Program.cs
@@ -2,6 +2,7 @@
 using System.Reflection.Metadata;
 
 [assembly: MetadataUpdateHandler(typeof(UpdateHandler))]
+[assembly: MetadataUpdateHandler(typeof(Dep.UpdateHandler))]
 
 // delete the dependency dll to cause load failure of DepSubType
 var depPath = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location!)!, "Dep.dll");

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Update.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Update.cs
@@ -1,0 +1,13 @@
+using System;
+
+class DepSubType : Dep
+{
+    int F() => 1;
+}
+
+class Printer
+{
+    public static void Print()
+        => Console.WriteLine("Hello!");
+}
+

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Update.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/App/Update.cs
@@ -1,6 +1,6 @@
 using System;
 
-class DepSubType : Dep
+class DepSubType : Dep.DepType
 {
     int F() => 1;
 }

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
@@ -1,0 +1,7 @@
+﻿public class Dep
+{
+    void F()
+    {
+        Console.WriteLine(1);
+    }
+}

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
@@ -8,7 +8,7 @@ public class DepType
     }
 }
 
-static class UpdateHandler
+public static class UpdateHandler
 {
     // Lock to avoid the updated Print method executing concurrently with the update handler.
     public static object Guard = new object();

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.cs
@@ -1,7 +1,23 @@
-﻿public class Dep
+﻿namespace Dep;
+
+public class DepType
 {
     void F()
     {
         Console.WriteLine(1);
+    }
+}
+
+static class UpdateHandler
+{
+    // Lock to avoid the updated Print method executing concurrently with the update handler.
+    public static object Guard = new object();
+
+    public static void UpdateApplication(Type[] types)
+    {
+        lock (Guard)
+        {
+            Console.WriteLine($"Dep Updated types: {(types == null ? "<null>" : types.Length == 0 ? "<empty>" : string.Join(",", types.Select(t => t.Name)))}");
+        }
     }
 }

--- a/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.csproj
+++ b/test/TestAssets/TestProjects/WatchAppMissingAssemblyFailure/Dep/Dep.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -145,6 +145,20 @@ namespace Microsoft.DotNet.Watcher.Tests
                         Console.WriteLine("Changed!");
                     }
                 }
+
+                static class UpdateHandler
+                {
+                    // Lock to avoid the updated Print method executing concurrently with the update handler.
+                    public static object Guard = new object();
+
+                    public static void UpdateApplication(Type[] types)
+                    {
+                        lock (Guard)
+                        {
+                            Console.WriteLine($"Dep Updated types: {(types == null ? "<null>" : types.Length == 0 ? "<empty>" : string.Join(",", types.Select(t => t.Name)))}");
+                        }
+                    }
+                }
                 """;
 
             // Delete all files in testAsset.Path named Dep.dll

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Watcher.Tests
                     }
                 }
 
-                static class UpdateHandler
+                public static class UpdateHandler
                 {
                     // Lock to avoid the updated Print method executing concurrently with the update handler.
                     public static object Guard = new object();

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         }
 
         // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
-        [CoreMSBuildOnlyFact]
+        [CoreMSBuildOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/42850")]
         public async Task HandleMissingAssemblyFailure()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchAppMissingAssemblyFailure")

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.WaitForSessionStarted();
 
             var newSrc = /* lang=c#-test */"""
-                class DepSubType : Dep
+                class DepSubType : Dep.DepType
                 {
                     int F() => 2;
                 }

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertWaitingForChanges();
 
-            var newSrc = /* lang=c#-test */"""
+            var newSrc = """
                 class DepSubType : Dep
                 {
                     int F() => 2;
@@ -128,9 +128,9 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchAppMissingAssemblyFailure")
                 .WithSource();
 
-            await App.StartWatcherAsync(testAsset, "App");
+            App.Start(testAsset, [], "App");
 
-            await App.WaitForSessionStarted();
+            await App.AssertWaitingForChanges();
 
             var newSrc = /* lang=c#-test */"""
                 class DepSubType : Dep.DepType


### PR DESCRIPTION
This change is about https://developercommunity.visualstudio.com/t/WSL-HotReload-does-not-invoke-MetadataUp/10643733, where metadata updates may fail when assemblies cannot be found in a cross-platform scenario.

In failure context, an app is built from Visual Studio, then executed on Linux, where WPF assemblies are not present, but some non-loaded assemblies reference WPF. When metadata update gets applied, searching for the `MetadataUpdateHandler` may fail because some dependencies may not be found when `Assembly.GetCustomAttributesData()` is called and fails to find the rest of the handlers which stops invoking `MetadataUpdateHandler` types.

Skipping the assembly entirely allows for hot reload to successfully completely.

This change is technically not useful for dotnet watch, but I understand from @danroth27 that these files are synchronized to Visual Studio, where the above scenario applies.