### PR TITLE
Fix frameworks option forwarding for 'dotnet nuget why'

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -225,7 +225,9 @@ namespace Microsoft.DotNet.Cli
             whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
             whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
 
-            whyCommand.Options.Add(new CliOption<string>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore });
+            whyCommand.Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
+                .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
+                .AllowSingleArgPerToken());
 
             whyCommand.SetAction(NuGetCommand.Run);
 

--- a/test/dotnet.Tests/ParserTests/NuGetCommandParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/NuGetCommandParserTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class NuGetCommandParserTests
+    {
+        [Theory]
+        [InlineData("--framework net472")]
+        [InlineData("-f net472")]
+        [InlineData("--framework net472 --framework net6.0")]
+        [InlineData("-f net472 -f net6.0")]
+        [InlineData("--framework net472 -f net6.0")]
+        public void NuGetWhyCommandCanParseFrameworkOptions(string inputOptions)
+        {
+            var result = Parser.Instance.Parse($"dotnet nuget why C:\\path Fake.Package {inputOptions}");
+
+            result.Errors.Should().BeEmpty();
+            var parsedArguments = result.GetArguments();
+
+            foreach (var token in inputOptions.Split())
+            {
+                Assert.Contains(token, parsedArguments);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/13547

The frameworks option for 'dotnet nuget why' was not configured correctly, so the sdk wasn't able to parse and forward the option parameters to NuGet. This change fixes the bug.