### PR TITLE
Fix a leak of ProjectCollection in dotnet-add-reference

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Add.ProjectToProjectReference
 
         public override int Execute()
         {
-            var projects = new ProjectCollection();
+            using var projects = new ProjectCollection();
             bool interactive = _parseResult.GetValue(AddProjectToProjectReferenceParser.InteractiveOption);
             MsbuildProject msbuildProj = MsbuildProject.FromFileOrDirectory(
                 projects,


### PR DESCRIPTION
ProjectCollection is an IDisposable, but it's currently not disposed.