### PR TITLE
Pass along top-level UseSystemLibs option to runtime

### DIFF
--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -23,6 +23,7 @@
     <BuildArgs Condition="'$(DotNetBuildMonoAOTEnableLLVM)' != ''">$(BuildArgs) /p:DotNetBuildMonoAOTEnableLLVM=$(DotNetBuildMonoAOTEnableLLVM)</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildMonoBundleLLVMOptimizer)' != ''">$(BuildArgs) /p:DotNetBuildMonoBundleLLVMOptimizer=$(DotNetBuildMonoBundleLLVMOptimizer)</BuildArgs>
     <BuildArgs Condition="'$(PgoInstrument)' == 'true'">$(BuildArgs) $(FlagParameterPrefix)pgoinstrument</BuildArgs>
+    <BuildArgs Condition="'$(UseSystemLibs)' != ''">$(BuildArgs) /p:UseSystemLibs=$(UseSystemLibs)</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">


### PR DESCRIPTION
Some environments, at least some Linux distributions, want to use system versions of certain libraries rather than the source code copy shipped with the .NET runtime source repository. We can provide a top-level flag to support this scenario that can be used like this:

    ./build.sh -p:UseSystemLibs=brotli+libunwind+rapidjson+zlib

Which makes the VMR build the runtime repo such that it uses the system version of brotli, libunwind, rapidjson and zlib.

This is another attempt at https://github.com/dotnet/installer/pull/19640

It depends on https://github.com/dotnet/runtime/pull/104440 to work.