### PR TITLE
Fix minimum macOS version in the .pkg manifest

### DIFF
--- a/src/Installer/redist-installer/targets/GeneratePKG.targets
+++ b/src/Installer/redist-installer/targets/GeneratePKG.targets
@@ -97,8 +97,7 @@
       </DistributionTemplateReplacement>
       <DistributionTemplateReplacement Include="{minOsVersion}">
         <!-- keep in sync with SetOSTargetMinVersions in the root Directory.Build.props in dotnet/runtime -->
-        <ReplacementString>10.15</ReplacementString>
-        <ReplacementString Condition="'$(Architecture)' == 'arm64'" >11.0</ReplacementString>
+        <ReplacementString>12.0</ReplacementString>
       </DistributionTemplateReplacement>
       <DistributionTemplateReplacement Include="{x64EmulationPkgInstallDirectory}">
         <ReplacementString>$(x64EmulationPkgInstallDirectory)</ReplacementString>


### PR DESCRIPTION
.NET 9 supports macOS 12.0+ but the installer still claimed 10.15 support which meant the installer didn't block installation on older macOS versions.

https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md#macos