### PR TITLE
Fix double build of test packages for Helix

### DIFF
--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -65,8 +65,8 @@
     <None Include="BuildTestPackages.targets" />
   </ItemGroup>
 
-  <Import Project="SetupTestRoot.targets" />
-  <Import Project="BuildTestPackages.targets" />
+  <Import Project="SetupTestRoot.targets" Condition="'$(BuildTestPackages)' != 'false'" />
+  <Import Project="BuildTestPackages.targets" Condition="'$(BuildTestPackages)' != 'false'" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -116,7 +116,6 @@
     <Copy SourceFiles="@(AssetFiles)" DestinationFiles="@(AssetFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\Assets\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
-
   <Target Name="AppendHelixPreCommand" BeforeTargets="CoreTest" DependsOnTargets="CopyHelixFiles">
     <PropertyGroup>
       <HelixPreCommands Condition="!$(IsPosixShell)">call %HELIX_CORRELATION_PAYLOAD%\t\RunTestsOnHelix.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
@@ -179,4 +178,5 @@
         HelixCorrelationPayload="@(HelixCorrelationPayload)"
         TestOutputDirectory="$(RepoRoot)artifacts\bin\localHelixTestLayout" />
   </Target>
+
 </Project>

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -54,7 +54,7 @@
       <_CurrentRuntimeTargetFramework Condition="'$(_CurrentRuntimeTargetFramework)' == ''">$(SDKCustomXUnitRuntimeTargetFramework)</_CurrentRuntimeTargetFramework>
       <_CurrentAdditionalProperties>%(SDKCustomXUnitProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
-    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="PublishWithOutput" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
+    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="PublishWithOutput" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(BuildTestPackages)=false;$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" PropertyName="_PublishOutputDir" />
     </MSBuild>
     <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetTargetPath" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -54,7 +54,7 @@
       <_CurrentRuntimeTargetFramework Condition="'$(_CurrentRuntimeTargetFramework)' == ''">$(SDKCustomXUnitRuntimeTargetFramework)</_CurrentRuntimeTargetFramework>
       <_CurrentAdditionalProperties>%(SDKCustomXUnitProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
-    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="PublishWithOutput" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(BuildTestPackages)=false;$(_CurrentAdditionalProperties)">
+    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="PublishWithOutput" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);BuildTestPackages=false;$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" PropertyName="_PublishOutputDir" />
     </MSBuild>
     <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetTargetPath" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">


### PR DESCRIPTION
Resolves: https://github.com/dotnet/sdk/issues/42045

## Summary

After looking over the binlog, it looks like the `BuildTestPackages.target` is running twice. It runs once as part of the normal build process of `Microsoft.NET.TestFramework.csproj`, but also runs prior in the sibling MSBuild process used by `XUnitRunner.targets` to run the `PublishWithOutput` target. The `XUnitRunner.targets` is imported in `UnitTests.proj`, so that ends up causing `Microsoft.NET.TestFramework.csproj` to build twice.

Now, likely, there is a way to simplify this whole process of producing the test payload for Helix, but in lieu of that, this should fix it double building the test packages, which causes intermittent failures in CI. To resolve this, I've added a `BuildTestPackages` property to control importing the `BuildTestPackages.targets` (and `SetupTestRoot.targets`, which is part of the same process for Helix usage). This means that local dev builds will still run these targets properly, but only the `XUnitRunner.targets` won't cause them to be imported.