### PR TITLE
zlib-ng patch for build failure caught in sdk but not in runtime

### DIFF
--- a/src/SourceBuild/patches/runtime/0001-Fix-zlib-ng-build-failure-caught-in-the-sdk-repo.patch
+++ b/src/SourceBuild/patches/runtime/0001-Fix-zlib-ng-build-failure-caught-in-the-sdk-repo.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Carlos=20S=C3=A1nchez=20L=C3=B3pez?=
+ <1175054+carlossanlop@users.noreply.github.com>
+Date: Thu, 11 Jul 2024 11:28:54 -0700
+Subject: [PATCH] Fix zlib-ng build failure caught in the sdk repo.
+
+---
+ .../BuildIntegration/Microsoft.NETCore.Native.Unix.targets | 4 ++--
+ .../libs/System.IO.Compression.Native/CMakeLists.txt       | 7 ++++++-
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+index 3ff044e94d9..107e7b1209e 100644
+--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
++++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+@@ -24,7 +24,7 @@ The .NET Foundation licenses this file to you under the MIT license.
+     <LinkerFlavor Condition="'$(LinkerFlavor)' == '' and '$(_linuxLibcFlavor)' == 'bionic'">lld</LinkerFlavor>
+     <LinkerFlavor Condition="'$(LinkerFlavor)' == '' and '$(_targetOS)' == 'linux'">bfd</LinkerFlavor>
+     <IlcDefaultStackSize Condition="'$(IlcDefaultStackSize)' == '' and '$(_linuxLibcFlavor)' == 'musl'">1572864</IlcDefaultStackSize>
+-    <UseSystemZlib Condition="!Exists('$(IlcSdkPath)libz.a')">true</UseSystemZlib>
++    <UseSystemZlib Condition="'$(UseSystemZlib)' == '' and !Exists('$(IlcFrameworkNativePath)libz.a')">true</UseSystemZlib>
+   </PropertyGroup>
+ 
+   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
+@@ -130,13 +130,13 @@ The .NET Foundation licenses this file to you under the MIT license.
+       <NativeLibrary Condition="'$(_targetArchitecture)' == 'x64'" Include="$(IlcSdkPath)$(VxSortSupportName)$(LibFileExt)" />
+       <NativeLibrary Include="$(IlcSdkPath)$(StandaloneGCSupportName)$(LibFileExt)" />
+       <NativeLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' != 'true' and '$(StaticICULinking)' != 'true'" Include="$(IlcSdkPath)libstdc++compat.a" />
+-      <NativeLibrary Condition="'$(UseSystemZlib)' != 'true'" Include="$(IlcSdkPath)libz.a" />
+     </ItemGroup>
+ 
+     <ItemGroup>
+       <NetCoreAppNativeLibrary Include="System.Native" />
+       <NetCoreAppNativeLibrary Include="System.Globalization.Native" Condition="'$(StaticICULinking)' != 'true' and '$(InvariantGlobalization)' != 'true'" />
+       <NetCoreAppNativeLibrary Include="System.IO.Compression.Native" />
++      <NetCoreAppNativeLibrary Condition="'$(UseSystemZlib)' != 'true'" Include="'z'" /> <!-- zlib must be added after System.IO.Compression.Native, order matters. -->
+       <NetCoreAppNativeLibrary Include="System.Net.Security.Native" Condition="!$(_targetOS.StartsWith('tvos')) and '$(_linuxLibcFlavor)' != 'bionic'" />
+       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(_IsApplePlatform)' == 'true'" />
+       <!-- Not compliant for iOS-like platforms -->
+diff --git a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+index 69d333ae53f..7fa92062d8e 100644
+--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
++++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+@@ -184,7 +184,12 @@ else ()
+ endif ()
+ 
+ if((NOT CLR_CMAKE_USE_SYSTEM_ZLIB) AND STATIC_LIBS_ONLY)
+-    install_static_library(zlib aotsdk nativeaot)
++    if (CLR_CMAKE_TARGET_UNIX)
++        # zlib on Unix needs to be installed in the same location as System.IO.Compression.Native so that we can then treat is as a 'z' native library.
++        install_static_library(zlib ${STATIC_LIB_DESTINATION} nativeaot)
++    else()
++        install_static_library(zlib aotsdk nativeaot)
++    endif()
+ endif()
+ 
+ install (TARGETS System.IO.Compression.Native-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)


### PR DESCRIPTION
I followed these instructions: https://github.com/dotnet/source-build/blob/main/Documentation/patching-guidelines.md

CI failure in the SDK ingestion of runtime: https://dev.azure.com/dnceng-public/public/_build/results?buildId=734455&view=logs&j=684db19f-7f29-59a3-2a09-79422e6d4bae&t=d0c42288-a203-5a4c-a6e2-3bd237c51a8d

Fix currently being tested in a runtime PR: https://github.com/dotnet/runtime/pull/104750

I do not know if we would normally want a patch like this merged into the repo or just open a PR to verify the fix worked. Please let me know. Meanwhile I will convert this to draft.
