### PR TITLE
Do not go beyond the root when searching for a previously installed tool Fixes #40655

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public CommandResult Execute()
         {
-            return Execute(_ => { });
+            return Execute(null);
         }
         public CommandResult Execute(Action<Process> processStarted)
         {

--- a/src/Cli/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -13,10 +13,10 @@ namespace Microsoft.DotNet.ToolPackage
     internal static class ToolPackageFactory
     {
         public static (IToolPackageStore, IToolPackageStoreQuery, IToolPackageDownloader) CreateToolPackageStoresAndDownloader(
-            DirectoryPath? nonGlobalLocation = null, IEnumerable<string> additionalRestoreArguments = null)
+            DirectoryPath? nonGlobalLocation = null, IEnumerable<string> additionalRestoreArguments = null, string runtimeJsonPathForTests = null)
         {
             ToolPackageStoreAndQuery toolPackageStore = CreateConcreteToolPackageStore(nonGlobalLocation);
-            var toolPackageDownloader = new ToolPackageDownloader(toolPackageStore);
+            var toolPackageDownloader = new ToolPackageDownloader(toolPackageStore, runtimeJsonPathForTests);
 
             return (toolPackageStore, toolPackageStore, toolPackageDownloader);
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             IToolManifestFinder toolManifestFinder = null,
             IToolManifestEditor toolManifestEditor = null,
             ILocalToolsResolverCache localToolsResolverCache = null,
-            IReporter reporter = null
+            IReporter reporter = null,
+            string runtimeJsonPathForTests = null
             )
             : base(parseResult)
         {
@@ -54,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                                   new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
             _toolManifestEditor = toolManifestEditor ?? new ToolManifestEditor();
             _localToolsResolverCache = localToolsResolverCache ?? new LocalToolsResolverCache();
-            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader);
+            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader, runtimeJsonPathForTests);
             _toolPackageDownloader = toolPackageDownloader;
             _allowRollForward = parseResult.GetValue(ToolInstallCommandParser.RollForwardOption);
             _allowPackageDowngrade = parseResult.GetValue(ToolInstallCommandParser.AllowPackageDowngradeOption);

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
@@ -26,7 +26,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
         public ToolInstallLocalInstaller(
             ParseResult parseResult,
-            IToolPackageDownloader toolPackageDownloader = null)
+            IToolPackageDownloader toolPackageDownloader = null,
+            string runtimeJsonPathForTests = null)
         {
             _parseResult = parseResult;
             _packageVersion = parseResult.GetValue(ToolInstallCommandParser.VersionOption);
@@ -38,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 IToolPackageStoreQuery,
                 IToolPackageDownloader downloader) toolPackageStoresAndDownloader
                     = ToolPackageFactory.CreateToolPackageStoresAndDownloader(
-                        additionalRestoreArguments: parseResult.OptionValuesToBeForwarded(ToolInstallCommandParser.GetCommand()));
+                        additionalRestoreArguments: parseResult.OptionValuesToBeForwarded(ToolInstallCommandParser.GetCommand()), runtimeJsonPathForTests: runtimeJsonPathForTests);
             _toolPackageStore = toolPackageStoresAndDownloader.store;
             _toolPackageDownloader = toolPackageDownloader ?? toolPackageStoresAndDownloader.downloader;
 

--- a/src/Cli/dotnet/commands/dotnet-tool/run/ToolRunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/run/ToolRunCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Tool.Run
                 CommandName = $"dotnet-{_toolCommandName}",
                 CommandArguments = _forwardArgument,
 
-            }, _allowRollForward); ;
+            }, _allowRollForward);
 
             if (commandspec == null)
             {

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ToolsetUtils.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ToolsetUtils.cs
@@ -11,13 +11,7 @@ internal static class ToolsetUtils
     /// <returns></returns>
     internal static string GetRuntimeGraphFilePath()
     {
-        string dotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
-
-        DirectoryInfo sdksDir = new(Path.Combine(dotnetRoot, "sdk"));
-
-        var lastWrittenSdk = sdksDir.EnumerateDirectories().OrderByDescending(di => di.LastWriteTime).First();
-
-        return lastWrittenSdk.GetFiles("RuntimeIdentifierGraph.json").Single().FullName;
+        return TestContext.GetRuntimeGraphFilePath();
     }
 
     internal static IManifestPicker RidGraphManifestPicker { get; } = new RidGraphManifestPicker(GetRuntimeGraphFilePath());

--- a/test/Microsoft.NET.TestFramework/TestContext.cs
+++ b/test/Microsoft.NET.TestFramework/TestContext.cs
@@ -51,6 +51,17 @@ namespace Microsoft.NET.TestFramework
 
         public const string LatestRuntimePatchForNetCoreApp2_0 = "2.0.9";
 
+        public static string GetRuntimeGraphFilePath()
+        {
+            string dotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+
+            DirectoryInfo sdksDir = new(Path.Combine(dotnetRoot, "sdk"));
+
+            var lastWrittenSdk = sdksDir.EnumerateDirectories().OrderByDescending(di => di.LastWriteTime).First();
+
+            return lastWrittenSdk.GetFiles("RuntimeIdentifierGraph.json").Single().FullName;
+        }
+
         public void AddTestEnvironmentVariables(IDictionary<string, string> environment)
         {
             environment["DOTNET_MULTILEVEL_LOOKUP"] = "0";

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -41,11 +41,10 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             Directory.CreateDirectory("/tmp/folder/sub");
             var directory = Directory.GetCurrentDirectory();
+            var ridGraphPath = TestContext.GetRuntimeGraphFilePath();
             try
             {
                 Directory.SetCurrentDirectory("/tmp/folder");
-                var sdkPath = new DirectoryInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dotnet", "sdk"));
-                var ridGraphPath = Path.Combine(sdkPath.EnumerateDirectories().First().FullName, "RuntimeIdentifierGraph.json");
 
                 new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder").WithWorkingDirectory("/tmp/folder").Execute().Should().Pass();
                 var parseResult = Parser.Instance.Parse("tool install dotnetsay");

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tool.Run;

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             try
             {
                 Directory.SetCurrentDirectory("/tmp/folder");
-                var sdkPath = new DirectoryInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly()), "dotnet", "sdk"));
+                var sdkPath = new DirectoryInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dotnet", "sdk"));
                 var ridGraphPath = Path.Combine(sdkPath.EnumerateDirectories().First().FullName, "RuntimeIdentifierGraph.json");
 
                 new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder").WithWorkingDirectory("/tmp/folder").Execute().Should().Pass();

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tool.Run;
@@ -41,17 +43,19 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             try
             {
                 Directory.SetCurrentDirectory("/tmp/folder");
+                var sdkPath = new DirectoryInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly()), "dotnet", "sdk"));
+                var ridGraphPath = Path.Combine(sdkPath.EnumerateDirectories().First().FullName, "RuntimeIdentifierGraph.json");
 
                 new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder").WithWorkingDirectory("/tmp/folder").Execute().Should().Pass();
-                var parseResult = Parser.Instance.Parse("dotnet tool install dotnetsay");
-                new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
+                var parseResult = Parser.Instance.Parse("tool install dotnetsay");
+                new ToolInstallLocalCommand(parseResult, runtimeJsonPathForTests: ridGraphPath).Execute().Should().Be(0);
 
                 Directory.SetCurrentDirectory("/tmp/folder/sub");
                 new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder/sub").WithWorkingDirectory("/tmp/folder/sub").Execute().Should().Pass();
-                parseResult = Parser.Instance.Parse("dotnet tool install dotnetsay");
-                new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
+                parseResult = Parser.Instance.Parse("tool install dotnetsay");
+                new ToolInstallLocalCommand(parseResult, runtimeJsonPathForTests: ridGraphPath).Execute().Should().Be(0);
 
-                new ToolRunCommand(Parser.Instance.Parse($"dotnet tool run dotnetsay")).Execute().Should().Be(0);
+                new ToolRunCommand(Parser.Instance.Parse($"tool run dotnetsay")).Execute().Should().Be(0);
             }
             finally
             {

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -37,16 +37,26 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         public void WhenRunWithRoot()
         {
             Directory.CreateDirectory("/tmp/folder/sub");
+            var directory = Directory.GetCurrentDirectory();
+            try
+            {
+                Directory.SetCurrentDirectory("/tmp/folder");
 
-            new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder").WithWorkingDirectory("/tmp/folder").Execute().Should().Pass();
-            var parseResult = Parser.Instance.Parse($"dotnet tool install --tool-path /tmp/folder {PackageId}");
-            new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
+                new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder").WithWorkingDirectory("/tmp/folder").Execute().Should().Pass();
+                var parseResult = Parser.Instance.Parse("dotnet tool install dotnetsay");
+                new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
 
-            new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder/sub").WithWorkingDirectory("/tmp/folder/sub").Execute().Should().Pass();
-            parseResult = Parser.Instance.Parse($"dotnet tool install --tool-path /tmp/folder/sub {PackageId}");
-            new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
+                Directory.SetCurrentDirectory("/tmp/folder/sub");
+                new DotnetNewCommand(Log, "tool-manifest").WithCustomHive("/tmp/folder/sub").WithWorkingDirectory("/tmp/folder/sub").Execute().Should().Pass();
+                parseResult = Parser.Instance.Parse("dotnet tool install dotnetsay");
+                new ToolInstallLocalCommand(parseResult).Execute().Should().Be(0);
 
-            new ToolRunCommand(Parser.Instance.Parse($"dotnet tool run {PackageId} --tool-path /tmp/folder/sub")).Execute().Should().Be(0);
+                new ToolRunCommand(Parser.Instance.Parse($"dotnet tool run dotnetsay")).Execute().Should().Be(0);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(directory);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #40655

dotnet tool install currently looks for a previously installed tools manifest. It reads manifests it finds in looking for one that has the manifest it's trying to install but does not check whether that manifest 'isRoot', which means it keeps going outside the root.

We don't use a tool beyond the root, which means we can't install then use a tool as would be expected.

@nagilson, can you take a look at this? I don't know all that much about dotnet tool.