### PR TITLE
Dispose HttpClient in NugetToolSearchApiRequest

### DIFF
--- a/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.NugetSearch
                 nugetSearchApiParameter.Take,
                 nugetSearchApiParameter.Prerelease);
 
-            var httpClient = new HttpClient();
+            using var httpClient = new HttpClient();
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             HttpResponseMessage response = await httpClient.GetAsync(queryUrl, cancellation.Token);
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
We create a new instance every time, we should probably Dispose it too.