### PR TITLE
Make the CleanupRepo target use inputs & outputs

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -513,6 +513,8 @@
   </Target>
 
   <Target Name="CleanupRepo"
+          Inputs="$(MSBuildProjectFullPath)"
+          Outputs="$(BaseIntermediateOutputPath)CleanupRepo.complete"
           Condition="'$(IsUtilityProject)' != 'true' and
                      '$(CleanWhileBuilding)' == 'true' and
                      Exists('$(ProjectDirectory)artifacts')">
@@ -541,11 +543,9 @@
     <!-- Make a copy of the build logs & project.assets.json files -->
     <Copy SourceFiles="@(LogFilesToCopy)"
           DestinationFolder="$(BuildLogsDir)%(RecursiveDir)"
-          SkipUnchangedFiles="true"
           Condition="'@(LogFilesToCopy)' != ''" />
     <Copy SourceFiles="@(ObjFilesToCopy)"
           DestinationFolder="$(BuildObjDir)%(RecursiveDir)"
-          SkipUnchangedFiles="true"
           Condition="'@(ObjFilesToCopy)' != ''" />
 
     <ItemGroup>
@@ -564,6 +564,11 @@
 
     <Message Text="DirSize After CleanupRepo $(RepositoryName)" Importance="High" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
     <Exec Command="df -h $(RepoRoot)" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
+
+    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <Touch Files="$(BaseIntermediateOutputPath)CleanupRepo.complete" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
   </Target>
 
   <Target Name="DiscoverToolPackageVersions" DependsOnTargets="GetProducedPackages">


### PR DESCRIPTION
... for better incremental build UX.

Using a semaphore as an approximation (as we do in most other cases, i.e. RepoBuild) as pointing to the repo's artifacts folder significantly slows down msbuild's input & output calculation.

Before this change incremental repo builds always print the following:

```
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully.
  Shutting down VB/C# compiler server...
  VB/C# compiler server shut down successfully
```