### PR TITLE
Increase test timeout because of slow arm64 legs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -123,7 +123,7 @@ jobs:
   - name: additionalBuildArgs
     value: ''
   - name: runTestsTimeout
-    value: 20
+    value: 30
 
   - ${{ if parameters.isBuiltFromVmr }}:
     - name: vmrPath


### PR DESCRIPTION
The arm64 legs are slower than amd64 and are timing out frequently.  The are taking right around 20 minutes so the timeout needs to be increased.