### PR TITLE
Fix empty lines when logging repo artifacts

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -457,8 +457,8 @@
           Outputs="$(BaseIntermediateOutputPath)LogRepoArtifacts.complete"
           Condition="'$(IsUtilityProject)' != 'true'">
     <Message Importance="High" Text="New artifact(s) after building $(RepositoryName):" />
-    <Message Importance="High" Text="  -> %(ProducedPackage.Identity)/%(ProducedPackage.Version)" />
-    <Message Importance="High" Text="  -> %(ProducedAsset.Identity)" />
+    <Message Importance="High" Text="  -> %(ProducedPackage.Identity)/%(ProducedPackage.Version)" Condition="'@(ProducedPackage)' != ''" />
+    <Message Importance="High" Text="  -> %(ProducedAsset.Identity)" Condition="'@(ProducedAsset)' != ''" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
     <Touch Files="$(BaseIntermediateOutputPath)LogRepoArtifacts.complete" AlwaysCreate="true">


### PR DESCRIPTION
Example before:

```
 New artifact(s) after building scenario-tests:
    -> Microsoft.DotNet.ScenarioTests.SdkTemplateTests/9.0.0-preview.24272.1
    -> 
```