### PR TITLE
Specify a version of cmake in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
     }
   },
   "native-tools": {
-    "cmake": "latest"
+    "cmake": "3.21.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24305.5",


### PR DESCRIPTION
`latest` is not supported by Arcade, and there's no `latest` archive in the Azure blob store, so force the most recent supported value here.

```
CommonLibrary\DownloadAndExtract : Download failed from
  https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/cmake/cmake-latest-win64-x64.zip
  At C:\d\source-indexer\bin\repo\sdk\eng\common\native\install-tool.ps1:90 char:22
```