### PR TITLE
Update branch filters for SB SDK Diff Pipeline

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -14,8 +14,8 @@ resources:
     trigger:
       branches:
         include:
-          - release/*.0.1xx*
-          - internal/release/*.0.1xx*
+          - refs/heads/release/*.0.1xx*
+          - refs/heads/internal/release/*.0.1xx*
 
 pr: none
 trigger: none


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4439

According to https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-filters, if our branch filters aren't working, we should `try using the prefix refs/heads/. For example, use refs/heads/releases/old*instead of releases/old*.`.

This PR applies the above suggestion to the branch filters specified for the SDK diff pipeline.

Note: This should be backported to preview5 and 8.0.