### PR TITLE
Fix build-configuration.json upload

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -53,11 +53,11 @@ jobs:
     - ${{ if eq(parameters.publishRetryConfig, true) }}:
       # Publishes the build-configuration.json to the artifacts which Arcade uses to allow all the jobs in the pipeline to retry automatically.
       # See: https://github.com/dotnet/arcade/blob/main/Documentation/Projects/Build%20Analysis/BuildRetryOnboard.md
-      - task: ${{ parameters.oneESCompat.publishTaskPrefix }}PublishBuildArtifacts@1
+      - task: ${{ parameters.oneESCompat.publishTaskPrefix }}PublishPipelineArtifact@1
         displayName: Publish build-configuration.json
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/eng/BuildConfiguration
-          ArtifactName: BuildConfiguration
+          targetPath: $(Build.SourcesDirectory)/eng/BuildConfiguration
+          artifactName: BuildConfiguration
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - ${{ if eq(parameters.pool.os, 'windows') }}:
         - powershell: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1 -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token


### PR DESCRIPTION
Fixes: https://github.com/dotnet/dnceng/issues/2947

## Summary

When I changed the CI pipelines, I went through a few different iterations. During that, I changed how the `build-configuration.json` was being uploaded to the artifacts. This file sets a build retry mechanism in Arcade when it is present. From my testing, I didn't notice a problem. However, dnceng has seen an issue with uploading this file as a build artifact instead of a pipeline artifact. So, I've changed this back to be a pipeline artifact instead.

AFAIK, unless you are a service accessing these artifacts in a specific way, generally there is no difference between a build artifact and a pipeline artifact. However, *this is* a service accessing this artifact in a specific way, so it needed to be changed.

CC @riarenas