### PR TITLE
Adding SignalR CustomAwaitable feature switch

### DIFF
--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -57,6 +57,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Enable the built-in source generators. -->
     <EnableRequestDelegateGenerator Condition="'$(EnableRequestDelegateGenerator)' == ''">true</EnableRequestDelegateGenerator>
     <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">true</EnableConfigurationBindingGenerator>
+
+    <!-- Default feature switch values for trimmed apps. -->
+    <SignalRCustomAwaitableSupport Condition="'$(SignalRCustomAwaitableSupport)' == ''">false</SignalRCustomAwaitableSupport>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/WebSdk/Web/Targets/Sdk.Server.targets
+++ b/src/WebSdk/Web/Targets/Sdk.Server.targets
@@ -31,4 +31,19 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk.Web.ProjectSystem" Project="Sdk.targets" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" />
+
+  <!--
+  ============================================================
+    DefaultRuntimeHostConfigurationOptions
+  Defaults @(RuntimeHostConfigurationOption) items based on MSBuild properties.
+  ============================================================
+  -->
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Microsoft.AspNetCore.SignalR.Hub.IsCustomAwaitableSupported"
+                                    Condition="'$(SignalRCustomAwaitableSupport)' != ''"
+                                    Value="$(SignalRCustomAwaitableSupport)"
+                                    Trim="true" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -39,6 +39,8 @@ namespace Microsoft.NET.Sdk.Web.Tests
             JsonNode runtimeConfig = JsonNode.Parse(runtimeConfigContents);
             JsonNode configProperties = runtimeConfig["runtimeOptions"]["configProperties"];
 
+            configProperties["Microsoft.AspNetCore.SignalR.Hub.IsCustomAwaitableSupported"].GetValue<bool>()
+                    .Should().BeFalse();
             configProperties["System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault"].GetValue<bool>()
                     .Should().BeFalse();
         }
@@ -94,6 +96,7 @@ namespace Microsoft.NET.Sdk.Web.Tests
             string responseFile = Path.Combine(outputDirectory, "native", $"{projectName}.ilc.rsp");
             var responseFileContents = File.ReadLines(responseFile);
 
+            responseFileContents.Should().Contain("--feature:Microsoft.AspNetCore.SignalR.Hub.IsCustomAwaitableSupported=false");
             responseFileContents.Should().Contain("--feature:System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault=false");
             responseFileContents.Should().Contain("--feature:System.Diagnostics.Tracing.EventSource.IsSupported=true");
             responseFileContents.Should().Contain("--runtimeknob:System.GC.DynamicAdaptationMode=1");


### PR DESCRIPTION
This is the SDK portion of changes needed to make SignalR compatible with native AOT. See https://github.com/dotnet/aspnetcore/pull/56460.