### PR TITLE
source-build: bundle NativeAOT libraries with the SDK.

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -406,7 +406,7 @@ jobs:
 
           # Only use Docker when a container is specified
           if [[ -n "${{ parameters.container }}" ]]; then
-            docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)
+            docker run --rm $dockerVolumeArgs -e MSBUILDENSURESTDOUTFORTASKPROCESSES=1 -w /vmr ${{ parameters.container }} ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)
           else
             cd $(sourcesPath)
             ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -406,7 +406,7 @@ jobs:
 
           # Only use Docker when a container is specified
           if [[ -n "${{ parameters.container }}" ]]; then
-            docker run --rm $dockerVolumeArgs -e MSBUILDENSURESTDOUTFORTASKPROCESSES=1 -w /vmr ${{ parameters.container }} ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)
+            docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)
           else
             cd $(sourcesPath)
             ./build.sh --test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $customBuildArgs $extraBuildProperties $(additionalBuildArgs)

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -123,7 +123,7 @@ jobs:
   - name: additionalBuildArgs
     value: ''
   - name: runTestsTimeout
-    value: 60
+    value: 30
 
   - ${{ if parameters.isBuiltFromVmr }}:
     - name: vmrPath

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -123,7 +123,7 @@ jobs:
   - name: additionalBuildArgs
     value: ''
   - name: runTestsTimeout
-    value: 30
+    value: 60
 
   - ${{ if parameters.isBuiltFromVmr }}:
     - name: vmrPath

--- a/src/Installer/redist-installer/redist-installer.csproj
+++ b/src/Installer/redist-installer/redist-installer.csproj
@@ -8,7 +8,8 @@
     <ResolveAssemblyReferencesSilent>true</ResolveAssemblyReferencesSilent>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>none</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
-    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(SourceBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
+    <!-- DotNetBuildOrchestrator is (currently) needed in order to obtain NuGet packages from the runtime build. -->
+    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(SourceBuildUseMonoRuntime)' != 'true' and '$(DotNetBuildOrchestrator)' == 'true'">true</BundleNativeAotCompiler>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -202,6 +202,17 @@
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
       </BundledLayoutPackage>
 
+      <BundledLayoutPackage Include="MicrosoftDotNetILCompilerPackNupkg" Condition="'$(BundleNativeAotCompiler)' == 'true'">
+        <PackageName>runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler</PackageName>
+        <PackageVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</PackageVersion>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+        <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
+      </BundledLayoutPackage>
+
+      <BundledLayoutLibraryPackage Include="$(SourceBuiltShippingPackagesDir)/../runtime/Microsoft.DotNet.ILCompiler.$(MicrosoftNETCoreAppRuntimePackageVersion).nupkg" Condition="'$(BundleNativeAotCompiler)' == 'true'" />
+
+      <BundledLayoutLibraryPackage Include="$(SourceBuiltShippingPackagesDir)/../runtime/Microsoft.NET.ILLink.Tasks.$(MicrosoftNETILLinkTasksPackageVersion).nupkg" Condition="'$(BundleNativeAotCompiler)' == 'true'" />
+
       <BundledInstallerComponent Include="DownloadedRuntimeDepsInstallerFile"
                                  Condition="('$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true') And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
@@ -457,6 +468,11 @@
 
     <Copy SourceFiles="@(BundledLayoutPackageDownloadFilesWithDestination)"
           DestinationFiles="@(BundledLayoutPackageDownloadFilesWithDestination->'%(DestinationPath)')"
+          SkipUnchangedFiles="true"
+          />
+
+    <Copy SourceFiles="@(BundledLayoutLibraryPackage)"
+          DestinationFolder="$(RedistLayoutPath)/library-packs"
           SkipUnchangedFiles="true"
           />
 

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -219,6 +219,8 @@ targets="/t:Build"
 if [[ "$test" == true ]]; then
   project="$scriptroot/test/tests.proj"
   targets="$targets;VSTest"
+  # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
+  export MSBUILDENSURESTDOUTFORTASKPROCESSES=1
 fi
 
 function Build {

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -60,6 +60,8 @@ $targets = "/t:Build"
 if ($test) {
   $project = Join-Path (Join-Path $RepoRoot "test") "tests.proj"
   $targets += ";VSTest"
+  # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
+  $env:MSBUILDENSURESTDOUTFORTASKPROCESSES="1"
 }
 
 if ($buildRepoTests) {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DebugTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DebugTests.cs
@@ -30,7 +30,7 @@ public class DebugTests : SdkTests
         StringBuilder issueDetails = new();
         foreach (var fileName in fileNames)
         {
-            if (!IsElfFile(fileName))
+            if (!IsElfFile(fileName) || SkipFile(fileName))
             {
                 continue;
             }
@@ -68,6 +68,14 @@ public class DebugTests : SdkTests
     {
         string fileStdOut = ExecuteHelper.ExecuteProcessValidateExitCode("file", $"{fileName}", OutputHelper);
         return Regex.IsMatch(fileStdOut, @"ELF 64-bit [LM]SB (?:pie )?(?:executable|shared object)");
+    }
+
+    private static bool SkipFile(string path)
+    {
+        string fileName = Path.GetFileName(path);
+
+        // 'ilc' is a NativeAOT-built application which doesn't meet the expectations set by the test.
+        return fileName == "ilc";
     }
 
     private ScanResult ScanFile(string fileName)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -788,16 +788,21 @@ namespace Microsoft.NET.Build.Tasks
 
                 var runtimePackName = packNamePattern.Replace("**RID**", hostRuntimeIdentifier);
 
-                if (EnableRuntimePackDownload)
+                var runtimePackItem = new TaskItem(runtimePackName);
+                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
+                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
+
+                string runtimePackPath = GetPackPath(runtimePackName, packVersion);
+                if (runtimePackPath != null)
+                {
+                    runtimePackItem.SetMetadata(MetadataKeys.PackageDirectory, runtimePackPath);
+                }
+                else if (EnableRuntimePackDownload)
                 {
                     // We need to download the runtime pack
                     runtimePackToDownload = new TaskItem(runtimePackName);
                     runtimePackToDownload.SetMetadata(MetadataKeys.Version, packVersion);
                 }
-
-                var runtimePackItem = new TaskItem(runtimePackName);
-                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
-                runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
 
                 switch (toolPackType)
                 {


### PR DESCRIPTION
This includes the libraries that are needed for source-built NativeAOT with the source-built SDK:
- runtime.\<rid>.Microsoft.DotNet.ILCompiler extracted under 'packs'.
- Microsoft.DotNet.ILCompiler and Microsoft.NET.ILLink.Tasks as NuGet packages under 'library-packs'.

Implements https://github.com/dotnet/source-build/issues/1215#issuecomment-2116395577
Contributes to https://github.com/dotnet/source-build/issues/1215

@dsplaisted @baronfel @ViktorHofer @jkotas ptal

cc @omajid