### PR TITLE
In BrowserScriptMiddleware, dispose GetManifestResourceStream()

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         {
             var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorHotReload.js";
             using var stream = new MemoryStream();
-            var manifestStream = typeof(WebSocketScriptInjection).Assembly.GetManifestResourceStream(jsFileName)!;
+            using var manifestStream = typeof(WebSocketScriptInjection).Assembly.GetManifestResourceStream(jsFileName)!;
             manifestStream.CopyTo(stream);
 
             return stream.ToArray();


### PR DESCRIPTION
We are disposing the MemoryStream in the previous line, so we should Dispose this too.