### PR TITLE
Fix getting path to full framework MSBuild

### DIFF
--- a/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -289,7 +289,7 @@ namespace Microsoft.NET.TestFramework
             {
                 if (TryResolveCommand("MSBuild", out string pathToMSBuild))
                 {
-                    ret.FullFrameworkMSBuildPath = Path.GetDirectoryName(pathToMSBuild);
+                    ret.FullFrameworkMSBuildPath = pathToMSBuild;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes a line of code which is probably only used when locally running tests and you've set `UseFullFrameworkMSBuild` to true.  It looks like this was broken in #31443.

Apparently, this would cause tests run in Visual Studio to abort with without showing any information about the exception thrown or what the problem was.