### PR TITLE
Use CPM in Binary Tool

### DIFF
--- a/src/SourceBuild/content/eng/tools/BinaryToolKit/BinaryToolKit.csproj
+++ b/src/SourceBuild/content/eng/tools/BinaryToolKit/BinaryToolKit.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CustomPackageVersionsProps></CustomPackageVersionsProps>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4487

In order for the binary tool to use the versions of the packages specified in CustomPackageVersionsProps, we need to specify that we are using CPM.

[Example build with change](https://dev.azure.com/dnceng/internal/_build/results?buildId=2486129&view=logs&j=609589e2-4f74-5576-cdb7-914bcaea778b) (internal Microsoft link)