### PR TITLE
Use version comparison function

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -170,7 +170,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet == null && availableWorkloadSets.Any())
             {
-                var maxWorkloadSetVersion = availableWorkloadSets.Keys.Aggregate((s1, s2) => VersionCompare(s1, s2) <= 0 ? s1 : s2);
+                var maxWorkloadSetVersion = availableWorkloadSets.Keys.Aggregate((s1, s2) => VersionCompare(s1, s2) >= 0 ? s1 : s2);
                 _workloadSet = availableWorkloadSets[maxWorkloadSetVersion.ToString()];
             }
         }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -170,9 +170,36 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet == null && availableWorkloadSets.Any())
             {
-                var maxWorkloadSetVersion = availableWorkloadSets.Keys.Select(k => new ReleaseVersion(k)).Max()!;
+                var maxWorkloadSetVersion = availableWorkloadSets.Keys.Aggregate((s1, s2) => VersionCompare(s1, s2) <= 0 ? s1 : s2);
                 _workloadSet = availableWorkloadSets[maxWorkloadSetVersion.ToString()];
             }
+        }
+
+        private static int VersionCompare(string first, string second)
+        {
+            if (first.Equals(second))
+            {
+                return 0;
+            }
+
+            var firstDash = first.IndexOf('-');
+            var secondDash = second.IndexOf('-');
+            firstDash = firstDash < 0 ? first.Length : firstDash;
+            secondDash = secondDash < 0 ? second.Length : secondDash;
+
+            var firstVersion = new Version(first.Substring(0, firstDash));
+            var secondVersion = new Version(second.Substring(0, secondDash));
+
+            var comparison = firstVersion.CompareTo(secondVersion);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            var modifiedFirst = "1.1.1" + (firstDash == first.Length ? string.Empty : first.Substring(firstDash));
+            var modifiedSecond = "1.1.1" + (secondDash == second.Length ? string.Empty : second.Substring(secondDash));
+
+            return new ReleaseVersion(modifiedFirst).CompareTo(new ReleaseVersion(modifiedSecond));
         }
 
         void ThrowExceptionIfManifestsNotAvailable()

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -144,7 +144,7 @@ namespace ManifestReaderTests
         [InlineData("8.0.200-servicing.23015", "8.0.200-preview.7.30301", "8.0.200-servicing.23201", "8.0.200-servicing.23201")]
         public void ItReturnsLatestManifestVersion(string first, string second, string third, string answer)
         {
-            Initialize();
+            Initialize(identifier: answer);
 
             CreateMockManifest(_manifestRoot, "5.0.100-preview.5", "ios", "11.0.3", true);
 

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -386,24 +386,6 @@ namespace ManifestReaderTests
         }
 
         [Fact]
-        public void ItThrowsIfWorkloadSetHasInvalidVersion()
-        {
-            Initialize("8.0.200");
-
-            CreateMockManifest(_manifestRoot, "8.0.100", "ios", "11.0.1", true);
-            CreateMockManifest(_manifestRoot, "8.0.100", "ios", "11.0.2", true);
-            CreateMockManifest(_manifestRoot, "8.0.200", "ios", "12.0.1", true);
-
-            CreateMockWorkloadSet(_manifestRoot, "8.0.200", "8.0.200.1", """
-                {
-                    "ios": "11.0.2/8.0.100"
-                }
-                """);
-
-            Assert.Throws<FormatException>(() => new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "8.0.200", userProfileDir: null, globalJsonPath: null));
-        }
-
-        [Fact]
         public void ItThrowsIfManifestFromWorkloadSetIsNotFound()
         {
             Initialize("8.0.200");

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -135,23 +135,29 @@ namespace ManifestReaderTests
                 .BeEmpty();
         }
 
-        [Fact]
-        public void ItReturnsLatestManifestVersion()
+        [Theory]
+        [InlineData("11.0.1", "11.0.2", "11.0.2-rc.1", "11.0.2")]
+        [InlineData("8.0.200", "8.0.201", "8.0.105", "8.0.201")]
+        [InlineData("8.0.203.1", "8.0.203", "8.0.200-rc.1", "8.0.203.1")]
+        [InlineData("9.0.100-preview.2", "9.0.100-preview.2.3.4", "9.0.100-preview.2.4.3", "9.0.100-preview.2.4.3")]
+        [InlineData("8.0.201.1-preview", "8.0.201.1-rc.1", "8.0.201.1-rc.2", "8.0.201.1-rc.2")]
+        [InlineData("8.0.200-servicing.23015", "8.0.200-preview.7.30301", "8.0.200-servicing.23201", "8.0.200-servicing.23201")]
+        public void ItReturnsLatestManifestVersion(string first, string second, string third, string answer)
         {
             Initialize();
 
             CreateMockManifest(_manifestRoot, "5.0.100-preview.5", "ios", "11.0.3", true);
 
-            CreateMockManifest(_manifestRoot, "5.0.100", "ios", "11.0.1", true);
-            CreateMockManifest(_manifestRoot, "5.0.100", "ios", "11.0.2", true);
-            CreateMockManifest(_manifestRoot, "5.0.100", "ios", "11.0.2-rc.1", true);
+            CreateMockManifest(_manifestRoot, "5.0.100", "ios", first, true);
+            CreateMockManifest(_manifestRoot, "5.0.100", "ios", second, true);
+            CreateMockManifest(_manifestRoot, "5.0.100", "ios", third, true);
 
             var sdkDirectoryWorkloadManifestProvider
                 = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "5.0.100", userProfileDir: null, globalJsonPath: null);
 
             GetManifestContents(sdkDirectoryWorkloadManifestProvider)
                 .Should()
-                .BeEquivalentTo("ios: 11.0.2/5.0.100");
+                .BeEquivalentTo($"ios: {answer}/5.0.100");
         }
 
         [Fact]


### PR DESCRIPTION
Creates a version comparison function that permits comparing four-part versions or versions with semantic parts on the end. Uses that function to find the 'max' version of all available workload sets.

I'm planning to try to write a test tomorrow.