### PR TITLE
[VMR] Turn off SBOM generation for logs/patches

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -148,12 +148,14 @@ jobs:
       condition: succeededOrFailed()
       targetPath: $(Build.StagingDirectory)/BuildLogs
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
+      sbomEnabled: false
 
     - output: pipelineArtifact
       path: $(Build.ArtifactStagingDirectory)/publishing
       artifact: $(Agent.JobName)_Artifacts
       displayName: Publish Artifacts
       condition: always()
+      sbomEnabled: true
 
     - ${{ if not(parameters.isBuiltFromVmr) }}:
       - output: pipelineArtifact
@@ -161,6 +163,7 @@ jobs:
         condition: failed()
         targetPath: $(Agent.TempDirectory)
         artifactName: $(System.JobDisplayName)_FailedPatches
+        sbomEnabled: false
 
   steps:
   - ${{ if not(parameters.isBuiltFromVmr) }}:


### PR DESCRIPTION
We only need SBOMs for the actual binaries/packages. This speeds up the build and makes it more reliable.