### PR TITLE
restore older WarningLevel default behavior based on AnalysisLevel

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The CSharp.props used to hard-code WarningLevel to 4, so to maintain parity with .NET Framework projects we do that here. -->
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">4</WarningLevel>
     <!-- .NET projects, however, infer their WarningLevel from AnalysisLevel (which itself infers from TFM) -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(EffectiveAnalysisLevel)' != ''  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(EffectiveAnalysisLevel.Substring(0, 1))</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(EffectiveAnalysisLevel)' != ''  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$([System.Text.RegularExpressions.Regex]::Replace($(EffectiveAnalysisLevel), '\.\d+', ''))</WarningLevel>
   </PropertyGroup>
 
   <!-- Enable Analyzers based on EffectiveAnalysisLevel -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -62,7 +62,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The CSharp.props used to hard-code WarningLevel to 4, so to maintain parity with .NET Framework projects we do that here. -->
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">4</WarningLevel>
     <!-- .NET projects, however, infer their WarningLevel from AnalysisLevel (which itself infers from TFM) -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(AnalysisLevel)</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(EffectiveAnalysisLevel)' != ''  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(EffectiveAnalysisLevel.Substring(0, 1))</WarningLevel>
   </PropertyGroup>
 
   <!-- Enable Analyzers based on EffectiveAnalysisLevel -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -49,11 +49,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'latest' or '$(AnalysisLevelPrefix)' == 'latest'">$(_LatestAnalysisLevel)</EffectiveAnalysisLevel>
     <EffectiveAnalysisLevel Condition="'$(AnalysisLevel)' == 'preview' or '$(AnalysisLevelPrefix)' == 'preview'">$(_PreviewAnalysisLevel)</EffectiveAnalysisLevel>
 
-    <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevel if it is a version number -->
+    <!-- Set EffectiveAnalysisLevel to the value of AnalysisLevelPrefix/AnalysisLevel if it is a numeric value -->
     <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
-                                       '$(AnalysisLevelPrefix)' != ''">$(AnalysisLevelPrefix)</EffectiveAnalysisLevel>
+                                       '$(AnalysisLevelPrefix)' != '' And
+                                        $([System.Text.RegularExpressions.Regex]::IsMatch($(AnalysisLevelPrefix), '^\d+$'))">$(AnalysisLevelPrefix)</EffectiveAnalysisLevel>
     <EffectiveAnalysisLevel Condition="'$(EffectiveAnalysisLevel)' == '' And
-                                       '$(AnalysisLevel)' != ''">$(AnalysisLevel)</EffectiveAnalysisLevel>
+                                       '$(AnalysisLevel)' != '' And
+                                       $([System.Text.RegularExpressions.Regex]::IsMatch($(AnalysisLevel), '^\d+$'))">$(AnalysisLevel)</EffectiveAnalysisLevel>
 
     <!-- Set WarningLevel based on all we know about the project -->
     <!-- NOTE: at this time only the C# compiler supports warning waves like this. -->
@@ -62,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The CSharp.props used to hard-code WarningLevel to 4, so to maintain parity with .NET Framework projects we do that here. -->
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">4</WarningLevel>
     <!-- .NET projects, however, infer their WarningLevel from AnalysisLevel (which itself infers from TFM) -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(EffectiveAnalysisLevel)' != ''  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$([System.Text.RegularExpressions.Regex]::Replace($(EffectiveAnalysisLevel), '\.\d+', ''))</WarningLevel>
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(EffectiveAnalysisLevel)' != ''  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(EffectiveAnalysisLevel)</WarningLevel>
   </PropertyGroup>
 
   <!-- Enable Analyzers based on EffectiveAnalysisLevel -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -61,8 +61,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(AnalysisLevel)' == 'preview'">9999</WarningLevel>
     <!-- The CSharp.props used to hard-code WarningLevel to 4, so to maintain parity with .NET Framework projects we do that here. -->
     <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETFramework' ">4</WarningLevel>
-    <!-- .NET projects, however, can float up to their TFM's major version -->
-    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(_TargetFrameworkVersionWithoutV.Substring(0, 1))</WarningLevel>
+    <!-- .NET projects, however, infer their WarningLevel from AnalysisLevel (which itself infers from TFM) -->
+    <WarningLevel Condition="'$(Language)' == 'C#' And '$(WarningLevel)' == '' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">$(AnalysisLevel)</WarningLevel>
   </PropertyGroup>
 
   <!-- Enable Analyzers based on EffectiveAnalysisLevel -->

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -58,13 +58,14 @@ namespace Microsoft.NET.Build.Tests
             computedWarningLevel.Should().Be(parsedWarningLevel.ToString());
         }
 
-        [InlineData(targetFrameworkNet6, "6", "6")]
-        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkVersion, ToolsetInfo.CurrentTargetFrameworkVersion)]
-        [InlineData(ToolsetInfo.CurrentTargetFramework, "12", "12")]
-        [InlineData(targetFrameworkNetFramework472, "4", "4")]
+        [InlineData(targetFrameworkNet6, "6")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, "9")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, "12")]
+        [InlineData(targetFrameworkNetFramework472, "4")]
         [Theory]
-        public void It_Defaults_WarningLevel_To_AnalysisLevel_When_That_Is_Provided(string tfm, string analysisLevel, string expectedWarningLevel)
+        public void It_Defaults_WarningLevel_To_AnalysisLevel_When_That_Is_Provided(string tfm, string analysisLevel)
         {
+            var intLevel = int.Parse(analysisLevel);
             var testProject = new TestProject
             {
                 Name = "HelloWorld",
@@ -87,7 +88,7 @@ namespace Microsoft.NET.Build.Tests
                     ",
                 }
             };
-            testProject.AdditionalProperties.Add("AnalysisLevel", analysisLevel);
+            testProject.AdditionalProperties.Add("AnalysisLevel", intLevel.ToString());
 
             var testAsset = _testAssetsManager
                 .CreateTestProject(testProject, identifier: "warningLevelAnalysisLevelConsoleApp" + tfm, targetExtension: ".csproj");
@@ -102,7 +103,7 @@ namespace Microsoft.NET.Build.Tests
             var buildResult = buildCommand.Execute();
             var computedWarningLevel = buildCommand.GetValues()[0];
             buildResult.StdErr.Should().Be(string.Empty);
-            computedWarningLevel.Should().Be(expectedWarningLevel.ToString());
+            computedWarningLevel.Should().Be(intLevel.ToString());
         }
 
         [InlineData(1, "1")]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToFloatWarningLevels.cs
@@ -58,6 +58,53 @@ namespace Microsoft.NET.Build.Tests
             computedWarningLevel.Should().Be(parsedWarningLevel.ToString());
         }
 
+        [InlineData(targetFrameworkNet6, "6", "6")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkVersion, ToolsetInfo.CurrentTargetFrameworkVersion)]
+        [InlineData(ToolsetInfo.CurrentTargetFramework, "12", "12")]
+        [InlineData(targetFrameworkNetFramework472, "4", "4")]
+        [Theory]
+        public void It_Defaults_WarningLevel_To_AnalysisLevel_When_That_Is_Provided(string tfm, string analysisLevel, string expectedWarningLevel)
+        {
+            var testProject = new TestProject
+            {
+                Name = "HelloWorld",
+                TargetFrameworks = tfm,
+                IsExe = true,
+                SourceFiles =
+                {
+                    ["Program.cs"] = @"
+                        using System;
+
+                        namespace ConsoleCore
+                        {
+                            class Program
+                            {
+                                static void Main()
+                                {
+                                }
+                            }
+                        }
+                    ",
+                }
+            };
+            testProject.AdditionalProperties.Add("AnalysisLevel", analysisLevel);
+
+            var testAsset = _testAssetsManager
+                .CreateTestProject(testProject, identifier: "warningLevelAnalysisLevelConsoleApp" + tfm, targetExtension: ".csproj");
+
+            var buildCommand = new GetValuesCommand(
+                Log,
+                Path.Combine(testAsset.TestRoot, testProject.Name),
+                tfm, "WarningLevel")
+            {
+                DependsOnTargets = "Build"
+            };
+            var buildResult = buildCommand.Execute();
+            var computedWarningLevel = buildCommand.GetValues()[0];
+            buildResult.StdErr.Should().Be(string.Empty);
+            computedWarningLevel.Should().Be(expectedWarningLevel.ToString());
+        }
+
         [InlineData(1, "1")]
         [InlineData(null, ToolsetInfo.CurrentTargetFrameworkVersion)]
         [RequiresMSBuildVersionTheory("16.8")]


### PR DESCRIPTION
May fix #41372

If tests pass, will need backports to 8.0.1xx, 8.0.3xx, and 8.0.4xx