### PR TITLE
Add back Microsoft.Dotnet.Sdk.Internal project

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Sdk.Internal/Microsoft.Dotnet.Sdk.Internal.csproj
+++ b/src/Installer/Microsoft.Dotnet.Sdk.Internal/Microsoft.Dotnet.Sdk.Internal.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- This is an empty project that exists to be published by DARC and trigger
+  dependency uptake for this repo. -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable Condition="$(PublishInternalAsset) == true">true</IsPackable>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This is used by a bunch of repos to pick up the latest SDK: https://github.com/search?q=org%3Adotnet+MicrosoftDotnetSdkInternal+-repo%3Adotnet%2Fdotnet&type=code

Add it back until we transition these repos onto another package.