### PR TITLE
Make dotnet help understand subcommands

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Help
         private bool TryGetDocsLink(string[] command, out string docsLink)
         {
             var parsedCommand = Parser.Instance.Parse(["dotnet", .. command]);
-            if (parsedCommand != null && parsedCommand.CommandResult is not null && parsedCommand.CommandResult.Command is DocumentedCommand dc)
+            if (parsedCommand?.CommandResult?.Command is DocumentedCommand dc)
             {
                 docsLink = dc.DocsLink;
                 return true;

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Help
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            if (result.GetValue(HelpCommandParser.Argument) is string[] args)
+            if (result.GetValue(HelpCommandParser.Argument) is string[] args && args is not [])
             {
                 return new HelpCommand(args).Execute();
             }

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -8,24 +8,17 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Help
 {
-    public class HelpCommand
+    public class HelpCommand(string[] helpArgs)
     {
-        private readonly ParseResult _parseResult;
-
-        public HelpCommand(ParseResult parseResult)
-        {
-            _parseResult = parseResult;
-        }
-
         public static int Run(ParseResult result)
         {
             result.HandleDebugSwitch();
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            if (!string.IsNullOrEmpty(result.GetValue(HelpCommandParser.Argument)))
+            if (result.GetValue(HelpCommandParser.Argument) is string[] args)
             {
-                return new HelpCommand(result).Execute();
+                return new HelpCommand(args).Execute();
             }
 
             PrintHelp();
@@ -85,7 +78,7 @@ namespace Microsoft.DotNet.Tools.Help
         public int Execute()
         {
             if (TryGetDocsLink(
-                _parseResult.GetValue(HelpCommandParser.Argument),
+                helpArgs,
                 out var docsLink) &&
                 !string.IsNullOrEmpty(docsLink))
             {
@@ -99,18 +92,18 @@ namespace Microsoft.DotNet.Tools.Help
                 Reporter.Error.WriteLine(
                     string.Format(
                         LocalizableStrings.CommandDoesNotExist,
-                        _parseResult.GetValue(HelpCommandParser.Argument)).Red());
+                        helpArgs).Red());
                 Reporter.Output.WriteLine(HelpUsageText.UsageText);
                 return 1;
             }
         }
 
-        private bool TryGetDocsLink(string commandName, out string docsLink)
+        private bool TryGetDocsLink(string[] command, out string docsLink)
         {
-            var command = Parser.GetBuiltInCommand(commandName);
-            if (command != null && command as DocumentedCommand != null)
+            var parsedCommand = Parser.Instance.Parse(["dotnet", .. command]);
+            if (parsedCommand != null && parsedCommand.CommandResult is not null && parsedCommand.CommandResult.Command is DocumentedCommand dc)
             {
-                docsLink = (command as DocumentedCommand).DocsLink;
+                docsLink = dc.DocsLink;
                 return true;
             }
             docsLink = null;

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommandParser.cs
@@ -10,10 +10,10 @@ namespace Microsoft.DotNet.Tools.Help
     {
         public static readonly string DocsLink = "https://aka.ms/dotnet-help";
 
-        public static readonly CliArgument<string> Argument = new(LocalizableStrings.CommandArgumentName)
+        public static readonly CliArgument<string[]> Argument = new(LocalizableStrings.CommandArgumentName)
         {
             Description = LocalizableStrings.CommandArgumentDescription,
-            Arity = ArgumentArity.ZeroOrOne
+            Arity = ArgumentArity.ZeroOrMore
         };
 
         private static readonly CliCommand Command = ConstructCommand();

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -125,13 +125,13 @@ namespace Microsoft.DotNet.Cli
             CliOption<bool> allowUntrustedRoot = new("--allow-untrusted-root");
             CliOption<string> owners = new("--owners");
 
-            trustCommand.Subcommands.Add (new CliCommand("list"));
-            trustCommand.Subcommands.Add (AuthorCommand());
-            trustCommand.Subcommands.Add (RepositoryCommand());
-            trustCommand.Subcommands.Add (SourceCommand());
-            trustCommand.Subcommands.Add (CertificateCommand());
-            trustCommand.Subcommands.Add (RemoveCommand());
-            trustCommand.Subcommands.Add (SyncCommand());
+            trustCommand.Subcommands.Add(new CliCommand("list"));
+            trustCommand.Subcommands.Add(AuthorCommand());
+            trustCommand.Subcommands.Add(RepositoryCommand());
+            trustCommand.Subcommands.Add(SourceCommand());
+            trustCommand.Subcommands.Add(CertificateCommand());
+            trustCommand.Subcommands.Add(RemoveCommand());
+            trustCommand.Subcommands.Add(SyncCommand());
 
             CliOption<string> configFile = new("--configfile");
 
@@ -168,7 +168,8 @@ namespace Microsoft.DotNet.Cli
                 new CliOption<string>("--source-url"),
             };
 
-            CliCommand CertificateCommand() {
+            CliCommand CertificateCommand()
+            {
                 CliOption<string> algorithm = new("--algorithm")
                 {
                     DefaultValueFactory = (_argResult) => "SHA256"
@@ -218,20 +219,23 @@ namespace Microsoft.DotNet.Cli
             return signCommand;
         }
 
-        private static CliCommand GetWhyCommand()
+        private static CliCommand GetWhyCommand() => new WhyCommand();
+
+        private class WhyCommand : DocumentedCommand
         {
-            CliCommand whyCommand = new("why");
+            static string _name = "why";
+            static string _docsLink = "https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-why";
+            public WhyCommand() : base(_name, _docsLink)
+            {
+                Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
+                Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
 
-            whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
-            whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
+                Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
+                    .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
+                    .AllowSingleArgPerToken());
 
-            whyCommand.Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
-                .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
-                .AllowSingleArgPerToken());
-
-            whyCommand.SetAction(NuGetCommand.Run);
-
-            return whyCommand;
+                SetAction(NuGetCommand.Run);
+            }
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -219,23 +219,18 @@ namespace Microsoft.DotNet.Cli
             return signCommand;
         }
 
-        private static CliCommand GetWhyCommand() => new WhyCommand();
-
-        private class WhyCommand : DocumentedCommand
+        private static CliCommand GetWhyCommand()
         {
-            static string _name = "why";
-            static string _docsLink = "https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-why";
-            public WhyCommand() : base(_name, _docsLink)
-            {
-                Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
-                Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
+            DocumentedCommand whyCommand = new("why", "https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-why");
+            whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
+            whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
 
-                Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
-                    .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
-                    .AllowSingleArgPerToken());
+            whyCommand.Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
+                .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
+                .AllowSingleArgPerToken());
 
-                SetAction(NuGetCommand.Run);
-            }
+            whyCommand.SetAction(NuGetCommand.Run);
+            return whyCommand;
         }
     }
 }

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetHelpCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetHelpCommand.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Help.Tests
   .NET CLI help utility
 
 Usage:
-  dotnet help [<COMMAND_NAME>] [options]
+  dotnet help [<COMMAND_NAME>...] [options]
 
 Arguments:
   <COMMAND_NAME>  The SDK command to launch online help for.


### PR DESCRIPTION
`dotnet help` doesn't support supplying an entire subcommand and providing help docs for that subcommand. This is unfortunate because so many of our commands are in fact subcommands!

This change makes the help command understand all subcommands, and if they are DocumentedCommands then the browser will open with those commands. I've also updated the `dotnet nuget why` command to address one feedback from @zivkan and prove out the new functionality.

<details>
<summary>'dotnet help nuget why' before this change</summary>

```terminal
>dotnet help nuget why
Specified command 'nuget' is not a valid SDK command. Specify a valid SDK command. For more information, run dotnet help.
Usage: dotnet [runtime-options] [path-to-application] [arguments]

Execute a .NET application.

runtime-options:
  --additionalprobingpath <path>   Path containing probing policy and assemblies to probe for.
  --additional-deps <path>         Path to additional deps.json file.
  --depsfile                       Path to <application>.deps.json file.
  --fx-version <version>           Version of the installed Shared Framework to use to run the application.
  --roll-forward <setting>         Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).
  --runtimeconfig                  Path to <application>.runtimeconfig.json file.

path-to-application:
  The path to an application .dll file to execute.

Usage: dotnet [sdk-options] [command] [command-options] [arguments]

Execute a .NET SDK command.

sdk-options:
  -d|--diagnostics  Enable diagnostic output.
  -h|--help         Show command line help.
  --info            Display .NET information.
  --list-runtimes   Display the installed runtimes.
  --list-sdks       Display the installed SDKs.
  --version         Display .NET SDK version in use.

SDK commands:
  add               Add a package or reference to a .NET project.
  build             Build a .NET project.
  build-server      Interact with servers started by a build.
  clean             Clean build outputs of a .NET project.
  format            Apply style preferences to a project or solution.
  help              Opens the reference page in a browser for the specified command.
  list              List packages or references of a .NET project.
  msbuild           Run Microsoft Build Engine (MSBuild) commands.
  new               Create a new .NET project or file.
  nuget             Provides additional NuGet commands.
  pack              Create a NuGet package.
  publish           Publish a .NET project for deployment.
  remove            Remove a package or reference from a .NET project.
  restore           Restore dependencies specified in a .NET project.
  run               Build and run a .NET project output.
  sdk               Manage .NET SDK installation.
  sln               Modify Visual Studio solution files.
  store             Store the specified assemblies in the runtime package store.
  test              Run unit tests using the test runner specified in a .NET project.
  tool              Install or manage tools that extend the .NET experience.
  vstest            Run Microsoft Test Engine (VSTest) commands.
  workload          Manage optional workloads.

Additional commands from bundled tools:
  dev-certs         Create and manage development certificates.
  fsi               Start F# Interactive / execute F# scripts.
  user-jwts         Manage JSON Web Tokens in development.
  user-secrets      Manage development user secrets.
  watch             Start a file watcher that runs a command when files change.

Run 'dotnet [command] --help' for more information on a command.
```

</details>

<details>

<summary>'dotnet help nuget why' after this change</summary>

```terminal
>dotnet help nuget why
>
```

</details>

(the after has no output because it's opened the online docs in my browser)