### PR TITLE
[LoongArch64] Add linux-loongarch64 RID for `Net90AppHostRids` and `Net90RuntimePackRids`.

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -224,6 +224,7 @@
         @(Net80AppHostRids);
         linux-riscv64;
         linux-musl-riscv64;
+        linux-loongarch64;
         linux-musl-loongarch64;
         " />
 
@@ -231,6 +232,7 @@
         @(Net80RuntimePackRids);
         linux-riscv64;
         linux-musl-riscv64;
+        linux-loongarch64;
         linux-musl-loongarch64;
         " />
 


### PR DESCRIPTION
Add linux-loongarch64 RID for `Net90AppHostRids` and `Net90RuntimePackRids`.