### PR TITLE
Revert "Disable templating tests on windows to unblock PR builds"

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -13,8 +13,7 @@ parameters:
     # This job uses the build step for testing, so the extra test step is not necessary.
     runTests: false
   - categoryName: TemplateEngine
-    # Stop running the dotnet-new tests as they are timing out on windows until we can investigate. ";$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj"
-    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true


### PR DESCRIPTION
Reverts dotnet/sdk#41794 The runtime team identified the potential issue and it's been resolved so let's try reenabling the templating tests on windows: https://github.com/dotnet/runtime/issues/103624