### PR TITLE
Update Documentation to fix issues when running `zsh`

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -113,6 +113,8 @@ Run the following commands from the root of the repository to setup the test env
 source ./eng/dogfood.sh
 ```
 
+NOTE: If you are running on MacOS you will need to use a `bash` shell rather than the default `zsh`. You can either change your default shell or type `bash` before executing the above command.
+
 Ensure the `dotnet` being used is from the artifacts directory:
 
 ```


### PR DESCRIPTION
When trying to use the sdk on macOS via `source ./eng/dogfood.sh` we get the following output.

```
./eng/dogfood.sh:.:12: no such file or directory: ~/Documents/Sandbox/DotNet/sdk/common/tools.sh
./eng/dogfood.sh:.:13: no such file or directory: ~/Documents/Sandbox/DotNet/sdk/configure-toolset.sh
./eng/dogfood.sh:14: command not found: InitializeToolset
./eng/dogfood.sh:.:15: no such file or directory: ~/Documents/Sandbox/DotNet/sdk/restore-toolset.sh
./eng/dogfood.sh:17: command not found: ReadGlobalVersion
ls: /bin/redist//dotnet/sdk: No such file or directory
```

This is because the use of `BASH_SOURCE[0]` does not work in `zsh` and the `#!/usr/bin/env bash` does not seem to be launching a `bash` shell. Rather than change the script to not use `BASH_SOURCE[0]` just update the documentation so that Mac users are aware they need to use the correct shell.