### PR TITLE
Fix well known non-checked in infrastructure binaries

### DIFF
--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -5,7 +5,7 @@
 
 # Well known non-checked in infrastructure
 artifacts/*/BinaryToolKit/
-**/.dotnet/
+.dotnet/
 .git/
 .packages/
 prereqs/packages/

--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -4,8 +4,9 @@
 # If importing a file, include the relative path to the file
 
 # Well known non-checked in infrastructure
+artifacts/*/BinaryToolKit/
+**/.dotnet/
 .git/
-.dotnet/
 .packages/
 prereqs/packages/
 

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -16,13 +16,14 @@ stages:
     - script: |
         source ./eng/common/tools.sh
         InitializeDotNetCli true
-        ./.dotnet/dotnet tool restore
+        cd src/sdk
+        ../../.dotnet/dotnet tool restore
       displayName: Initialize tooling
-      workingDirectory: $(Build.SourcesDirectory)/src/sdk
+      workingDirectory: $(Build.SourcesDirectory)
 
     - script: |
         set -e
-        sha=`./.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" sdk`
+        sha=`../../.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" sdk`
         echo "##vso[build.addbuildtag]$sha"
       displayName: Tag the build
       workingDirectory: $(Build.SourcesDirectory)/src/sdk
@@ -34,7 +35,7 @@ stages:
       continueOnError: true
 
     - script: >
-        ./.dotnet/dotnet darc vmr scan-cloaked-files
+        ../../.dotnet/dotnet darc vmr scan-cloaked-files
         --vmr "$(Build.SourcesDirectory)"
         --tmp "$(Agent.TempDirectory)"
         || (echo '##[error]Found cloaked files in the VMR' && exit 1)


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4395

Adds `artifacts/*/BinaryToolKit/` to the list of well-known infrastructure binaries and adjusted `.dotnet/` to be `**/.dotnet/` in order to address dotnet being installed in sdk.