### PR TITLE
Fix license scan test results path for trx files

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -139,8 +139,8 @@ jobs:
     continueOnError: true
     inputs:
       testRunner: vSTest
-      testResultsFiles: '*.trx'
-      searchFolder: $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.SmokeTests/TestResults
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Build.SourcesDirectory)/artifacts/TestResults
       mergeTestResults: true
       publishRunAttachments: true
       testRunTitle: $(Agent.JobName)


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4430

The test results were moved to the artifacts directory, so the license scan test pipeline is failing to find these files.