### PR TITLE
Fix newline bug when updating exclusion baseline

### DIFF
--- a/src/SourceBuild/content/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/src/SourceBuild/content/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -134,7 +134,8 @@ public class PRCreator
                 {
                     if (!parsedFile.Contains(line))
                     {
-                        content = content.Replace(line + "\n", "");
+                        // If the newline character is not present, the line is at the end of the file
+                        content = content.Contains(line + "\n") ? content.Replace(line + "\n", "") : content.Replace(line, "");
                     }
                 }
             }


### PR DESCRIPTION
When investigating https://github.com/dotnet/source-build/issues/4351, I noticed that the exclusion was no longer required. Upon investigation, I discovered that the exclusion was being removed in the updated files, but the PR creator was still including this exclusion in [the created PR](https://github.com/dotnet/sdk/pull/41624/files#diff-c69327d64b34c2f46dbba48d9da331f0f52a34f49263b1bf0fae2137e32e50adL92).

The reason the line was being included was because the exclusion is at the end of the `SdkFileDiffExclusions.txt` file, but the exclusion is not followed by a newline. This means that the content was not being properly replaced.

Note that if the newline exists, is necessary to include it when replacing the content. Otherwise, the exclusion will get removed, but it will be replaced with an empty line (see [this example](https://github.com/ellahathaway/sdk/pull/8/files#diff-c69327d64b34c2f46dbba48d9da331f0f52a34f49263b1bf0fae2137e32e50adR81)).