### PR TITLE
Prefer the portable ILCompiler when publishing for the portable RID on a source-built SDK.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -782,19 +782,11 @@ namespace Microsoft.NET.Build.Tasks
 
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
                 var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-                string hostRuntimeIdentifier = null;
-                // When a non-portable SDK publishes for its non-portable RID specifically, prefer a non-portable host package.
-                string portableSdkRid = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier) ? NETCoreSdkPortableRuntimeIdentifier : RuntimeIdentifier;
-                bool isNonPortablePublish = RuntimeIdentifier == NETCoreSdkRuntimeIdentifier && NETCoreSdkRuntimeIdentifier != portableSdkRid;
-                if (isNonPortablePublish)
-                {
-                    hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
-                }
-                // Otherwise, non-portable SDKs behave the same as portable SDKs.
-                if (hostRuntimeIdentifier == null)
-                {
-                    hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, portableSdkRid, packSupportedRuntimeIdentifiers, out bool wasInGraph);
-                }
+                // When publishing for the RuntimeIdentifier that matches NETCoreSdkPortableRuntimeIdentifier, prefer NETCoreSdkPortableRuntimeIdentifier for the host.
+                // This makes us use a portable ILCompiler when publishing for a portable RID on a non-portable SDK.
+                string hostRuntimeIdentifier = RuntimeIdentifier == NETCoreSdkPortableRuntimeIdentifier ? NETCoreSdkPortableRuntimeIdentifier : NETCoreSdkRuntimeIdentifier;
+                // Find the best ILCompiler for hostRuntimeIdentifier.
+                hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, hostRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
                 if (hostRuntimeIdentifier == null)
                 {
                     return ToolPackSupport.UnsupportedForHostRuntimeIdentifier;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -780,12 +780,11 @@ namespace Microsoft.NET.Build.Tasks
                 var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
                 var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(';');
 
-                // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
-                var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
                 // When publishing for the RuntimeIdentifier that matches NETCoreSdkPortableRuntimeIdentifier, prefer NETCoreSdkPortableRuntimeIdentifier for the host.
                 // This makes us use a portable ILCompiler when publishing for a portable RID on a non-portable SDK.
                 string hostRuntimeIdentifier = RuntimeIdentifier == NETCoreSdkPortableRuntimeIdentifier ? NETCoreSdkPortableRuntimeIdentifier : NETCoreSdkRuntimeIdentifier;
-                // Find the best ILCompiler for hostRuntimeIdentifier.
+                // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
+                var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
                 hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, hostRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
                 if (hostRuntimeIdentifier == null)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -132,6 +132,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 KnownWebAssemblySdkPacks="@(KnownWebAssemblySdkPack)"
                                 UsingMicrosoftNETSdkWebAssembly="$(UsingMicrosoftNETSdkWebAssembly)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
+                                NETCoreSdkPortableRuntimeIdentifier="$(NETCoreSdkPortableRuntimeIdentifier)"
                                 NetCoreRoot="$(NetCoreRoot)"
                                 NETCoreSdkVersion="$(NETCoreSdkVersion)">
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/41727.

cc @omajid @am11 @dsplaisted @baronfel @jkotas @ViktorHofer