### PR TITLE
Fix userlocal

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -93,9 +93,9 @@ namespace Microsoft.DotNet.Workloads.Workload
 
             _dotnetPath = creationResult.DotnetPath;
             _userProfileDir = creationResult.UserProfileDir;
+            _sdkFeatureBand = new SdkFeatureBand(creationResult.SdkVersion);
             _workloadRootDir = WorkloadFileBasedInstall.IsUserLocal(_dotnetPath, _sdkFeatureBand.ToString()) ? _userProfileDir : _dotnetPath;
             _sdkVersion = creationResult.SdkVersion;
-            _sdkFeatureBand = new SdkFeatureBand(creationResult.SdkVersion);
             _workloadResolver = creationResult.WorkloadResolver;
             _targetSdkVersion ??= _sdkVersion;
 

--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         protected readonly string _downloadToCacheOption;
         protected readonly string _dotnetPath;
         protected readonly string _userProfileDir;
+        protected readonly string _workloadRootDir;
         protected readonly bool _checkIfManifestExist;
         protected readonly ReleaseVersion _sdkVersion;
         protected readonly SdkFeatureBand _sdkFeatureBand;
@@ -92,6 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
             _dotnetPath = creationResult.DotnetPath;
             _userProfileDir = creationResult.UserProfileDir;
+            _workloadRootDir = WorkloadFileBasedInstall.IsUserLocal(_dotnetPath, _sdkFeatureBand.ToString()) ? _userProfileDir : _dotnetPath;
             _sdkVersion = creationResult.SdkVersion;
             _sdkFeatureBand = new SdkFeatureBand(creationResult.SdkVersion);
             _workloadResolver = creationResult.WorkloadResolver;
@@ -125,7 +127,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
         InstallStateContents GetCurrentInstallState()
         {
-            return GetCurrentInstallState(_sdkFeatureBand, _dotnetPath);
+            return GetCurrentInstallState(_sdkFeatureBand, _workloadRootDir);
         }
 
         static InstallStateContents GetCurrentInstallState(SdkFeatureBand sdkFeatureBand, string dotnetDir)
@@ -141,7 +143,7 @@ namespace Microsoft.DotNet.Workloads.Workload
 
         protected void UpdateWorkloadManifests(ITransactionContext context, DirectoryPath? offlineCache)
         {
-            var updateToLatestWorkloadSet = ShouldUseWorkloadSetMode(_sdkFeatureBand, _dotnetPath);
+            var updateToLatestWorkloadSet = ShouldUseWorkloadSetMode(_sdkFeatureBand, _workloadRootDir);
             if (UseRollback && updateToLatestWorkloadSet)
             {
                 // Rollback files are only for loose manifests. Update the mode to be loose manifests.
@@ -157,7 +159,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                 //  If a workload set version is specified, then switch to workload set update mode
                 //  Check to make sure the value needs to be changed, as updating triggers a UAC prompt
                 //  for MSI-based installs.
-                if (!ShouldUseWorkloadSetMode(_sdkFeatureBand, _dotnetPath))
+                if (!ShouldUseWorkloadSetMode(_sdkFeatureBand, _workloadRootDir))
                 {
                     _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, true);
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli
                 reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion()}");
             }
 
-            var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.DotnetPath), "default.json")).UseWorkloadSets;
+            var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;
             var workloadSetsString = useWorkloadSets == true ? "workload sets" : "loose manifests";
             reporter.WriteLine(string.Format(CommonStrings.WorkloadManifestInstallationConfiguration, workloadSetsString));
 

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
         public readonly SdkFeatureBand _currentSdkFeatureBand;
         private readonly string _targetSdkVersion;
         public string DotnetPath { get; }
+        public string UserLocalPath { get; }
 
         public WorkloadInfoHelper(
             bool isInteractive,
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 
             WorkloadRecordRepo = workloadRecordRepo ?? Installer.GetWorkloadInstallationRecordRepository();
 
-            DotnetPath = dotnetDir ?? (WorkloadFileBasedInstall.IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
+            UserLocalPath = dotnetDir ?? (WorkloadFileBasedInstall.IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
         }
 
         public IInstaller Installer { get; private init; }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -61,6 +61,8 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 shouldLog: false);
 
             WorkloadRecordRepo = workloadRecordRepo ?? Installer.GetWorkloadInstallationRecordRepository();
+
+            DotnetPath = dotnetDir ?? (WorkloadFileBasedInstall.IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
         }
 
         public IInstaller Installer { get; private init; }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
                     if (!_skipManifestUpdate)
                     {
-                        var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _dotnetPath), "default.json");
+                        var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkFeatureBand, _workloadRootDir), "default.json");
                         if (string.IsNullOrWhiteSpace(_fromRollbackDefinition) &&
                             !SpecifiedWorkloadSetVersionOnCommandLine &&
                             !SpecifiedWorkloadSetVersionInGlobalJson &&

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                 Reporter.WriteLine();
                 var shouldPrintTable = globalJsonInformation?.WorkloadVersionInstalled != false;
                 var shouldShowWorkloadSetVersion = globalJsonInformation is not null ||
-                    InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(_workloadListHelper._currentSdkFeatureBand, _workloadListHelper.DotnetPath), "default.json")).UseWorkloadSets == true;
+                    InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(_workloadListHelper._currentSdkFeatureBand, _workloadListHelper.UserLocalPath), "default.json")).UseWorkloadSets == true;
 
                 if (shouldShowWorkloadSetVersion)
                 {

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
             {
                 _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(
                     _includePreviews,
-                    ShouldUseWorkloadSetMode(_sdkFeatureBand, _dotnetPath),
+                    ShouldUseWorkloadSetMode(_sdkFeatureBand, _workloadRootDir),
                     string.IsNullOrWhiteSpace(_fromCacheOption) ?
                         null :
                         new DirectoryPath(_fromCacheOption))

--- a/src/Common/WorkloadFileBasedInstall.cs
+++ b/src/Common/WorkloadFileBasedInstall.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload
 {
@@ -34,7 +35,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                 sdkFeatureBand = $"{sdkVersionParsed.Major}.{sdkVersionParsed.Minor}.{Last2DigitsTo0(sdkVersionParsed.Build)}";
             }
 
-            return Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand, "userlocal");
+            return Path.Combine(dotnetDir, "metadata", "workloads", new SdkFeatureBand(sdkFeatureBand).ToString(), "userlocal");
         }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -64,13 +64,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
 
             _sdkRootPath = sdkRootPath;
-            _sdkOrUserLocalPath = sdkRootPath;
             _sdkVersionBand = new SdkFeatureBand(sdkVersion);
             _workloadSetVersionFromConstructor = workloadSetVersion;
             _globalJsonPathFromConstructor = globalJsonPath;
 
             string? userManifestsRoot = userProfileDir is null ? null : Path.Combine(userProfileDir, "sdk-manifests");
-            string dotnetManifestRoot = Path.Combine(_sdkOrUserLocalPath, "sdk-manifests");
+            string dotnetManifestRoot = Path.Combine(_sdkRootPath, "sdk-manifests");
             if (userManifestsRoot != null && WorkloadFileBasedInstall.IsUserLocal(_sdkRootPath, _sdkVersionBand.ToString()) && Directory.Exists(userManifestsRoot))
             {
                 _sdkOrUserLocalPath = userProfileDir ?? _sdkRootPath;
@@ -84,10 +83,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 _manifestRoots = new[] { dotnetManifestRoot };
             }
 
-            var knownManifestIdsFilePath = Path.Combine(_sdkOrUserLocalPath, "sdk", sdkVersion, "KnownWorkloadManifests.txt");
+            _sdkOrUserLocalPath ??= _sdkRootPath;
+
+            var knownManifestIdsFilePath = Path.Combine(_sdkRootPath, "sdk", sdkVersion, "KnownWorkloadManifests.txt");
             if (!File.Exists(knownManifestIdsFilePath))
             {
-                knownManifestIdsFilePath = Path.Combine(_sdkOrUserLocalPath, "sdk", sdkVersion, "IncludedWorkloadManifests.txt");
+                knownManifestIdsFilePath = Path.Combine(_sdkRootPath, "sdk", sdkVersion, "IncludedWorkloadManifests.txt");
             }
 
             if (File.Exists(knownManifestIdsFilePath))

--- a/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -161,7 +161,17 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var updateParseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-previous-sdk" });
             var updateCommand = new WorkloadUpdateCommand(updateParseResult, reporter: _reporter, workloadResolverFactory, nugetPackageDownloader: nugetDownloader,
                 workloadManifestUpdater: manifestUpdater, tempDirPath: testDirectory);
+            var installStatePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(new SdkFeatureBand(sdkFeatureVersion), installRoot), "default.json");
+            var oldInstallState = InstallStateContents.FromPath(installStatePath);
+            oldInstallState.Manifests = new Dictionary<string, string>()
+            {
+                {installingWorkload, $"6.0.102/{sdkFeatureVersion}" }
+            };
+            Directory.CreateDirectory(Path.GetDirectoryName(installStatePath));
+            File.WriteAllText(installStatePath, oldInstallState.ToString());
             updateCommand.Execute();
+            var newInstallState = InstallStateContents.FromPath(installStatePath);
+            newInstallState.Manifests.Should().BeNull();
 
             foreach (var pack in workloadPacks)
             {


### PR DESCRIPTION
Fixes #41420 and #41726 

This attempts to find everywhere that we currently assume not-userlocal (where it's supported) and changes it to respect userlocal if specified.

As far as testing, I tried to do `dotnet workload update` with an SDK without this update, and it broke. I then tried it with these changes, and it succeeded.

I'm not very knowledgeable about what scenarios I should target. I'll keep testing things I can think of, but do either of you have a suggestion on where to focus my testing energy @baronfel @tmds?