### PR TITLE
Containers telemetry

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -32,6 +32,19 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string UseArtifactsOutputTelemetryPropertyKey = "UseArtifactsOutput";
         internal const string ArtifactsPathLocationTypeTelemetryPropertyKey = "ArtifactsPathLocationType";
 
+        /// <summary>
+        /// This is defined in <see cref="ComputeDotnetBaseImageAndTag.cs"/>
+        /// </summary>
+        internal const string SdkContainerPublishBaseImageInferenceEventName = "sdk/container/inference";
+        /// <summary>
+        /// This is defined in <see cref="CreateNewImage.cs"/>
+        /// </summary>
+        internal const string SdkContainerPublishSuccessEventName = "sdk/container/publish/success";
+        /// <summary>
+        /// This is defined in <see cref="CreateNewImage.cs"/>
+        /// </summary>
+        internal const string SdkContainerPublishErrorEventName = "sdk/container/publish/error";
+
         public MSBuildLogger()
         {
             try
@@ -130,7 +143,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 case PublishPropertiesTelemetryEventName:
                 case ReadyToRunTelemetryEventName:
                 case WorkloadPublishPropertiesTelemetryEventName:
-                    TrackEvent(telemetry, args.EventName, args.Properties, Array.Empty<string>(), Array.Empty<string>() );
+                case SdkContainerPublishBaseImageInferenceEventName:
+                case SdkContainerPublishSuccessEventName:
+                case SdkContainerPublishErrorEventName:
+                    TrackEvent(telemetry, args.EventName, args.Properties, Array.Empty<string>(), Array.Empty<string>());
                     break;
                 default:
                     // Ignore unknown events

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             {
                 if (eventProperties.TryGetValue(propertyToBeHashed, out string value))
                 {
-                    // Lets lazy allocate in case there is tons of telemetry 
+                    // Lets lazy allocate in case there is tons of telemetry
                     properties ??= new Dictionary<string, string>(eventProperties);
                     properties[propertyToBeHashed] = Sha256Hasher.HashWithNormalizedCasing(value);
                 }
@@ -173,7 +173,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             {
                 if (eventProperties.TryGetValue(propertyToBeMeasured, out string value))
                 {
-                    // Lets lazy allocate in case there is tons of telemetry 
+                    // Lets lazy allocate in case there is tons of telemetry
                     properties ??= new Dictionary<string, string>(eventProperties);
                     properties.Remove(propertyToBeMeasured);
                     if (double.TryParse(value, CultureInfo.InvariantCulture, out double realValue))

--- a/src/Containers/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
@@ -6,5 +6,11 @@ namespace Microsoft.NET.Build.Containers;
 public sealed class BaseImageNotFoundException : Exception
 {
     internal BaseImageNotFoundException(string specifiedRuntimeIdentifier, string repositoryName, string reference, IEnumerable<string> supportedRuntimeIdentifiers)
-            : base($"The RuntimeIdentifier '{specifiedRuntimeIdentifier}' is not supported by {repositoryName}:{reference}. The supported RuntimeIdentifiers are {String.Join(",", supportedRuntimeIdentifiers)}") {}
+            : base($"The RuntimeIdentifier '{specifiedRuntimeIdentifier}' is not supported by {repositoryName}:{reference}. The supported RuntimeIdentifiers are {String.Join(",", supportedRuntimeIdentifiers)}")
+    {
+        RequestedRuntimeIdentifier = specifiedRuntimeIdentifier;
+        AvailableRuntimeIdentifiers = supportedRuntimeIdentifiers;
+    }
+    internal string RequestedRuntimeIdentifier { get; }
+    internal IEnumerable<string> AvailableRuntimeIdentifiers { get; }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -46,6 +46,7 @@
     <Compile Include="KnownStrings.cs" />
     <Compile Include="DockerLoadException.cs" />
     <Compile Include="LocalDaemons/DockerCli.cs" />
+    <Compile Include="Registry/RegistryConstants.cs" />
     <Compile Include="Tasks/ParseContainerProperties.cs" />
     <Compile Include="Tasks/CreateNewImage.Interface.cs" />
     <Compile Include="Tasks/CreateNewImageToolTask.cs" />

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -13,6 +13,9 @@ Microsoft.NET.Build.Containers.Port.Port() -> void
 Microsoft.NET.Build.Containers.Port.Port(int Number, Microsoft.NET.Build.Containers.PortType Type) -> void
 Microsoft.NET.Build.Containers.Port.Type.get -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.Port.Type.set -> void
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.get -> string?
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UserBaseImage.get -> string?
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UserBaseImage.set -> void
 ~override Microsoft.NET.Build.Containers.Port.ToString() -> string
 static Microsoft.NET.Build.Containers.Port.operator !=(Microsoft.NET.Build.Containers.Port left, Microsoft.NET.Build.Containers.Port right) -> bool
 static Microsoft.NET.Build.Containers.Port.operator ==(Microsoft.NET.Build.Containers.Port left, Microsoft.NET.Build.Containers.Port right) -> bool
@@ -126,7 +129,6 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantG
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantGlobalization.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ComputeDotnetBaseImageAndTag() -> void
-Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.set -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ const Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.Podman = "Podman" -
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ComputedContainerBaseImage.get -> string?
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.get -> string?
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkReferences.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.FrameworkReferences.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsAotPublished.get -> bool
@@ -13,6 +14,8 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContaine
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.IsSelfContained.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetRuntimeIdentifier.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetRuntimeIdentifier.set -> void
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UserBaseImage.get -> string?
+Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UserBaseImage.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantGlobalization.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantGlobalization.set -> void
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
@@ -125,7 +128,6 @@ Microsoft.NET.Build.Containers.PortType.tcp = 0 -> Microsoft.NET.Build.Container
 Microsoft.NET.Build.Containers.PortType.udp = 1 -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ComputeDotnetBaseImageAndTag() -> void
-Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.ContainerFamily.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.set -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
@@ -39,7 +39,7 @@ internal static class HttpExtensions
     internal static bool IsAmazonECRRegistry(this Uri uri)
     {
         // If this the registry is to public ECR the name will contain "public.ecr.aws".
-        if (uri.Authority.Contains("public.ecr.aws"))
+        if (uri.Authority.Contains(RegistryConstants.PublicAmazonElasticContainerRegistryDomain))
         {
             return true;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -120,12 +120,12 @@ internal sealed class Registry
     /// <summary>
     /// Check to see if the registry is GitHub Packages, which always uses ghcr.io.
     /// </summary>
-    public bool IsGithubPackageRegistry => RegistryName.StartsWith("ghcr.io", StringComparison.Ordinal);
+    public bool IsGithubPackageRegistry => RegistryName.StartsWith(RegistryConstants.GitHubPackageRegistryDomain, StringComparison.Ordinal);
 
     /// <summary>
     /// Is this registry the public Microsoft Container Registry.
     /// </summary>
-    public bool IsMcr => RegistryName.Equals("mcr.microsoft.com", StringComparison.Ordinal);
+    public bool IsMcr => RegistryName.Equals(RegistryConstants.MicrosoftContainerRegistryDomain, StringComparison.Ordinal);
 
     /// <summary>
     /// Check to see if the registry is Docker Hub, which uses two well-known domains.

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -140,6 +140,8 @@ internal sealed class Registry
         get => RegistryName.EndsWith("-docker.pkg.dev", StringComparison.Ordinal);
     }
 
+    public bool IsAzureContainerRegistry => RegistryName.EndsWith(".azurecr.io", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
     /// Pushing to ECR uses a much larger chunk size. To avoid getting too many socket disconnects trying to do too many
     /// parallel uploads be more conservative and upload one layer at a time.

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -123,6 +123,11 @@ internal sealed class Registry
     public bool IsGithubPackageRegistry => RegistryName.StartsWith("ghcr.io", StringComparison.Ordinal);
 
     /// <summary>
+    /// Is this registry the public Microsoft Container Registry.
+    /// </summary>
+    public bool IsMCR => RegistryName.Equals("mcr.microsoft.com", StringComparison.Ordinal);
+
+    /// <summary>
     /// Check to see if the registry is Docker Hub, which uses two well-known domains.
     /// </summary>
     public bool IsDockerHub => RegistryName.Equals(ContainerHelpers.DockerRegistryAlias, StringComparison.Ordinal)

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -125,7 +125,7 @@ internal sealed class Registry
     /// <summary>
     /// Is this registry the public Microsoft Container Registry.
     /// </summary>
-    public bool IsMCR => RegistryName.Equals("mcr.microsoft.com", StringComparison.Ordinal);
+    public bool IsMcr => RegistryName.Equals("mcr.microsoft.com", StringComparison.Ordinal);
 
     /// <summary>
     /// Check to see if the registry is Docker Hub, which uses two well-known domains.

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistryConstants.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistryConstants.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Containers;
+
+internal static class RegistryConstants
+{
+    public static string GitHubPackageRegistryDomain = "ghcr.io";
+    public static string MicrosoftContainerRegistryDomain = "mcr.microsoft.com";
+    public static string PublicAmazonElasticContainerRegistryDomain = "public.ecr.aws";
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -117,7 +117,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
             if (ComputeRepositoryAndTag(out var repository, out var tag))
             {
                 ComputedContainerBaseImage = $"{defaultRegistry}/{repository}:{tag}";
-                LogInferencePerformedTelemetry($"{defaultRegistry}/{repository}", tag);
+                LogInferencePerformedTelemetry($"{defaultRegistry}/{repository}", tag!);
             }
             return !Log.HasLoggedErrors;
         }
@@ -211,7 +211,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
                 // in question, and the app is globalized, we can help and add -extra so the app will actually run
 
                 if (
-                    (!IsMuslRid && ContainerFamily.EndsWith("-chiseled")) // default for linux RID
+                    (!IsMuslRid && ContainerFamily!.EndsWith("-chiseled")) // default for linux RID
                     && !UsesInvariantGlobalization
                     && versionAllowsUsingAOTAndExtrasImages
                     // the extras only became available on the stable tags of the FirstVersionWithNewTaggingScheme

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -325,7 +325,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
         LogTelemetryData(telemetryData);
     }
 
-    private PublishMode GetTelemetryPublishMode() => IsAotPublished ? PublishMode.AOT : IsTrimmed ? PublishMode.Trimmed : IsSelfContained ? PublishMode.SelfContained : PublishMode.FrameworkDependent;
+    private PublishMode GetTelemetryPublishMode() => IsAotPublished ? PublishMode.Aot : IsTrimmed ? PublishMode.Trimmed : IsSelfContained ? PublishMode.SelfContained : PublishMode.FrameworkDependent;
     private ProjectType GetTelemetryProjectType() => IsAspNetCoreProject ? ProjectType.AspNetCore : ProjectType.Console;
 
     private string ParseSemVerToMajorMinor(string semver) => SemanticVersion.Parse(semver).ToString("x.y", VersionFormatter.Instance);
@@ -371,7 +371,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
         FrameworkDependent,
         SelfContained,
         Trimmed,
-        AOT
+        Aot
     }
 
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -113,7 +113,7 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
         }
         else
         {
-            var defaultRegistry = "mcr.microsoft.com";
+            var defaultRegistry = RegistryConstants.MicrosoftContainerRegistryDomain;
             if (ComputeRepositoryAndTag(out var repository, out var tag))
             {
                 ComputedContainerBaseImage = $"{defaultRegistry}/{repository}:{tag}";

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -105,7 +105,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             }
             catch (BaseImageNotFoundException e)
             {
-                telemetry.LogRIDMismatch(e.RequestedRuntimeIdentifier, e.AvailableRuntimeIdentifiers.ToArray());
+                telemetry.LogRidMismatch(e.RequestedRuntimeIdentifier, e.AvailableRuntimeIdentifiers.ToArray());
                 Log.LogErrorFromException(e, showStackTrace: false, showDetail: true, file: null);
                 return !Log.HasLoggedErrors;
             }
@@ -356,7 +356,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     private RegistryType GetRegistryType(Registry r)
     {
-        if (r.IsMCR) return RegistryType.MCR;
+        if (r.IsMcr) return RegistryType.MCR;
         if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
         if (r.IsAmazonECRRegistry) return RegistryType.AWS;
         if (r.IsAzureContainerRegistry) return RegistryType.Azure;
@@ -424,7 +424,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             Log.LogTelemetry("sdk/container/publish/error", props);
         }
 
-        public void LogRIDMismatch(string desiredRid, string[] availableRids)
+        public void LogRidMismatch(string desiredRid, string[] availableRids)
         {
             var props = ContextProperties();
             props.Add("error", "rid_mismatch");

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -118,7 +118,6 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         if (imageBuilder is null)
         {
             Log.LogErrorWithCodeFromResources(nameof(Strings.BaseImageNotFound), sourceImageReference, ContainerRuntimeIdentifier);
-
             return !Log.HasLoggedErrors;
         }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -356,6 +356,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     private RegistryType GetRegistryType(Registry r)
     {
+        if (r.IsMCR) return RegistryType.MCR;
         if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
         if (r.IsAmazonECRRegistry) return RegistryType.AWS;
         if (r.IsAzureContainerRegistry) return RegistryType.Azure;
@@ -374,7 +375,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
     }
 
     private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
-    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, Other }
+    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
     private enum LocalStorageType { Docker, Podman, Tarball }
 
     private class Telemetry(Microsoft.Build.Utilities.TaskLoggingHelper Log, PublishTelemetryContext context)

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -374,6 +374,14 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         else return LocalStorageType.Podman;
     }
 
+    /// <summary>
+    /// Interesting data about the container publish - used to track the usage rates of various sources/targets of the process
+    /// and to help diagnose issues with the container publish overall.
+    /// </summary>
+    /// <param name="RemotePullType">If the base image came from a remote registry, what kind of registry was it?</param>
+    /// <param name="LocalPullType">If the base image came from a local store of some kind, what kind of store was it?</param>
+    /// <param name="RemotePushType">If the new image is being pushed to a remote registry, what kind of registry is it?</param>
+    /// <param name="LocalPushType">If the new image is being stored in a local store of some kind, what kind of store is it?</param>
     private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
     private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
     private enum LocalStorageType { Docker, Podman, Tarball }

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -38,12 +38,10 @@
            For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == ''">linux-$(NETCoreSdkPortableRuntimeIdentifier.Split('-')[1])</ContainerRuntimeIdentifier>
-      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' == ''">true</_ContainerIsUsingMicrosoftDefaultImages>
-      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' != ''">false</_ContainerIsUsingMicrosoftDefaultImages>
     </PropertyGroup>
 
     <ComputeDotnetBaseImageAndTag
-      Condition="$(_ContainerIsUsingMicrosoftDefaultImages)"
+      UserBaseImage="$(ContainerBaseImage)"
       SdkVersion="$(NetCoreSdkVersion)"
       TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV).0"
       FrameworkReferences="@(FrameworkReference)"

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -38,6 +38,8 @@
            For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == ''">linux-$(NETCoreSdkPortableRuntimeIdentifier.Split('-')[1])</ContainerRuntimeIdentifier>
+      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' == ''">true</_ContainerIsUsingMicrosoftDefaultImages>
+      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' != ''">false</_ContainerIsUsingMicrosoftDefaultImages>
     </PropertyGroup>
 
     <ComputeDotnetBaseImageAndTag


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/539

Adds telemetry for base image inference, container publishing, and a variety of errors that can occur along the process.

- [x] add success telemetry
- [x] add error telemetry
- [x] add telemetry to allowlist in SDK's MSBuild logger
- [x] verify telemetry is ingested
- [x] classify new data points
- [x] [document new data points in the CLI docs/Containers docs](https://github.com/dotnet/sdk-container-builds/pull/586)

