### PR TITLE
Use `src/<repo>/` as regex

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -189,7 +189,7 @@ public class LicenseScanTests : TestBase
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
 
         // We only care about the license expressions that are in the target repo.
-        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, "^" + Regex.Escape(_relativeRepoPath));
+        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", BaselineSubDir, "^" + Regex.Escape(_relativeRepoPath) + "/");
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4431

This adds a path separator at the end of the regex so that the pattern matches `src/roslyn/` but not `src/roslyn-analyzers/`