### PR TITLE
Fix CodeOwners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,10 +46,10 @@
 /test/dotnet-fsi.Tests @dotnet/fsharp
 
 # Area-DotNet Test
-/src/Cli/dotnet/commands/dotnet-test @dotnet/dotnet-test-templates-admin
-/src/Cli/dotnet/commands/dotnet-vstest @dotnet/dotnet-test-templates-admin
-/test/dotnet-test.Tests @dotnet/dotnet-test-templates-admin
-/test/dotnet-vstest.Tests @dotnet/dotnet-test-templates-admin
+/src/Cli/dotnet/commands/dotnet-test @dotnet/dotnet-testing-admin
+/src/Cli/dotnet/commands/dotnet-vstest @dotnet/dotnet-testing-admin
+/test/dotnet-test.Tests @dotnet/dotnet-testing-admin
+/test/dotnet-vstest.Tests @dotnet/dotnet-testing-admin
 
 # Area-Templates
 /src/Cli/dotnet/commands/dotnet-new @dotnet/templating-engine-maintainers 
@@ -61,13 +61,13 @@
 
 # ILLink and ReadyToRun targets and tasks owned by runtime team
 # Area-ILLink Area-ReadyToRun
-/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets clrappmodel@microsoft.com @dotnet/illink-contrib
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets @dotnet/illink-contrib
 /src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs @AntonLapounov
 /src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs @AntonLapounov
-/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs clrappmodel@microsoft.com @dotnet/illink-contrib
+/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs @dotnet/illink-contrib
 /test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs @AntonLapounov
 # Publish.targets related to ILLink and ReadyToRun is own by both runtime and SDK team
-/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets clrappmodel@microsoft.com @dotnet/illink-contrib @AntonLapounov @dotnet/dotnet-cli
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink-contrib @AntonLapounov @dotnet/dotnet-cli
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
 
 # Area-Watch


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/40739

## Summary

- Replaced @dotnet/dotnet-test-templates-admin (since the team does not exist) with @dotnet/dotnet-testing-admin
- Removed clrappmodel@microsoft.com since the user does not exist
- @dotnet/illink-contrib did not have correct permissions for the repo. Applied the same permissions to them as the other code owners.