### PR TITLE
Re-enable test that was blocking codeflow

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -95,7 +95,7 @@ namespace Microsoft.NET.Publish.Tests
             DoesDepsFileHaveAssembly(depsFile, unusedFrameworkAssembly).Should().BeFalse();
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/40882")]
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
         public void ILLink_links_simple_app_without_analysis_warnings_and_it_runs(string targetFramework)
         {
@@ -105,10 +105,11 @@ namespace Microsoft.NET.Publish.Tests
                 var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
                 var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
+                testProject.AdditionalProperties["PublishTrimmed"] = "true";
                 var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework + trimMode);
 
                 var publishCommand = new PublishCommand(testAsset);
-                publishCommand.Execute($"/p:RuntimeIdentifier={rid}", "/p:PublishTrimmed=true", $"/p:TrimMode={trimMode}", "/p:SuppressTrimAnalysisWarnings=true")
+                publishCommand.Execute($"/p:RuntimeIdentifier={rid}", $"/p:TrimMode={trimMode}", "/p:SuppressTrimAnalysisWarnings=true")
                     .Should().Pass()
                     .And.NotHaveStdOutContaining("warning IL2075")
                     .And.NotHaveStdOutContaining("warning IL2026");


### PR DESCRIPTION
This test is running `GetValuesCommand` with `PublishTrimmed` set to `true` in the generated
`<project>.WriteValuesToFile.g.targets`. In the failure case, `ImportProjectExtensionProps` is false (due to
https://github.com/dotnet/msbuild/blob/147ecadd19ae031d5a511ad55908cff9bcdc17c5/src/Tasks/Microsoft.Common.props#L68 imported from full framework MSBuild props) during restore, so this file isn't imported, we don't set `PublishTrimmed`, Microsoft.NET.ILLink.Tasks isn't restored, and then `ILLinkTargetsPath` never gets set.

I was wondering why this wasn't failing in main on .NET Core, and found that the `GetValuesCommand` behavior was fixed as part of https://github.com/dotnet/sdk/pull/39088 to not rely on `ImportProjectExtensionProps`. So an alternative fix would be to backport the GetValuesCommand fix.

This change is just a simpler fix to set `PublishTrimmed` in the project file for this testcase.

fixes https://github.com/dotnet/sdk/issues/40882