### PR TITLE
Dispose HttpClient and Stream in AddPackageParser

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Cli
 
         public static IEnumerable<string> QueryNuGet(string match)
         {
-            var httpClient = new HttpClient();
+            using var httpClient = new HttpClient();
 
             Stream result;
 
@@ -104,6 +104,8 @@ namespace Microsoft.DotNet.Cli
             {
                 yield return packageId;
             }
+
+            stream.Dispose();
         }
 
         internal static IEnumerable<string> EnumerablePackageIdFromQueryResponse(Stream result)

--- a/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli
                 yield return packageId;
             }
 
-            stream.Dispose();
+            result.Dispose();
         }
 
         internal static IEnumerable<string> EnumerablePackageIdFromQueryResponse(Stream result)


### PR DESCRIPTION
The Stream instance and HttpClient instance are both IDisposable. So clean them up.