### PR TITLE
Use the VMR commit hash for dotnet --info

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -149,15 +149,6 @@
     <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
     <EnvironmentVariables Include="PreReleaseVersionLabel=$(PreReleaseVersionLabel)" />
     <EnvironmentVariables Include="PackageVersionStamp=$(PreReleaseVersionLabel)" />
-
-    <!-- Give build access to commit info without necessarily requiring git queries. -->
-    <EnvironmentVariables Include="GitCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GitInfoCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="SourceRevisionId=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryCommit=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="COMMIT_SHA=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryType=Git" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove the logic that overrides the git commit info for each repo. Let each repo infer the VMR's git commit (via sourcelink).

That will let the sdk, runtime, aspnetcore (and other) repos use the VMR's commit hash and show that in dotnet --info.

This works for both when building the VMR directly in a git repository, as well as when building it from a git-archive tarball thanks to sourcelink's support for minimal git metadata [1].

This is a port of https://github.com/dotnet/installer/pull/18941 to dotnet/sdk since the installer was merged into sdk.

[1] https://github.com/dotnet/sourcelink/tree/main/docs#minimal-git-repository-metadata

Fixes: dotnet/source-build#3643