### PR TITLE
Fix ignored paths used by binary tool

### DIFF
--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -3,6 +3,11 @@
 # This file is used by the Binary Tool to remove binaries from the VMR
 # If importing a file, include the relative path to the file
 
+.git/
+.dotnet/
+.packages/
+prereqs/packages/
+
 **/*.bmp
 **/*.doc
 **/*.docx

--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -3,6 +3,7 @@
 # This file is used by the Binary Tool to remove binaries from the VMR
 # If importing a file, include the relative path to the file
 
+# Well known non-checked in infrastructure
 .git/
 .dotnet/
 .packages/

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -54,14 +54,12 @@ public static class DetectBinaries
             "**/.packages/**/*",
             "**/artifacts/**/*",
             "**/prereqs/packages/**/*",
-            "src/nuget-client/NuGet.config",
             "**/*.binlog",
             "**/bin/**/*",
             "**/obj/**/*",
             "**/.vs/**/*",
             "**/.vscode/**/*",
             "**/.tools/**/*",
-            "**/.packages/**/*"
         };
     }
 

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -47,71 +47,22 @@ public static class DetectBinaries
 
     private static async Task<List<string>> GetIgnoredPatternsAsync(string targetDirectory)
     {
-        string gitDirectory = Path.Combine(targetDirectory, ".git");
-        bool isGitRepo = Directory.Exists(gitDirectory);
-
-        try 
+        return new List<string>
         {
-            // Look for a .gitignore file, if it's not present, hardcode classic paths to ignore
-            string gitIgnorePath = Path.Combine(targetDirectory, ".gitignore");
-            if (!File.Exists(gitIgnorePath))
-            {
-                return new List<string>
-                {
-                    "**/.git/**/*",
-                    "**/.dotnet/**/*",
-                    "**/.packages/**/*",
-                    "**/artifacts/**/*",
-                    "**/prereqs/packages/**/*",
-                    "src/nuget-client/NuGet.config",
-                    "**/*.binlog",
-                    "**/bin/**/*",
-                    "**/obj/**/*",
-                    "**/.vs/**/*",
-                    "**/.vscode/**/*",
-                    "**/.tools/**/*",
-                    "**/.packages/**/*",
-                };
-            }
-
-            if (!isGitRepo)
-            {
-                // Configure a fake git repo to use so that we can run git clean -ndx
-                await ExecuteProcessAsync("git", $"-C {targetDirectory} init -q");
-            }
-
-            await ExecuteProcessAsync("git", $"-C {targetDirectory} config --global safe.directory {targetDirectory}");
-
-            if (!isGitRepo)
-            {
-                // Need to stage all files in the fake git repo so that git clean -ndx works
-                await ExecuteProcessAsync("git", $"-C {targetDirectory} config core.safecrlf false");
-                await ExecuteProcessAsync("git", $"-C {targetDirectory} add .");
-            }
-
-            string output = await ExecuteProcessAsync("git", $"-C {targetDirectory} clean -ndx");
-
-            List<string> ignoredPaths = output.Split(Environment.NewLine)
-                .Select(line => GitCleanRegex.Match(line))
-                .Where(match => match.Success)
-                .Select(match => match.Groups[3].Value)
-                .ToList();
-
-            if (isGitRepo)
-            {
-                ignoredPaths.Add(".git");
-            }
-
-            return ignoredPaths;
-        }
-        finally
-        {
-            // Ensure .git directory is deleted if it wasn't originally a git repo
-            if (!isGitRepo && Directory.Exists(gitDirectory))
-            {
-                Directory.Delete(gitDirectory, true);
-            }
-        }
+            "**/.git/**/*",
+            "**/.dotnet/**/*",
+            "**/.packages/**/*",
+            "**/artifacts/**/*",
+            "**/prereqs/packages/**/*",
+            "src/nuget-client/NuGet.config",
+            "**/*.binlog",
+            "**/bin/**/*",
+            "**/obj/**/*",
+            "**/.vs/**/*",
+            "**/.vscode/**/*",
+            "**/.tools/**/*",
+            "**/.packages/**/*"
+        };
     }
 
     private static async Task<bool> IsBinaryAsync(string filePath)

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -45,7 +45,7 @@ public static class DetectBinaries
         return unmatchedBinaryFiles;
     }
 
-    private static async List<string> GetIgnoredPatterns(string targetDirectory)
+    private static List<string> GetIgnoredPatterns(string targetDirectory)
     {
         return new List<string>
         {

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -22,7 +22,6 @@ public static class DetectBinaries
 
         var matcher = new Matcher(StringComparison.Ordinal);
         matcher.AddInclude("**/*");
-        matcher.AddExcludePatterns(GetIgnoredPatterns(targetDirectory));
 
         IEnumerable<string> matchingFiles = matcher.GetResultsInFullPath(targetDirectory);
 
@@ -43,24 +42,6 @@ public static class DetectBinaries
         Log.LogInformation($"Finished binary detection.");
 
         return unmatchedBinaryFiles;
-    }
-
-    private static List<string> GetIgnoredPatterns(string targetDirectory)
-    {
-        return new List<string>
-        {
-            "**/.git/**/*",
-            "**/.dotnet/**/*",
-            "**/.packages/**/*",
-            "**/artifacts/**/*",
-            "**/prereqs/packages/**/*",
-            "**/*.binlog",
-            "**/bin/**/*",
-            "**/obj/**/*",
-            "**/.vs/**/*",
-            "**/.vscode/**/*",
-            "**/.tools/**/*",
-        };
     }
 
     private static async Task<bool> IsBinaryAsync(string filePath)

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -22,7 +22,7 @@ public static class DetectBinaries
 
         var matcher = new Matcher(StringComparison.Ordinal);
         matcher.AddInclude("**/*");
-        matcher.AddExcludePatterns(await GetIgnoredPatternsAsync(targetDirectory));
+        matcher.AddExcludePatterns(GetIgnoredPatterns(targetDirectory));
 
         IEnumerable<string> matchingFiles = matcher.GetResultsInFullPath(targetDirectory);
 
@@ -45,7 +45,7 @@ public static class DetectBinaries
         return unmatchedBinaryFiles;
     }
 
-    private static async Task<List<string>> GetIgnoredPatternsAsync(string targetDirectory)
+    private static async List<string> GetIgnoredPatterns(string targetDirectory)
     {
         return new List<string>
         {

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -52,6 +52,28 @@ public static class DetectBinaries
 
         try 
         {
+            // Look for a .gitignore file, if it's not present, hardcode classic paths to ignore
+            string gitIgnorePath = Path.Combine(targetDirectory, ".gitignore");
+            if (!File.Exists(gitIgnorePath))
+            {
+                return new List<string>
+                {
+                    "**/.git/**/*",
+                    "**/.dotnet/**/*",
+                    "**/.packages/**/*",
+                    "**/artifacts/**/*",
+                    "**/prereqs/packages/**/*",
+                    "src/nuget-client/NuGet.config",
+                    "**/*.binlog",
+                    "**/bin/**/*",
+                    "**/obj/**/*",
+                    "**/.vs/**/*",
+                    "**/.vscode/**/*",
+                    "**/.tools/**/*",
+                    "**/.packages/**/*",
+                };
+            }
+
             if (!isGitRepo)
             {
                 // Configure a fake git repo to use so that we can run git clean -ndx

--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/DetectBinaries.cs
@@ -60,6 +60,13 @@ public static class DetectBinaries
 
             await ExecuteProcessAsync("git", $"-C {targetDirectory} config --global safe.directory {targetDirectory}");
 
+            if (!isGitRepo)
+            {
+                // Need to stage all files in the fake git repo so that git clean -ndx works
+                await ExecuteProcessAsync("git", $"-C {targetDirectory} config core.safecrlf false");
+                await ExecuteProcessAsync("git", $"-C {targetDirectory} add .");
+            }
+
             string output = await ExecuteProcessAsync("git", $"-C {targetDirectory} clean -ndx");
 
             List<string> ignoredPaths = output.Split(Environment.NewLine)


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4391

The binary tool was not detecting binaries in repos where a .git repo was not present, because all files were being ignored upon initialization of said git repo.

Furthermore, some repos have been including binaries in their .gitignore files. This results in those binaries going undetected by the tool. See https://github.com/dotnet/dotnet/blob/8f3d7c26c231d54ad230f427a1005278c815dde6/src/fsharp/.gitignore#L43 as an example.

This PR changes the ignored paths from relying on the .gitignore files to simply hardcoding paths to ignore.