### PR TITLE
Add SdkTarballPath prop

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <SdkTarballItem Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
+      <SdkTarballItem Condition="'$(SdkTarballPath)' != ''" Include="$(SdkTarballPath)" />
+      <SdkTarballItem Condition="'$(SdkTarballPath)' == ''" Include="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*$(ArchiveExtension)"
                       Exclude="$(ArtifactsAssetsDir)Sdk/**/$(SdkFilenamePrefix)*.wixpack.zip" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4442

The source-build SDK diff tests were failing with "Didn't find an SDK archive", which has been fixed in `main` branch https://github.com/dotnet/sdk/pull/41124, but the tests failing in [9.0.1xx-preview5 build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2464539) now.