### PR TITLE
List `win-x86` under known runtime packs for AOT

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -407,6 +407,7 @@
         linux-musl-arm;
         linux-musl-arm64;
         win-x64;
+        win-x86;
         win-arm64;
         browser-wasm;
         wasi-wasm;


### PR DESCRIPTION
Rest of the items are done: https://github.com/dotnet/runtime/issues/86573#issuecomment-2007795553

cc @filipnavara, @MichalStrehovsky 