### PR TITLE
[VMR] Skip Publish Scenario Test Results for dev versions job

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -508,7 +508,7 @@ jobs:
 
     - task: PublishTestResults@2
       displayName: Publish Scenario Test Results
-      condition: succeededOrFailed()
+      condition: and(ne(parameters.useDevVersions, 'True'), succeededOrFailed())
       continueOnError: true
       inputs:
         testRunner: xUnit

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -508,7 +508,7 @@ jobs:
 
     - task: PublishTestResults@2
       displayName: Publish Scenario Test Results
-      condition: ${{ and(ne(parameters.useDevVersions, 'True'), succeededOrFailed()) }}
+      condition: and(${{ ne(parameters.useDevVersions, 'True') }}, succeededOrFailed())
       continueOnError: true
       inputs:
         testRunner: xUnit

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -508,7 +508,7 @@ jobs:
 
     - task: PublishTestResults@2
       displayName: Publish Scenario Test Results
-      condition: and(ne(parameters.useDevVersions, 'True'), succeededOrFailed())
+      condition: ${{ and(ne(parameters.useDevVersions, 'True'), succeededOrFailed()) }}
       continueOnError: true
       inputs:
         testRunner: xUnit


### PR DESCRIPTION
Scenario tests only run when we're using official build ids so we're getting a warning on the dev versions job that the .xml doesn't exist.