### PR TITLE
Fix MSBuildVersionMajorMinor assignment

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1276,7 +1276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
     <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
-    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').Major.%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
+    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').Major).%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
     <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionNotEquals('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
   </PropertyGroup>
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1257,7 +1257,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ReadLinesFromFile>
 
     <PropertyGroup>
-      <_BundledMSBuildVersionMajorMinor>$([System.Version]::Parse('$(BundledMSBuildVersion)').ToString(2))</_BundledMSBuildVersionMajorMinor>
+      <_BundledMSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(BundledMSBuildVersion)').Major).%24([System.Version]::Parse('%24(BundledMSBuildVersion)').Minor)</_BundledMSBuildVersionMajorMinor>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -1276,7 +1276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
     <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
-    <_MSBuildVersionMajorMinor>$([System.Version]::Parse('$(MSBuildVersion)').Major).$([System.Version]::Parse('$(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
+    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').Major).%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
     <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionNotEquals('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
   </PropertyGroup>
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1276,7 +1276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
     <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
-    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').ToString(2))</_MSBuildVersionMajorMinor>
+    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
     <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionNotEquals('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
   </PropertyGroup>
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1276,7 +1276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
     <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
-    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').Major).%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
+    <_MSBuildVersionMajorMinor>$([System.Version]::Parse('$(MSBuildVersion)').Major).$([System.Version]::Parse('$(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
     <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionNotEquals('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
   </PropertyGroup>
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1276,7 +1276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
     <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
-    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
+    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').Major.%24([System.Version]::Parse('%24(MSBuildVersion)').Minor)</_MSBuildVersionMajorMinor>
     <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionNotEquals('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Workarounds: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2111557/?view=edit

The issue is caused by `ToString `usage. On the first evaluation iteration, this method can't be resolved ,because MSBuild doesn't parse the argument "2" as integer, so runtime can't resolve the right method from System.Version.

![image](https://github.com/user-attachments/assets/7969ae62-5265-4559-b30f-1165924e967a)

![image](https://github.com/user-attachments/assets/311d98af-de15-4d66-b675-5a018c5c5d12)

System.Version lib provides a secure way to parse major/minor version parts. 

## Testing
Manual, the evidence is provided on the screenshot above.