### PR TITLE
Exception --> logged error in ResolvePackageAssets

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -949,7 +949,8 @@ You may need to build the project on another operating system or architecture, o
     <comment>{StrBegin="NETSDK1213: "}</comment>
   </data>
   <data name="ItemMissingValue" xml:space="preserve">
-    <value>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</value>
+    <value>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</value>
+    <comment>{StrBegin="NETSDK1214: "}</comment>
   </data>
   <!-- The latest message added is ItemMissingValue. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -948,5 +948,8 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1213: Targeting .NET 8.0 or higher in Visual Studio 2022 17.7 is not supported.</value>
     <comment>{StrBegin="NETSDK1213: "}</comment>
   </data>
-  <!-- The latest message added is Net8NotCompatibleWithDev177. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="ItemMissingValue" xml:space="preserve">
+    <value>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</value>
+  </data>
+  <!-- The latest message added is ItemMissingValue. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: Knihovna JIT {0} se nenašla.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: Die JIT-Bibliothek "{0}" wurde nicht gefunden.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: No se encontró la biblioteca JIT "{0}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: la bibliothèque JIT '{0}' est introuvable.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: la libreria '{0}' di JIT non è stata trovata.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: JIT ライブラリ '{0}' が見つかりません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: JIT 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', „{0}”))"&gt;wartość prawda&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: nie znaleziono biblioteki JIT "{0}".</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;verdadeiro&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: biblioteca JIT '{0}' não encontrada.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: библиотека JIT "{0}" не найдена.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: JIT kitaplığı '{0}' bulunamadı.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: 找不到 JIT 库“{0}”。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
 &lt;IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '{0}'))"&gt;true&lt;/IsTrimmable&gt;</target>
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
+      <trans-unit id="ItemMissingValue">
+        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>
         <target state="translated">NETSDK1157: 找不到 JIT 程式庫 '{0}'。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -584,9 +584,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegin="NETSDK1212: "}</note>
       </trans-unit>
       <trans-unit id="ItemMissingValue">
-        <source>Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
-        <target state="new">Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
-        <note />
+        <source>NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</source>
+        <target state="new">NETSDK1214: Method {0} failed with a null reference exception. This typically indicates that the corresponding input to the ResolvePackageAssets task is missing a value.</target>
+        <note>{StrBegin="NETSDK1214: "}</note>
       </trans-unit>
       <trans-unit id="JitLibraryNotFound">
         <source>NETSDK1157: JIT library '{0}' not found.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Security.Cryptography;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
@@ -345,7 +346,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             catch (AcceptableNullReferenceException nre)
             {
-                Log.LogError(nre.Message);
+                Log.LogError(Strings.ItemMissingValue, nre.Message);
             }
         }
 
@@ -1125,13 +1126,13 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     writeItems();
                 }
-                catch (NullReferenceException nre)
+                catch (NullReferenceException)
                 {
                     // If one of the items has null metadata, it may throw a null reference exception in trying
                     // to write it here. This may be unexpected but is more likely to be "accept default"
                     // behavior. Regardless, we may have corrupted this stream, so we can't reuse it. Throw a
                     // user-visible but graceful exception.
-                    throw new AcceptableNullReferenceException(nre.Message);
+                    throw new AcceptableNullReferenceException(writeItems.GetMethodInfo().Name);
                 }
 
                 FlushMetadata();


### PR DESCRIPTION
Resolves AB#2047667

I confirmed with the customer that this was not an unexpected error for them but rather one where they hadn't expected to see a full stack trace; they'd just wanted to see a clean message about what went wrong.

This is in the ResolvePackageAssets task. It would be nice if instead of throwing an exception, we could log an error. Unfortunately, the code that actually throws is deep in another class, which means we would have to either return the error up the stack or catch any NRE from almost anywhere in ResolvePackageAssets. This does neither by converting the NRE into a new exception type at the point where the exception might be expected, then catching it and logging an error at the top level.

Also let me know if you want me to push the catch (AcceptableNullReferenceException) down the stack a bit.