### PR TITLE
Add new property: VerifySdkTarballItem

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -12,7 +12,7 @@
                       Exclude="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*.wixpack.zip" />
     </ItemGroup>
 
-    <Error Text="Didn't find an SDK archive." Condition="'@(SdkTarballItem)' == ''" />
+    <Error Text="Didn't find an SDK archive." Condition="'@(SdkTarballItem)' == '' and '$(VerifySdkTarballItem)' == 'true'" />
     <Error Text="Found more than one SDK archive." Condition="@(SdkTarballItem->Count()) &gt; 1" />
 
     <!--

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -115,6 +115,7 @@ while [[ $# > 0 ]]; do
       ;;
     -test|-t)
       test=true
+      properties+=("/p:VerifySdkTarballItem=true")
       ;;
 
     # Source-only settings


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4420

The smoke test project will fail if no SDK archive under `$(ArtifactsAssetsDir)Sdk/**/`, but for `LicenseScanTests`, no SDK tarball items will be generated or copied, so I add a new property to skip verify the Sdk tarball items. For other which will generate SDK files under `$(ArtifactsAssetsDir)Sdk/**/`, the file will continued to be checked for uniqueness.