### PR TITLE
Add tab completion for 'dotnet nuget why' command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Cli
             whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
             whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
 
-            whyCommand.Options.Add(new CliOption<string>("--framework", "-f") { Arity = ArgumentArity.OneOrMore });
+            whyCommand.Options.Add(new CliOption<string>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore });
 
             whyCommand.SetAction(NuGetCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.Cli
             command.Subcommands.Add(GetVerifyCommand());
             command.Subcommands.Add(GetTrustCommand());
             command.Subcommands.Add(GetSignCommand());
+            command.Subcommands.Add(GetWhyCommand());
 
             command.SetAction(NuGetCommand.Run);
 
@@ -215,6 +216,20 @@ namespace Microsoft.DotNet.Cli
             signCommand.SetAction(NuGetCommand.Run);
 
             return signCommand;
+        }
+
+        private static CliCommand GetWhyCommand()
+        {
+            CliCommand whyCommand = new("why");
+
+            whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
+            whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
+
+            whyCommand.Options.Add(new CliOption<string>("--framework", "-f") { Arity = ArgumentArity.OneOrMore });
+
+            whyCommand.SetAction(NuGetCommand.Run);
+
+            return whyCommand;
         }
     }
 }

--- a/test/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
+++ b/test/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
@@ -75,6 +75,9 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                                    "--interactive",
                                    "--verbosity", "detailed",
                                    "--format", "json"}, 0)]
+        [InlineData(new[] { "why" }, 0)]
+        [InlineData(new[] { "why", "C:\\path", "Fake.Package" }, 0)]
+        [InlineData(new[] { "why", "C:\\path", "Fake.Package", "--framework", "net472", "-f", "netcoreapp5.0" }, 0)]
 
         public void ItPassesCommandIfSupported(string[] inputArgs, int result)
         {

--- a/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -118,7 +118,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 "push",
                 "verify",
                 "trust",
-                "sign"
+                "sign",
+                "why"
             };
 
             var reporter = new BufferedReporter();
@@ -283,6 +284,24 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var reporter = new BufferedReporter();
             CompleteCommand.RunWithReporter(new[] { "dotnet nuget sign " }, reporter).Should().Be(0);
+            reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
+        }
+
+        [Fact]
+        public void GivenNuGetWhyCommandItDisplaysCompletions()
+        {
+            var expected = new[] {
+                "--framework",
+                "--help",
+                "-?",
+                "-f",
+                "-h",
+                "/?",
+                "/h"
+            };
+
+            var reporter = new BufferedReporter();
+            CompleteCommand.RunWithReporter(new[] { "dotnet nuget why " }, reporter).Should().Be(0);
             reporter.Lines.OrderBy(c => c).Should().Equal(expected.OrderBy(c => c));
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/2861
(Part of https://github.com/NuGet/Home/issues/11943)

# Description

I work on the NuGet.Client team. We added a new command to the dotnet CLI: "**_dotnet nuget why_**" (https://github.com/NuGet/NuGet.Client/pull/5761). This command allows a user to see the dependency graph for a particular package for a given project or solution.

The feature has been implemented on the NuGet.Client side. The changes here are needed to enable tab completion. 

Design spec for the command: [dotnet nuget why command](https://github.com/NuGet/Home/blob/dev/accepted/2022/dotnet-nuget-why-proposal.md)

NuGet.Client implementation: https://github.com/NuGet/NuGet.Client/pull/5761

Sample output:

`dotnet nuget why -h`
![image](https://github.com/NuGet/NuGet.Client/assets/82980589/583af1fd-59af-4f69-ae8f-4158dcf3651b)

`dotnet nuget why C:\TestProject.sln System.Text.Json`
![image](https://github.com/NuGet/NuGet.Client/assets/82980589/30dd455e-63cd-4761-85e5-33fa0ff8da4c)