### PR TITLE
Update Fedora and Ubuntu CI legs to latest

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -87,7 +87,7 @@ stages:
     - template: ../jobs/vmr-build.yml
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: $[format('{0}_Online_MsftSdk', variables['centOSStreamName'])]
+        buildName: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
@@ -107,7 +107,7 @@ stages:
       - template: ../jobs/vmr-build.yml
         parameters:
           # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: $[format('{0}_Online_CurrentSourceBuiltSdk', variables['centOSStreamName'])]
+          buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
           isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
           vmrBranch: ${{ variables.VmrBranch }}
           architecture: x64
@@ -120,12 +120,12 @@ stages:
           runOnline: true                    # ✅
           useMonoRuntime: false              # 🚫
           withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: $[format('{0}_Online_MsftSdk', variables['centOSStreamName'])]
+          reuseBuildArtifactsFrom: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
 
       - template: ../jobs/vmr-build.yml
         parameters:
           # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: $[format('{0}_Offline_PreviousSourceBuiltSdk', variables['alpineName'])]
+          buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.alpineName) }}
           isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
           vmrBranch: ${{ variables.VmrBranch }}
           architecture: x64
@@ -146,7 +146,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Online_MsftSdk', variables['alpineName'])]
+            buildName: ${{ format('{0}_Online_MsftSdk', variables.alpineName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -163,7 +163,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Offline_MsftSdk', variables['centOSStreamName'])]
+            buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -180,7 +180,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Online_PreviousSourceBuiltSdk', variables['centOSStreamName'])]
+            buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -198,7 +198,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Offline_PreviousSourceBuiltSdk', variables['centOSStreamName'])]
+            buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -216,7 +216,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Mono_Offline_MsftSdk', variables['centOSStreamName'])]
+            buildName: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -233,7 +233,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
+            buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -250,7 +250,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Offline_MsftSdk', variables['ubuntuName'])]
+            buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -267,7 +267,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}Arm64_Offline_MsftSdk', variables['ubuntuName'])]
+            buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: arm64
@@ -284,7 +284,7 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: $[format('{0}_Offline_CurrentSourceBuiltSdk', variables['fedoraName'])]
+            buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
@@ -297,7 +297,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
+            reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:
@@ -312,7 +312,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: $[format('{0}_DevVersions', variables['ubuntuName'])]
+        buildName: ${{ format('{0}_DevVersions', variables.ubuntuName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -87,12 +87,12 @@ stages:
     - template: ../jobs/vmr-build.yml
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream9_Online_MsftSdk
+        buildName: $[format('{0}_Online_MsftSdk', variables['centOSStreamName'])]
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ variables.centOSStream9Container }}
+        container: ${{ variables.centOSStreamContainer }}
         buildFromArchive: false            # 🚫
         buildSourceOnly: true              # ✅
         enablePoison: false                # 🚫
@@ -107,12 +107,12 @@ stages:
       - template: ../jobs/vmr-build.yml
         parameters:
           # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: CentOSStream9_Online_CurrentSourceBuiltSdk
+          buildName: $[format('{0}_Online_CurrentSourceBuiltSdk', variables['centOSStreamName'])]
           isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
           vmrBranch: ${{ variables.VmrBranch }}
           architecture: x64
           pool: ${{ parameters.pool_Linux }}
-          container: ${{ variables.centOSStream9Container }}
+          container: ${{ variables.centOSStreamContainer }}
           buildFromArchive: false            # 🚫
           buildSourceOnly: true              # ✅
           enablePoison: false                # 🚫
@@ -120,18 +120,18 @@ stages:
           runOnline: true                    # ✅
           useMonoRuntime: false              # 🚫
           withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: centOSStream9_Online_MsftSdk
+          reuseBuildArtifactsFrom: $[format('{0}_Online_MsftSdk', variables['centOSStreamName'])]
 
       - template: ../jobs/vmr-build.yml
         parameters:
           # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: Alpine319_Offline_PreviousSourceBuiltSdk
+          buildName: $[format('{0}_Offline_PreviousSourceBuiltSdk', variables['alpineName'])]
           isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
           vmrBranch: ${{ variables.VmrBranch }}
           architecture: x64
-          artifactsRid: alpine.3.19-x64
+          artifactsRid: ${{ variables.alpineX64Rid }}
           pool: ${{ parameters.pool_Linux }}
-          container: ${{ variables.alpine319Container }}
+          container: ${{ variables.alpineContainer }}
           buildFromArchive: false            # 🚫
           buildSourceOnly: true              # ✅
           enablePoison: true                 # ✅
@@ -146,12 +146,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Alpine319_Online_MsftSdk
+            buildName: $[format('{0}_Online_MsftSdk', variables['alpineName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.alpine319Container }}
+            container: ${{ variables.alpineContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -163,12 +163,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: CentOSStream9_Offline_MsftSdk
+            buildName: $[format('{0}_Offline_MsftSdk', variables['centOSStreamName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStream9Container }}
+            container: ${{ variables.centOSStreamContainer }}
             buildFromArchive: true             # ✅
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -180,13 +180,13 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: CentOSStream9_Online_PreviousSourceBuiltSdk
+            buildName: $[format('{0}_Online_PreviousSourceBuiltSdk', variables['centOSStreamName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
-            artifactsRid: centos.9-x64
+            artifactsRid: ${{ variables.centOSStreamX64Rid }}
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStream9Container }}
+            container: ${{ variables.centOSStreamContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -198,13 +198,13 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: CentOSStream9_Offline_PreviousSourceBuiltSdk
+            buildName: $[format('{0}_Offline_PreviousSourceBuiltSdk', variables['centOSStreamName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
-            artifactsRid: centos.9-x64
+            artifactsRid: ${{ variables.centOSStreamX64Rid }}
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStream9Container }}
+            container: ${{ variables.centOSStreamContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -216,12 +216,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: CentOSStream9_Mono_Offline_MsftSdk
+            buildName: $[format('{0}_Mono_Offline_MsftSdk', variables['centOSStreamName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStream9Container }}
+            container: ${{ variables.centOSStreamContainer }}
             buildFromArchive: true             # ✅
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -233,12 +233,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Fedora40_Offline_MsftSdk
+            buildName: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedora40Container }}
+            container: ${{ variables.fedoraContainer }}
             buildFromArchive: true             # ✅
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -250,12 +250,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Ubuntu2404_Offline_MsftSdk
+            buildName: $[format('{0}_Offline_MsftSdk', variables['ubuntuName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.ubuntu2404Container }}
+            container: ${{ variables.ubuntuContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -267,12 +267,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Ubuntu2404Arm64_Offline_MsftSdk
+            buildName: $[format('{0}Arm64_Offline_MsftSdk', variables['ubuntuName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: arm64
             pool: ${{ parameters.pool_LinuxArm64 }}
-            container: ${{ variables.ubuntu2404ArmContainer }}
+            container: ${{ variables.ubuntuArmContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -284,12 +284,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Fedora40_Offline_CurrentSourceBuiltSdk
+            buildName: $[format('{0}_Offline_CurrentSourceBuiltSdk', variables['fedoraName'])]
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedora40Container }}
+            container: ${{ variables.fedoraContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -297,7 +297,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: Fedora40_Offline_MsftSdk
+            reuseBuildArtifactsFrom: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:
@@ -317,7 +317,7 @@ stages:
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ variables.ubuntu2404Container }}
+        container: ${{ variables.ubuntuContainer }}
         targetOS: linux
         targetArchitecture: x64
         useDevVersions: true # Use dev versions for CI validation of the experience. If we decide to ship assets from this leg, then we should remove this option.
@@ -329,7 +329,7 @@ stages:
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ variables.ubuntu2404Container }}
+        container: ${{ variables.ubuntuContainer }}
         targetOS: linux
         targetArchitecture: x64
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -233,12 +233,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Fedora39_Offline_MsftSdk
+            buildName: Fedora40_Offline_MsftSdk
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedora39Container }}
+            container: ${{ variables.fedora40Container }}
             buildFromArchive: true             # ✅
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -250,12 +250,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Ubuntu2204_Offline_MsftSdk
+            buildName: Ubuntu2404_Offline_MsftSdk
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.ubuntu2204Container }}
+            container: ${{ variables.ubuntu2404Container }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -267,12 +267,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Ubuntu2204Arm64_Offline_MsftSdk
+            buildName: Ubuntu2404Arm64_Offline_MsftSdk
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: arm64
             pool: ${{ parameters.pool_LinuxArm64 }}
-            container: ${{ variables.ubuntu2204ArmContainer }}
+            container: ${{ variables.ubuntu2404ArmContainer }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -284,12 +284,12 @@ stages:
         - template: ../jobs/vmr-build.yml
           parameters:
             # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: Fedora39_Offline_CurrentSourceBuiltSdk
+            buildName: Fedora40_Offline_CurrentSourceBuiltSdk
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedora39Container }}
+            container: ${{ variables.fedora40Container }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫
@@ -297,7 +297,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: Fedora39_Offline_MsftSdk
+            reuseBuildArtifactsFrom: Fedora40_Offline_MsftSdk
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:
@@ -312,24 +312,24 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: Ubuntu2204_DevVersions
+        buildName: Ubuntu2404_DevVersions
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ variables.ubuntu2204Container }}
+        container: ${{ variables.ubuntu2404Container }}
         targetOS: linux
         targetArchitecture: x64
         useDevVersions: true # Use dev versions for CI validation of the experience. If we decide to ship assets from this leg, then we should remove this option.
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: Ubuntu2204
+        buildName: Ubuntu2404
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ variables.ubuntu2204Container }}
+        container: ${{ variables.ubuntu2404Container }}
         targetOS: linux
         targetArchitecture: x64
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -312,7 +312,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: Ubuntu2404_DevVersions
+        buildName: $[format('{0}_DevVersions', variables['ubuntuName'])]
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
@@ -324,7 +324,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: Ubuntu2404
+        buildName: ${{ variables.ubuntuName }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -53,7 +53,7 @@ variables:
 - name: centOSStreamX64Rid
   value: centos.9-x64
 - name: fedoraX64Rid
-  value: fedora.39-x64
+  value: fedora.40-x64
 - name: ubuntux64Rid
   value: ubuntu.24.04-x64
 - name: ubuntuArm64Rid

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -55,7 +55,7 @@ variables:
 - name: fedoraX64Rid
   value: fedora.39-x64
 - name: ubuntux64Rid
-  value: ubuntu.22.04-x64
+  value: ubuntu.24.04-x64
 - name: ubuntuArm64Rid
   value: ubuntu.24.04-arm64
 

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -10,15 +10,15 @@ variables:
   - name: VmrBranch
     value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
 
-- name: alpine319Container
+- name: alpineContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-- name: centOSStream9Container
+- name: centOSStreamContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-- name: fedora40Container
+- name: fedoraContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
-- name: ubuntu2404Container
+- name: ubuntuContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04
-- name: ubuntu2404ArmContainer
+- name: ubuntuArmContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-arm64
 - name: marinerX64CrossContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
@@ -38,6 +38,26 @@ variables:
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
 - name: wasiCrossContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
+
+- name: alpineName
+  value: Alpine3.19
+- name: centOSStreamName
+  value: CentOSStream9
+- name: fedoraName
+  value: Fedora40
+- name: ubuntuName
+  value: Ubuntu24.04
+
+- name: alpineX64Rid
+  value: alpine.3.19-x64
+- name: centOSStreamX64Rid
+  value: centos.9-x64
+- name: fedoraX64Rid
+  value: fedora.39-x64
+- name: ubuntux64Rid
+  value: ubuntu.22.04-x64
+- name: ubuntuArm64Rid
+  value: ubuntu.24.04-arm64
 
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: defaultPoolName

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -14,12 +14,12 @@ variables:
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
 - name: centOSStream9Container
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-- name: fedora39Container
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-- name: ubuntu2204Container
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-- name: ubuntu2204ArmContainer
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
+- name: fedora40Container
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+- name: ubuntu2404Container
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04
+- name: ubuntu2404ArmContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-arm64
 - name: marinerX64CrossContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
 - name: marinerArmCrossContainer

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -40,13 +40,13 @@ variables:
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
 
 - name: alpineName
-  value: Alpine3.19
+  value: Alpine319
 - name: centOSStreamName
   value: CentOSStream9
 - name: fedoraName
   value: Fedora40
 - name: ubuntuName
-  value: Ubuntu24.04
+  value: Ubuntu2404
 
 - name: alpineX64Rid
   value: alpine.3.19-x64

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -24,14 +24,16 @@ parameters:
   default: ' '
 
 variables:
+- template: /src/sdk/eng/common/templates/variables/pool-providers.yml@self
+
 # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
 - group: DotNet-Source-Build-Bot-Secrets-MVP
 
 jobs:
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: CentOSStream9_Offline_MsftSdk
-    targetRid: centos.9-x64
+    buildName: $[format('{0}_Offline_MsftSdk', variables['centOSStreamName'])]
+    targetRid: ${{ variables.centOSStreamX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
     includeArtifactsSize: true
@@ -39,28 +41,28 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Alpine319_Online_MsftSdk
-    targetRid: alpine.3.19-x64
+    buildName: $[format('{0}_Online_MsftSdk', variables['alpineName'])]
+    targetRid: ${{ variables.alpineX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Fedora39_Offline_MsftSdk
-    targetRid: fedora.39-x64
+    buildName: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
+    targetRid: ${{ variables.fedoraX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Ubuntu2204_Offline_MsftSdk
-    targetRid: ubuntu.22.04-x64
+    buildName: $[format('{0}_Offline_MsftSdk', variables['ubuntuName'])]
+    targetRid: ${{ variables.ubuntuX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Ubuntu2204Arm64_Offline_MsftSdk
-    targetRid: ubuntu.22.04-arm64
+    buildName: $[format('{0}Arm64_Offline_MsftSdk', variables['ubuntuName'])]
+    targetRid: ${{ variables.ubuntuArm64Rid }}
     architecture: arm64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -24,7 +24,7 @@ parameters:
   default: ' '
 
 variables:
-- template: /src/sdk/eng/common/templates/variables/pool-providers.yml@self
+- template: /src/sdk/eng/pipelines/templates/variables/vmr-build.yml@self
 
 # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
 - group: DotNet-Source-Build-Bot-Secrets-MVP
@@ -32,7 +32,7 @@ variables:
 jobs:
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: $[format('{0}_Offline_MsftSdk', variables['centOSStreamName'])]
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
     targetRid: ${{ variables.centOSStreamX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
@@ -41,28 +41,28 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: $[format('{0}_Online_MsftSdk', variables['alpineName'])]
+    buildName: ${{ format('{0}_Online_MsftSdk', variables.alpineName) }}
     targetRid: ${{ variables.alpineX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: $[format('{0}_Offline_MsftSdk', variables['fedoraName'])]
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
     targetRid: ${{ variables.fedoraX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: $[format('{0}_Offline_MsftSdk', variables['ubuntuName'])]
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
     targetRid: ${{ variables.ubuntuX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: $[format('{0}Arm64_Offline_MsftSdk', variables['ubuntuName'])]
+    buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
     targetRid: ${{ variables.ubuntuArm64Rid }}
     architecture: arm64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4399 and https://github.com/dotnet/source-build/issues/4301

Updated Fedora 39 to 40
Update Ubuntu 22.04 to Ubuntu 24.04