### PR TITLE
Add back a line that was lost in dotnet/installer migration

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -373,6 +373,7 @@
         @(Net80ILCompilerSupportedRids);
         linux-arm;
         linux-musl-arm;
+        win-x86;
         " />
 
       <!-- The subset of ILCompiler target RIDs that are officially supported. Should be a subset of


### PR DESCRIPTION
dotnet/installer main has had this line since April. This repo doesn't have it.

Cc @dotnet/ilc-contrib 