### PR TITLE
Fixup SDK build

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -59,18 +59,6 @@ jobs:
         inputs:
           targetPath: $(Build.SourcesDirectory)/eng/BuildConfiguration
           artifactName: BuildConfiguration
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - ${{ if eq(parameters.pool.os, 'windows') }}:
-        - powershell: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1 -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          displayName: Setup Private Feeds Credentials
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      # The PowerShell script above would work fine on Linux/Mac, but the Linux containers don't have PowerShell installed.
-      - ${{ else }}:
-        - script: . $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $Token
-          displayName: Setup Private Feeds Credentials
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
     ############### BUILDING ###############
     - ${{ if eq(parameters.pool.os, 'windows') }}:


### PR DESCRIPTION
Fix SDK build by removing calls to SetupNugetSources. These are incomplete right now anyway (missing for many platforms), have some odd interactions with workloads NuGetAuthenticate.