### PR TITLE
Use exclusions that contain "src/<repo>"

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -188,7 +188,7 @@ public class LicenseScanTests : TestBase
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
 
         // We only care about the license expressions that are in the target repo.
-        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, _relativeRepoPath);
+        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, "^" + Regex.Escape(_relativeRepoPath));
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -188,7 +188,7 @@ public class LicenseScanTests : TestBase
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
 
         // We only care about the license expressions that are in the target repo.
-        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, _targetRepo);
+        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, _relativeRepoPath);
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {


### PR DESCRIPTION
As described in https://github.com/dotnet/sdk/pull/41016#issuecomment-2120887728, there was a bug in the parsing of the License Scan exclusions.

The exclusions helper allows use of a regex to refine the exclusions parsing scope for file paths. For license scanning, this regex was set to the target repository being scanned. For instance, if `msbuild` was the subject of the scan, any exclusion containing the string `msbuild` was included. However, this approach faced a challenge when exclusions from other repositories contained the target repo string. An example is the arcade exclusion `src/arcade/eng/xcopy-msbuild/msbuild.nuspec|ms-visual-2015-sdk`, which was erroneously picked up as an exclusion for msbuild during the license scan. (Note that `sdk` did not pick up this exclusion because the regex is only used on the file path). Since msbuild does not require this exclusion, its removal in the updated file led to failures for arcade.

The fix for this is to create a more specific search. Since each exclusion in the baseline is relative to the VMR, I've set the search string to be `src/<repo>` instead of `repo`.