### PR TITLE
Make SDK produced template nupkgs lowercase

### DIFF
--- a/src/Installer/redist-installer/targets/BundledTemplates.targets
+++ b/src/Installer/redist-installer/targets/BundledTemplates.targets
@@ -111,8 +111,8 @@
 
   <Target Name="GetRepoTemplates" DependsOnTargets="ResolveProjectReferences">
     <ItemGroup>
-      <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.symbols.nupkg" />
-      <RepoTemplates Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.symbols.nupkg" />
+      <RepoTemplate Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ItemTemplates.*.symbols.nupkg" />
+      <RepoTemplate Include="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.nupkg" Exclude="$(ArtifactsShippingPackagesDir)Microsoft.DotNet.Common.ProjectTemplates.*.symbols.nupkg" />
     </ItemGroup>
   </Target>
 
@@ -131,8 +131,8 @@
       <CurrentTemplateInstallPath Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '9.0'">%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)</CurrentTemplateInstallPath>
     </PropertyGroup>
 
-    <Copy SourceFiles="%(RepoTemplates.Identity)"
-          DestinationFolder="$(RedistLayoutPath)templates\$(CurrentTemplateInstallPath)" />
+    <Copy SourceFiles="@(RepoTemplate)"
+          DestinationFiles="$(RedistLayoutPath)templates\$(CurrentTemplateInstallPath)\$([System.String]::Copy('%(Filename)%(Extension)').ToLowerInvariant())" />
   </Target>
 
   <Target Name="LayoutTemplatesForMSI" DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions;GetRepoTemplates" Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
@@ -144,8 +144,8 @@
       <CurrentTemplateInstallPath Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '9.0'">%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)</CurrentTemplateInstallPath>
       <CurrentTemplateFrameworkVersion>%(CurrentVersionBundledTemplates.TemplateFrameworkVersion)</CurrentTemplateFrameworkVersion>
     </PropertyGroup>
-    <Copy SourceFiles="%(RepoTemplates.Identity)"
-          DestinationFolder="$(BaseOutputPath)$(Configuration)\templates-$(CurrentTemplateFrameworkVersion)\templates\$(CurrentTemplateInstallPath)" />
+    <Copy SourceFiles="@(RepoTemplate)"
+          DestinationFiles="$(BaseOutputPath)$(Configuration)\templates-$(CurrentTemplateFrameworkVersion)\templates\$(CurrentTemplateInstallPath)\$([System.String]::Copy('%(Filename)%(Extension)').ToLowerInvariant())" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Those were lowercase in the sdk layout before but
that changed with the repo merge.

Make the Filename and Extension metadata lowercase when copying the files.

P4:

![image](https://github.com/dotnet/sdk/assets/7412651/192a5919-d4ce-40e4-a1cd-02447c6ed03e)

main:

![image](https://github.com/dotnet/sdk/assets/7412651/78a79bad-a681-4dd1-bcb8-686b27f17725)
