### PR TITLE
[wasm] Import StaticWebAssets SDK only for browser-wasm

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -27,9 +27,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <_WasmSdkImportsMicrosoftNETSdkPublish Condition="'$(UsingMicrosoftNETSdkPublish)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkPublish>
     <_WasmSdkImportsMicrosoftNETSdkStaticWebAssets Condition="'$(UsingMicrosoftNETSdkStaticWebAssets)' != 'true'">true</_WasmSdkImportsMicrosoftNETSdkStaticWebAssets>
+    <_WasmSdkImportsMicrosoftNetSdk Condition="'$(UsingMicrosoftNETSdk)' != 'true'">true</_WasmSdkImportsMicrosoftNetSdk>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.props" Condition="'$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <!-- For browser-wasm, we want to import StaticWebAssets SDK which imports SDK. -->
+  <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
+  <!-- This file runs before user csproj is evaluated and thus the switch here is just for completeness - SWA props file will always be imported. -->
+  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />
   <Import Project="$(_WebAssemblyPropsFile)" Condition="'$(_WebAssemblyPropsFile)' != ''" />
 </Project>

--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -34,7 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
   <!-- This file runs before user csproj is evaluated and thus the switch here is just for completeness - SWA props file will always be imported. -->
   <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />
   <Import Project="$(_WebAssemblyPropsFile)" Condition="'$(_WebAssemblyPropsFile)' != ''" />

--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -34,7 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
   <!-- This file runs before user csproj is evaluated and thus the switch here is just for completeness - SWA props file will always be imported. -->
   <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.props" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />
   <Import Project="$(_WebAssemblyPropsFile)" Condition="'$(_WebAssemblyPropsFile)' != ''" />

--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -10,7 +10,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project ToolsVersion="14.0">
-  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.targets" Condition="'$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <!-- For browser-wasm, we want to import StaticWebAssets SDK which imports SDK. -->
+  <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
+  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
+
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />
   <Import Project="$(_WebAssemblyTargetsFile)" Condition="'$(_WebAssemblyTargetsFile)' != ''" />
 </Project>


### PR DESCRIPTION
- Since we default to `browser-wasm` we can't identify wasi project when importing SDK props, and thus SWA props will always be imported.
- When importing SDK targets, we already know values from user's csproj, and thus we can skip SWA import

Contributes to https://github.com/dotnet/runtime/issues/96869#issuecomment-2141516436