### PR TITLE
Pass TargetRID to AlmaLinux job

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -154,6 +154,7 @@ stages:
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
             container: ${{ variables.almaLinuxContainer }}
+            extraProperties: /p:TargetRID=${{ variables.almaLinuxX64Rid }}
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4509

When the AlmaLinux job runs for source build, it generates a RID that, by default, includes the full version number (e.g. 8.10). But we only expect the RID to contain the major version number.

This is fixed by explicitly setting the `TargetRID` property used by the job to the expected RID value.