### PR TITLE
Dispose ZipArchive after usage in ExtractArchiveToDirectory

### DIFF
--- a/src/Installer/core-sdk-tasks/ExtractArchiveToDirectory.cs
+++ b/src/Installer/core-sdk-tasks/ExtractArchiveToDirectory.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Build.Tasks
                         // Partial archive extraction
                         if (isZipArchive)
                         {
-                            var zip = new ZipArchive(File.OpenRead(SourceArchive));
+                            using var zip = new ZipArchive(File.OpenRead(SourceArchive));
                             string loc = DestinationDirectory;
                             foreach (var entry in zip.Entries)
                             {


### PR DESCRIPTION
It's an IDisposable, so we should Dispose it when done with it.