### PR TITLE
Avoid crossgen for Microsoft.CodeAnalysis.VisualBasic

### DIFF
--- a/src/Installer/redist-installer/targets/Crossgen.targets
+++ b/src/Installer/redist-installer/targets/Crossgen.targets
@@ -58,6 +58,9 @@
 
       <RemainingFiles Include="$(SdkOutputDirectory)**\*" Exclude="$(SdkOutputDirectory)FSharp\FSharp.Build.dll;@(RoslynFiles);@(FSharpFiles)" />
 
+      <!-- Don't crossgen VB since the usage doesn't justify the size cost for everyone -->
+      <RoslynFiles Remove="$(SdkOutputDirectory)Roslyn\bincore\Microsoft.CodeAnalysis.VisualBasic.dll" />
+
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error, and they need to stay their original architecture. -->
       <RemainingFiles Remove="$(SdkOutputDirectory)TestHost*\**\*" />
       <!-- Removing Full CLR built DumpMiniTool executables from Crossgen, because they need to stay their original architecture to allow creating dumps with a given bitness. -->


### PR DESCRIPTION
Visual Basic is used less than C#; we can reduce SDK size for all customers by distributing a JITted version of it instead of crossgening it (at a cost of ~7MB).
