### PR TITLE
Create 0001-define-runtime-dependencies.patch

### DIFF
--- a/src/SourceBuild/patches/fsharp/0001-define-runtime-dependencies.patch
+++ b/src/SourceBuild/patches/fsharp/0001-define-runtime-dependencies.patch
@@ -1,0 +1,65 @@
+From cfa1c6a72f1e98418b7abcfcd0a818a62fedf512 Mon Sep 17 00:00:00 2001
+From: Viktor Hofer <viktor.hofer@microsoft.com>
+Date: Mon, 24 Jun 2024 19:57:06 +0200
+Subject: [PATCH] Add dependencies for System libraries
+
+Fixes https://github.com/dotnet/source-build/issues/4477
+
+Source-build lifts the MSBuild package versions to the N-1
+(previously produced assets) but fsharp pins the
+System.Reflection.Metadata (and similar System libs) version
+which is a transitive dependency to 8.0.0. That results in a
+package downgrade error. Define a dependency for
+System.Reflection.Metadata (and other System libs) so that
+source-build can lift that version as well.
+
+Backport PR: https://github.com/dotnet/fsharp/pull/17344
+
+---
+ eng/Version.Details.xml | 12 ++++++++++++
+ eng/Versions.props      |  2 --
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index dea57c3b5..1bc5f3bf0 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -28,6 +28,18 @@
+       <Uri>https://github.com/dotnet/msbuild</Uri>
+       <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+     </Dependency>
++    <Dependency Name="System.Reflection.Metadata" Version="8.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
++    </Dependency>
++    <Dependency Name="System.Collections.Immutable" Version="8.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
++    </Dependency>
++    <Dependency Name="System.Threading.Tasks.Dataflow" Version="8.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
++    </Dependency>
+   </ProductDependencies>
+   <ToolsetDependencies>
+     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 9a1da2fc0..4a8517632 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -91,7 +91,6 @@
+     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
+     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
+     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
+-    <!-- -->
+     <!-- Versions for package groups -->
+     <RoslynVersion>4.11.0-2.24264.2</RoslynVersion>
+     <VisualStudioEditorPackagesVersion>17.10.191</VisualStudioEditorPackagesVersion>
+@@ -99,7 +98,6 @@
+     <VisualStudioProjectSystemPackagesVersion>17.10.526-pre-g1b474069f5</VisualStudioProjectSystemPackagesVersion>
+     <MicrosoftVisualStudioThreadingPackagesVersion>17.10.41</MicrosoftVisualStudioThreadingPackagesVersion>
+     <MicrosoftBuildVersion>17.11.0-preview-24178-03</MicrosoftBuildVersion>
+-    <!-- -->
+     <!-- Roslyn packages -->
+     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
+     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>


### PR DESCRIPTION
9.0 Preview 6 patch for https://github.com/dotnet/fsharp/pull/17344

Tell-mode as necessary to ship source-build.