### PR TITLE
Remove live msbuild and runtime dependencies from fsharp

### DIFF
--- a/src/SourceBuild/content/repo-projects/fsharp.proj
+++ b/src/SourceBuild/content/repo-projects/fsharp.proj
@@ -25,8 +25,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="msbuild" />
-    <RepositoryReference Include="runtime" />
     <RepositoryReference Include="source-build-reference-packages" />
   </ItemGroup>
 


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/41616

Those aren't necessary for source-build. I also checked that nothing in fsharp redistributes runtime or msbuild assemblies when building from source.