### PR TITLE
Fix workload install or update with workload set specified in global.json

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -141,7 +141,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadAlreadyInstalled, string.Join(" ", previouslyInstalledWorkloads)).Yellow());
                     }
                     workloadIds = workloadIds.Concat(installedWorkloads).Distinct();
-                    workloadIds = WriteSDKInstallRecordsForVSWorkloads(workloadIds);
 
                     if (!_skipManifestUpdate)
                     {
@@ -168,6 +167,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                             }
                             UpdateWorkloadManifests(context, offlineCache);
                         }
+
+                        //   This depends on getting the available workloads, so it needs to run after manifests hae potentially been installed
+                        workloadIds = WriteSDKInstallRecordsForVSWorkloads(workloadIds);
+
                         _workloadInstaller.InstallWorkloads(workloadIds, _sdkFeatureBand, context, offlineCache);
 
                         //  Write workload installation records

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -94,13 +94,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 Reporter.WriteLine();
                 try
                 {
-                    var workloadIds = WriteSDKInstallRecordsForVSWorkloads(GetUpdatableWorkloads());
+                    IEnumerable<WorkloadId> workloadIds = Enumerable.Empty<WorkloadId>();                    
 
                     DirectoryPath? offlineCache = string.IsNullOrWhiteSpace(_fromCacheOption) ? null : new DirectoryPath(_fromCacheOption);
 
                     RunInNewTransaction(context =>
                     {
                         UpdateWorkloadManifests(context, offlineCache);
+
+                        //   This depends on getting the available workloads, so it needs to run after manifests hae potentially been installed
+                        workloadIds = WriteSDKInstallRecordsForVSWorkloads(GetUpdatableWorkloads());
+
                         _workloadInstaller.InstallWorkloads(workloadIds, _sdkFeatureBand, context, offlineCache);
                     });
 

--- a/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -137,6 +137,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             }
             else
             {
+                //  TODO: This doesn't work if we've installed additional runtimes to support the SDK
                 VM.GetRemoteDirectory($@"c:\Program Files\dotnet")
                     .Should()
                     .NotExist();

--- a/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/src/Tests/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -189,8 +189,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--source", @"c:\SdkTesting\workloadsets")
                 .Execute()
                 .Should()
-                .Pass()
-                .And.HaveStdOutContaining("No workload update found");
+                .Fail();
 
             VM.CreateRunCommand("dotnet", "workload", "search")
                 .WithIsReadOnly(true)


### PR DESCRIPTION
Fixes issue where if a workload set was specified in global.json, and that workload set wasn't installed, then workload install and update commands would fail.  This was because the process to write install records for VS workloads depended on having valid manifests.  Fixed this by moving the process to write install records to after manifests are updated.

Also updated VM tests to be able to install additional .NET runtimes, which should allow us to continue to use the same baseline installer and workload set versions over time.