### PR TITLE
Error condition fix Fixes #40297

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -123,6 +123,13 @@ namespace Microsoft.DotNet.Workloads.Workload
                 _workloadInstaller.UpdateInstallMode(_sdkFeatureBand, true);
             }
 
+            // Delete the current advertising manifest because if we fail to find the right workload version, we want to fail.
+            var advertisingPackagePath = Path.Combine(_userProfileDir, "sdk-advertising", _sdkFeatureBand.ToString(), "microsoft.net.workloads");
+            if (Directory.Exists(advertisingPackagePath))
+            {
+                Directory.Delete(advertisingPackagePath, recursive: true);
+            }
+
             _workloadManifestUpdater.DownloadWorkloadSet(_workloadSetVersionFromGlobalJson ?? _workloadSetVersion, offlineCache);
             return TryInstallWorkloadSet(context, out updates, throwOnFailure: true);
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/LocalizableStrings.resx
@@ -160,6 +160,6 @@
     <value>No workload update found.</value>
   </data>
   <data name="WorkloadVersionRequestedNotFound" xml:space="preserve">
-    <value>Workload version {0} not found.</value>
+    <value>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.cs.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Verze úlohy {0} nebyla nalezena.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Verze úlohy {0} nebyla nalezena.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.de.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Die Workloadversion „{0}“ wurde nicht gefunden.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Die Workloadversion „{0}“ wurde nicht gefunden.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.es.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">No se encontró la versión de carga de trabajo {0}.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">No se encontró la versión de carga de trabajo {0}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.fr.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Nous n’avons pas pu trouver la version de la charge de travail {0}.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Nous n’avons pas pu trouver la version de la charge de travail {0}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.it.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Versione del carico di lavoro {0} non trovata.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Versione del carico di lavoro {0} non trovata.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ja.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">ワークロード バージョン {0} が見つかりませんでした。</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">ワークロード バージョン {0} が見つかりませんでした。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ko.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">워크로드 버전 {0}을(를) 찾을 수 없습니다.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">워크로드 버전 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pl.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Nie znaleziono wersji obciążenia {0}.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Nie znaleziono wersji obciążenia {0}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">A versão da carga de trabalho {0} não foi encontrada.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">A versão da carga de trabalho {0} não foi encontrada.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.ru.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">Версия рабочей нагрузки {0} не найдена.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">Версия рабочей нагрузки {0} не найдена.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.tr.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">{0} iş yükü sürümü bulunamadı.</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">{0} iş yükü sürümü bulunamadı.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">找不到工作负载版本 {0}。</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">找不到工作负载版本 {0}。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WorkloadVersionRequestedNotFound">
-        <source>Workload version {0} not found.</source>
-        <target state="translated">找不到工作負載版本 {0}。</target>
+        <source>Workload version {0} not found. Adding a feed that contains it to your NuGet.config may help.</source>
+        <target state="needs-review-translation">找不到工作負載版本 {0}。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #40297

This makes an error message a little more clear and ensures that the error actually fires when appropriate. Previously, if a user had successfully installed a workload set, then immediately tried to run, for example, `dotnet workload update --version 8.0.422` where 8.0.422 doesn't exist, it would fail to find 8.0422 and instead find the previous version found and 'install' that instead, claiming success. Then it would butcher the install state file and fail. This ensures that it fails early enough to not do that and in a clearer way.