### PR TITLE
[VMR] Update internal mac pool image label

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -92,6 +92,6 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal
   - name: poolImage_Mac
-    value: macos-13-arm64
+    value: macos-latest-internal
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64


### PR DESCRIPTION
We're being asked to use this new label since the pool will be upgraded to macOS 14, making the old label inaccurate.