### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -70,6 +70,7 @@ jobs:
           displayName: Setup Private Feeds Credentials
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - task: NugetAuthenticate@1
 
     ############### BUILDING ###############
     - ${{ if eq(parameters.pool.os, 'windows') }}:


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.