### PR TITLE
[Blazor] Resolve tokens before copying files

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
+++ b/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                     if (asset.ShouldCopyToOutputDirectory())
                     {
                         // We have an asset we want to copy to the output folder.
-                        fileOutputPath = Path.Combine(normalizedOutputPath, asset.RelativePath);
+                        fileOutputPath = Path.Combine(normalizedOutputPath, asset.ComputeTargetPath("", Path.DirectorySeparatorChar, StaticWebAssetTokenResolver.Instance));
                         string source = null;
                         if (asset.IsComputed())
                         {

--- a/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
@@ -78,7 +78,7 @@ public class ResolveCompressedAssets : Task
                 continue;
             }
 
-            var relativePath = asset.RelativePath;
+            var relativePath = asset.ComputePathWithoutTokens(asset.RelativePath);
             var match = matcher.Match(relativePath);
 
             if (!match.HasMatches)

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -221,20 +221,21 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private (string mimeType, string cache) ResolveContentType(StaticWebAsset asset, ContentTypeMapping[] contentTypeMappings)
         {
+            var relativePath = asset.ComputePathWithoutTokens(asset.RelativePath);
             foreach (var mapping in contentTypeMappings)
             {
-                if (mapping.Matches(Path.GetFileName(asset.RelativePath)))
+                if (mapping.Matches(Path.GetFileName(relativePath)))
                 {
-                    Log.LogMessage(MessageImportance.Low, $"Matched {asset.RelativePath} to {mapping.MimeType} using pattern {mapping.Pattern}");
+                    Log.LogMessage(MessageImportance.Low, $"Matched {relativePath} to {mapping.MimeType} using pattern {mapping.Pattern}");
                     return (mapping.MimeType, mapping.Cache);
                 }
                 else
                 {
-                    Log.LogMessage(MessageImportance.Low, $"No match for {asset.RelativePath} using pattern {mapping.Pattern}");
+                    Log.LogMessage(MessageImportance.Low, $"No match for {relativePath} using pattern {mapping.Pattern}");
                 }
             }
 
-            Log.LogMessage(MessageImportance.Low, $"No match for {asset.RelativePath}. Using default content type 'application/octet-stream'");
+            Log.LogMessage(MessageImportance.Low, $"No match for {relativePath}. Using default content type 'application/octet-stream'");
 
             return ("application/octet-stream", null);
         }

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -422,7 +422,11 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             // Bin folder manifest does not exist
             new FileInfo(finalPath).Should().NotExist();
         }
+    }
 
+    public class StaticWebAssetsAppWithPackagesIntegrationTest(ITestOutputHelper log)
+        : IsolatedNuGetPackageFolderAspNetSdkBaselineTest(log, nameof(StaticWebAssetsAppWithPackagesIntegrationTest))
+    {
         [Fact]
         public void Build_Fails_WhenConflictingAssetsFoundBetweenAStaticWebAssetAndAFileInTheWebRootFolder()
         {
@@ -440,11 +444,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             var build = CreateBuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
             ExecuteCommand(build).Should().Fail();
         }
-    }
 
-    public class StaticWebAssetsAppWithPackagesIntegrationTest(ITestOutputHelper log)
-        : IsolatedNuGetPackageFolderAspNetSdkBaselineTest(log, nameof(StaticWebAssetsAppWithPackagesIntegrationTest))
-    {
         [Fact]
         public void BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets()
         {


### PR DESCRIPTION
Just follow ups from the fingerprinting work.
* We weren't resolving tokens before copying files during build, and that was causing errors.
* The Matcher doesn't like some characters on the expression when running on full framework, the fix is to strip the tokens before trying to match.