### PR TITLE
Fix license scan test results path for trx files

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -139,8 +139,8 @@ jobs:
     continueOnError: true
     inputs:
       testRunner: vSTest
-      testResultsFiles: '*.trx'
-      searchFolder: $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.SmokeTests/TestResults
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Build.SourcesDirectory)/artifacts/TestResults
       mergeTestResults: true
       publishRunAttachments: true
       testRunTitle: $(Agent.JobName)


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4443

The test results were moved to the artifacts directory, so the license scan test pipeline is failing to find these files., which has been fixed in main branch https://github.com/dotnet/sdk/pull/41255, but the tests failing in [9.0.1xx-preview5 build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2465238&view=logs&j=280a01c8-006d-5537-2980-fc0860fb6840&t=8c5c7c98-db07-56c7-5f69-77b9074e6633&l=11) now.