### PR TITLE
[release/8.0.1xx] Use a more reasonable timeout for HttpClient operations for Container Registry interactions

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -49,7 +49,11 @@ internal class DefaultRegistryAPI : IRegistryAPI
             clientHandler = new AmazonECRMessageHandler(clientHandler);
         }
 
-        HttpClient client = new(clientHandler);
+        HttpClient client = new(clientHandler)
+        {
+            // blob upload operations can take quite a while, we should allow them to take as long as they need
+            Timeout = Timeout.InfiniteTimeSpan
+        };
 
         client.DefaultRequestHeaders.Add("User-Agent", $".NET Container Library v{Constants.Version}");
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -14,6 +14,14 @@ internal class DefaultRegistryAPI : IRegistryAPI
     private readonly HttpClient _client;
     private readonly ILogger _logger;
 
+    // Empirical value - Unoptimized .NET application layers can be ~200MB
+    // * .NET Runtime (~80MB)
+    // * ASP.NET Runtime (~25MB)
+    // * application and dependencies - variable, but _probably_ not more than the BCL?
+    // Given a 200MB target and a 1Mb/s upload speed, we'd expect an upload speed of 27m:57s.
+    // Making this a round 30 for convenience.
+    private static TimeSpan LongRequestTimeout = TimeSpan.FromMinutes(30);
+
     internal DefaultRegistryAPI(string registryName, Uri baseUri, ILogger logger)
     {
         bool isAmazonECRRegistry = baseUri.IsAmazonECRRegistry();
@@ -33,7 +41,7 @@ internal class DefaultRegistryAPI : IRegistryAPI
         var innerHandler = new SocketsHttpHandler()
         {
             UseCookies = false,
-            // the rest of the HTTP stack has an infinite timeout (see below) but we should still have a reasonable timeout for the initial connection
+            // the rest of the HTTP stack has an very long timeout (see below) but we should still have a reasonable timeout for the initial connection
             ConnectTimeout = TimeSpan.FromSeconds(30)
         };
 
@@ -56,8 +64,7 @@ internal class DefaultRegistryAPI : IRegistryAPI
 
         HttpClient client = new(clientHandler)
         {
-            // blob upload operations can take quite a while, we should allow them to take as long as they need
-            Timeout = Timeout.InfiniteTimeSpan
+            Timeout = LongRequestTimeout
         };
 
         client.DefaultRequestHeaders.Add("User-Agent", $".NET Container Library v{Constants.Version}");

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -30,7 +30,12 @@ internal class DefaultRegistryAPI : IRegistryAPI
 
     private static HttpClient CreateClient(string registryName, Uri baseUri, ILogger logger, bool isAmazonECRRegistry = false)
     {
-        var innerHandler = new SocketsHttpHandler();
+        var innerHandler = new SocketsHttpHandler()
+        {
+            UseCookies = false,
+            // the rest of the HTTP stack has an infinite timeout (see below) but we should still have a reasonable timeout for the initial connection
+            ConnectTimeout = TimeSpan.FromSeconds(30)
+        };
 
         // Ignore certificate for https localhost repository.
         if (baseUri.Host == "localhost" && baseUri.Scheme == "https")


### PR DESCRIPTION
Backport of #38938 to release/8.0.1xx

This is a manual backport because the patch didn't apply cleanly. This should have been backported to 8.0.1xx at the same time as I asked for servicing for 8.0.2xx, but wasn't.

