### PR TITLE
Don't force base image manifests to have a mediaType

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -33,7 +33,7 @@ internal sealed class ImageBuilder
     /// <summary>
     /// MediaType of the output manifest.
     /// </summary>
-    public string ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
+    public string? ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
 
     internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig, ILogger logger)
     {

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -50,7 +50,7 @@ internal class Layer
         return new(ContentStore.PathForDescriptor(descriptor), descriptor);
     }
 
-    public static Layer FromDirectory(string directory, string containerPath, bool isWindowsLayer, string manifestMediaType)
+    public static Layer FromDirectory(string directory, string containerPath, bool isWindowsLayer, string? manifestMediaType)
     {
         long fileSize;
         Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
@@ -191,7 +191,7 @@ internal class Layer
         string layerMediaType = manifestMediaType switch
         {
             // TODO: configurable? gzip always?
-            SchemaTypes.DockerManifestV2 => SchemaTypes.DockerLayerGzip,
+            SchemaTypes.DockerManifestV2 or null => SchemaTypes.DockerLayerGzip,
             SchemaTypes.OciManifestV1 => SchemaTypes.OciLayerGzipV1,
             _ => throw new ArgumentException(Resource.FormatString(nameof(Strings.UnrecognizedMediaType), manifestMediaType))
         };

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
@@ -30,7 +30,7 @@ public class ManifestV2
     /// When used, this field MUST contain the media type application/vnd.oci.image.manifest.v1+json. This field usage differs from the descriptor use of mediaType.
     /// </summary>
     [JsonPropertyName("mediaType")]
-    public required string MediaType { get; init; }
+    public string? MediaType { get; set; }
 
     /// <summary>
     /// This REQUIRED property references a configuration object for a container, by digest.

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -78,8 +78,8 @@ Microsoft.NET.Build.Containers.ManifestV2.KnownDigest.set -> void
 Microsoft.NET.Build.Containers.ManifestV2.Layers.get -> System.Collections.Generic.List<Microsoft.NET.Build.Containers.ManifestLayer>!
 Microsoft.NET.Build.Containers.ManifestV2.Layers.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.ManifestV2() -> void
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string!
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.init -> void
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string?
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.set -> void
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.get -> int
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.init -> void
 Microsoft.NET.Build.Containers.PlatformInformation

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -42,7 +42,7 @@ internal class DefaultManifestOperations : IManifestOperations
     {
         string jsonString = JsonSerializer.SerializeToNode(manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
-        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType);
+        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType ?? SchemaTypes.DockerManifestV2);
 
         HttpResponseMessage putResponse = await _client.PutAsync(new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}"), manifestUploadContent, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
The field is optional per the spec, and Docker seems to default to `application/vnd.docker.distribution.manifest.v2+json` (see the [Docker CLI Manifest handling code](https://github.com/distribution/distribution/blob/main/registry/handlers/manifests.go#L103C28-L105)) so we should try to handle this as well.

Firing this PR off to see what it does to our tests, but a complete PR would need a test to pin the 'able to parse and publish a manifest without a mediaType' behavior down.