### PR TITLE
Include HTTP status in ContainerHttpException

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/AmazonECRMessageHandler.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AmazonECRMessageHandler.cs
@@ -26,7 +26,7 @@ internal sealed class AmazonECRMessageHandler : DelegatingHandler
         catch (HttpRequestException e) when (e.InnerException is IOException ioe && ioe.Message.Equals("The response ended prematurely.", StringComparison.OrdinalIgnoreCase))
         {
             string message = Resource.GetString(nameof(Strings.AmazonRegistryFailed));
-            throw new ContainerHttpException(message, request.RequestUri?.ToString());
+            throw new ContainerHttpException(message, request.RequestUri?.ToString(), e.StatusCode);
         }
         catch
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/Exceptions/ContainerHttpException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Exceptions/ContainerHttpException.cs
@@ -1,14 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+
 namespace Microsoft.NET.Build.Containers;
 
 internal sealed class ContainerHttpException : Exception
 {
     private const string ErrorPrefix = "Containerize: error CONTAINER004:";
     string? uri;
-    public ContainerHttpException(string message, string? targetUri)
-            : base($"{ErrorPrefix} {message}\nURI: {targetUri ?? "Unknown"}")
+    public ContainerHttpException(string message, string? targetUri, HttpStatusCode? statusCode)
+            : base($"{ErrorPrefix} {message}\nURI: {targetUri ?? "Unknown"}\nHTTP status code: {statusCode?.ToString() ?? "Unknown"}")
     {
         uri = targetUri;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
@@ -76,6 +76,6 @@ internal class DefaultBlobOperations : IBlobOperations
     private async Task<T> LogAndThrowContainerHttpException<T>(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         await response.LogHttpResponseAsync(_logger, cancellationToken).ConfigureAwait(false);
-        throw new ContainerHttpException(Resource.GetString(nameof(Strings.RegistryPullFailed)), response.RequestMessage?.RequestUri?.ToString());
+        throw new ContainerHttpException(Resource.GetString(nameof(Strings.RegistryPullFailed)), response.RequestMessage?.RequestUri?.ToString(), response.StatusCode);
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -49,13 +49,13 @@ internal class DefaultManifestOperations : IManifestOperations
         if (!putResponse.IsSuccessStatusCode)
         {
             await putResponse.LogHttpResponseAsync(_logger, cancellationToken).ConfigureAwait(false);
-            throw new ContainerHttpException(Resource.FormatString(nameof(Strings.RegistryPushFailed), putResponse.StatusCode), putResponse.RequestMessage?.RequestUri?.ToString());
+            throw new ContainerHttpException(Resource.FormatString(nameof(Strings.RegistryPushFailed), putResponse.StatusCode), putResponse.RequestMessage?.RequestUri?.ToString(), putResponse.StatusCode);
         }
     }
 
     private async Task<T> LogAndThrowContainerHttpException<T>(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         await response.LogHttpResponseAsync(_logger, cancellationToken).ConfigureAwait(false);
-        throw new ContainerHttpException(Resource.GetString(nameof(Strings.RegistryPullFailed)), response.RequestMessage?.RequestUri?.ToString());
+        throw new ContainerHttpException(Resource.GetString(nameof(Strings.RegistryPullFailed)), response.RequestMessage?.RequestUri?.ToString(), response.StatusCode);
     }
 }


### PR DESCRIPTION
Include the original HTTP status code, if available, when `ContainerHttpException` is thrown.

Otherwise if an HTTP request to a registry fails, no further details about what occurred are shown in the errors.

For example, below an error occurred, which I assume was a transient error from MAR, but there's nothing in the logs to indicate what the HTTP error was, just its URL.

```console
Run dotnet publish ./src/Costellobot --arch x64 --os linux -p:PublishProfile=DefaultContainer
  Determining projects to restore...
  Restored /home/runner/work/costellobot/costellobot/src/Costellobot/Costellobot.csproj (in 457 ms).
  Costellobot -> /home/runner/work/costellobot/costellobot/artifacts/bin/Costellobot/release_linux-x64/Costellobot.dll
  Costellobot -> /home/runner/work/costellobot/costellobot/artifacts/publish/Costellobot/release_linux-x64/
/usr/share/dotnet/sdk/8.0.300/Containers/build/Microsoft.NET.Build.Containers.targets(242,5): error : ContainerHttpException: Containerize: error CONTAINER004: CONTAINER1014: Manifest pull failed. [/home/runner/work/costellobot/costellobot/src/Costellobot/Costellobot.csproj]
/usr/share/dotnet/sdk/8.0.300/Containers/build/Microsoft.NET.Build.Containers.targets(242,5): error : URI: https://mcr.microsoft.com/v2/dotnet/runtime-deps/manifests/8.0-noble-chiseled-extra [/home/runner/work/costellobot/costellobot/src/Costellobot/Costellobot.csproj]
/usr/share/dotnet/sdk/8.0.300/Containers/build/Microsoft.NET.Build.Containers.targets(242,5): error :  [/home/runner/work/costellobot/costellobot/src/Costellobot/Costellobot.csproj]
```