### PR TITLE
Do not leak a TextReader in BuildFPMToolPreReqs.cs

### DIFF
--- a/src/Installer/core-sdk-tasks/BuildFPMToolPreReqs.cs
+++ b/src/Installer/core-sdk-tasks/BuildFPMToolPreReqs.cs
@@ -35,8 +35,7 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             // Open the Config Json and read the values into the model
-            TextReader projectFileReader = File.OpenText(ConfigJsonFile);
-            string jsonFileText = projectFileReader.ReadToEnd();
+            string jsonFileText = File.ReadAllText(ConfigJsonFile, Encoding.UTF8);
             ConfigJson configJson = JsonConvert.DeserializeObject<ConfigJson>(jsonFileText);
 
             // Update the Changelog and Copyright files by replacing tokens with values from config json


### PR DESCRIPTION
The method wasn't disposing the Reader when done. Instead, use File.ReadAllText to skip dealing with opening/disposing the file.

Use an explicit encoding of UTF8 to match what File.OpenText() is supposed to do.