### PR TITLE
Added missing -nativeToolsOnMachine

### DIFF
--- a/restore.cmd
+++ b/restore.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\build.ps1""" -restore -msbuildEngine dotnet %*"
+powershell -NoLogo -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\build.ps1""" -restore -nativeToolsOnMachine -msbuildEngine dotnet %*"
 exit /b %ErrorLevel%

--- a/test.cmd
+++ b/test.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\build.ps1""" -test -msbuildEngine dotnet %*"
+powershell -NoLogo -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\build.ps1""" -test -nativeToolsOnMachine -msbuildEngine dotnet %*"
 exit /b %ErrorLevel%


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/40859

## Summary

When migrating from dotnet/installer to dotnet/sdk, the `-nativeToolsOnMachine` flag was required to allow the build to use CMake properly. I did this for `build.cmd` as dotnet/installer only had a `build.cmd`. However, this repo also has `restore.cmd` and `test.cmd`. So, I forgot to add that flag to these build files too.