### PR TITLE
Delete trn, not tmp, in cleaning up

### DIFF
--- a/src/Cli/dotnet/Telemetry/PersistenceChannel/StorageService.cs
+++ b/src/Cli/dotnet/Telemetry/PersistenceChannel/StorageService.cs
@@ -321,18 +321,17 @@ namespace Microsoft.DotNet.Cli.Telemetry.PersistenceChannel
         }
 
         /// <summary>
-        ///     Enqueue is saving a transmission to a <c>tmp</c> file and after a successful write operation it renames it to a
+        ///     Enqueue is saving a transmission to a file with a guid, and after a successful write operation it renames it to a
         ///     <c>trn</c> file.
         ///     A file without a <c>trn</c> extension is ignored by Storage.Peek(), so if a process is taken down before rename
-        ///     happens
-        ///     it will stay on the disk forever.
-        ///     This thread deletes files with the <c>tmp</c> extension that exists on disk for more than 5 minutes.
+        ///     happens it will stay on the disk forever.
+        ///     This thread deletes files with the <c>trn</c> extension that exists on disk for more than 5 minutes.
         /// </summary>
         private void DeleteObsoleteFiles()
         {
             try
             {
-                IEnumerable<string> files = GetFiles("*.tmp", 50);
+                IEnumerable<string> files = GetFiles("*.trn", 50);
                 foreach (string file in files)
                 {
                     DateTime creationTime = File.GetCreationTimeUtc(Path.Combine(StorageFolder, file));


### PR DESCRIPTION
This is progress on #41796

It cleans up .trn files rather than .tmp files, since they typically stay on disk as .trns.

This likely resolves the core issue.