### PR TITLE
Ensure all template code files(C#, F#, VB) have consistent BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -466,6 +466,10 @@ dotnet_diagnostic.SA1202.severity = none
 # Static elements should appear before instance elements
 dotnet_diagnostic.SA1204.severity = none
 
+# Code files
+[*.{cs,vb,fs}]
+charset = utf-8-bom
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ClassLibrary-VisualBasic/Class1.vb
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ClassLibrary-VisualBasic/Class1.vb
@@ -1,3 +1,3 @@
-Public Class Class1
+﻿Public Class Class1
 
 End Class

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ConsoleApplication-VisualBasic/Program.vb
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ConsoleApplication-VisualBasic/Program.vb
@@ -1,4 +1,4 @@
-Imports System
+﻿Imports System
 
 Module Program
     Sub Main(args As String())


### PR DESCRIPTION
Ensure that all template code files in the repository are marked as UTF-8 BOM.

Fixes #41433