### PR TITLE
[StaticWebAssets] Adds metadata to JS initializers and JS modules

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Root</StaticWebAssetProjectMode>
     <StaticWebAssetsAdditionalPublishProperties>$(StaticWebAssetsAdditionalPublishProperties);_PublishingBlazorWasmProject=true</StaticWebAssetsAdditionalPublishProperties>
     <StaticWebAssetsAdditionalEmbeddedPublishProperties>$(StaticWebAssetsAdditionalEmbeddedPublishProperties);_PublishingBlazorWasmProject=true</StaticWebAssetsAdditionalEmbeddedPublishProperties>
-
+    <StaticWebAssetStandaloneHosting Condition="'$(StaticWebAssetStandaloneHosting)' == '' and '$(StaticWebAssetProjectMode)' == 'Root'">true</StaticWebAssetStandaloneHosting>
     <StaticWebAssetsGetEmbeddedPublishAssetsTargets>ComputeFilesToPublish;GetCurrentProjectEmbeddedPublishStaticWebAssetItems</StaticWebAssetsGetEmbeddedPublishAssetsTargets>
   </PropertyGroup>
 

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
@@ -113,11 +113,48 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="Endpoints" ItemName="_JSModuleStaticWebAssetEndpoint" />
     </DefineStaticWebAssetEndpoints>
 
+    <ItemGroup Condition="'@(_JSModuleStaticWebAsset)' != ''">
+      <!-- Append a property 'script-type' so that we include the file on the import map -->
+      <_AddPropertyToInitializers Include="Append">
+        <UpdateTarget>Property</UpdateTarget>
+        <Name>script-type</Name>
+        <Value>module</Value>
+      </_AddPropertyToInitializers>
+
+      <!-- Append a property 'dependency-group' so that we can link and preload the file without using the name -->
+      <_AddPropertyToInitializers Include="Append">
+        <UpdateTarget>Property</UpdateTarget>
+        <Name>dependency-group</Name>
+        <Value>js-initializer</Value>
+      </_AddPropertyToInitializers>
+    </ItemGroup>
+
+    <FilterStaticWebAssetEndpoints Condition="'@(_JSModuleStaticWebAsset)' != ''"
+      Endpoints="@(StaticWebAssetEndpoint);@(_JSModuleStaticWebAssetEndpoint)"
+      Assets="@(_JSModuleStaticWebAsset)"
+      Filters=""
+    >
+      <Output TaskParameter="FilteredEndpoints" ItemName="_FilteredJSModuleStaticWebAssetEndpoint" />
+      <Output TaskParameter="AssetsWithoutMatchingEndpoints" ItemName="_MissingJSModuleStaticWebAsset" />
+    </FilterStaticWebAssetEndpoints>
+
+    <Error Condition="'@(_MissingJSModuleStaticWebAsset)' != ''"
+      Text="The following JS module files do not have matching endpoints: @(_MissingJSModuleStaticWebAsset->'%(Identity)')" />
+
+    <UpdateStaticWebAssetEndpoints
+      Condition="'@(_AddPropertyToInitializers)' != ''"
+      EndpointsToUpdate="@(_FilteredJSModuleStaticWebAssetEndpoint)"
+      AllEndpoints="@(_FilteredJSModuleStaticWebAssetEndpoint)"
+      Operations="@(_AddPropertyToInitializers)"
+    >
+      <Output TaskParameter="UpdatedEndpoints" ItemName="_FilteredJSModuleStaticWebAssetEndpointWithProperty" />
+    </UpdateStaticWebAssetEndpoints>
+
     <ItemGroup>
       <StaticWebAsset Remove="@(_JSModuleStaticWebAsset)" />
       <StaticWebAsset Include="@(_JSModuleStaticWebAsset)" />
-      <StaticWebAssetEndpoint Remove="@(_JSModuleStaticWebAssetEndpoint)" />
-      <StaticWebAssetEndpoint Include="@(_JSModuleStaticWebAssetEndpoint)" />
+      <StaticWebAssetEndpoint Remove="@(_FilteredJSModuleStaticWebAssetEndpointWithProperty)" />
+      <StaticWebAssetEndpoint Include="@(_FilteredJSModuleStaticWebAssetEndpointWithProperty)" />
     </ItemGroup>
 
   </Target>
@@ -407,11 +444,26 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ApplyJsModules>
 
     <ItemGroup>
+      <_AddPropertyToJsModules Include="Append" Condition="'@(_MvcJSModuleEndpoint)' != '' or '@(_ComponentJSModuleEndpoint)' != ''">
+        <UpdateTarget>Property</UpdateTarget>
+        <Name>script-type</Name>
+        <Value>module</Value>
+      </_AddPropertyToJsModules>
+    </ItemGroup>
+
+    <UpdateStaticWebAssetEndpoints
+      Condition="'@(_AddPropertyToJsModules)' != ''"
+      EndpointsToUpdate="@(_MvcJSModuleEndpoint);@(_ComponentJSModuleEndpoint)"
+      AllEndpoints="@(_MvcJSModuleEndpoint);@(_ComponentJSModuleEndpoint)"
+      Operations="@(_AddPropertyToJsModules)"
+    >
+      <Output TaskParameter="UpdatedEndpoints" ItemName="_JSModuleEndpointsWithProperty" />
+    </UpdateStaticWebAssetEndpoints>
+
+    <ItemGroup>
       <StaticWebAsset Remove="@(_JsFileModuleStaticWebAsset)" />
       <StaticWebAsset Include="@(_JsFileModuleStaticWebAsset)" />
-
-      <StaticWebAssetEndpoint Include="@(_ComponentJSModuleEndpoint)" />
-      <StaticWebAssetEndpoint Include="@(_MvcJSModuleEndpoint)" />
+      <StaticWebAssetEndpoint Include="@(_JSModuleEndpointsWithProperty)" />
 
       <!-- Remove the items from their original groups since they've now become a StaticWebAsset -->
       <Content Remove="@(_JsFileModuleStaticWebAsset->'%(OriginalItemSpec)')" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -110,7 +110,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask
     TaskName="Microsoft.AspNetCore.StaticWebAssets.Tasks.ResolveStaticWebAssetEndpointRoutes"
     AssemblyFile="$(StaticWebAssetsSdkBuildTasksAssembly)"
-    Condition="'$(StaticWebAssetsSdkBuildTasksAssembly)' != ''" />    
+    Condition="'$(StaticWebAssetsSdkBuildTasksAssembly)' != ''" />
+
+  <UsingTask
+    TaskName="Microsoft.AspNetCore.StaticWebAssets.Tasks.ResolveFingerprintedStaticWebAssetEndpointsForAssets"
+    AssemblyFile="$(StaticWebAssetsSdkBuildTasksAssembly)"
+    Condition="'$(StaticWebAssetsSdkBuildTasksAssembly)' != ''" />
 
   <!-- Static web assets define how web content needs to be served from web applications, class libraries and packages during
        development and what and where web contents need to be served on the published application.

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -53,7 +53,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         return result;
     }
 
-    internal static StaticWebAssetEndpoint FromTaskItem(ITaskItem item)
+    public static StaticWebAssetEndpoint FromTaskItem(ITaskItem item)
     {
         var result = new StaticWebAssetEndpoint()
         {

--- a/src/StaticWebAssetsSdk/Tasks/ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
+
+namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
+
+// There is a common operation that several targets need to perform when they want to reference endpoints
+// inside the contents of an application. This can be done by a combination of tasks in the SDK, but it is
+// cumbersome to do so, specially for third-party targets and SDKs. This task encapsulates the logic to
+// resolve the preferrred set of endpoints for a given set of assets, taking into account the hosting model
+// (Standalone or Hosted) and ensuring that fingerprinted endpoints are used when possible.
+public class ResolveFingerprintedStaticWebAssetEndpointsForAssets : Task
+{
+    [Required] public ITaskItem[] CandidateEndpoints { get; set; }
+
+    [Required] public ITaskItem[] CandidateAssets { get; set; }
+
+    public bool IsStandalone { get; set; }
+
+    [Output] public ITaskItem[] ResolvedEndpoints { get; set; }
+
+    public override bool Execute()
+    {
+        var candidateEndpoints = StaticWebAssetEndpoint.FromItemGroup(CandidateEndpoints);
+        var candidateAssets = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray();
+        var resolvedEndpoints = new List<StaticWebAssetEndpoint>();
+
+        var endpointsByAsset = candidateEndpoints.GroupBy(e => e.AssetFile, OSPath.PathComparer)
+            .ToDictionary(g => g.Key, g => g.ToArray(), OSPath.PathComparer);
+
+        for (var i = 0; i < candidateAssets.Length; i++)
+        {
+            var asset = candidateAssets[i];
+            if (!endpointsByAsset.TryGetValue(asset.Identity, out var endpoints))
+            {
+                Log.LogError($"No endpoint found for asset '{asset.Identity}'");
+            }
+            else
+            {
+                if (IsStandalone)
+                {
+                    var assetPath = asset.ComputeTargetPath("", '/', StaticWebAssetTokenResolver.Instance);
+                    var foundMatchingEndpoint = false;
+                    for (var j = 0; j < endpoints.Length; j++)
+                    {
+                        var endpoint = endpoints[j];
+                        if (MatchesAssetPath(asset, assetPath, endpoint))
+                        {
+                            foundMatchingEndpoint = true;
+                            resolvedEndpoints.Add(endpoint);
+                            break;
+                        }
+                    }
+                    if (!foundMatchingEndpoint)
+                    {
+                        Log.LogError($"No endpoint found for asset '{asset.Identity}' with path '{assetPath}' whose route matches its path.");
+                        break;
+                    }
+                }
+                else
+                {
+                    var foundFingerprintedEndpoint = false;
+                    for (var j = 0; j < endpoints.Length; j++)
+                    {
+                        var endpoint = endpoints[j];
+                        if (HasFingerprint(endpoint))
+                        {
+                            foundFingerprintedEndpoint = true;
+                            var route = asset.ReplaceTokens(endpoint.Route, StaticWebAssetTokenResolver.Instance);
+                            Log.LogMessage(MessageImportance.Low, $"Selected endpoint '{endpoint.Route}' for asset '{asset.Identity}' because it has a fingerprinted route '{route}'.");
+                            endpoint.Route = route;
+                            resolvedEndpoints.Add(endpoint);
+                            break;
+                        }
+                    }
+
+                    if (!foundFingerprintedEndpoint)
+                    {
+                        // By definition there's always at least one endpoint for an asset, so we can safely
+                        // assume that the first one is the one that should be used when no fingerprinted
+                        // endpoint is found.
+                        endpoints[0].Route = asset.ReplaceTokens(endpoints[0].Route, StaticWebAssetTokenResolver.Instance);
+                        Log.LogMessage(MessageImportance.Low, $"Selected endpoint '{endpoints[0].Route}' for asset '{asset.Identity}' because no fingerprinted endpoint was found.");
+                        resolvedEndpoints.Add(endpoints[0]);
+                    }
+                }
+            }
+        }
+
+        ResolvedEndpoints = resolvedEndpoints.Select(e => e.ToTaskItem()).ToArray();
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private bool HasFingerprint(StaticWebAssetEndpoint endpoint)
+    {
+        for (var i = 0; i < endpoint.EndpointProperties.Length; i++)
+        {
+            var property = endpoint.EndpointProperties[i];
+            if (string.Equals(property.Name, "fingerprint", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool MatchesAssetPath(StaticWebAsset asset, string assetPath, StaticWebAssetEndpoint endpoint)
+    {
+        var route = asset.ReplaceTokens(endpoint.Route, StaticWebAssetTokenResolver.Instance);
+        if (string.Equals(route, assetPath, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.LogMessage(MessageImportance.Low, $"Selected endpoint '{endpoint.Route}' for asset '{asset.Identity}' because '{assetPath}' matches resolved route '{route}'.");
+            return true;
+        }
+        else
+        {
+            Log.LogMessage(MessageImportance.Low, $"Skipping endpoint '{endpoint.Route}' for asset '{asset.Identity}' because '{assetPath}' does not match resolved route '{route}'.");
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/Build_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/Build_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest.Build.staticwebassets.json
@@ -36755,8 +36755,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -36992,8 +37000,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JSModules_ManifestIncludesModuleTargetPaths.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JSModules_ManifestIncludesModuleTargetPaths.Build.staticwebassets.json
@@ -37674,8 +37674,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -38222,8 +38230,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -38396,8 +38412,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -38633,8 +38657,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_CanCustomizeBlazorInitialization.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_CanCustomizeBlazorInitialization.Publish.staticwebassets.json
@@ -5734,8 +5734,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -20134,8 +20142,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -22739,8 +22755,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_CanHaveDifferentBuildAndPublishModules.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_CanHaveDifferentBuildAndPublishModules.Publish.staticwebassets.json
@@ -5671,8 +5671,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -19871,8 +19879,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -22439,8 +22455,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_Hosted_CanCustomizeBlazorInitialization.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/JsModules_Hosted_CanCustomizeBlazorInitialization.Publish.staticwebassets.json
@@ -6579,8 +6579,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -21279,8 +21287,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -24432,8 +24448,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/Publish_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/StaticWebAssetsBaselines/Publish_DoesNotGenerateManifestJson_IncludesJSModulesOnBlazorBootJsonManifest.Publish.staticwebassets.json
@@ -5671,8 +5671,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -19871,8 +19879,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -22439,8 +22455,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
         private string _baselinesFolder;
 
-#if !GENERATE_SWA_BASELINES
+#if GENERATE_SWA_BASELINES
         public static bool GenerateBaselines = true;
 #else
         public static bool GenerateBaselines = bool.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_TEST_BASELINES"), out var result) && result;

--- a/test/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/AspNetSdkBaselineTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
         private string _baselinesFolder;
 
-#if GENERATE_SWA_BASELINES
+#if !GENERATE_SWA_BASELINES
         public static bool GenerateBaselines = true;
 #else
         public static bool GenerateBaselines = bool.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_TEST_BASELINES"), out var result) && result;

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest.cs
@@ -1,0 +1,294 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
+using Moq;
+
+namespace Microsoft.NET.Sdk.Razor.Tests.StaticWebAssets;
+
+public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
+{
+    [Theory]
+    [InlineData("candidate#[.{fingerprint}]?.js", "candidate.js")]
+    [InlineData("candidate#[.{fingerprint}]!.js", "candidate.asdf1234.js")]
+    public void Standalone_Selects_EndpointMatching_FilePath(string pattern, string expectedRoute)
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                pattern,
+                "All",
+                "All",
+                "asdf1234",
+                "integrity"
+            )
+        ];
+
+        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+
+        var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
+        {
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = [..endpoints.Select(e => e.ToTaskItem())],
+            IsStandalone = true,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = resolvedEndpoints.Execute();
+        result.Should().BeTrue();
+
+        // Assert
+        resolvedEndpoints.ResolvedEndpoints.Should().HaveCount(1);
+        var endpoint = StaticWebAssetEndpoint.FromTaskItem(resolvedEndpoints.ResolvedEndpoints[0]);
+
+        endpoint.Route.Should().Be(expectedRoute);
+    }
+
+    [Fact]
+    public void StandaloneFails_MatchingEndpointNotFound()
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                "candidate#[.{fingerprint}]!.js",
+                "All",
+                "All",
+                "asdf1234",
+                "integrity"
+            )
+        ];
+
+        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        endpoints = endpoints.Where(e => !e.Route.Contains("asdf1234")).ToArray();
+
+        var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
+        {
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = [.. endpoints.Select(e => e.ToTaskItem())],
+            IsStandalone = true,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = resolvedEndpoints.Execute();
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("candidate#[.{fingerprint}]?.js", "candidate.asdf1234.js")]
+    [InlineData("candidate#[.{fingerprint}]!.js", "candidate.asdf1234.js")]
+    public void Hosted_AlwaysPrefers_FingerprintedEndpoint(string pattern, string expectedRoute)
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                pattern,
+                "All",
+                "All",
+                "asdf1234",
+                "integrity"
+            )
+        ];
+
+        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+
+        var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
+        {
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = [.. endpoints.Select(e => e.ToTaskItem())],
+            IsStandalone = false,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = resolvedEndpoints.Execute();
+        result.Should().BeTrue();
+
+        // Assert
+        resolvedEndpoints.ResolvedEndpoints.Should().HaveCount(1);
+        var endpoint = StaticWebAssetEndpoint.FromTaskItem(resolvedEndpoints.ResolvedEndpoints[0]);
+
+        endpoint.Route.Should().Be(expectedRoute);
+    }
+
+    [Fact]
+    public void Hosted_FallsBackToNonFingerprintedEndpoint_WhenFingerprintedVersionNotAvailable()
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                "candidate.js",
+                "All",
+                "All",
+                "asdf1234",
+                "integrity"
+            )
+        ];
+
+        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+
+        var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
+        {
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = [.. endpoints.Select(e => e.ToTaskItem())],
+            IsStandalone = false,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = resolvedEndpoints.Execute();
+        result.Should().BeTrue();
+
+        // Assert
+        resolvedEndpoints.ResolvedEndpoints.Should().HaveCount(1);
+        var endpoint = StaticWebAssetEndpoint.FromTaskItem(resolvedEndpoints.ResolvedEndpoints[0]);
+
+        endpoint.Route.Should().Be("candidate.js");
+    }
+
+    [Fact]
+    public void Hosted_FailsWhen_DoesnotFindMatchingEndpoint()
+    {
+        var now = DateTime.Now;
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        List<ITaskItem> candidateAssets = [
+            CreateCandidate(
+                Path.Combine("wwwroot", "candidate.js"),
+                "MyPackage",
+                "Discovered",
+                "candidate.js",
+                "All",
+                "All",
+                "asdf1234",
+                "integrity"
+            )
+        ];
+
+        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        endpoints = endpoints.Where(e => !e.Route.Contains("asdf1234")).ToArray();
+        endpoints[0].AssetFile = Path.GetFullPath("other.js");
+
+        var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
+        {
+            CandidateAssets = [.. candidateAssets],
+            CandidateEndpoints = [.. endpoints.Select(e => e.ToTaskItem())],
+            IsStandalone = false,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = resolvedEndpoints.Execute();
+        result.Should().BeFalse();
+    }
+
+    private ITaskItem CreateCandidate(
+        string itemSpec,
+        string sourceId,
+        string sourceType,
+        string relativePath,
+        string assetKind,
+        string assetMode,
+        string fingerprint = "",
+        string integrity = "",
+        string relatedAsset = "",
+        string assetTraitName = "",
+        string assetTraitValue = "")
+    {
+        var result = new StaticWebAsset()
+        {
+            Identity = Path.GetFullPath(itemSpec),
+            SourceId = sourceId,
+            SourceType = sourceType,
+            ContentRoot = Directory.GetCurrentDirectory(),
+            BasePath = "base",
+            RelativePath = relativePath,
+            AssetKind = assetKind,
+            AssetMode = assetMode,
+            AssetRole = "Primary",
+            RelatedAsset = relatedAsset,
+            AssetTraitName = assetTraitName,
+            AssetTraitValue = assetTraitValue,
+            CopyToOutputDirectory = "",
+            CopyToPublishDirectory = "",
+            OriginalItemSpec = itemSpec,
+            // Add these to avoid accessing the disk to compute them
+            Integrity = integrity,
+            Fingerprint = fingerprint,
+        };
+
+        result.ApplyDefaults();
+        result.Normalize();
+
+        return result.ToTaskItem();
+    }
+
+    private StaticWebAssetEndpoint[] CreateEndpoints(StaticWebAsset[] assets)
+    {
+        var defineStaticWebAssetEndpoints = new DefineStaticWebAssetEndpoints
+        {
+            CandidateAssets = assets.Select(a => a.ToTaskItem()).ToArray(),
+            ExistingEndpoints = [],
+            ContentTypeMappings =
+            [
+                CreateContentMapping("*.html", "text/html"),
+                CreateContentMapping("*.js", "application/javascript"),
+                CreateContentMapping("*.css", "text/css"),
+            ]
+        };
+        defineStaticWebAssetEndpoints.BuildEngine = Mock.Of<IBuildEngine>();
+        defineStaticWebAssetEndpoints.TestLengthResolver = name => 10;
+        defineStaticWebAssetEndpoints.TestLastWriteResolver = name => DateTime.UtcNow;
+
+        defineStaticWebAssetEndpoints.Execute();
+        return StaticWebAssetEndpoint.FromItemGroup(defineStaticWebAssetEndpoints.Endpoints);
+    }
+
+    private TaskItem CreateContentMapping(string pattern, string contentType)
+    {
+        return new TaskItem(contentType, new Dictionary<string, string>
+        {
+            { "Pattern", pattern },
+            { "Priority", "0" }
+        });
+    }
+}

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselineFactory.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselineFactory.cs
@@ -145,6 +145,7 @@ public partial class StaticWebAssetsBaselineFactory
                 {
                     case "fingerprint":
                         property.Value = "__fingerprint__";
+                        endpoint.Route = endpoint.Route.Replace(property.Value, $"__{property.Name}__");
                         break;
                     case "integrity":
                         property.Value = "__integrity__";
@@ -153,7 +154,6 @@ public partial class StaticWebAssetsBaselineFactory
                         break;
                 }
 
-                endpoint.Route = endpoint.Route.Replace(property.Value, $"__{property.Name}__");
                 ReplaceFileName(endpoint.Route);
             }
 

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_IncorporatesInitializersFromClassLibraries.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/BuildProjectWithReferences_IncorporatesInitializersFromClassLibraries.Build.staticwebassets.json
@@ -689,8 +689,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -926,8 +934,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -2167,8 +2183,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -2486,8 +2510,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DiscoversJsModulesBasedOnPatterns.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Build_DiscoversJsModulesBasedOnPatterns.Build.staticwebassets.json
@@ -212,6 +212,10 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -249,6 +253,10 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -781,6 +789,10 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -881,6 +893,10 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Build.staticwebassets.json
@@ -647,8 +647,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -884,8 +892,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_DifferentBuildAndPublish_LibraryInitializers.Publish.staticwebassets.json
@@ -899,8 +899,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1199,8 +1207,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1436,8 +1452,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Build.staticwebassets.json
@@ -689,8 +689,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -926,8 +934,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/PublishProjectWithReferences_IncorporatesInitializersFromClassLibrariesAndPublishesAssetsToTheRightLocation.Publish.staticwebassets.json
@@ -962,8 +962,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1262,8 +1270,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1499,8 +1515,16 @@
       ],
       "EndpointProperties": [
         {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
@@ -38,27 +38,6 @@
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz"
     },
     {
-      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "SourceId": "ComponentApp",
-      "SourceType": "Discovered",
-      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
-      "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "AssetKind": "All",
-      "AssetMode": "All",
-      "AssetRole": "Alternative",
-      "AssetMergeBehavior": "",
-      "AssetMergeSource": "",
-      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
-      "AssetTraitName": "Content-Encoding",
-      "AssetTraitValue": "gzip",
-      "Fingerprint": "__fingerprint__",
-      "Integrity": "__integrity__",
-      "CopyToOutputDirectory": "Never",
-      "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz"
-    },
-    {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "SourceId": "ComponentApp",
       "SourceType": "Computed",
@@ -78,6 +57,27 @@
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "_content/ComponentApp",
+      "RelativePath": "ComponentApp.lib.module.js.gz",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz"
     },
     {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
@@ -101,27 +101,6 @@
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br"
     },
     {
-      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "SourceId": "ComponentApp",
-      "SourceType": "Discovered",
-      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\",
-      "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "AssetKind": "All",
-      "AssetMode": "All",
-      "AssetRole": "Alternative",
-      "AssetMergeBehavior": "",
-      "AssetMergeSource": "",
-      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
-      "AssetTraitName": "Content-Encoding",
-      "AssetTraitValue": "br",
-      "Fingerprint": "__fingerprint__",
-      "Integrity": "__integrity__",
-      "CopyToOutputDirectory": "Never",
-      "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br"
-    },
-    {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "SourceId": "ComponentApp",
       "SourceType": "Computed",
@@ -141,6 +120,27 @@
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\",
+      "BasePath": "_content/ComponentApp",
+      "RelativePath": "ComponentApp.lib.module.js.br",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "br",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp.lib.module.js.br"
     },
     {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.modules.json.br",
@@ -253,7 +253,7 @@
       "SourceType": "Discovered",
       "ContentRoot": "${ProjectPath}\\wwwroot\\",
       "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp#[.{fingerprint}]!.lib.module.js",
+      "RelativePath": "ComponentApp.lib.module.js",
       "AssetKind": "All",
       "AssetMode": "All",
       "AssetRole": "Primary",
@@ -487,222 +487,6 @@
       ]
     },
     {
-      "Route": "ComponentApp.lib.module.js.gz",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.__fingerprint__.lib.module.js.gz",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "max-age=31536000, immutable"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "ComponentApp.lib.module.js.gz"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.__fingerprint__.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "max-age=31536000, immutable"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "ComponentApp.lib.module.js"
-        }
-      ]
-    },
-    {
       "Route": "ComponentApp.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
@@ -915,6 +699,114 @@
         {
           "Name": "label",
           "Value": "ComponentApp.styles.css"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1135,222 +1027,6 @@
       ]
     },
     {
-      "Route": "ComponentApp.lib.module.js.br",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.__fingerprint__.lib.module.js.br",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "max-age=31536000, immutable"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "ComponentApp.lib.module.js.br"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.__fingerprint__.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "max-age=31536000, immutable"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "label",
-          "Value": "ComponentApp.lib.module.js"
-        }
-      ]
-    },
-    {
       "Route": "ComponentApp.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
@@ -1563,6 +1239,114 @@
         {
           "Name": "label",
           "Value": "ComponentApp.styles.css"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js.br",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "br",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     },
@@ -1999,53 +1783,16 @@
       ],
       "EndpointProperties": [
         {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.__fingerprint__.lib.module.js",
-      "AssetFile": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "max-age=31536000, immutable"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "fingerprint",
-          "Value": "__fingerprint__"
+          "Name": "dependency-group",
+          "Value": "js-initializer"
         },
         {
           "Name": "integrity",
           "Value": "__integrity__"
         },
         {
-          "Name": "label",
-          "Value": "ComponentApp.lib.module.js"
+          "Name": "script-type",
+          "Value": "module"
         }
       ]
     }

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselines/Publish_PublishesJsModuleBundleBundleToTheRightLocation.Publish.staticwebassets.json
@@ -38,6 +38,27 @@
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz"
     },
     {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "_content/ComponentApp",
+      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz"
+    },
+    {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "SourceId": "ComponentApp",
       "SourceType": "Computed",
@@ -57,27 +78,6 @@
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz"
-    },
-    {
-      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
-      "SourceId": "ComponentApp",
-      "SourceType": "Discovered",
-      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
-      "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp.lib.module.js.gz",
-      "AssetKind": "All",
-      "AssetMode": "All",
-      "AssetRole": "Alternative",
-      "AssetMergeBehavior": "",
-      "AssetMergeSource": "",
-      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
-      "AssetTraitName": "Content-Encoding",
-      "AssetTraitValue": "gzip",
-      "Fingerprint": "__fingerprint__",
-      "Integrity": "__integrity__",
-      "CopyToOutputDirectory": "Never",
-      "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz"
     },
     {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br",
@@ -101,6 +101,27 @@
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.br"
     },
     {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\",
+      "BasePath": "_content/ComponentApp",
+      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "br",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br"
+    },
+    {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "SourceId": "ComponentApp",
       "SourceType": "Computed",
@@ -120,27 +141,6 @@
       "CopyToOutputDirectory": "Never",
       "CopyToPublishDirectory": "PreserveNewest",
       "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br"
-    },
-    {
-      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
-      "SourceId": "ComponentApp",
-      "SourceType": "Discovered",
-      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\",
-      "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp.lib.module.js.br",
-      "AssetKind": "All",
-      "AssetMode": "All",
-      "AssetRole": "Alternative",
-      "AssetMergeBehavior": "",
-      "AssetMergeSource": "",
-      "RelatedAsset": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
-      "AssetTraitName": "Content-Encoding",
-      "AssetTraitValue": "br",
-      "Fingerprint": "__fingerprint__",
-      "Integrity": "__integrity__",
-      "CopyToOutputDirectory": "Never",
-      "CopyToPublishDirectory": "PreserveNewest",
-      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\_content\\ComponentApp\\ComponentApp.lib.module.js.br"
     },
     {
       "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.modules.json.br",
@@ -253,7 +253,7 @@
       "SourceType": "Discovered",
       "ContentRoot": "${ProjectPath}\\wwwroot\\",
       "BasePath": "_content/ComponentApp",
-      "RelativePath": "ComponentApp.lib.module.js",
+      "RelativePath": "ComponentApp#[.{fingerprint}]!.lib.module.js",
       "AssetKind": "All",
       "AssetMode": "All",
       "AssetRole": "Primary",
@@ -487,6 +487,238 @@
       ]
     },
     {
+      "Route": "ComponentApp.lib.module.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.lib.module.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.lib.module.js.gz"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.lib.module.js"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
+        }
+      ]
+    },
+    {
       "Route": "ComponentApp.styles.css.gz",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
       "Selectors": [],
@@ -699,114 +931,6 @@
         {
           "Name": "label",
           "Value": "ComponentApp.styles.css"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js.gz",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_content\\ComponentApp\\ComponentApp.lib.module.js.gz",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "gzip"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "dependency-group",
-          "Value": "js-initializer"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "script-type",
-          "Value": "module"
         }
       ]
     },
@@ -1027,6 +1151,238 @@
       ]
     },
     {
+      "Route": "ComponentApp.lib.module.js.br",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.lib.module.js.br",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.lib.module.js.br"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "br",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.lib.module.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]!.lib.module.js.br",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "br",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "br"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Content-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.lib.module.js"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
+        }
+      ]
+    },
+    {
       "Route": "ComponentApp.styles.css.br",
       "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.br",
       "Selectors": [],
@@ -1239,114 +1595,6 @@
         {
           "Name": "label",
           "Value": "ComponentApp.styles.css"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js.br",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
-      "Selectors": [],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        }
-      ]
-    },
-    {
-      "Route": "ComponentApp.lib.module.js",
-      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\publish\\_content\\ComponentApp\\ComponentApp.lib.module.js.br",
-      "Selectors": [
-        {
-          "Name": "Content-Encoding",
-          "Value": "br",
-          "Quality": "__quality__"
-        }
-      ],
-      "ResponseHeaders": [
-        {
-          "Name": "Accept-Ranges",
-          "Value": "bytes"
-        },
-        {
-          "Name": "Cache-Control",
-          "Value": "no-cache"
-        },
-        {
-          "Name": "Content-Encoding",
-          "Value": "br"
-        },
-        {
-          "Name": "Content-Length",
-          "Value": "__content-length__"
-        },
-        {
-          "Name": "Content-Type",
-          "Value": "text/javascript"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "ETag",
-          "Value": "__etag__"
-        },
-        {
-          "Name": "Last-Modified",
-          "Value": "__last-modified__"
-        },
-        {
-          "Name": "Vary",
-          "Value": "Content-Encoding"
-        }
-      ],
-      "EndpointProperties": [
-        {
-          "Name": "dependency-group",
-          "Value": "js-initializer"
-        },
-        {
-          "Name": "integrity",
-          "Value": "__integrity__"
-        },
-        {
-          "Name": "script-type",
-          "Value": "module"
         }
       ]
     },
@@ -1789,6 +2037,59 @@
         {
           "Name": "integrity",
           "Value": "__integrity__"
+        },
+        {
+          "Name": "script-type",
+          "Value": "module"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.lib.module.js",
+      "AssetFile": "${ProjectPath}\\wwwroot\\ComponentApp.lib.module.js",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Accept-Ranges",
+          "Value": "bytes"
+        },
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "dependency-group",
+          "Value": "js-initializer"
+        },
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.lib.module.js"
         },
         {
           "Name": "script-type",


### PR DESCRIPTION
* Adds a couple of endpoint properties `script-type` and `dependency-group`.
  * `script-type` allows us to identify JS modules explicitly as opposed to anything with a JS extension to reduce the size of import maps.
  * `dependency-group` allows us to reference a group of assets/endpoints by name, so that we can do things like "Preload all JS initializers" without the runtime needing to know about the file names.
* Adds a task to compute the set of URLs to write as content on different manifests we generate