### PR TITLE
[Static Web Assets] Fix compressed endpoint headers

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetPathPattern.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetPathPattern.cs
@@ -190,6 +190,8 @@ public class StaticWebAssetPathPattern : IEquatable<StaticWebAssetPathPattern>
                         }
                         else if (!string.IsNullOrEmpty(part.Value))
                         {
+                            // Token was embedded, so add it to the dictionary.
+                            dictionary[part.Name] = part.Value;
                             result.Append(part.Value);
                         }
                         else

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_BuildMinimal_Works.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_BuildMinimal_Works.Build.staticwebassets.json
@@ -36900,7 +36900,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -36929,8 +36929,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.bundle.scp.css.gz"
         }
       ]
     },
@@ -37006,7 +37014,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -37108,7 +37116,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -37137,8 +37145,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.styles.css.gz"
         }
       ]
     },
@@ -37214,7 +37230,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_PublishMinimal_Works.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_PublishMinimal_Works.Publish.staticwebassets.json
@@ -5858,7 +5858,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -5887,8 +5887,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.bundle.scp.css.gz"
         }
       ]
     },
@@ -5964,7 +5972,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -6011,7 +6019,7 @@
       ]
     },
     {
-      "Route": "blazorwasm-minimal.__fingerprint__.styles.css.gz",
+      "Route": "blazorwasm-minimal.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm-minimal#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6056,7 +6064,7 @@
       ]
     },
     {
-      "Route": "blazorwasm-minimal.styles.css.gz",
+      "Route": "blazorwasm-minimal.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm-minimal#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6066,7 +6074,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -6095,8 +6103,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.styles.css.gz"
         }
       ]
     },
@@ -6172,7 +6188,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20474,7 +20490,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20503,8 +20519,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.bundle.scp.css.br"
         }
       ]
     },
@@ -20580,7 +20604,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20682,7 +20706,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20711,8 +20735,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm-minimal.styles.css.br"
         }
       ]
     },
@@ -20788,7 +20820,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_Publish_DoesNotIncludeXmlDocumentationFiles_AsAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_Publish_DoesNotIncludeXmlDocumentationFiles_AsAssets.Publish.staticwebassets.json
@@ -6122,7 +6122,7 @@
       ]
     },
     {
-      "Route": "blazorwasm.__fingerprint__.styles.css.gz",
+      "Route": "blazorwasm.styles.css.gz",
       "AssetFile": "${ProjectPath}\\blazorwasm\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6167,7 +6167,7 @@
       ]
     },
     {
-      "Route": "blazorwasm.styles.css.gz",
+      "Route": "blazorwasm.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\blazorwasm\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6177,7 +6177,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -6206,8 +6206,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm.styles.css.gz"
         }
       ]
     },
@@ -6283,7 +6291,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20785,7 +20793,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20814,8 +20822,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm.styles.css.br"
         }
       ]
     },
@@ -20891,7 +20907,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_Publish_Hosted_Works.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/StaticWebAssets_Publish_Hosted_Works.Publish.staticwebassets.json
@@ -6122,7 +6122,7 @@
       ]
     },
     {
-      "Route": "blazorwasm.__fingerprint__.styles.css.gz",
+      "Route": "blazorwasm.styles.css.gz",
       "AssetFile": "${ProjectPath}\\blazorwasm\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6167,7 +6167,7 @@
       ]
     },
     {
-      "Route": "blazorwasm.styles.css.gz",
+      "Route": "blazorwasm.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\blazorwasm\\obj\\Debug\\${Tfm}\\compressed\\blazorwasm#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -6177,7 +6177,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -6206,8 +6206,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm.styles.css.gz"
         }
       ]
     },
@@ -6283,7 +6291,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20785,7 +20793,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -20814,8 +20822,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "blazorwasm.styles.css.br"
         }
       ]
     },
@@ -20891,7 +20907,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text.Json;
 using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 using Moq;
 
@@ -30,6 +33,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "original-fingerprint",
                     "original"
                 ),
                 CreateCandidate(
@@ -39,6 +43,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "compressed-fingerprint",
                     "compressed",
                     Path.Combine("wwwroot", "candidate.js"),
                     "Content-Encoding",
@@ -116,6 +121,714 @@ public class ApplyCompressionNegotiationTest
     }
 
     [Fact]
+    public void AppliesContentNegotiationRules_ForExistingAssets_WithFingerprints()
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                "candidate#[.{fingerprint}]?.js",
+                "All",
+                "All",
+                "original-fingerprint",
+                "original"
+            )
+        ];
+
+        var compressedTask = new ResolveCompressedAssets
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [.. candidateAssets],
+            Formats = "gzip;brotli",
+            IncludePatterns = "*.js",
+            OutputPath = AppContext.BaseDirectory
+        };
+        compressedTask.Execute().Should().BeTrue();
+
+        var compressedAssets = compressedTask.AssetsToCompress;
+        compressedAssets[0].SetMetadata(nameof(StaticWebAsset.Fingerprint), "gzip");
+        compressedAssets[0].SetMetadata(nameof(StaticWebAsset.Integrity), "compressed-gzip");
+        compressedAssets[1].SetMetadata(nameof(StaticWebAsset.Fingerprint), "brotli");
+        compressedAssets[1].SetMetadata(nameof(StaticWebAsset.Integrity), "compressed-brotli");
+        candidateAssets.AddRange(compressedAssets);
+        var defineStaticAssetEndpointsTask = new DefineStaticWebAssetEndpoints
+        {
+            TestLengthResolver = value => value switch
+            {
+                string candidateBr when candidateBr.EndsWith(".br") => 7,
+                string candidateGz when candidateGz.EndsWith(".gz") => 9,
+                string candidate when candidate.EndsWith(".js") => 20,
+                _ => throw new InvalidOperationException()
+            },
+            TestLastWriteResolver = value => now,
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [.. candidateAssets],
+            ExistingEndpoints = [],
+            ContentTypeMappings =
+            [
+                new TaskItem("text/javascript", new Dictionary<string, string>
+                {
+                    { "Pattern", "*.js" },
+                    { "Priority", "0" }
+                }),
+                new TaskItem("text/javascript", new Dictionary<string, string>
+                {
+                    { "Pattern", "*.js.gz" },
+                    { "Priority", "1" }
+                })
+            ]
+        };
+        defineStaticAssetEndpointsTask.Execute().Should().BeTrue();
+        var compressed = defineStaticAssetEndpointsTask.Endpoints;
+
+        var task = new ApplyCompressionNegotiation
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = compressed,
+            TestResolveFileLength = value => value switch
+            {
+                string candidateBr when candidateBr.EndsWith(".br") => 7,
+                string candidateGz when candidateGz.EndsWith(".gz") => 9,
+                string candidate when candidate.EndsWith(".js") => 20,
+                _ => throw new InvalidOperationException()
+            }
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.UpdatedEndpoints);
+        var expectedEndpoints = new StaticWebAssetEndpoint[]
+        {
+            new()
+            {
+                Route = "candidate.fingerprint.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+                Selectors = [
+                    new ()
+                    {
+                            Name = "Content-Encoding",
+                            Value = "br",
+                            Quality = "0.125000000000"
+                    }
+                ],
+            ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "max-age=31536000, immutable"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "br"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "7"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-brotli\u0022"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "W/\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "fingerprint",
+                Value = "fingerprint"
+            },
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-original"
+            },
+            new ()
+            {
+                Name = "label",
+                Value = "candidate.js"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.fingerprint.js",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            Selectors = [
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "gzip",
+            Quality = "0.100000000000"
+            }
+        ],
+        ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "max-age=31536000, immutable"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "gzip"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "9"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-gzip\u0022"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "W/\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "fingerprint",
+                Value = "fingerprint"
+            },
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-original"
+            },
+            new ()
+            {
+                Name = "label",
+                Value = "candidate.js"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.fingerprint.js",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot\\candidate.js"),
+            ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "max-age=31536000, immutable"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "20"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            }
+        ],
+        EndpointProperties = [
+                new ()
+                {
+                    Name = "fingerprint",
+                    Value = "fingerprint"
+                },
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-original"
+                },
+                new ()
+                {
+                    Name = "label",
+                    Value = "candidate.js"
+                }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.fingerprint.js.br",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            ResponseHeaders = [
+            new ()
+            {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "max-age=31536000, immutable"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "br"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "7"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "application/octet-stream"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-brotli\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "fingerprint",
+                Value = "fingerprint"
+            },
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-compressed-brotli"
+            },
+            new ()
+            {
+                Name = "label",
+                Value = "candidate.js.br"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.fingerprint.js.gz",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "max-age=31536000, immutable"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "gzip"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "9"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-gzip\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "fingerprint",
+                Value = "fingerprint"
+            },
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-compressed-gzip"
+            },
+            new ()
+            {
+                Name = "label",
+                Value = "candidate.js.gz"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.js",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            Selectors = [
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "br",
+            Quality = "0.125000000000"
+            }
+        ],
+        ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "no-cache"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "br"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "7"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-brotli\u0022"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "W/\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-original"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.js",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            Selectors = [
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "gzip",
+            Quality = "0.100000000000"
+            }
+        ],
+        ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "no-cache"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "gzip"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "9"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-gzip\u0022"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "W/\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-original"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.js",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot\\candidate.js"),
+            ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "no-cache"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "20"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022original\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-original"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.js.br",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            ResponseHeaders = [
+            new ()
+            {
+                Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new ()
+            {
+                Name = "Cache-Control",
+                Value = "no-cache"
+            },
+            new ()
+            {
+                Name = "Content-Encoding",
+                Value = "br"
+            },
+            new ()
+            {
+                Name = "Content-Length",
+                Value = "7"
+            },
+            new ()
+            {
+                Name = "Content-Type",
+                Value = "application/octet-stream"
+            },
+            new ()
+            {
+                Name = "ETag",
+                Value = "\u0022compressed-brotli\u0022"
+            },
+            new ()
+            {
+                Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new ()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new ()
+            {
+                Name = "integrity",
+                Value = "sha256-compressed-brotli"
+            }
+            ]
+        },
+        new()
+        {
+            Route = "candidate.js.gz",
+            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            ResponseHeaders = [
+            new () {
+            Name = "Accept-Ranges",
+                Value = "bytes"
+            },
+            new () {
+            Name = "Cache-Control",
+                Value = "no-cache"
+            },
+            new () {
+            Name = "Content-Encoding",
+                Value = "gzip"
+            },
+            new () {
+            Name = "Content-Length",
+                Value = "9"
+            },
+            new () {
+            Name = "Content-Type",
+                Value = "text/javascript"
+            },
+            new () {
+            Name = "ETag",
+                Value = "\u0022compressed-gzip\u0022"
+            },
+            new () {
+            Name = "Last-Modified",
+                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+            },
+            new () {
+            Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ],
+        EndpointProperties = [
+            new () {
+            Name = "integrity",
+                Value = "sha256-compressed-gzip"
+            }
+            ]
+        }
+};
+
+        endpoints.Should().BeEquivalentTo(expectedEndpoints);
+    }
+
+    [Fact]
     public void AppliesContentNegotiationRules_ToAllRelatedAssetEndpoints()
     {
         var errorMessages = new List<string>();
@@ -135,6 +848,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "original-fingerprint",
                     "original"
                 ),
                 CreateCandidate(
@@ -144,6 +858,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "compressed-fingerprint",
                     "compressed",
                     Path.Combine("wwwroot", "candidate.js"),
                     "Content-Encoding",
@@ -264,6 +979,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "original-fingerprint",
                     "original"
                 ),
                 CreateCandidate(
@@ -273,6 +989,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "compressed-fingerprint",
                     "compressed",
                     Path.Combine("wwwroot", "candidate.js"),
                     "Content-Encoding",
@@ -281,10 +998,11 @@ public class ApplyCompressionNegotiationTest
             ],
             CandidateEndpoints = new StaticWebAssetEndpoint[]
             {
-                new() {
-                    Route = "candidate.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Encoding", Value = "gzip" },
                         new (){ Name = "Content-Type", Value = "text/javascript" },
@@ -293,20 +1011,22 @@ public class ApplyCompressionNegotiationTest
                     EndpointProperties = [],
                     Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
-                new() {
-                    Route = "candidate.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
+                        ResponseHeaders =
                     [
                         new (){ Name = "Content-Type", Value = "text/javascript" }
                     ],
                     EndpointProperties = [],
                     Selectors = [],
                 },
-                new() {
-                    Route = "candidate.fingerprint.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.fingerprint.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new (){ Name = "Content-Encoding", Value = "gzip" },
                         new (){ Name = "Content-Type", Value = "text/javascript" },
@@ -315,20 +1035,22 @@ public class ApplyCompressionNegotiationTest
                     EndpointProperties = [],
                     Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
-                new() {
-                    Route = "candidate.fingerprint.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.fingerprint.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Type", Value = "text/javascript" }
                     ],
                     EndpointProperties = [],
                     Selectors = [],
                 },
-                new() {
-                    Route = "candidate.js.gz",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js.gz",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Encoding", Value = "gzip" },
                         new () { Name = "Content-Type", Value = "text/javascript" },
@@ -437,6 +1159,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "original-fingerprint",
                     "original"
                 ),
                 CreateCandidate(
@@ -446,6 +1169,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "compressed-gzip",
                     "compressed",
                     Path.Combine("wwwroot", "candidate.js"),
                     "Content-Encoding",
@@ -458,6 +1182,7 @@ public class ApplyCompressionNegotiationTest
                     "candidate.js",
                     "All",
                     "All",
+                    "compressed-brotli",
                     "compressed",
                     Path.Combine("wwwroot", "candidate.js"),
                     "Content-Encoding",
@@ -466,10 +1191,11 @@ public class ApplyCompressionNegotiationTest
             ],
             CandidateEndpoints = new StaticWebAssetEndpoint[]
             {
-                new() {
-                    Route = "candidate.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Encoding", Value = "gzip" },
                         new (){ Name = "Content-Type", Value = "text/javascript" },
@@ -478,20 +1204,22 @@ public class ApplyCompressionNegotiationTest
                     EndpointProperties = [],
                     Selectors = [ new StaticWebAssetEndpointSelector { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
-                new() {
-                    Route = "candidate.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
+                        ResponseHeaders =
                     [
                         new (){ Name = "Content-Type", Value = "text/javascript" }
                     ],
                     EndpointProperties = [],
                     Selectors = [],
                 },
-                new() {
-                    Route = "candidate.fingerprint.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.fingerprint.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new (){ Name = "Content-Encoding", Value = "gzip" },
                         new (){ Name = "Content-Type", Value = "text/javascript" },
@@ -500,20 +1228,22 @@ public class ApplyCompressionNegotiationTest
                     EndpointProperties = [],
                     Selectors = [ new () { Name = "Content-Encoding", Value = "gzip", Quality = "0.100000000000" } ],
                 },
-                new() {
-                    Route = "candidate.fingerprint.js",
-                    AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.fingerprint.js",
+                        AssetFile = Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Type", Value = "text/javascript" }
                     ],
                     EndpointProperties = [],
                     Selectors = [],
                 },
-                new() {
-                    Route = "candidate.js.gz",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js.gz",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.gz")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Encoding", Value = "gzip" },
                         new () { Name = "Content-Type", Value = "text/javascript" },
@@ -522,10 +1252,11 @@ public class ApplyCompressionNegotiationTest
                     EndpointProperties = [],
                     Selectors = []
                 },
-                new() {
-                    Route = "candidate.js.br",
-                    AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.br")),
-                    ResponseHeaders =
+                new()
+                {
+                        Route = "candidate.js.br",
+                        AssetFile = Path.GetFullPath(Path.Combine("compressed", "candidate.js.br")),
+                        ResponseHeaders =
                     [
                         new () { Name = "Content-Type", Value = "text/javascript" },
                     ],
@@ -659,7 +1390,7 @@ public class ApplyCompressionNegotiationTest
             new StaticWebAssetEndpointSelector
             {
                 Name = name,
-                Value = value,
+                    Value = value,
                 Quality = "0.100000000000"
             }
         ];
@@ -671,7 +1402,7 @@ public class ApplyCompressionNegotiationTest
         [
             new StaticWebAssetEndpointResponseHeader {
                 Name = "Content-Type",
-                Value = contentType
+                    Value = contentType
             },
             ..(AdditionalHeaders ?? []).Select(h => new StaticWebAssetEndpointResponseHeader { Name = h.name, Value = h.value })
         ];
@@ -684,6 +1415,7 @@ public class ApplyCompressionNegotiationTest
         string relativePath,
         string assetKind,
         string assetMode,
+        string fingerprint = "",
         string integrity = "",
         string relatedAsset = "",
         string assetTraitName = "",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
@@ -288,120 +288,66 @@ public class ApplyCompressionNegotiationTest
             }
             ]
         },
-        new()
-        {
-            Route = "candidate.fingerprint.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
-            Selectors = [
-            new ()
+            new()
             {
-                Name = "Content-Encoding",
-                Value = "gzip",
-            Quality = "0.100000000000"
-            }
-        ],
-        ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
-                Name = "Cache-Control",
-                Value = "max-age=31536000, immutable"
-            },
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "gzip"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "9"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022compressed-gzip\u0022"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "W/\u0022original\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
-                Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "fingerprint",
-                Value = "fingerprint"
-            },
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-original"
-            },
-            new ()
-            {
-                Name = "label",
-                Value = "candidate.js"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.fingerprint.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot\\candidate.js"),
+                Route = "candidate.fingerprint.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
+                Selectors = [
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "gzip",
+                Quality = "0.100000000000"
+                }
+            ],
             ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
-                Name = "Cache-Control",
-                Value = "max-age=31536000, immutable"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "20"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022original\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            }
-        ],
-        EndpointProperties = [
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "max-age=31536000, immutable"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "gzip"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "9"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-gzip\u0022"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "W/\u0022original\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
                 new ()
                 {
                     Name = "fingerprint",
@@ -417,413 +363,467 @@ public class ApplyCompressionNegotiationTest
                     Name = "label",
                     Value = "candidate.js"
                 }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.fingerprint.js.br",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
-            ResponseHeaders = [
-            new ()
+                ]
+            },
+            new()
             {
+                Route = "candidate.fingerprint.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot", "candidate.js"),
+                ResponseHeaders = [
+                new ()
+                {
                     Name = "Accept-Ranges",
                     Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "max-age=31536000, immutable"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "20"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022original\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                }
+            ],
+            EndpointProperties = [
+                    new ()
+                    {
+                        Name = "fingerprint",
+                        Value = "fingerprint"
+                    },
+                    new ()
+                    {
+                        Name = "integrity",
+                        Value = "sha256-original"
+                    },
+                    new ()
+                    {
+                        Name = "label",
+                        Value = "candidate.js"
+                    }
+                ]
             },
-            new ()
+            new()
             {
-                Name = "Cache-Control",
-                Value = "max-age=31536000, immutable"
+                Route = "candidate.fingerprint.js.br",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
+                ResponseHeaders = [
+                new ()
+                {
+                        Name = "Accept-Ranges",
+                        Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "max-age=31536000, immutable"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "br"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "7"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "application/octet-stream"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-brotli\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "fingerprint",
+                    Value = "fingerprint"
+                },
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-compressed-brotli"
+                },
+                new ()
+                {
+                    Name = "label",
+                    Value = "candidate.js.br"
+                }
+                ]
             },
-            new ()
+            new()
             {
-                Name = "Content-Encoding",
-                Value = "br"
+                Route = "candidate.fingerprint.js.gz",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
+                ResponseHeaders = [
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "max-age=31536000, immutable"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "gzip"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "9"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-gzip\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "fingerprint",
+                    Value = "fingerprint"
+                },
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-compressed-gzip"
+                },
+                new ()
+                {
+                    Name = "label",
+                    Value = "candidate.js.gz"
+                }
+                ]
             },
-            new ()
+            new()
             {
-                Name = "Content-Length",
-                Value = "7"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "application/octet-stream"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022compressed-brotli\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
-                Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "fingerprint",
-                Value = "fingerprint"
-            },
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-compressed-brotli"
-            },
-            new ()
-            {
-                Name = "label",
-                Value = "candidate.js.br"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.fingerprint.js.gz",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
+                Route = "candidate.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
+                Selectors = [
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "br",
+                Quality = "0.125000000000"
+                }
+            ],
             ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "no-cache"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "br"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "7"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-brotli\u0022"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "W/\u0022original\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-original"
+                }
+                ]
             },
-            new ()
+            new()
             {
-                Name = "Cache-Control",
-                Value = "max-age=31536000, immutable"
-            },
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "gzip"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "9"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022compressed-gzip\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
-                Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "fingerprint",
-                Value = "fingerprint"
-            },
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-compressed-gzip"
-            },
-            new ()
-            {
-                Name = "label",
-                Value = "candidate.js.gz"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
-            Selectors = [
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "br",
-            Quality = "0.125000000000"
-            }
-        ],
-        ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
-                Name = "Cache-Control",
-                Value = "no-cache"
-            },
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "br"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "7"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022compressed-brotli\u0022"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "W/\u0022original\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
-                Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-original"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
-            Selectors = [
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "gzip",
-            Quality = "0.100000000000"
-            }
-        ],
-        ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
-                Name = "Cache-Control",
-                Value = "no-cache"
-            },
-            new ()
-            {
-                Name = "Content-Encoding",
-                Value = "gzip"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "9"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022compressed-gzip\u0022"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "W/\u0022original\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
-                Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-original"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot\\candidate.js"),
+                Route = "candidate.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
+                Selectors = [
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "gzip",
+                Quality = "0.100000000000"
+                }
+            ],
             ResponseHeaders = [
-            new ()
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "no-cache"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "gzip"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "9"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-gzip\u0022"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "W/\u0022original\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-original"
+                }
+                ]
+            },
+            new()
             {
+                Route = "candidate.js",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, "wwwroot", "candidate.js"),
+                ResponseHeaders = [
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "no-cache"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "20"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022original\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-original"
+                }
+                ]
+            },
+            new()
+            {
+                Route = "candidate.js.br",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
+                ResponseHeaders = [
+                new ()
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new ()
+                {
+                    Name = "Cache-Control",
+                    Value = "no-cache"
+                },
+                new ()
+                {
+                    Name = "Content-Encoding",
+                    Value = "br"
+                },
+                new ()
+                {
+                    Name = "Content-Length",
+                    Value = "7"
+                },
+                new ()
+                {
+                    Name = "Content-Type",
+                    Value = "application/octet-stream"
+                },
+                new ()
+                {
+                    Name = "ETag",
+                    Value = "\u0022compressed-brotli\u0022"
+                },
+                new ()
+                {
+                    Name = "Last-Modified",
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new ()
+                {
+                    Name = "Vary",
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new ()
+                {
+                    Name = "integrity",
+                    Value = "sha256-compressed-brotli"
+                }
+                ]
+            },
+            new()
+            {
+                Route = "candidate.js.gz",
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
+                ResponseHeaders = [
+                new () {
                 Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
+                    Value = "bytes"
+                },
+                new () {
                 Name = "Cache-Control",
-                Value = "no-cache"
-            },
-            new ()
-            {
-                Name = "Content-Length",
-                Value = "20"
-            },
-            new ()
-            {
-                Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new ()
-            {
-                Name = "ETag",
-                Value = "\u0022original\u0022"
-            },
-            new ()
-            {
-                Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
-                Name = "integrity",
-                Value = "sha256-original"
-            }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.js.br",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
-            ResponseHeaders = [
-            new ()
-            {
-                Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new ()
-            {
-                Name = "Cache-Control",
-                Value = "no-cache"
-            },
-            new ()
-            {
+                    Value = "no-cache"
+                },
+                new () {
                 Name = "Content-Encoding",
-                Value = "br"
-            },
-            new ()
-            {
+                    Value = "gzip"
+                },
+                new () {
                 Name = "Content-Length",
-                Value = "7"
-            },
-            new ()
-            {
+                    Value = "9"
+                },
+                new () {
                 Name = "Content-Type",
-                Value = "application/octet-stream"
-            },
-            new ()
-            {
+                    Value = "text/javascript"
+                },
+                new () {
                 Name = "ETag",
-                Value = "\u0022compressed-brotli\u0022"
-            },
-            new ()
-            {
+                    Value = "\u0022compressed-gzip\u0022"
+                },
+                new () {
                 Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new ()
-            {
+                    Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
+                },
+                new () {
                 Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new ()
-            {
+                    Value = "Content-Encoding"
+                }
+            ],
+            EndpointProperties = [
+                new () {
                 Name = "integrity",
-                Value = "sha256-compressed-brotli"
+                    Value = "sha256-compressed-gzip"
+                }
+                ]
             }
-            ]
-        },
-        new()
-        {
-            Route = "candidate.js.gz",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
-            ResponseHeaders = [
-            new () {
-            Name = "Accept-Ranges",
-                Value = "bytes"
-            },
-            new () {
-            Name = "Cache-Control",
-                Value = "no-cache"
-            },
-            new () {
-            Name = "Content-Encoding",
-                Value = "gzip"
-            },
-            new () {
-            Name = "Content-Length",
-                Value = "9"
-            },
-            new () {
-            Name = "Content-Type",
-                Value = "text/javascript"
-            },
-            new () {
-            Name = "ETag",
-                Value = "\u0022compressed-gzip\u0022"
-            },
-            new () {
-            Name = "Last-Modified",
-                Value = now.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
-            },
-            new () {
-            Name = "Vary",
-                Value = "Content-Encoding"
-            }
-        ],
-        EndpointProperties = [
-            new () {
-            Name = "integrity",
-                Value = "sha256-compressed-gzip"
-            }
-            ]
-        }
 };
 
         endpoints.Should().BeEquivalentTo(expectedEndpoints);

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ApplyCompressionNegotiationTest.cs
@@ -158,6 +158,7 @@ public class ApplyCompressionNegotiationTest
         compressedAssets[1].SetMetadata(nameof(StaticWebAsset.Fingerprint), "brotli");
         compressedAssets[1].SetMetadata(nameof(StaticWebAsset.Integrity), "compressed-brotli");
         candidateAssets.AddRange(compressedAssets);
+        var expectedName = Path.GetFileNameWithoutExtension(compressedAssets[0].ItemSpec);
         var defineStaticAssetEndpointsTask = new DefineStaticWebAssetEndpoints
         {
             TestLengthResolver = value => value switch
@@ -213,7 +214,7 @@ public class ApplyCompressionNegotiationTest
             new()
             {
                 Route = "candidate.fingerprint.js",
-                AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+                AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
                 Selectors = [
                     new ()
                     {
@@ -290,7 +291,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.fingerprint.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
             Selectors = [
             new ()
             {
@@ -421,7 +422,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.fingerprint.js.br",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
             ResponseHeaders = [
             new ()
             {
@@ -485,7 +486,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.fingerprint.js.gz",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
             ResponseHeaders = [
             new ()
             {
@@ -549,7 +550,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
             Selectors = [
             new ()
             {
@@ -616,7 +617,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.js",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
             Selectors = [
             new ()
             {
@@ -727,7 +728,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.js.br",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.br"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.br"),
             ResponseHeaders = [
             new ()
             {
@@ -781,7 +782,7 @@ public class ApplyCompressionNegotiationTest
         new()
         {
             Route = "candidate.js.gz",
-            AssetFile = Path.Combine(AppContext.BaseDirectory, "fpqnkdkwzy.gz"),
+            AssetFile = Path.Combine(AppContext.BaseDirectory, $"{expectedName}.gz"),
             ResponseHeaders = [
             new () {
             Name = "Accept-Ranges",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
@@ -200,6 +200,126 @@ public class DefineStaticWebAssetEndpointsTest
     }
 
     [Fact]
+    public void CanDefineFingerprintedEndpoints_WithEmbeddedFingerprint()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate#[.{fingerprint=yolo}]?.js", "All", "All", fingerprint: "1234asdf", integrity: "asdf1234")],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.js", "text/javascript")],
+            TestLengthResolver = asset => asset.EndsWith("candidate.js") ? 10 : throw new InvalidOperationException(),
+            TestLastWriteResolver = asset => asset.EndsWith("candidate.js") ? lastWrite : throw new InvalidOperationException(),
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        endpoints.Length.Should().Be(2);
+        var endpoint = endpoints[1];
+
+        endpoint.Route.Should().Be("candidate.yolo.js");
+        endpoint.AssetFile.Should().Be(Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")));
+        endpoint.EndpointProperties.Should().BeEquivalentTo([
+            new StaticWebAssetEndpointProperty
+            {
+                Name = "fingerprint",
+                Value = "yolo"
+            },
+            new StaticWebAssetEndpointProperty
+            {
+                Name = "integrity",
+                Value = "sha256-asdf1234"
+            },
+            new StaticWebAssetEndpointProperty
+            {
+                Name = "label",
+                Value = "candidate.js"
+            }
+            ]);
+        endpoint.ResponseHeaders.Should().BeEquivalentTo(
+            [
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Content-Length",
+                    Value = "10"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "ETag",
+                    Value = "\"asdf1234\""
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Last-Modified",
+                    Value = "Thu, 15 Nov 1990 00:00:00 GMT"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Cache-Control",
+                    Value = "max-age=31536000, immutable"
+                }
+            ]);
+
+        var otherEndpoint = endpoints[0];
+        otherEndpoint.Route.Should().Be("candidate.js");
+        otherEndpoint.AssetFile.Should().Be(Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")));
+        otherEndpoint.ResponseHeaders.Should().BeEquivalentTo(
+                [
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Accept-Ranges",
+                    Value = "bytes"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Cache-Control",
+                    Value = "no-cache"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Content-Length",
+                    Value = "10"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Content-Type",
+                    Value = "text/javascript"
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "ETag",
+                    Value = "\"asdf1234\""
+                },
+                new StaticWebAssetEndpointResponseHeader
+                {
+                    Name = "Last-Modified",
+                    Value = "Thu, 15 Nov 1990 00:00:00 GMT"
+                }
+            ]);
+    }
+
+    [Fact]
     public void DoesNotDefineNewEndpointsWhenAnExistingEndpointAlreadyExists()
     {
         var errorMessages = new List<string>();

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_CorrectlyBundlesScopedCssFiles.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_CorrectlyBundlesScopedCssFiles.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1208,7 +1208,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1237,8 +1237,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1318,7 +1326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1465,69 +1473,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1832,7 +1777,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1877,7 +1822,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1887,7 +1832,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1916,8 +1861,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -1997,7 +1950,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2144,69 +2097,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2656,7 +2546,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2685,8 +2575,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2762,7 +2660,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3009,7 +2907,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3054,7 +2952,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3064,7 +2962,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3093,8 +2991,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3170,7 +3076,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_IncorporatesInitializersFromClassLibraries.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_IncorporatesInitializersFromClassLibraries.Build.staticwebassets.json
@@ -1006,7 +1006,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1051,7 +1051,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1061,7 +1061,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1090,8 +1090,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1171,7 +1179,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1418,69 +1426,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1967,7 +1912,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1996,8 +1941,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2073,7 +2026,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_NoDependencies_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_NoDependencies_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_NoDependencies_GeneratesJsonManifestAndCopiesItToOutputFolder_NoDependencies.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_NoDependencies_GeneratesJsonManifestAndCopiesItToOutputFolder_NoDependencies.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Build.staticwebassets.json
@@ -701,7 +701,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -746,7 +746,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -756,7 +756,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -785,8 +785,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -866,7 +874,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1213,69 +1221,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_CreatesEndpointsForAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_CreatesEndpointsForAssets.Build.staticwebassets.json
@@ -200,7 +200,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -229,8 +229,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -306,7 +314,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -408,7 +416,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -437,8 +445,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -514,7 +530,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DeployOnBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -137,7 +137,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -192,7 +192,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -221,8 +221,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -298,7 +306,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -400,7 +408,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -429,8 +437,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -506,7 +522,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -553,7 +569,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
+      "Route": "ComponentApp.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -598,7 +614,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.br",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -608,7 +624,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -637,8 +653,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -714,7 +738,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -816,7 +840,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -845,8 +869,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -922,7 +954,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DiscoversJsModulesBasedOnPatterns.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DiscoversJsModulesBasedOnPatterns.Build.staticwebassets.json
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -298,7 +298,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -308,7 +308,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -337,8 +337,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -414,7 +422,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -516,7 +524,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -545,8 +553,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -622,7 +638,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DoesNotUpdateManifest_WhenHasNotChanged.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DoesNotUpdateManifest_WhenHasNotChanged.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_FingerprintsContent_WhenEnabled.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_FingerprintsContent_WhenEnabled.Build.staticwebassets.json
@@ -145,7 +145,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -190,7 +190,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -200,7 +200,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -229,8 +229,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -306,7 +314,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -408,7 +416,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -437,8 +445,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -514,7 +530,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -616,7 +632,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -645,8 +661,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "css/fingerprint-site.css.gz"
         }
       ]
     },
@@ -722,7 +746,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_GeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_UpdatesManifest_WhenFilesChange.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_UpdatesManifest_WhenFilesChange.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_UpdatesManifest_WhenFilesChange_Updated.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_UpdatesManifest_WhenFilesChange_Updated.Build.staticwebassets.json
@@ -200,7 +200,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -229,8 +229,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -306,7 +314,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -408,7 +416,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -437,8 +445,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -514,7 +530,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Clean_RemovesManifestFrom_BuildAndIntermediateOutput.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Clean_RemovesManifestFrom_BuildAndIntermediateOutput.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_AppendTargetFrameworkToOutputPathFalse_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_AppendTargetFrameworkToOutputPathFalse_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_AppendTargetFrameworkToOutputPathFalse_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_AppendTargetFrameworkToOutputPathFalse_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1208,7 +1208,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1237,8 +1237,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1318,7 +1326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1465,69 +1473,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1922,7 +1867,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1967,7 +1912,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1977,7 +1922,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2006,8 +1951,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -2087,7 +2040,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2234,69 +2187,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2601,7 +2491,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.gz",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2646,7 +2536,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.gz",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2656,7 +2546,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2685,8 +2575,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2762,7 +2660,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3091,7 +2989,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3136,7 +3034,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3146,7 +3044,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3175,8 +3073,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3252,7 +3158,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Build.staticwebassets.json
@@ -964,7 +964,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1009,7 +1009,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1019,7 +1019,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1048,8 +1048,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1129,7 +1137,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1376,69 +1384,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1925,7 +1870,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1954,8 +1899,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2031,7 +1984,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Publish.staticwebassets.json
@@ -1516,7 +1516,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1561,7 +1561,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1571,7 +1571,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1600,8 +1600,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1681,7 +1689,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1828,69 +1836,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2195,7 +2140,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2240,7 +2185,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2250,7 +2195,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2279,8 +2224,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -2360,7 +2313,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2707,69 +2660,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -3256,7 +3146,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3285,8 +3175,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -3362,7 +3260,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3609,7 +3507,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3654,7 +3552,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3664,7 +3562,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3693,8 +3591,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3770,7 +3676,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1208,7 +1208,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1237,8 +1237,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1318,7 +1326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1465,69 +1473,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1832,7 +1777,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1877,7 +1822,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1887,7 +1832,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1916,8 +1861,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -1997,7 +1950,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2144,69 +2097,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2656,7 +2546,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2685,8 +2575,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2762,7 +2660,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3064,7 +2962,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3093,8 +2991,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3170,7 +3076,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Build.staticwebassets.json
@@ -1006,7 +1006,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1051,7 +1051,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1061,7 +1061,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1090,8 +1090,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1171,7 +1179,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1418,69 +1426,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2067,7 +2012,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2096,8 +2041,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2173,7 +2126,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Publish.staticwebassets.json
@@ -1579,7 +1579,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1624,7 +1624,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1634,7 +1634,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1663,8 +1663,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1744,7 +1752,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1891,69 +1899,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2258,7 +2203,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2303,7 +2248,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2313,7 +2258,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2342,8 +2287,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -2423,7 +2376,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2770,69 +2723,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -3419,7 +3309,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3448,8 +3338,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -3525,7 +3423,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3872,7 +3770,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3917,7 +3815,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3927,7 +3825,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3956,8 +3854,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -4033,7 +3939,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1208,7 +1208,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1237,8 +1237,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1318,7 +1326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1465,69 +1473,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1832,7 +1777,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1877,7 +1822,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1887,7 +1832,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1916,8 +1861,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -1997,7 +1950,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2144,69 +2097,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2601,7 +2491,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.gz",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2646,7 +2536,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.gz",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -2656,7 +2546,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2685,8 +2575,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2762,7 +2660,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3064,7 +2962,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3093,8 +2991,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3170,7 +3076,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1055,69 +1063,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1567,7 +1512,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1596,8 +1541,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -1673,7 +1626,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1208,7 +1208,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1237,8 +1237,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1318,7 +1326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1465,69 +1473,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -1832,7 +1777,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1877,7 +1822,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.br",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\publish\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1887,7 +1832,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1916,8 +1861,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -1997,7 +1950,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2144,69 +2097,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2656,7 +2546,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2685,8 +2575,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.gz"
         }
       ]
     },
@@ -2762,7 +2660,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3009,7 +2907,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3054,7 +2952,7 @@
       ]
     },
     {
-      "Route": "_content/ClassLibrary/ClassLibrary.bundle.scp.css.br",
+      "Route": "_content/ClassLibrary/ClassLibrary.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\ClassLibrary\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ClassLibrary\\ClassLibrary#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -3064,7 +2962,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -3093,8 +2991,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ClassLibrary.bundle.scp.css.br"
         }
       ]
     },
@@ -3170,7 +3076,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Build.staticwebassets.json
@@ -701,7 +701,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -746,7 +746,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -756,7 +756,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -785,8 +785,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -866,7 +874,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1213,69 +1221,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_WorksWithStaticWebAssetsV1ClassLibraries.Publish.staticwebassets.json
@@ -890,7 +890,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -935,7 +935,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -945,7 +945,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -974,8 +974,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1055,7 +1063,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1402,69 +1410,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2024,7 +1969,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2053,8 +1998,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -2134,7 +2087,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2481,69 +2434,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_CreatesEndpointsForAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_CreatesEndpointsForAssets.Publish.staticwebassets.json
@@ -208,7 +208,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -263,7 +263,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -292,8 +292,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -369,7 +377,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -416,7 +424,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.styles.css.gz",
+      "Route": "ComponentApp.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -461,7 +469,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.styles.css.gz",
+      "Route": "ComponentApp.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -471,7 +479,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -500,8 +508,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -577,7 +593,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -724,7 +740,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
+      "Route": "ComponentApp.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -769,7 +785,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.br",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -779,7 +795,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -808,8 +824,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -885,7 +909,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -932,7 +956,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.styles.css.br",
+      "Route": "ComponentApp.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -977,7 +1001,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.styles.css.br",
+      "Route": "ComponentApp.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -987,7 +1011,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1016,8 +1040,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -1093,7 +1125,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_CreatesEndpointsForAssets_BuildAndPublish_Assets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_CreatesEndpointsForAssets_BuildAndPublish_Assets.Publish.staticwebassets.json
@@ -263,7 +263,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -292,8 +292,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -369,7 +377,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -471,7 +479,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -500,8 +508,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -577,7 +593,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -779,7 +795,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -808,8 +824,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -885,7 +909,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -932,7 +956,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.styles.css.br",
+      "Route": "ComponentApp.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -977,7 +1001,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.styles.css.br",
+      "Route": "ComponentApp.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -987,7 +1011,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1016,8 +1040,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -1093,7 +1125,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -137,7 +137,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -192,7 +192,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -221,8 +221,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -298,7 +306,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -400,7 +408,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -429,8 +437,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -506,7 +522,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -553,7 +569,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
+      "Route": "ComponentApp.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -598,7 +614,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.br",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -608,7 +624,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -637,8 +653,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -714,7 +738,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -816,7 +840,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -845,8 +869,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -922,7 +954,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_NoBuild_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -137,7 +137,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -192,7 +192,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -221,8 +221,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -298,7 +306,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -400,7 +408,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -429,8 +437,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -506,7 +522,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -553,7 +569,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
+      "Route": "ComponentApp.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -598,7 +614,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.br",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -608,7 +624,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -637,8 +653,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -714,7 +738,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -816,7 +840,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -845,8 +869,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -922,7 +954,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishSingleFile_GeneratesPublishJsonManifestAndCopiesPublishAssets.Publish.staticwebassets.json
@@ -137,7 +137,7 @@
   ],
   "Endpoints": [
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "Route": "ComponentApp.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.gz",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -192,7 +192,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -221,8 +221,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -298,7 +306,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -400,7 +408,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -429,8 +437,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -506,7 +522,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -553,7 +569,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
+      "Route": "ComponentApp.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -598,7 +614,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.bundle.scp.css.br",
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\${Rid}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -608,7 +624,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -637,8 +653,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -714,7 +738,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -816,7 +840,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -845,8 +869,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -922,7 +954,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
@@ -326,7 +326,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -355,8 +355,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -432,7 +440,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -479,7 +487,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.styles.css.gz",
+      "Route": "ComponentApp.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -524,7 +532,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.styles.css.gz",
+      "Route": "ComponentApp.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -534,7 +542,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -563,8 +571,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -640,7 +656,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -842,7 +858,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -871,8 +887,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.br"
         }
       ]
     },
@@ -948,7 +972,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -995,7 +1019,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.__fingerprint__.styles.css.br",
+      "Route": "ComponentApp.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1040,7 +1064,7 @@
       ]
     },
     {
-      "Route": "ComponentApp.styles.css.br",
+      "Route": "ComponentApp.__fingerprint__.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1050,7 +1074,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1079,8 +1103,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.br"
         }
       ]
     },
@@ -1156,7 +1188,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Rebuild_RegeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Rebuild_RegeneratesJsonManifestAndCopiesItToOutputFolder.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Rebuild_RegeneratesJsonManifestAndCopiesItToOutputFolder_Rebuild.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Rebuild_RegeneratesJsonManifestAndCopiesItToOutputFolder_Rebuild.Build.staticwebassets.json
@@ -150,7 +150,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -179,8 +179,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
         }
       ]
     },
@@ -256,7 +264,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -358,7 +366,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -387,8 +395,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
         }
       ]
     },
@@ -464,7 +480,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_IsBackwardsCompatible_WithPreviousVersions.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_IsBackwardsCompatible_WithPreviousVersions.Build.staticwebassets.json
@@ -743,7 +743,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -788,7 +788,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -798,7 +798,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -827,8 +827,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -908,7 +916,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1355,69 +1363,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_PublishIsBackwardsCompatible_WithPreviousVersions.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/ScopedCss_PublishIsBackwardsCompatible_WithPreviousVersions.Publish.staticwebassets.json
@@ -953,7 +953,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -998,7 +998,7 @@
       ]
     },
     {
-      "Route": "AppWithPackageAndP2PReference.styles.css.gz",
+      "Route": "AppWithPackageAndP2PReference.__fingerprint__.styles.css.gz",
       "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\AppWithPackageAndP2PReference\\AppWithPackageAndP2PReference#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
       "ResponseHeaders": [
@@ -1008,7 +1008,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1037,8 +1037,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.gz"
         }
       ]
     },
@@ -1118,7 +1126,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -1565,69 +1573,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },
@@ -2187,7 +2132,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2216,8 +2161,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "AppWithPackageAndP2PReference.styles.css.br"
         }
       ]
     },
@@ -2297,7 +2250,7 @@
         },
         {
           "Name": "Cache-Control",
-          "Value": "no-cache"
+          "Value": "max-age=31536000, immutable"
         },
         {
           "Name": "Content-Encoding",
@@ -2744,69 +2697,6 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "_content/RazorPackageLibraryDirectDependency/RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css",
-      "AssetFile": "${ProjectPath}\\AppWithPackageAndP2PReference\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\RazorPackageLibraryDirectDependency\\RazorPackageLibraryDirectDependency.__fingerprint__.bundle.scp.css.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/css"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "RazorPackageLibraryDirectDependency.bundle.scp.css"
         }
       ]
     },


### PR DESCRIPTION
* When fingerprinting assets the headers were not being correctly applied to the compressed endpoints with fingerprint.
* Added a fix and a test to cover the scenario.