### PR TITLE
Use ZipFile.ExtractToDirectory for extracting nupkg in tests

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
@@ -67,15 +67,7 @@ public static class Utilities
 
     public static void ExtractNupkg(string package, string outputDir)
     {
-        Directory.CreateDirectory(outputDir);
-
-        using ZipArchive zip = ZipFile.OpenRead(package);
-        foreach (ZipArchiveEntry entry in zip.Entries)
-        {
-            string outputPath = Path.Combine(outputDir, entry.FullName);
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            entry.ExtractToFile(outputPath);
-        }
+        ZipFile.ExtractToDirectory(package, outputDir);
     }
 
     public static async Task RetryAsync(Func<Task> executor, ITestOutputHelper outputHelper)

--- a/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Utilities.cs
@@ -144,15 +144,7 @@ public static class Utilities
 
     public static void ExtractNupkg(string package, string outputDir)
     {
-        Directory.CreateDirectory(outputDir);
-
-        using ZipArchive zip = ZipFile.OpenRead(package);
-        foreach (ZipArchiveEntry entry in zip.Entries)
-        {
-            string outputPath = Path.Combine(outputDir, entry.FullName);
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            entry.ExtractToFile(outputPath);
-        }
+        ZipFile.ExtractToDirectory(package, outputDir);
     }
 
     public static async Task RetryAsync(Func<Task> executor, ITestOutputHelper outputHelper)


### PR DESCRIPTION
We don't need to manually extract the zip entries and it also resolves a CodeQL finding related to zipslip.