### PR TITLE
Add support to generate SBRP usage report

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -314,6 +314,7 @@ jobs:
 
         if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
           customBuildArgs="$customBuildArgs --source-only"
+          extraBuildProperties="$extraBuildProperties /p:ReportSbrpUsage=true"
         fi
 
         if [[ '${{ parameters.useMonoRuntime }}' == 'True' ]]; then
@@ -433,8 +434,7 @@ jobs:
 
         cd "$(sourcesPath)"
 
-        CopyWithRelativeFolders "artifacts/log/"             $targetFolder "*.binlog"
-        CopyWithRelativeFolders "artifacts/log/"             $targetFolder "*.log"
+        CopyWithRelativeFolders "artifacts/log/"             $targetFolder "*"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.binlog"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.log"
 
@@ -468,8 +468,7 @@ jobs:
         mkdir -p ${targetFolder}
 
         cd "$(sourcesPath)"
-        find artifacts/log/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
-        find artifacts/log/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;
+        find artifacts/log/ -exec rsync -R {} -t ${targetFolder} \;
         if [ -d "artifacts/scenario-tests/" ]; then
           find artifacts/scenario-tests/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
           echo "##vso[task.setvariable variable=hasScenarioTestResults]true"

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -172,6 +172,7 @@
     <PackageReportDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'prebuilt-report'))</PackageReportDir>
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
 
+    <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -21,6 +21,14 @@
     <MSBuild Projects="$(RepoProjectsDir)$(RootRepo).proj" Targets="WritePrebuiltUsageData;ReportPrebuiltUsage" />
   </Target>
 
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WriteSBRPUsageReport" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="ReportSbrpUsage"
+          AfterTargets="Build"
+          Condition="'$(ReportSbrpUsage)' == 'true'">
+    <WriteSbrpUsageReport SrcPath="$(SrcDir)" 
+                          OutputPath="$(ArtifactsLogDir)" />
+  </Target>
+
   <!--
     Determine symbols tarball names and discover all intermediate symbols,
     to be used as inputs and outputs of symbols repackaging targets.

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -25,7 +25,8 @@
   <Target Name="ReportSbrpUsage"
           AfterTargets="Build"
           Condition="'$(ReportSbrpUsage)' == 'true'">
-    <WriteSbrpUsageReport SrcPath="$(SrcDir)" 
+    <WriteSbrpUsageReport SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
+                          SrcPath="$(SrcDir)"
                           OutputPath="$(ArtifactsLogDir)" />
   </Target>
 

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
@@ -111,9 +111,7 @@ public class WriteSbrpUsageReport : Task
 
     private void ReadSbrpPackages(string packageType, bool trackTfms)
     {
-        EnumerationOptions options = new() { RecurseSubdirectories = true };
-
-        foreach (string projectPath in Directory.GetFiles(GetSbrpPackagesPath(packageType), "*.csproj", options))
+        foreach (string projectPath in Directory.GetFiles(GetSbrpPackagesPath(packageType), "*.csproj", SearchOption.AllDirectories))
         {
             DirectoryInfo? directory = Directory.GetParent(projectPath);
             string version = directory!.Name;
@@ -151,9 +149,7 @@ public class WriteSbrpUsageReport : Task
 
     private void ScanProjectReferences()
     {
-        EnumerationOptions options = new() { RecurseSubdirectories = true };
-
-        foreach (string projectJsonFile in Directory.GetFiles(SrcPath, "project.assets.json", options))
+        foreach (string projectJsonFile in Directory.GetFiles(SrcPath, "project.assets.json", SearchOption.AllDirectories))
         {
             LockFile lockFile = new LockFileFormat().Read(projectJsonFile);
             foreach (LockFileTargetLibrary lib in lockFile.Targets.SelectMany(t => t.Libraries))

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
@@ -82,9 +82,7 @@ public class WriteSbrpUsageReport : Task
         do
         {
             hasPurged = false;
-            PackageInfo[] unrefPkgs = GetUnreferencedSbrps()
-                .Select(pkg => pkg)
-                .ToArray();
+            PackageInfo[] unrefPkgs = GetUnreferencedSbrps().ToArray();
 
             foreach (PackageInfo sbrpPkg in _sbrpPackages.Values)
             {
@@ -106,8 +104,7 @@ public class WriteSbrpUsageReport : Task
     private IEnumerable<PackageInfo> GetUnreferencedSbrps() =>
         _sbrpPackages.Values.Where(pkg => pkg.References.Count == 0);
 
-    private string GetSbrpPackagesPath(string packageType) =>
-        Path.Combine(SbrpRepoSrcPath, packageType, "src");
+    private string GetSbrpPackagesPath(string packageType) => Path.Combine(SbrpRepoSrcPath, packageType, "src");
 
     private void ReadSbrpPackages(string packageType, bool trackTfms)
     {

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.ProjectModel;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks;
+
+/// <summary>
+/// Reports the usage of the source-build-reference-packages:
+/// 1. Unreferenced packages
+/// 2. Unreferenced TFMs
+/// </summary>
+public class WriteSbrpUsageReport : Task
+{
+    private const string SbrpRepoName = "source-build-reference-packages";
+
+    private readonly Dictionary<string, PackageInfo> _sbrpPackages = [];
+
+    /// <summary>
+    /// Path to the VMR src directory.
+    /// </summary>
+    [Required]
+    public string SrcPath { get; set; }
+
+    /// <summary>
+    /// Path to the usage report to.
+    /// </summary>
+    [Required]
+    public string OutputPath { get; set; }
+
+    public override bool Execute()
+    {
+        Log.LogMessage($"Scanning for SBRP Package Usage...");
+
+        ReadSbrpPackages("referencePackages", trackTfms: true);
+        ReadSbrpPackages("textOnlyPackages", trackTfms: false);
+
+        ScanProjectReferences();
+
+        GenerateUsageReport();
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private void GenerateUsageReport()
+    {
+        Report report = new();
+        report.Sbrps = [.. _sbrpPackages.Values.OrderBy(pkg => pkg.Id)];
+        PurgeNonReferencedReferences();
+        report.UnreferencedSbrps = [.. GetUnreferencedSbrps().Select(pkg => pkg.Id).OrderBy(id => id)];
+
+        string reportFilePath = Path.Combine(OutputPath, "sbrpPackageUsage.json");
+#pragma warning disable CA1869 // Cache and reuse 'JsonSerializerOptions' instances
+        string jsonContent = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
+#pragma warning restore CA1869 // Cache and reuse 'JsonSerializerOptions' instances
+        File.WriteAllText(reportFilePath, jsonContent);
+    }
+
+    /// <summary>
+    /// Removes all references from unreferenced SBRP packages. This is necessary to determine the
+    /// complete set of unreferenced SBRP packages.
+    /// </summary>
+    private void PurgeNonReferencedReferences()
+    {
+        bool hasPurged;
+        do
+        {
+            hasPurged = false;
+            PackageInfo[] unrefPkgs = GetUnreferencedSbrps()
+                .Select(pkg => pkg)
+                .ToArray();
+
+            foreach (PackageInfo sbrpPkg in _sbrpPackages.Values)
+            {
+                foreach (PackageInfo unrefPkg in unrefPkgs)
+                {
+                    var unref = sbrpPkg.References.Keys
+                        .SingleOrDefault(path => path.Contains(SbrpRepoName) && path.Contains($"{unrefPkg.Name}.{unrefPkg.Version}"));
+                    if (unref != null)
+                    {
+                        Log.LogMessage($"Removing {unrefPkg.Id} from {sbrpPkg.Id}'s references.");
+                        sbrpPkg.References.Remove(unref);
+                        hasPurged = true;
+                    }
+                }
+            }
+        } while (hasPurged);
+    }
+
+    private IEnumerable<PackageInfo> GetUnreferencedSbrps() =>
+        _sbrpPackages.Values.Where(pkg => pkg.References.Count == 0);
+
+    private string GetSbrpPackagesPath(string packageType) =>
+        Path.Combine(SrcPath, SbrpRepoName, "src", packageType, "src");
+
+    private void ReadSbrpPackages(string packageType, bool trackTfms)
+    {
+        EnumerationOptions options = new() { RecurseSubdirectories = true };
+
+        foreach (string projectPath in Directory.GetFiles(GetSbrpPackagesPath(packageType), "*.csproj", options))
+        {
+            DirectoryInfo directory = Directory.GetParent(projectPath);
+            string version = directory.Name;
+            string projectName = Path.GetFileNameWithoutExtension(projectPath);
+            PackageInfo info = new()
+            {
+                Version = version,
+                Name = projectName[..(projectName.Length - 1 - version.Length)],
+                Path = directory.FullName,
+            };
+
+            if (trackTfms)
+            {
+                XDocument xmlDoc = XDocument.Load(projectPath);
+                // Reference packages are generated using the TargetFrameworks property
+                // so there is no need to handle the TargetFramework property.
+                string[] tfms = xmlDoc.Element("Project")?
+                    .Elements("PropertyGroup")
+                    .Elements("TargetFrameworks")
+                    .FirstOrDefault()?.Value?.Split(';');
+
+                if (tfms == null || tfms.Length == 0)
+                {
+                    Log.LogError($"No TargetFrameworks were delected in {projectPath}.");
+                }
+
+                info.Tfms = new HashSet<string>(tfms);
+            }
+            else
+            {
+                info.Tfms = [];
+            }
+
+            _sbrpPackages.Add(info.Id, info);
+            Log.LogMessage($"Detected package: {info.Id}");
+        }
+    }
+
+    private void ScanProjectReferences()
+    {
+        EnumerationOptions options = new() { RecurseSubdirectories = true };
+
+        foreach (string projectJsonFile in Directory.GetFiles(SrcPath, "project.assets.json", options))
+        {
+            LockFile lockFile = new LockFileFormat().Read(projectJsonFile);
+            foreach (LockFileTargetLibrary lib in lockFile.Targets.SelectMany(t => t.Libraries))
+            {
+                if (!_sbrpPackages.TryGetValue($"{lib.Name}/{lib.Version}", out PackageInfo info))
+                {
+                    continue;
+                }
+
+                if (!info.References.TryGetValue(lockFile.Path, out HashSet<string> referencedTfms))
+                {
+                    referencedTfms = [];
+                    info.References.Add(lockFile.Path, referencedTfms);
+                }
+
+                IEnumerable<string> tfms = lib.CompileTimeAssemblies
+                    .Where(asm => asm.Path.StartsWith("lib") || asm.Path.StartsWith("ref"))
+                    .Select(asm => asm.Path.Split('/')[1]);
+                foreach (string tfm in tfms)
+                {
+                    referencedTfms.Add(tfm);
+                }
+            }
+        }
+    }
+
+    private class PackageInfo
+    {
+        public string Id => $"{Name}/{Version}";
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public string Path { get; set; }
+        public HashSet<string> Tfms { get; set; }
+
+        // Dictionary of projects referencing the SBRP and the TFMs referenced by each project
+        public Dictionary<string, HashSet<string>> References { get; } = [];
+    }
+
+    private class Report
+    {
+        public PackageInfo[] Sbrps { get; set; }
+        public string[] UnreferencedSbrps { get; set; }
+    }
+}

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -103,7 +103,6 @@
     <PropertyGroup>
       <!-- Dev innerloop opt-in feed: /p:ExtraRestoreSourcePath=... -->
       <ExtraSourcesNuGetSourceName>ExtraSources</ExtraSourcesNuGetSourceName>
-      <SbrpRepoSrcPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'source-build-reference-packages', 'src'))</SbrpRepoSrcPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
@@ -187,7 +186,7 @@
       NuGetConfigFile="$(NuGetConfigFile)"
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
       SourceBuildSources="@(_BuildSources)"
-      SbrpRepoSrcPath="$(SbrpRepoSrcPath)"
+      SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
       SbrpCacheSourceName="$(SbrpCacheNuGetSourceName)"
       ReferencePackagesSourceName="$(ReferencePackagesNuGetSourceName)"
       PreviouslySourceBuiltSourceName="$(PreviouslySourceBuiltNuGetSourceName)"


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2357.

Over time we can modify the report as needed.  In it's current form, it is meant to easily identity unused SBRPs.  Additionally with a transform/search you can easily see select TFM usage.

I wasn't sure where to place the report.  It is currently located in the logs directory.  I had thought about a separate folder but the report is only one file. I am open to feedback.

[Sample report](https://artprodcus3.artifacts.visualstudio.com/A6fcc92e5-73a7-4f88-8d13-d9045b45fb27/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2RuY2VuZy1wdWJsaWMvcHJvamVjdElkL2NiYjE4MjYxLWM0OGYtNGFiYi04NjUxLThjZGNiNTQ3NDY0OS9idWlsZElkLzc0Mzc2Ny9hcnRpZmFjdE5hbWUvQ2VudE9TU3RyZWFtOV9PbmxpbmVfTXNmdFNka194NjRfQnVpbGRMb2dzX0F0dGVtcHQx0/content?format=file&subPath=%2Fartifacts%2Flog%2FRelease%2FsbrpPackageUsage.json).