### PR TITLE
[wasm] Use plain mariner container for vmr build

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -35,7 +35,7 @@ variables:
 - name: androidCrossContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-android-amd64
 - name: browserCrossContainer
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230917141449-2aaa02c
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0
 - name: wasiCrossContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
 


### PR DESCRIPTION
We do not require preinstalled emscripten anymore