### PR TITLE
Fix DisableWorkloadResolverSentinelPath on .NET Framework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -141,7 +141,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        putting an EnableWorkloadResolver.sentinel file beside the MSBuild SDK resolver DLL -->
   <PropertyGroup Condition="'$(MSBuildEnableWorkloadResolver)' == ''">
     <__DisableWorkloadResolverSentinelPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildBinPath)\DisableWorkloadResolver.sentinel</__DisableWorkloadResolverSentinelPath>
-    <__DisableWorkloadResolverSentinelPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildBinPath)\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\DisableWorkloadResolver.sentinel</__DisableWorkloadResolverSentinelPath>
+    <__DisableWorkloadResolverSentinelPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildToolsPath32)\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\DisableWorkloadResolver.sentinel</__DisableWorkloadResolverSentinelPath>
     <MSBuildEnableWorkloadResolver Condition="!Exists('$(__DisableWorkloadResolverSentinelPath)')">true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
 


### PR DESCRIPTION
As pointed out in https://github.com/dotnet/msbuild/pull/10118, we currently look for the file in arch subfolders such as `MSBuild\Current\Bin\amd64\SdkResolvers`), which doesn't look expected. `SdkResolvers` is present only under the base (x86) installation path.