### PR TITLE
Fix expected exit code for mono in source-build smoke tests

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -216,8 +216,7 @@ internal class DotNetHelper
 
     public void ExecuteRunWeb(string projectName, DotNetTemplate template)
     {
-        // 'dotnet run' exit code differs between CoreCLR and Mono (https://github.com/dotnet/sdk/issues/30095).
-        int expectedExitCode = IsMonoRuntime ? 143 : 0;
+        int expectedExitCode = 0;
 
         ExecuteWeb(
             projectName,


### PR DESCRIPTION
The mono issue that caused the different exit code was fixed in https://github.com/dotnet/runtime/pull/100056.

We now have the same exit code as coreclr so remove the mono special case.

Fixes https://github.com/dotnet/source-build/issues/3174
Fixes https://github.com/dotnet/source-build/issues/4514