### PR TITLE
Add missing Restore option for ArtifactsPath and tests

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -25,11 +25,12 @@ namespace Microsoft.DotNet.Cli
         }.ForwardAsSingle(o => $"-property:RestoreSources={string.Join("%3B", o)}")
         .AllowSingleArgPerToken();
 
-        private static IEnumerable<CliOption> FullRestoreOptions() => 
+        private static IEnumerable<CliOption> FullRestoreOptions() =>
             ImplicitRestoreOptions(true, true, true, true).Concat(
-                new CliOption[] {
+                [
                     CommonOptions.VerbosityOption,
                     CommonOptions.InteractiveMsBuildForwardOption,
+                    CommonOptions.ArtifactsPathOption,
                     new ForwardedOption<bool>("--use-lock-file")
                     {
                         Description = LocalizableStrings.CmdUseLockFileOptionDescription,
@@ -46,7 +47,8 @@ namespace Microsoft.DotNet.Cli
                     new ForwardedOption<bool>("--force-evaluate")
                     {
                         Description = LocalizableStrings.CmdReevaluateOptionDescription
-                    }.ForwardAs("-property:RestoreForceEvaluate=true") });
+                    }.ForwardAs("-property:RestoreForceEvaluate=true"),
+                ]);
 
         private static readonly CliCommand Command = ConstructCommand();
 
@@ -169,8 +171,6 @@ namespace Microsoft.DotNet.Cli
             yield return forceOption;
 
             yield return CommonOptions.PropertiesOption;
-
-            yield return CommonOptions.ArtifactsPathOption;
 
             if (includeRuntimeOption)
             {

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -170,6 +170,8 @@ namespace Microsoft.DotNet.Cli
 
             yield return CommonOptions.PropertiesOption;
 
+            yield return CommonOptions.ArtifactsPathOption;
+
             if (includeRuntimeOption)
             {
                 CliOption<IEnumerable<string>> runtimeOption = new ForwardedOption<IEnumerable<string>>("--runtime")

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -83,6 +83,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.ArchitectureOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
+            command.Options.Add(CommonOptions.ArtifactsPathOption);
 
             command.Arguments.Add(ApplicationArguments);
 

--- a/src/Tests/dotnet.Tests/ParserTests/BuildRelatedCommandParserTests.cs
+++ b/src/Tests/dotnet.Tests/ParserTests/BuildRelatedCommandParserTests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLineValidation;
+using Microsoft.DotNet.Tools.Common;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class BuildRelatedCommandParserTests
+    {
+
+        /// <summary>
+        /// These commands all implicitly use MSBuild under the covers and generally should expose
+        /// the same set of property- and behavior-impacting options.
+        /// </summary>
+        private static string[] BuildRelatedCommands = [
+            "build",
+            "clean",
+            "pack",
+            "publish",
+            "restore",
+            "run",
+            "test"
+        ];
+
+        private static string[] OptionsToVerify = [
+            "--artifacts-path"
+        ];
+
+        public static TheoryData<string, string> BuildRelatedCommandsAndOptions()
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var cmd in BuildRelatedCommands)
+            {
+                foreach (var opt in OptionsToVerify)
+                {
+                    data.Add(cmd, opt);
+                }
+            }
+            return data;
+        }
+
+        [MemberData(nameof(BuildRelatedCommandsAndOptions))]
+        [Theory]
+        public void Build(string command, string option)
+        {
+            var cliCommand = Parser.Instance.RootCommand.Children.OfType<CliCommand>().FirstOrDefault(c => c.Name == command);
+            if (cliCommand is null)
+            {
+                throw new ArgumentException($"Command {command} not found in the dotnet CLI");
+            }
+            var cliOption = cliCommand.Children.OfType<CliOption>().FirstOrDefault(o => o.Name == option || o.Aliases.Contains(option));
+            if (cliOption is null)
+            {
+                throw new ArgumentException($"Option {option} not found in the {command} command");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #41530

The commands that implicitly drive MSBuild by forwarding properties should all be available across the set of MSBuild-invoking commands. An important exception to this rule is the `dotnet msbuild` command itself, which is a kind of `low-level` command that doesn't apply as many convenience tools.