### PR TITLE
Fix dogfood script

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -39,7 +39,7 @@ try {
 
   $TestDotnetRoot = Join-Path $ArtifactsDir "bin\redist\$configuration\dotnet"
 
-  $testDotnetVersion = (Get-Childitem -Directory "$TestDotnetRoot\sdk")[-1]
+  $testDotnetVersion = (Get-Childitem -Directory "$TestDotnetRoot\sdk")[-1].Name
   $env:DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR = Join-Path $TestDotnetRoot "sdk\$testDotnetVersion\Sdks"
   $env:MicrosoftNETBuildExtensionsTargets = Join-Path $ArtifactsDir "bin\$configuration\Sdks\Microsoft.NET.Build.Extensions\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.targets"
 


### PR DESCRIPTION
It was setting `DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR` to something like `D:\sdk-3\artifacts\bin\redist\Debug\dotnet\sdk\D:\sdk-3\artifacts\bin\redist\Debug\dotnet\sdk\9.0.100-dev\Sdks` (because `$testDotnetVersion` was a full path not a directory name) and so a build using that dogfood SDK and msbuild was then failing with

```
D:\sdk-3\artifacts\bin\redist\Debug\dotnet\sdk\D:\sdk-3\artifacts\bin\redist\Debug\dotnet\sdk\9.0.100-dev\Sdks\Microsoft.NET.Sdk.Web\Sdk not found
```