### PR TITLE
Rebootstrap source-build/unified-build

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -23,9 +23,8 @@
       of a .NET major or minor release, prebuilts may be needed. When the release is mature, prebuilts
       are not necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSdkVersion>9.0.100-preview.5.24256.1</PrivateSourceBuiltSdkVersion>
-    <PrivateSourceBuiltArtifactsVersion>9.0.100-preview.5.24256.1</PrivateSourceBuiltArtifactsVersion>
-    <PrivateSourceBuiltPrebuiltsVersion>9.0.100-preview.5.24256.4</PrivateSourceBuiltPrebuiltsVersion>
+    <PrivateSourceBuiltSdkVersion>9.0.100-preview.5.24257.1</PrivateSourceBuiltSdkVersion>
+    <PrivateSourceBuiltArtifactsVersion>9.0.100-preview.5.24257.1</PrivateSourceBuiltArtifactsVersion>
     <!-- command-line-api dependencies -->
     <SystemCommandLineVersion>2.0.0-beta4.24126.1</SystemCommandLineVersion>
     <!-- msbuild dependencies -->

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.5.24253.16"
+    "dotnet": "9.0.100-preview.5.24258.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4376

Note: The arcade version didn't change so there is nothing to update.