### PR TITLE
Update Directory.Packages.props

### DIFF
--- a/src/SourceBuild/content/Directory.Packages.props
+++ b/src/SourceBuild/content/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>

--- a/src/SourceBuild/content/Directory.Packages.props
+++ b/src/SourceBuild/content/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4487

Needed because https://github.com/NuGet/NuGet.Client/pull/5876 reverts implicitly setting `ManagePackageVersionsCentrally` to true.