### PR TITLE
Permit loose manifest priority

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -190,6 +190,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             {
                 var maxWorkloadSetVersion = availableWorkloadSets.Keys.Aggregate((s1, s2) => VersionCompare(s1, s2) >= 0 ? s1 : s2);
                 _workloadSet = availableWorkloadSets[maxWorkloadSetVersion.ToString()];
+                _useManifestsFromInstallState = false;
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -169,28 +169,24 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 }
             }
 
+            _installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkRootPath), "default.json");
+            var installState = InstallStateContents.FromPath(_installStateFilePath);
             if (_workloadSet is null)
             {
-                var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkRootPath), "default.json");
-                if (File.Exists(installStateFilePath))
+                if (!string.IsNullOrEmpty(installState.WorkloadVersion))
                 {
-                    var installState = InstallStateContents.FromPath(installStateFilePath);
-                    if (!string.IsNullOrEmpty(installState.WorkloadVersion))
+                    if (!TryGetWorkloadSet(installState.WorkloadVersion!, out _workloadSet))
                     {
-                        if (!TryGetWorkloadSet(installState.WorkloadVersion!, out _workloadSet))
-                        {
-                            throw new FileNotFoundException(string.Format(Strings.WorkloadVersionFromInstallStateNotFound, installState.WorkloadVersion, installStateFilePath));
-                        }
+                        throw new FileNotFoundException(string.Format(Strings.WorkloadVersionFromInstallStateNotFound, installState.WorkloadVersion, _installStateFilePath));
                     }
-
-                    //  Note: It is possible here to have both a workload set and loose manifests listed in the install state.  This might happen if there is a
-                    //  third-party workload manifest installed that's not part of the workload set
-                    _manifestsFromInstallState = installState.Manifests is null ? null : WorkloadSet.FromDictionaryForJson(installState.Manifests, _sdkVersionBand);
-                    _installStateFilePath = installStateFilePath;
                 }
+
+                //  Note: It is possible here to have both a workload set and loose manifests listed in the install state.  This might happen if there is a
+                //  third-party workload manifest installed that's not part of the workload set
+                _manifestsFromInstallState = installState.Manifests is null ? null : WorkloadSet.FromDictionaryForJson(installState.Manifests, _sdkVersionBand);
             }
 
-            if (_workloadSet == null && availableWorkloadSets.Any())
+            if (_workloadSet == null && installState.UseWorkloadSets == true && availableWorkloadSets.Any())
             {
                 var maxWorkloadSetVersion = availableWorkloadSets.Keys.Aggregate((s1, s2) => VersionCompare(s1, s2) >= 0 ? s1 : s2);
                 _workloadSet = availableWorkloadSets[maxWorkloadSetVersion.ToString()];

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.NET.Sdk.Localization;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
@@ -418,6 +419,13 @@ namespace ManifestReaderTests
             CreateMockManifest(_manifestRoot, "8.0.200", "android", "33.0.2-rc.1", true);
             CreateMockManifest(_manifestRoot, "8.0.200", "android", "33.0.2", true);
 
+            // To prepare the resolver to work with workload sets, we need to specify 'workload sets' in the install state file.
+            var installStateLocation = WorkloadInstallType.GetInstallStateFolder(new SdkFeatureBand("8.0.200"), Path.GetDirectoryName(_manifestRoot)!);
+            var installStateFilePath = Path.Combine(installStateLocation, "default.json");
+            var installState = InstallStateContents.FromPath(installStateFilePath);
+            installState.UseWorkloadSets = true;
+            Directory.CreateDirectory(installStateLocation);
+            File.WriteAllText(installStateFilePath, installState.ToString());
 
             var workloadSetDirectory = Path.Combine(_manifestRoot, "8.0.200", "workloadsets", "8.0.200");
             Directory.CreateDirectory(workloadSetDirectory);
@@ -1254,6 +1262,14 @@ Microsoft.Net.Workload.Emscripten.net7"
 
         private void CreateMockWorkloadSet(string manifestRoot, string featureBand, string workloadSetVersion, string workloadSetContents)
         {
+            // To prepare the resolver to work with workload sets, we need to specify 'workload sets' in the install state file.
+            var installStateLocation = WorkloadInstallType.GetInstallStateFolder(new SdkFeatureBand(featureBand), Path.GetDirectoryName(manifestRoot)!);
+            var installStateFilePath = Path.Combine(installStateLocation, "default.json");
+            var installState = InstallStateContents.FromPath(installStateFilePath);
+            installState.UseWorkloadSets = true;
+            Directory.CreateDirectory(installStateLocation);
+            File.WriteAllText(installStateFilePath, installState.ToString());
+
             var workloadSetDirectory = Path.Combine(manifestRoot, featureBand, "workloadsets", workloadSetVersion);
             if (!Directory.Exists(workloadSetDirectory))
             {

--- a/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/src/Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -61,7 +61,7 @@ namespace ManifestReaderTests
             var sdkDirectoryWorkloadManifestProvider
                 = new SdkDirectoryWorkloadManifestProvider(sdkRootPath: _fakeDotnetRootDirectory, sdkVersion: "8.0.400", userProfileDir: null, globalJsonPath: null);
 
-            sdkDirectoryWorkloadManifestProvider.GetManifests().Single().Should().NotBeNull();
+            sdkDirectoryWorkloadManifestProvider.GetManifests().Single().ManifestVersion.Should().Be(preferWorkloadSet ? "11.0.2" : "11.0.6");
 
             Directory.Delete(Path.Combine(_manifestRoot, "8.0.400"), recursive: true);
         }


### PR DESCRIPTION
### Description
If the user opts into using workload sets, installs a workload set, then tries to switch back to using loose manifests, we correctly permit installing or updating to loose manifests, but we do not garbage collect the workload sets, both because garbage collection isn't yet implemented for workload sets and because we would keep the latest workload set regardless. That workload set is still findable, therefore, and when the user tries `dotnet workload --version`, `dotnet workload update --print-rollback`, or anything else that uses the resolver to find workloads, it uses the workload set instead of correctly switching back to loose manifests.

### Customer Impact
Customers who ever use workload sets can never use loose manifests again unless they follow manual steps to delete their workload set(s).

### Regression
No; the resolver always worked this way, but workload sets didn't exist, so it wasn't an issue.

### Risk
Low. Relatively few people are using workload sets, and this is changing behavior to align with what the user explicitly requested (or got by using a rollback file), so it changes behavior to align with user expectations. If they'd switched to loose manifests by accident (somehow?), they can always switch back very easily.

### Testing
Changed automated tests to account for the change and walked through one in a debugger to make sure it did what I'd expect.