### PR TITLE
fix portuguese translation and formatting 

### DIFF
--- a/src/BuiltInTools/dotnet-watch/xlf/Resources.pt-BR.xlf
+++ b/src/BuiltInTools/dotnet-watch/xlf/Resources.pt-BR.xlf
@@ -144,7 +144,7 @@ Examples:
       </trans-unit>
       <trans-unit id="Warning_ProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="translated">Aviso NETSDK1174: a abreviação de-p para--projeto é preterida. Use --projeto.</target>
+        <target state="translated">Aviso NETSDK1174: a abreviação de -p para --project está deprecada. Use --project.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -133,7 +133,7 @@ O {1} atual é '{2}'.</target>
       </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
-        <target state="translated">Aviso NETSDK1174: a abreviação de-p para--projeto é preterida. Use --projeto.</target>
+        <target state="translated">Aviso NETSDK1174: a abreviação de -p para --project está deprecada. Use --project.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingLaunchSettingsFromMessage">


### PR DESCRIPTION
Hey,

I wanted to contribute by fixing a small formatting issue that has been bothering me a bit for a while, but I couldn't find any information about how to do that correctly. I apologize if this isn't the usual way to handle it (as I changed the .xlf files directly).

There was a space missing between the words "de" and "para" and their following argument, so I fixed it. Additionally, I changed "--projeto" to "--project" ("--projeto" is a literal translation of the word). 

Also, I'm not sure "preterida" is the correct translation of "deprecated"... it sounds a bit imprecise to me. I think a better fit would be "deprecada" ([dictionary entry](https://dicionario.priberam.org/deprecado) - "cuja utilização já não se recomenda ", that is, "whose use is no longer recommended").