### PR TITLE
Update CODEOWNERS to include ClickOnce contributors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,6 +68,7 @@
 /test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs @AntonLapounov
 # Publish.targets related to ILLink and ReadyToRun is own by both runtime and SDK team
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink-contrib @AntonLapounov @dotnet/dotnet-cli
+# Area-ClickOnce
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
 
 # Area-Watch


### PR DESCRIPTION
cc @sujitnayak - adding this CodeOwners line will make any issues with the label `Area-ClickOnce` get auto-assigned to you for triage, so we don't have to keep cc'ing you manually :)