### PR TITLE
Fix incremental build for extract-sdk-archive.proj

### DIFF
--- a/src/SourceBuild/content/eng/extract-sdk-archive.proj
+++ b/src/SourceBuild/content/eng/extract-sdk-archive.proj
@@ -8,13 +8,20 @@
           BeforeTargets="AfterBuild"
           DependsOnTargets="DetermineSourceBuiltSdkVersion"
           Inputs="$(SdkTarballPath)"
-          Outputs="$(DotNetSdkExtractDir)">
+          Outputs="$(BaseIntermediateOutputPath)ExtractSdkArchive.complete">
     <MakeDir Directories="$(DotNetSdkExtractDir)" />
+
     <Exec Condition="'$(ArchiveExtension)' == '.tar.gz'"
           Command="tar -xzf $(SdkTarballPath) -C $(DotNetSdkExtractDir)" />
     <Unzip Condition="'$(ArchiveExtension)' == '.zip'"
            SourceFiles="$(SdkTarballPath)"
            DestinationFolder="$(DotNetSdkExtractDir)" />
+
+    <Message Text="Extracted SDK archive file to '$(DotNetSdkExtractDir)'." Importance="high"  />
+
+    <Touch Files="$(BaseIntermediateOutputPath)ExtractSdkArchive.complete" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/eng/extract-sdk-archive.proj
+++ b/src/SourceBuild/content/eng/extract-sdk-archive.proj
@@ -17,7 +17,7 @@
            SourceFiles="$(SdkTarballPath)"
            DestinationFolder="$(DotNetSdkExtractDir)" />
 
-    <Message Text="Extracted SDK archive file to '$(DotNetSdkExtractDir)'." Importance="high"  />
+    <Message Text="Extracted SDK archive file '$(SdkTarballPath)' to '$(DotNetSdkExtractDir)'." Importance="high" />
 
     <Touch Files="$(BaseIntermediateOutputPath)ExtractSdkArchive.complete" AlwaysCreate="true">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />


### PR DESCRIPTION
The Outputs declaration didn't work as that needs to be a 1:1 mapping. 1 input file against 1 directory doesn't work.