### PR TITLE
Add SmokeTestsLicenseScanPath prop for LicenseScan Test

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -8,12 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath) and '$(SmokeTestsLicenseScanPath)' == ''" />
+      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath)" />
       <SdkTarballItem Condition="'$(SdkTarballPath)' == ''" Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
                       Exclude="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*.wixpack.zip" />
     </ItemGroup>
 
-    <Error Text="Didn't find an SDK archive." Condition="'@(SdkTarballItem)' == ''" />
+    <Error Text="Didn't find an SDK archive." Condition="'@(SdkTarballItem)' == '' and '$(SmokeTestsLicenseScanPath)' == ''" />
     <Error Text="Found more than one SDK archive." Condition="@(SdkTarballItem->Count()) &gt; 1" />
 
     <!--

--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath)" />
+      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath) and '$(SmokeTestsLicenseScanPath)' == ''" />
       <SdkTarballItem Condition="'$(SdkTarballPath)' == ''" Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
                       Exclude="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*.wixpack.zip" />
     </ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4420 and https://github.com/dotnet/sdk/pull/41124

The source-build License Scan tests were failing when there wasn't an SDK archive that had been produced and in the test no `SdkTarballPath` value provide. Add a condition to check if the test is `License Scan Tests`: '/p:SmokeTestsLicenseScanPath=/src/dotnet/src/roslyn-analyzers/'. If the value of `SmokeTestsLicenseScanPath` is null, then the test is determined not to be a License Scan Test then will continue to verify the `SdkTarballItem`.