### PR TITLE
Disable CET compatibility setting on apphost when `CetCompat` property is set to `false`

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateAppHost.cs
@@ -46,6 +46,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool EnableMacOSCodeSign { get; set; } = false;
 
+        public bool DisableCetCompat { get; set; } = false;
+
         protected override void ExecuteCore()
         {
             try
@@ -64,12 +66,12 @@ namespace Microsoft.NET.Build.Tasks
                                                 appBinaryFilePath: AppBinaryName,
                                                 windowsGraphicalUserInterface: isGUI,
                                                 assemblyToCopyResourcesFrom: resourcesAssembly,
-                                                enableMacOSCodeSign: EnableMacOSCodeSign);
+                                                enableMacOSCodeSign: EnableMacOSCodeSign,
+                                                disableCetCompat: DisableCetCompat);
                         return;
                     }
                     catch (Exception ex) when (ex is IOException ||
                                                ex is UnauthorizedAccessException ||
-                                               ex is HResultException ||
                                                (ex is AggregateException && (ex.InnerException is IOException || ex.InnerException is UnauthorizedAccessException)))
                     {
                         if (Retries < 0 || attempts == Retries)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -715,6 +715,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                    Retries="$(CopyRetryCount)"
                    RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
                    EnableMacOSCodeSign="$(_EnableMacOSCodeSign)"
+                   DisableCetCompat="$(_DisableCetCompat)"
                    />
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -719,6 +719,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                                '$(SingleFileHostSourcePath)' != '' and
                                                '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                                $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0))">true</_UseSingleFileHostForPublish>
+      <_DisableCetCompat Condition="'$(CetCompat)' == 'false'">true</_DisableCetCompat>
     </PropertyGroup>
   </Target>
 
@@ -746,6 +747,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                    Retries="$(CopyRetryCount)"
                    RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
                    EnableMacOSCodeSign="$(_EnableMacOSCodeSign)"
+                   DisableCetCompat="$(_DisableCetCompat)"
                    />
   </Target>
 

--- a/test/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/test/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -310,7 +310,7 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
 
             var outputDirectory = buildCommand.GetOutputDirectory(runtimeIdentifier: rid);
-            string apphostPath = Path.Combine(outputDirectory.FullName, $"{testProject.Name}{Constants.ExeSuffix}");
+            string apphostPath = Path.Combine(outputDirectory.FullName, $"{testProject.Name}.exe");
             bool isCetCompatible = PeReaderUtils.IsCetCompatible(apphostPath);
 
             // CetCompat not set : enabled

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -826,12 +826,14 @@ class C
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: cetCompat.HasValue ? cetCompat.Value.ToString() : "default");
             var publishCommand = new PublishCommand(testAsset);
-            publishCommand.Execute(PublishSingleFile, RuntimeIdentifier)
+            publishCommand.Execute(PublishSingleFile)
                 .Should()
                 .Pass();
 
-            string publishDir = GetPublishDirectory(publishCommand).FullName;
-            string singleFilePath = Path.Combine(publishDir, $"{testProject.Name}{Constants.ExeSuffix}");
+            DirectoryInfo publishDir = publishCommand.GetOutputDirectory(
+                targetFramework: testProject.TargetFrameworks,
+                runtimeIdentifier: rid);
+            string singleFilePath = Path.Combine(publishDir.FullName, $"{testProject.Name}.exe");
             bool isCetCompatible = PeReaderUtils.IsCetCompatible(singleFilePath);
 
             // CetCompat not set : enabled


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/103007 switched `apphost`/`singlefilehost` to enable CET shadow stack compatibility by default, with an option to disable it in `HostWriter.CreateAppHost`. This change updates the SDK to disable CET compat if the project sets `<CetCompat>false</CetCompat>`.

cc @dotnet/appmodel @AaronRobinsonMSFT @janvorli @mangod9