### PR TITLE
Use SdkTarballPath prop if provided

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <SdkTarballItem Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
+      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath)" />
+      <SdkTarballItem Condition="'$(SdkTarballPath)' == ''" Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
                       Exclude="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*.wixpack.zip" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4420

The source-build SDK diff tests were failing when there wasn't an SDK archive that had been produced. This PR addresses that issue by recognizing the `SdkTarballPath` value. More specifically, the changes allows for more flexibility in the inclusion of `SdkTarballItem` depending on the value of `SdkTarballPath`.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2459253&view=results) (internal Microsoft link)