### PR TITLE
Delete dangling comments from exclusions file

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/SdkFileDiffExclusions.txt
@@ -77,8 +77,6 @@
 
 ./sdk/x.y.z/*/dump/|msft
 
-# netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
-
 # runtime components in roslyn layout - https://github.com/dotnet/source-build/issues/4016
 ./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll|sb
 ./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll|sb
@@ -89,8 +87,6 @@
 ./sdk/x.y.z/*/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll|sb
 ./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll|sb
 ./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll|sb
-
-# https://github.com/dotnet/source-build/issues/3510
 
 # https://github.com/dotnet/source-build/issues/4351
 ./sdk/x.y.z/*/Microsoft.Build.NuGetSdkResolver.resources.dll|msft


### PR DESCRIPTION
The exclusions had been deleted in a previous change but the comments associated with those exclusions were left behind. Cleaning them up.