### PR TITLE
Improve repo artifacts logging

### DIFF
--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -6,7 +6,7 @@
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj" />
@@ -36,7 +36,7 @@
       <IntermediateSymbol Include="$(IntermediateSymbolsRootDir)**/*" />
     </ItemGroup>
   </Target>
- 
+
   <!-- After building, repackage symbols into a single tarball. -->
   <Target Name="RepackageSymbols"
           AfterTargets="Build"
@@ -171,7 +171,7 @@
     <Error Text="@(PrebuiltFile->Count()) Prebuilts Exist" />
   </Target>
 
-  
+
   <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
           DependsOnTargets="DetermineSourceBuiltSdkVersion;ResolveProjectReferences">
     <!-- Inputs: Packages to include in the tarball -->
@@ -197,11 +197,11 @@
   </Target>
 
   <!-- Discover the produced packages from the merged asset manifest -->
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownPackagesFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="GetProducedPackages" Returns="@(ProducedPackage)">
-    <GetKnownPackagesFromAssetManifests AssetManifests="$(MergedAssetManifestOutputPath)">
+    <GetKnownArtifactsFromAssetManifests AssetManifests="$(MergedAssetManifestOutputPath)">
       <Output TaskParameter="KnownPackages" ItemName="ProducedPackage" />
-    </GetKnownPackagesFromAssetManifests>
+    </GetKnownArtifactsFromAssetManifests>
   </Target>
 
   <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
 
             KnownBlobs = xDocuments
                 .SelectMany(doc => doc.Root!.Descendants("Blob"))
-                .Select(asset => new TaskItem(asset.Attribute("Path")!.Value))
+                .Select(asset => new TaskItem(asset.Attribute("Id")!.Value))
                 .ToArray();
 
             return true;

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownPackagesFromAssetManifests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -13,7 +11,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
     /// <summary>
     /// Get a list of MSBuild Items that represent the packages described in the asset manifests.
     /// </summary>
-    public sealed class GetKnownPackagesFromAssetManifests : Task
+    public sealed class GetKnownArtifactsFromAssetManifests : Build.Utilities.Task
     {
         [Required]
         public ITaskItem[] AssetManifests { get; set; }
@@ -21,13 +19,25 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
         [Output]
         public ITaskItem[] KnownPackages { get; set; }
 
+        [Output]
+        public ITaskItem[] KnownBlobs { get; set; }
+
         public override bool Execute()
         {
-            var knownPackages = from assetManifest in AssetManifests
-                                let doc = XDocument.Load(assetManifest.ItemSpec)
-                                from package in doc.Root.Descendants("Package")
-                                select new TaskItem(package.Attribute("Id").Value, new Dictionary<string, string>{ { "Version", package.Attribute("Version").Value } });
-            KnownPackages = knownPackages.ToArray();
+            XDocument[] xDocuments = AssetManifests
+                .Select(manifest => XDocument.Load(manifest.ItemSpec))
+                .ToArray();
+
+            KnownPackages = xDocuments
+                .SelectMany(doc => doc.Root!.Descendants("Package"))
+                .Select(package => new TaskItem(package.Attribute("Id")!.Value, new Dictionary<string, string> { { "Version", package.Attribute("Version")!.Value } }))
+                .ToArray();
+
+            KnownBlobs = xDocuments
+                .SelectMany(doc => doc.Root!.Descendants("Blob"))
+                .Select(asset => new TaskItem(asset.Attribute("Path")!.Value))
+                .ToArray();
+
             return true;
         }
     }

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -250,7 +250,7 @@
   <!-- Before a repository builds, set up the version property files that override the repo's defaults.
        There are 3 files generated -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownPackagesFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="CreateBuildInputProps"
           DependsOnTargets="GetProducedPackagesFromTransitiveReferences"
           Inputs="$(MSBuildProjectFullPath)"
@@ -261,9 +261,9 @@
       <_PrebuiltSourceBuiltAssetManifests Include="$(PrebuiltSourceBuiltPackagesPath)VerticalManifest.xml" />
     </ItemGroup>
 
-    <GetKnownPackagesFromAssetManifests AssetManifests="@(_PrebuiltSourceBuiltAssetManifests)" Condition="Exists(@(_PrebuiltSourceBuiltAssetManifests))">
+    <GetKnownArtifactsFromAssetManifests AssetManifests="@(_PrebuiltSourceBuiltAssetManifests)" Condition="Exists(@(_PrebuiltSourceBuiltAssetManifests))">
       <Output TaskParameter="KnownPackages" ItemName="_PreviouslyBuiltSourceBuiltPackages" />
-    </GetKnownPackagesFromAssetManifests>
+    </GetKnownArtifactsFromAssetManifests>
 
     <Error Condition="'$(PackageVersionPropsFlowType)' != 'AllPackages' and '$(PackageVersionPropsFlowType)' != 'DependenciesOnly'"
       Text="Invalid PackageVersionPropsFlowType '$(PackageVersionPropsFlowType)'. Must be 'AllPackages' or 'DependenciesOnly'." />
@@ -341,7 +341,6 @@
 
   <Target Name="DiscoverBuiltSdkOverrides"
           DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences">
-
     <!--
       Discover the Arcade SDKs built from the live Arcade source and set them as overrides here.
       This will automatically no-op for Arcade and SBRP, as these packages will not have been produced yet.
@@ -451,32 +450,35 @@
     <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)') and '$(MinimalConsoleLogOutput)' == 'true'" />
   </Target>
 
-  <Target Name="GetRepoAssetManifests" DependsOnTargets="RepoBuild" Returns="@(RepoAssetManifest)">
+  <!-- Log the new repo artifacts -->
+  <Target Name="LogRepoArtifacts"
+          DependsOnTargets="GetProducedPackages"
+          Inputs="@(RepoAssetManifest)"
+          Outputs="$(BaseIntermediateOutputPath)LogRepoArtifacts.complete"
+          Condition="'$(IsUtilityProject)' != 'true'">
+    <Message Importance="High" Text="New artifact(s) after building $(RepositoryName):" />
+    <Message Importance="High" Text="  -> %(ProducedPackage.Identity)/%(ProducedPackage.Version)" />
+    <Message Importance="High" Text="  -> %(ProducedAsset.Identity)" />
+
+    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <Touch Files="$(BaseIntermediateOutputPath)LogRepoArtifacts.complete" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
+  </Target>
+
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="GetProducedPackages" DependsOnTargets="GetRepoAssetManifests" Returns="@(ProducedPackage)">
     <ItemGroup>
       <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
     </ItemGroup>
-  </Target>
 
-  <!-- Log the new repo artifacts -->
-  <Target Name="LogRepoArtifacts"
-          DependsOnTargets="GetRepoAssetManifests"
-          Condition="'$(IsUtilityProject)' != 'true'">
-    <Error Text="Repo manifest files don't exist." Condition="'@(RepoAssetManifest)' == ''" />
+    <Error Text="Repository asset manifest files don't exist." Condition="'@(RepoAssetManifest)' == ''" />
 
-    <XmlPeek XmlInputPath="%(RepoAssetManifest.Identity)"
-             Query="/Build/*[self::Package | self::Blob]/@Id">
-        <Output TaskParameter="Result" ItemName="RepoManifestArtifact" />
-    </XmlPeek>
-
-    <Message Importance="High" Text="New artifact(s) after building $(RepositoryName):" />
-    <Message Importance="High" Text="  -> %(RepoManifestArtifact.Identity)" />
-  </Target>
-
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownPackagesFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="GetProducedPackages" DependsOnTargets="GetRepoAssetManifests" Returns="@(ProducedPackage)">
-    <GetKnownPackagesFromAssetManifests AssetManifests="@(RepoAssetManifest)">
+    <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifest)">
       <Output TaskParameter="KnownPackages" ItemName="ProducedPackage" />
-    </GetKnownPackagesFromAssetManifests>
+      <Output TaskParameter="KnownBlobs" ItemName="ProducedAsset" />
+    </GetKnownArtifactsFromAssetManifests>
+
     <ItemGroup>
       <ProducedPackage ReferenceOnly="$([MSBuild]::ValueOrDefault('$(ReferenceOnlyRepoArtifacts)', 'false'))" />
     </ItemGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -467,7 +467,9 @@
   </Target>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="GetProducedPackages" Returns="@(ProducedPackage)">
+  <Target Name="GetProducedPackages"
+          Condition="'$(IsUtilityProject)' != 'true'"
+          Returns="@(ProducedPackage)">
     <ItemGroup>
       <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
     </ItemGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -467,7 +467,7 @@
   </Target>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="GetProducedPackages" DependsOnTargets="GetRepoAssetManifests" Returns="@(ProducedPackage)">
+  <Target Name="GetProducedPackages" Returns="@(ProducedPackage)">
     <ItemGroup>
       <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
     </ItemGroup>


### PR DESCRIPTION
1. Include the version when logging new packages
2. Read the repo asset manifest files only once
3. Make the log target respect incremental builds