### PR TITLE
Dispose streams created by File.Create

### DIFF
--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateMSDeployScript.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateMSDeployScript.cs
@@ -19,16 +19,18 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
 
         public override bool Execute()
         {
-            if (!File.Exists(ScriptFullPath))
+            var parent = Directory.GetDirectory(ScriptFullPath);
+            if (!Directory.Exists(parent))
             {
-                File.Create(ScriptFullPath);
+                Directory.CreateDirectory(parent);
             }
 
             File.WriteAllLines(ScriptFullPath, GetReplacedFileContents(Resources.MsDeployBatchFile));
 
-            if (!File.Exists(ReadMeFullPath))
+            parent = Directory.GetDirectory(ReadMeFullPath);
+            if (!Directory.Exists(parent))
             {
-                File.Create(ReadMeFullPath);
+                Directory.CreateDirectory(parent);
             }
 
             File.WriteAllLines(ReadMeFullPath, GetReplacedFileContents(Resources.MsDeployReadMe));

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateManifestFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateManifestFile.cs
@@ -104,10 +104,6 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                 {
                     if (!string.IsNullOrEmpty(ManifestFile))
                     {
-                        if (!File.Exists(ManifestFile))
-                        {
-                            File.Create(ManifestFile);
-                        }
                         WriteManifestsToFile(Log, m_manifests, ManifestFile);
                     }
                 }

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [Fact]
         public void ItDoesNotReturnNullDotnetRootOnExtraPathSeparator()
         {
-            File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe"));
+            using var _ = File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe"));
             Func<string, string> getPathEnvVarFunc = (input) => input.Equals("PATH") ? $"fake{Path.PathSeparator}" : string.Empty;
             var result = NativeWrapper.EnvironmentProvider.GetDotnetExeDirectory(getPathEnvVarFunc);
             result.Should().NotBeNullOrWhiteSpace();

--- a/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             {
                 string path = Path.Combine(dotnetRoot, "metadata", "workloads", version.ToString(), "InstalledWorkloads");
                 Directory.CreateDirectory(path);
-                File.Create(Path.Combine(path, "6.0.100"));
+                using var _ = File.Create(Path.Combine(path, "6.0.100"));
             }
 
             IEnumerable<SdkFeatureBand> featureBands = installer.GetWorkloadInstallationRecordRepository().GetFeatureBandsWithInstallationRecords();

--- a/test/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/test/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         {
             (var manifestUpdater, var nugetDownloader, var sentinelPath) = GetTestUpdater();
 
-            File.Create(sentinelPath);
+            using var _ = File.Create(sentinelPath);
             var createTime = DateTime.Now;
 
             await manifestUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();

--- a/test/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
+++ b/test/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write workload install record for 6.0.300
             var workloadsRecordPath = Path.Combine(_dotnetRoot, "metadata", "workloads", sdkVersions[1], "InstalledWorkloads");
             Directory.CreateDirectory(workloadsRecordPath);
-            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build"));
+            using var _ = File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build"));
 
             installer.GarbageCollect(getResolver);
 

--- a/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -150,12 +150,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             foreach (var pack in workloadPacks)
             {
                 Directory.CreateDirectory(Path.Combine(packRecordDir, pack.Id, pack.Version));
-                File.Create(Path.Combine(packRecordDir, pack.Id, pack.Version, oldFeatureBand));
+                File.Create(Path.Combine(packRecordDir, pack.Id, pack.Version, oldFeatureBand)).Dispose();
             }
             Directory.CreateDirectory(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads"));
             Directory.CreateDirectory(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads"));
-            File.Create(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads", installingWorkload));
-            File.Create(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads", installingWorkload));
+            File.Create(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads", installingWorkload)).Dispose();
+            File.Create(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads", installingWorkload)).Dispose();
 
             // Update workload (without installing any workloads to this feature band)
             var updateParseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-previous-sdk" });


### PR DESCRIPTION
File.Create returns a FileStream, an IDisposable. That should be closed when we are done using it.

In some cases, we don't need to call File.Create at all, because we are using methods that create a new file already, or overwrite existing files.