### PR TITLE
Publish xUnit test results (non-Helix)

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -10,6 +10,7 @@ parameters:
   runTests: true
   testProjects: $(Build.SourcesDirectory)/test/UnitTests.proj
   publishRetryConfig: false
+  publishXunitResults: false
   enableSbom: true
   ### ENV VARS ###
   testFullMSBuild: false
@@ -160,6 +161,19 @@ jobs:
             RunAoTTests: ${{ parameters.runAoTTests }}
 
     ############### POST ###############
+    - ${{ if eq(parameters.publishXunitResults, true) }}:
+      # This is only necessary for non-Helix tests.
+      - task: PublishTestResults@2
+        displayName: Publish xUnit Test Results
+        inputs:
+          testResultsFormat: xUnit
+          testResultsFiles: artifacts/TestResults/$(buildConfiguration)/*.xml
+          testRunTitle: $(System.PhaseName)
+          buildPlatform: ${{ parameters.buildArchitecture }}
+          buildConfiguration: $(buildConfiguration)
+        continueOnError: true
+        condition: always()
+
     - task: CopyFiles@2
       displayName: Copy Logs
       inputs:

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -14,6 +14,7 @@ parameters:
     runTests: false
   - categoryName: TemplateEngine
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+    publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true
   ### LINUX ###
@@ -71,11 +72,13 @@ parameters:
   - categoryName: TemplateEngine
     osProperties: $(linuxOsPortableProperties)
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+    publishXunitResults: true
   ### MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild
   - categoryName: TemplateEngine
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+    publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true
 


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/40983

## Summary
After consolidating the CI pipelines, I missed that we still run non-Helix tests (specifically, the TemplateEngine tests). These tests produce the standard xUnit test information that needs to get published to the pipeline, or else it won't report the actual test failures. I added the ability for a job to specify that it should publish the xUnit test results. This parameter will work for any other xUnit test jobs we may need to add in the future (if we don't Helix-ify them right away).

Thanks to @Forgind for pointing out this issue, seen in [this pipeline run](https://dev.azure.com/dnceng-public/public/_build/results?buildId=696587).