### PR TITLE
Fix template ordering

### DIFF
--- a/src/Installer/redist-installer/targets/BundledTemplates.targets
+++ b/src/Installer/redist-installer/targets/BundledTemplates.targets
@@ -19,11 +19,6 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup Label="Repo Templates">
-    <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.symbols.nupkg" />
-    <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.symbols.nupkg" />
-  </ItemGroup>
-
   <ItemGroup Label=".NET 9.0 templates">
     <Bundled90Templates Include="Microsoft.DotNet.Web.ItemTemplates.9.0" PackageVersion="$(AspNetCorePackageVersionFor90Templates)" />
     <Bundled90Templates Include="Microsoft.DotNet.Web.ProjectTemplates.9.0" PackageVersion="$(AspNetCorePackageVersionFor90Templates)" UseVersionForTemplateInstallPath="true" />
@@ -128,7 +123,14 @@
   <Target Name="LayoutTemplates"
         DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesForMSI" />
 
-  <Target Name="LayoutTemplatesForSDK" DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions;DownloadBundledTemplateNupkgs">
+  <Target Name="GetRepoTemplates">
+    <ItemGroup>
+      <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.symbols.nupkg" />
+      <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.symbols.nupkg" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="LayoutTemplatesForSDK" DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions;DownloadBundledTemplateNupkgs;GetRepoTemplates">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
       <BundledTemplatesWithInstallPaths Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
       <BundledTemplatesWithInstallPaths Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
@@ -142,11 +144,12 @@
     <PropertyGroup>
       <CurrentTemplateInstallPath Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '9.0'">%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)</CurrentTemplateInstallPath>
     </PropertyGroup>
+
     <Copy SourceFiles="%(RepoTemplates.Identity)"
           DestinationFolder="$(RedistLayoutPath)templates\$(CurrentTemplateInstallPath)" />
   </Target>
 
-  <Target Name="LayoutTemplatesForMSI" DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions" Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
+  <Target Name="LayoutTemplatesForMSI" DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions;GetRepoTemplates" Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
     <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
           DestinationFolder="$(BaseOutputPath)$(Configuration)\templates-%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)\templates\%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)" />
 

--- a/src/Installer/redist-installer/targets/BundledTemplates.targets
+++ b/src/Installer/redist-installer/targets/BundledTemplates.targets
@@ -123,7 +123,7 @@
   <Target Name="LayoutTemplates"
         DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesForMSI" />
 
-  <Target Name="GetRepoTemplates">
+  <Target Name="GetRepoTemplates" DependsOnTargets="ResolveProjectReferences">
     <ItemGroup>
       <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.symbols.nupkg" />
       <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.symbols.nupkg" />


### PR DESCRIPTION
This fixes the non-deterministic behavior when some of the template packages are missing from the produced SDK which results in failing scenario-tests in unified-build and source-build:

![image](https://github.com/dotnet/sdk/assets/7412651/21b98a00-bf1f-4beb-936a-cee0db526ce4)

By moving the itemgroup into a target, it is guaranteed that the packages are available.