### PR TITLE
[Blazor] Removes problematic system.text.json switches

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -46,8 +46,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
     <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
 


### PR DESCRIPTION
The fix in https://github.com/dotnet/runtime/pull/102876 was not enough to resolve the problem so we've decided to not set the problematic feature flag to enable p5 to ship

/cc @lewing

## Customer Impact

Any project using using these runtime feature flags will not work with the latest System.Text.Json

- [ ] Customer reported
- [x] Found internally

[Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]

## Regression

- [x] Yes
- [ ] No

[If yes, specify when the regression was introduced. Provide the PR or commit if known.]

## Testing

[How was the fix verified? How was the issue missed previously? What tests were added?]

## Risk

[High/Medium/Low. Justify the indication by mentioning how risks were measured and addressed.]

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
