### PR TITLE
Avoid redistributing MSBuild.dll

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -29,7 +29,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(MSBuildPathInPackage)')" Text="Something moved around in Microsoft.Build.Runtime, adjust code here accordingly." />
     <ItemGroup>
-      <Reference Include="$(MSBuildPathInPackage)" />
+      <Reference Include="$(MSBuildPathInPackage)" Private="false" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Drops 4 copies of this ~400KB file from the SDK.

It should never be loaded from this location since the tasks only make sense in an already running MSBuild.
