### PR TITLE
Update init-source-only.proj

### DIFF
--- a/src/SourceBuild/content/eng/init-source-only.proj
+++ b/src/SourceBuild/content/eng/init-source-only.proj
@@ -13,47 +13,63 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
+  <PropertyGroup>
+    <ExternalTarballsDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'archive'))</ExternalTarballsDir>
+  </PropertyGroup>
+
   <Target Name="Build"
           DependsOnTargets="
       UnpackTarballs;
       BuildMSBuildSdkResolver;
       ExtractToolsetPackages" />
 
-  <Target Name="UnpackTarballs"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(BaseIntermediateOutputPath)UnpackTarballs.complete" >
-    <PropertyGroup>
-      <ExternalTarballsDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'archive'))</ExternalTarballsDir>
-    </PropertyGroup>
-
+  <!-- Unpacks the Private.SourceBuilt.Artifacts archive -->
+  <Target Name="UnpackSourceBuiltArtifactsArchive"
+          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''"
+          Inputs="$(ExternalTarballsDir)"
+          Outputs="$(PrebuiltSourceBuiltPackagesPath)">
     <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)"
-          WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
-          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
+          WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)" />
+  </Target>
 
-    <!--
-      Check for a prebuilt dependency tarball and extract if exists. If there isn't one, we expect
-      the build to be working without prebuilts.
-    -->
+  <!-- Check for a prebuilt dependency tarball and extract if exists. If there isn't one, we expect
+       the build to be working without prebuilts. -->
+  <Target Name="UnpackSourceBuiltPrebuiltsArchive"
+          Inputs="$(ExternalTarballsDir)"
+          Outputs="$(PrebuiltPackagesPath)">
     <ItemGroup>
       <SourceBuiltPrebuiltsTarballFile Include="$(ExternalTarballsDir)$(SourceBuiltPrebuiltsTarballName).*$(ArchiveExtension)" />
     </ItemGroup>
+
     <Exec Command="tar -xzf %(SourceBuiltPrebuiltsTarballFile.FullPath)"
           WorkingDirectory="$(PrebuiltPackagesPath)"
           Condition="'@(SourceBuiltPrebuiltsTarballFile)' != ''" />
+  </Target>
 
-    <!-- Copy SBRP packages to reference packages location -->
+  <!-- Copy SBRP packages to reference packages location. -->
+  <Target Name="CopySourceBuiltReferencePackages"
+          DependsOnTargets="UnpackSourceBuiltArtifactsArchive"
+          Inputs="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages"
+          Outputs="$(ReferencePackagesDir)">
     <ItemGroup>
-      <UnpackedSourceBuildReferencePackages Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*"/>
+      <UnpackedSourceBuildReferencePackage Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*" />
     </ItemGroup>
 
-    <Move SourceFiles="@(UnpackedSourceBuildReferencePackages)" DestinationFiles="$(ReferencePackagesDir)%(Filename)%(Extension)" />
-
-    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <Touch Files="$(BaseIntermediateOutputPath)UnpackTarballs.complete" AlwaysCreate="true">
-      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-    </Touch>
+    <!-- Either move or copy the unpacked SBRP packages.
+         Don't move when the packages directory is externally provided. -->
+    <Move SourceFiles="@(UnpackedSourceBuildReferencePackage)"
+          DestinationFolder="$(ReferencePackagesDir)"
+          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
+    <Copy SourceFiles="@(UnpackedSourceBuildReferencePackage)"
+          DestinationFolder="$(ReferencePackagesDir)"
+          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' != ''" />
   </Target>
+
+  <Target Name="UnpackTarballs"
+          DependsOnTargets="UnpackSourceBuiltArtifactsArchive;
+                            UnpackSourceBuiltPrebuiltsArchive;
+                            CopySourceBuiltReferencePackages" />
 
   <!-- Build the custom msbuild sdk resolver. -->
   <Target Name="BuildMSBuildSdkResolver"
@@ -74,10 +90,7 @@
   </Target>
 
   <!-- Extract toolset packages into the bootstrap folder -->
-  <Target Name="ExtractToolsetPackages"
-          DependsOnTargets="UnpackTarballs"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(BaseIntermediateOutputPath)ExtractToolsetPackages.complete">
+  <Target Name="ExtractToolsetPackages" DependsOnTargets="UnpackTarballs">
     <ItemGroup>
       <ToolsetPackage Include="Microsoft.DotNet.Arcade.Sdk" SourceFolder="$(PrebuiltSourceBuiltPackagesPath)" Version="$(ARCADE_BOOTSTRAP_VERSION)" />
       <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(ReferencePackagesDir)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
@@ -87,11 +100,6 @@
     <Unzip SourceFiles="%(ToolsetPackage.SourceFolder)%(ToolsetPackage.Identity).%(ToolsetPackage.Version).nupkg"
            DestinationFolder="$(BootstrapPackagesDir)$([System.String]::Copy('%(ToolsetPackage.Identity)').ToLowerInvariant())/%(ToolsetPackage.Version)"
            SkipUnchangedFiles="true" />
-
-    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <Touch Files="$(BaseIntermediateOutputPath)ExtractToolsetPackages.complete" AlwaysCreate="true">
-      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-    </Touch>
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/eng/init-source-only.proj
+++ b/src/SourceBuild/content/eng/init-source-only.proj
@@ -28,7 +28,7 @@
           Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''"
           Inputs="$(ExternalTarballsDir)"
           Outputs="$(PrebuiltSourceBuiltPackagesPath)">
-    <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
+    <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)"
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4423
Fixes https://github.com/dotnet/source-build/issues/4325

Split the UnpackTarballs target into multiple targets and define actual Inputs & Outputs instead of a semaphore.