### PR TITLE
make the workload resolver only light up for the specific entrypoint SDKs we control

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -36,6 +36,7 @@
     <ItemGroup>
       <ManifestLines Include="&lt;SdkResolver&gt;" />
       <ManifestLines Include="&lt;Path&gt;$(_TargetPathRelativePath)&lt;/Path&gt;" />
+      <ManifestLines Include="&lt;ResolvableSdkPattern&gt;FSharp\.NET\.Sdk|Microsoft\.Build\.Tasks\.Git|Microsoft\.Docker\.Sdk|Microsoft\.NET\.Sdk|Microsoft\.NET\.Sdk\.BlazorWebAssembly|Microsoft\.NET\.Sdk\.Publish|Microsoft\.NET\.Sdk\.Razor|Microsoft\.NET\.Sdk\.StaticWebAssets|Microsoft\.NET\.Sdk\.Web|Microsoft\.NET\.Sdk\.Web\.ProjectSystem|Microsoft\.NET\.Sdk\.WebAssembly|Microsoft\.NET\.Sdk\.WindowsDesktop|Microsoft\.NET\.Sdk\.Worker|Microsoft\.SourceLink\.AzureRepos\.Git|Microsoft\.SourceLink\.Bitbucket\.Git|Microsoft\.SourceLink\.Common|Microsoft\.SourceLink\.GitHub|Microsoft\.SourceLink\.GitLab|NuGet\.Build\.Tasks\.Pack&lt;/ResolvableSdkPattern&gt;" />
       <ManifestLines Include="&lt;/SdkResolver&gt;" />
     </ItemGroup>
 

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
       <ManifestLines Include="&lt;SdkResolver&gt;" />
       <ManifestLines Include="&lt;Path&gt;$(_TargetPathRelativePath)&lt;/Path&gt;" />
-      <ManifestLines Include="&lt;ResolvableSdkPattern&gt;FSharp\.NET\.Sdk|Microsoft\.Build\.Tasks\.Git|Microsoft\.Docker\.Sdk|Microsoft\.NET\.Sdk|Microsoft\.NET\.Sdk\.BlazorWebAssembly|Microsoft\.NET\.Sdk\.Publish|Microsoft\.NET\.Sdk\.Razor|Microsoft\.NET\.Sdk\.StaticWebAssets|Microsoft\.NET\.Sdk\.Web|Microsoft\.NET\.Sdk\.Web\.ProjectSystem|Microsoft\.NET\.Sdk\.WebAssembly|Microsoft\.NET\.Sdk\.WindowsDesktop|Microsoft\.NET\.Sdk\.Worker|Microsoft\.SourceLink\.AzureRepos\.Git|Microsoft\.SourceLink\.Bitbucket\.Git|Microsoft\.SourceLink\.Common|Microsoft\.SourceLink\.GitHub|Microsoft\.SourceLink\.GitLab|NuGet\.Build\.Tasks\.Pack&lt;/ResolvableSdkPattern&gt;" />
+      <ManifestLines Include="&lt;ResolvableSdkPattern&gt;Microsoft\..*|Samsung\..*|GtkSharp\..*|FSharp\.NET\.Sdk|NuGet\.Build\.Tasks\.Pack&lt;/ResolvableSdkPattern&gt;" />
       <ManifestLines Include="&lt;/SdkResolver&gt;" />
     </ItemGroup>
 

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml
@@ -1,0 +1,4 @@
+<SdkResolver>
+<Path>..\..\Microsoft.DotNet.MSBuildSdkResolver.dll</Path>
+<ResolvableSdkPattern>Microsoft\..*|Samsung\..*|GtkSharp\..*|FSharp\.NET\.Sdk|NuGet\.Build\.Tasks\.Pack</ResolvableSdkPattern>
+</SdkResolver>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
@@ -45,6 +45,7 @@
     <ItemGroup>
       <ManifestLines Include="&lt;SdkResolver&gt;" />
       <ManifestLines Include="&lt;Path&gt;$(_TargetPathRelativePath)&lt;/Path&gt;" />
+      <ManifestLines Include="&lt;ResolvableSdkPattern&gt;Microsoft\..*|Samsung\..*|GtkSharp\..*&lt;/ResolvableSdkPattern&gt;" />
       <ManifestLines Include="&lt;/SdkResolver&gt;" />
     </ItemGroup>
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
@@ -1,3 +1,4 @@
 <SdkResolver>
 <Path>..\..\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.dll</Path>
+<ResolvableSdkPattern>Microsoft.NET.SDK.WorkloadAutoImportPropsLocator|Microsoft.NET.SDK.WorkloadManifestTargetsLocator</ResolvableSdkPattern>
 </SdkResolver>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
@@ -1,4 +1,4 @@
 <SdkResolver>
 <Path>..\..\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.dll</Path>
-<ResolvableSdkPattern>Microsoft.NET.SDK.WorkloadAutoImportPropsLocator|Microsoft.NET.SDK.WorkloadManifestTargetsLocator</ResolvableSdkPattern>
+<ResolvableSdkPattern>Microsoft\.NET\.SDK\.WorkloadAutoImportPropsLocator|Microsoft\.NET\.SDK\.WorkloadManifestTargetsLocator|Microsoft\..*|Samsung\..*|GtkSharp\..*</ResolvableSdkPattern>
 </SdkResolver>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/SdkResolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.xml
@@ -1,4 +1,4 @@
 <SdkResolver>
 <Path>..\..\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.dll</Path>
-<ResolvableSdkPattern>Microsoft\.NET\.SDK\.WorkloadAutoImportPropsLocator|Microsoft\.NET\.SDK\.WorkloadManifestTargetsLocator|Microsoft\..*|Samsung\..*|GtkSharp\..*</ResolvableSdkPattern>
+<ResolvableSdkPattern>Microsoft\..*|Samsung\..*|GtkSharp\..*</ResolvableSdkPattern>
 </SdkResolver>

--- a/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
+++ b/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
@@ -61,7 +61,7 @@
         <DestinationPath>$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
       </VSMSBuildExtensionsContent>
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml"
-        DestinationPath="$(OutputPath)/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml" />
+        DestinationPath="$(OutputPath)/MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml" />
     </ItemGroup>
 
     <ItemGroup>
@@ -76,7 +76,9 @@
       <!-- Include the swr file in the nuget package for VS authoring -->
       <Content Include="$(SdkMSBuildExtensionsSwrFile)" PackagePath="/" />
       <Content Include="@(VSMSBuildExtensionsContent)"  PackagePath="/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)" />
-      <Content Update="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml" PackagePath="/MSBuildSdkResolver/" />
+      <Content Condition="%(Identity) == '$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml'">
+        <PackagePath>/MSBuildSdkResolver/</PackagePath>
+      </Content>
     </ItemGroup>
   </Target>
 

--- a/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
+++ b/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
@@ -56,21 +56,27 @@
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\arm64\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/arm64/" />
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.Deployment.DotNet.Releases*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.DotNet.MSBuildSdkResolver*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
-      <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\**\Microsoft.DotNet.MSBuildSdkResolver.xml" DeploymentSubpath="MSBuildSdkResolver/" />
 
       <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
         <DestinationPath>$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
       </VSMSBuildExtensionsContent>
+      <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml"
+        DestinationPath="$(OutputPath)/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="%(VSMSBuildExtensionsContent.DestinationPath)" />
+    <ItemGroup>
+      <_VSMSBuildExtensionsContentDestinations Include="@(VSMSBuildExtensionsContent->'%(DestinationPath)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="@(_VSMSBuildExtensionsContentDestinations)" />
 
     <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(OutputPath)"
                                   OutputFile="$(SdkMSBuildExtensionsSwrFile)" />
     <ItemGroup>
       <!-- Include the swr file in the nuget package for VS authoring -->
       <Content Include="$(SdkMSBuildExtensionsSwrFile)" PackagePath="/" />
-      <Content Include="@(VSMSBuildExtensionsContent)" PackagePath="/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)" />
+      <Content Include="@(VSMSBuildExtensionsContent)"  PackagePath="/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)" />
+      <Content Update="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml" PackagePath="/MSBuildSdkResolver/" />
     </ItemGroup>
   </Target>
 

--- a/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
+++ b/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
@@ -27,7 +27,26 @@
   <!-- Shared infra to build and use the sdk-tasks -->
   <Import Project="$(RepoRoot)src\Tasks\sdk-tasks\sdk-tasks.InTree.targets" />
 
-  <Target Name="GenerateLayout" Condition="'$(IsPackable)' == 'true'" DependsOnTargets="ResolveProjectReferences">
+  <Target Name="_DeclareRewriteResolverXmlInputsAndOutputs">
+    <PropertyGroup>
+        <_ResolverXmlPath>$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml</_ResolverXmlPath>
+        <_RewrittenResolverXmlPath>$(OutputPath)$([System.IO.Path]::GetFileName('$(_ResolverXmlPath)'))</_RewrittenResolverXmlPath>
+      </PropertyGroup>
+  </Target>
+
+  <Target Name="_RewriteResolverXml" DependsOnTargets="_DeclareRewriteResolverXmlInputsAndOutputs" Inputs="$(_ResolverXmlPath)" Outputs="$(_RewrittenResolverXmlPath)" Returns="@(VSMSBuildExtensionsContent)">
+    <WriteLinesToFile File="$(_RewrittenResolverXmlPath)" Lines="$([System.IO.File]::ReadAllText($(_ResolverXmlPath)).Replace('..\..\',''))" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+          <!-- The generated MSBuildSdkResolver XML file is emitted to the SdkResolvers directory, but needs to be installed colocated to the dll. This is hard to do using the
+           templating and packing mechanisms on the above lines, so for this file specifically I've hard-coded the expected layouts. -->
+      <VSMSBuildExtensionsContent Include="$(_RewrittenResolverXmlPath)"
+        DestinationPath="$(OutputPath)\MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml"
+        PackagePath="/MSBuildSdkResolver/" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateLayout" Condition="'$(IsPackable)' == 'true'" DependsOnTargets="ResolveProjectReferences;_RewriteResolverXml">
     <PropertyGroup>
       <MSBuildExtensionsOutputPath>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MSBuildExtensionsOutputPath>
       <SdkMSBuildExtensionsSwrFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr</SdkMSBuildExtensionsSwrFile>
@@ -57,14 +76,8 @@
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.Deployment.DotNet.Releases*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.DotNet.MSBuildSdkResolver*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
 
-      <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
-        <DestinationPath>$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
-      </VSMSBuildExtensionsContent>
-      <!-- The generated MSBuildSdkResolver XML file is emitted to the SdkResolvers directory, but needs to be installed colocated to the dll. This is hard to do using the
-           templating and packing mechanisms on the above lines, so for this file specifically I've hard-coded the expected layouts. -->
-      <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml"
-        DestinationPath="$(OutputPath)/MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml"
-        PackagePath="/MSBuildSdkResolver/" />
+      <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)"
+        DestinationPath="$([MSBuild]::ValueOrDefault(%(VSMSBuildExtensionsContent.DestinationPath), '$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)'))" />
     </ItemGroup>
 
     <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="@(VSMSBuildExtensionsContent->'%(DestinationPath)')" />
@@ -74,6 +87,7 @@
     <ItemGroup>
       <!-- Include the swr file in the nuget package for VS authoring -->
       <Content Include="$(SdkMSBuildExtensionsSwrFile)" PackagePath="/" />
-      <Content Include="@(VSMSBuildExtensionsContent)"  PackagePath="$([MSBuild]::ValueOrDefault(%(VSMSBuildExtensionsContent.PackagePath), '/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)'))" />
+      <Content Include="@(VSMSBuildExtensionsContent)" PackagePath="$([MSBuild]::ValueOrDefault(%(VSMSBuildExtensionsContent.PackagePath), '/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)'))" />
     </ItemGroup>
+    </Target>
 </Project>

--- a/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
+++ b/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
@@ -56,6 +56,7 @@
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\arm64\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/arm64/" />
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.Deployment.DotNet.Releases*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\**\Microsoft.DotNet.MSBuildSdkResolver*.dll" DeploymentSubpath="MSBuildSdkResolver/" />
+      <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\**\Microsoft.DotNet.MSBuildSdkResolver.xml" DeploymentSubpath="MSBuildSdkResolver/" />
 
       <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
         <DestinationPath>$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>

--- a/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
+++ b/src/VSMSBuildExtensions/VSMSBuildExtensions.proj
@@ -60,26 +60,20 @@
       <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
         <DestinationPath>$(OutputPath)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
       </VSMSBuildExtensionsContent>
+      <!-- The generated MSBuildSdkResolver XML file is emitted to the SdkResolvers directory, but needs to be installed colocated to the dll. This is hard to do using the
+           templating and packing mechanisms on the above lines, so for this file specifically I've hard-coded the expected layouts. -->
       <VSMSBuildExtensionsContent Include="$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml"
-        DestinationPath="$(OutputPath)/MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml" />
+        DestinationPath="$(OutputPath)/MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.xml"
+        PackagePath="/MSBuildSdkResolver/" />
     </ItemGroup>
 
-    <ItemGroup>
-      <_VSMSBuildExtensionsContentDestinations Include="@(VSMSBuildExtensionsContent->'%(DestinationPath)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="@(_VSMSBuildExtensionsContentDestinations)" />
+    <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="@(VSMSBuildExtensionsContent->'%(DestinationPath)')" />
 
     <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(OutputPath)"
                                   OutputFile="$(SdkMSBuildExtensionsSwrFile)" />
     <ItemGroup>
       <!-- Include the swr file in the nuget package for VS authoring -->
       <Content Include="$(SdkMSBuildExtensionsSwrFile)" PackagePath="/" />
-      <Content Include="@(VSMSBuildExtensionsContent)"  PackagePath="/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)" />
-      <Content Condition="%(Identity) == '$(ArtifactsBinDir)Microsoft.DotNet.MSBuildSdkResolver\$(Configuration)\net472\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.xml'">
-        <PackagePath>/MSBuildSdkResolver/</PackagePath>
-      </Content>
+      <Content Include="@(VSMSBuildExtensionsContent)"  PackagePath="$([MSBuild]::ValueOrDefault(%(VSMSBuildExtensionsContent.PackagePath), '/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)'))" />
     </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
This is part of https://github.com/dotnet/sdk/issues/26009

This makes https://github.com/NuGet/Home/issues/13471 easier to diagnose because it removes the workload resolver from the list of resolvers - you can see the before and after here:

before:
```
D:\temp\test01\test01.csproj : error : Could not resolve SDK "MSTest.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
D:\temp\test01\test01.csproj : error :   SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
D:\temp\test01\test01.csproj : error :   Unable to resolve 'MSTest.Sdk (= 3.3.1)' for '.NETStandard,Version=v0.0'. PackageSourceMapping is enabled, the following source(s) were not considered: Microsoft Visual Studio Offline Packages, NuGet official package source.
D:\temp\test01\test01.csproj : error MSB4236: The SDK 'MSTest.Sdk' specified could not be found.
```

after:
```
E:\Code\Scratch\test-app\test-app.csproj : error : Could not resolve SDK "MSTest.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
E:\Code\Scratch\test-app\test-app.csproj : error :   Unable to resolve 'MSTest.Sdk (= 3.3.1)' for '.NETStandard,Version=v0.0'. PackageSourceMapping is enabled, the following source(s) were not considered: nuget.
E:\Code\Scratch\test-app\test-app.csproj : error MSB4236: The SDK 'MSTest.Sdk/3.3.1' specified could not be found.
```

We save one line here, and with [additional work on the MSBuild side](https://github.com/dotnet/msbuild/pull/11726) we may be able to reduce the MSBuild resolver wrapper noise in this message.