### PR TITLE
Fix TestPackage paths

### DIFF
--- a/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -48,7 +48,7 @@
 
   <Target Name="SetupTestPackageProjectBaseData">
     <ItemGroup>
-      <BaseTestPackageProject Include="PackageWithFakeNativeDep"
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/PackageWithFakeNativeDep"
                               Condition="$([MSBuild]::IsOSPlatform(`Windows`))" >
         <Name>PackageWithFakeNativeDep</Name>
         <ProjectName>PackageWithFakeNativeDep.csproj</ProjectName>
@@ -57,7 +57,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-dependency-context-test">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-dependency-context-test">
         <Name>dotnet-dependency-context-test</Name>
         <ProjectName>dotnet-dependency-context-test.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -65,7 +65,7 @@
         <Version>$(Version)</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-hello/v1/dotnet-hello">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello">
         <Name>dotnet-hello</Name>
         <ProjectName>dotnet-hello.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -73,7 +73,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-hello/v2/dotnet-hello">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello">
         <Name>dotnet-hello</Name>
         <ProjectName>dotnet-hello.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -81,7 +81,7 @@
         <Version>2.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-outputsframeworkversion/dotnet-outputsframeworkversion-netcoreapp1.0">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-outputsframeworkversion/dotnet-outputsframeworkversion-netcoreapp1.0">
         <Name>dotnet-outputsframeworkversion-netcoreapp1.0</Name>
         <ProjectName>dotnet-outputsframeworkversion-netcoreapp1.0.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -89,7 +89,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-portable">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-portable">
         <Name>dotnet-portable</Name>
         <ProjectName>dotnet-portable.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -97,7 +97,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-portable-v1">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-portable-v1">
         <Name>dotnet-portable</Name>
         <ProjectName>dotnet-portable-v1.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -105,7 +105,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-portable-v1-prefercli">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-portable-v1-prefercli">
         <Name>dotnet-portable</Name>
         <ProjectName>dotnet-portable-v1-prefercli.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -113,7 +113,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-fallbackfoldertool">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-fallbackfoldertool">
         <Name>dotnet-fallbackfoldertool</Name>
         <ProjectName>dotnet-fallbackfoldertool.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -121,7 +121,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="dotnet-prefercliruntime">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/dotnet-prefercliruntime">
         <Name>dotnet-prefercliruntime</Name>
         <ProjectName>dotnet-prefercliruntime.csproj</ProjectName>
         <IsTool>True</IsTool>
@@ -129,7 +129,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="ToolWithOutputName">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/ToolWithOutputName">
         <Name>dotnet-tool-with-output-name</Name>
         <ProjectName>ToolWithOutputName.csproj</ProjectName>
         <NuPkgName>ToolWithOutputName</NuPkgName>
@@ -138,7 +138,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="Library.ContainsAnalyzer">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/Library.ContainsAnalyzer">
         <Name>Library.ContainsAnalyzer</Name>
         <ProjectName>Library.ContainsAnalyzer.csproj</ProjectName>
         <NuPkgName>Library.ContainsAnalyzer</NuPkgName>
@@ -146,7 +146,7 @@
         <Version>1.0.0</Version>
         <Clean>True</Clean>
       </BaseTestPackageProject>
-      <BaseTestPackageProject Include="Library.ContainsAnalyzer2">
+      <BaseTestPackageProject Include="test/TestAssets/TestPackages/Library.ContainsAnalyzer2">
         <Name>Library.ContainsAnalyzer2</Name>
         <ProjectName>Library.ContainsAnalyzer2.csproj</ProjectName>
         <NuPkgName>Library.ContainsAnalyzer2</NuPkgName>
@@ -165,7 +165,7 @@
       </BaseTestPackageProject>
 
       <BaseTestPackageProject>
-        <ProjectDir>$(RepoRoot)test/TestAssets/TestPackages/%(Identity)/</ProjectDir>
+        <ProjectDir>$(RepoRoot)%(Identity)/</ProjectDir>
         <PackageOutput>$(TestPackagesDir)/%(NuPkgName).%(Version).nupkg</PackageOutput>
       </BaseTestPackageProject>
 


### PR DESCRIPTION
## Summary

In https://github.com/dotnet/sdk/pull/41924, I changed the assumption to be that all TestPackages come from `test/TestAssets/TestPackages/`. Earlier today, there was [this PR](https://github.com/dotnet/sdk/pull/41951) that added a TestPackage that is at `src/Microsoft.Net.Sdk.Compilers.Toolset`. So, the simplification I made in my PR wouldn't work and caused the build to fail. This fixes it by reverting to the previous logic where there is no assumption of the path to the TestPackages after the repo root.