### PR TITLE
Fix Target Branch for PR Updator

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/steps/create-baseline-update-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/steps/create-baseline-update-pr.yml
@@ -26,10 +26,12 @@ parameters:
 
 steps:
   - script: |
-     restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
-     restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+      restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+      restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
 
-     .dotnet/dotnet run \
+      branchName=$(echo "$(Build.SourceBranch)" | sed 's/refs\/heads\///g')
+
+      .dotnet/dotnet run \
         --project eng/tools/CreateBaselineUpdatePR/ \
         --property:RestoreSources="$restoreSources" \
         "${{ parameters.pipeline }}" \
@@ -38,7 +40,7 @@ steps:
         "${{ parameters.updatedFilesDirectory }}" \
         "$(Build.BuildId)" \
         --title "${{ parameters.pullRequestTitle }}" \
-        --branch "$(Build.SourceBranchName)"
+        --branch "$branchName"
     displayName: Publish Test Results PR
     workingDirectory: $(Build.SourcesDirectory)
     condition: succeededOrFailed()


### PR DESCRIPTION
As seen in [this run of the SDK diff pipeline](https://dev.azure.com/dnceng/internal/_build/results?buildId=2465665&view=logs&j=c2a3fba4-babc-5882-e82a-8e0dc9edd6ec&t=05b0bcef-5dd3-54fb-91f3-90c6da6d779a&l=12) (internal Microsoft link), the PR updater tool failed to create the PR because the target branch was given as "9.0.1xx-preview5" instead of "release/9.0.1xx-preview5". The reason for this is that `Build.SourceBranchName` returns the value after the last `/` in the branch, and not what occurs after `refs/heads/`. The way to remedy this is to use `Build.SourceBranch` and remove `refs/heads/`.

This PR also fixes the spacing of the script from a 1 space indent to a 2 space indent.

This change should be backported to preview5.