### PR TITLE
Fix license scan test pipeline

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -99,6 +99,7 @@ jobs:
       /p:SmokeTestsWarnOnLicenseScanDiffs=false
       /p:TargetRid=linux-x64
       /p:PortableRid=linux-x64
+      /p:SkipPrepareSdkArchive=true
     displayName: Run Tests
     workingDirectory: $(Build.SourcesDirectory)
 
@@ -167,7 +168,7 @@ jobs:
       artifact: ''
       patterns: '**/Updated*'
       displayName: Download Updated Test Files
-  
+
   - script: |
       find $(Pipeline.Workspace)/Artifacts -type f -exec mv {} $(Pipeline.Workspace)/Artifacts \;
     displayName: Move Artifacts to root

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Microsoft.DotNet.SourceBuild.SmokeTests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Microsoft.DotNet.SourceBuild.SmokeTests.csproj
@@ -10,6 +10,10 @@
     <!-- Multiple loggers are specified so that results are captured in trx and pipelines can fail with AzDO pipeline warnings
          Workaround https://github.com/dotnet/source-build/issues/4003 by disabling VSTestUseMSBuildOutput -->
     <VSTestUseMSBuildOutput>false</VSTestUseMSBuildOutput>
+    <!-- The license scan test pipeline invokes this project directly and only runs the license scan tests.
+         They don't require the SDK archive and therefore don't build the VMR. The DetermineSourceBuiltSdkVersion
+         target would fail as the SDK archive doesn't exist. This hook disables invoking the target and the P2P below. -->
+    <SetRuntimeConfigOptionsDependsOn Condition="'$(SkipPrepareSdkArchive)' != 'true'">DetermineSourceBuiltSdkVersion</SetRuntimeConfigOptionsDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" ReferenceOutputAssembly="false" Condition="'$(SkipPrepareSdkArchive)' != 'true'" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
 
@@ -32,7 +36,7 @@
   </ItemGroup>
 
   <Target Name="SetRuntimeConfigOptions"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion"
+          DependsOnTargets="$(SetRuntimeConfigOptionsDependsOn)"
           BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
     <ItemGroup Condition="'$(SourceBuiltArtifactsPath)' == ''">
       <SourceBuiltArtifactsItem Include="$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4429

This adds a hook to not extract the SDK archive
and not fail as the license scan tests don't
require it.

This is an alternative appraoch of
https://github.com/dotnet/sdk/pull/41143