### PR TITLE
Improve `Microsoft.Net.Sdk.Compilers.Toolset` package description

### DIFF
--- a/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
+++ b/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <Description><![CDATA[
-      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only: do not reference this package directly.
+      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only: do not reference this package directly as it is explicitly not supported in that fashion.
 
       This package is automatically downloaded when your MSBuild version does not match your SDK version.
       Then your project uses the compiler version matching your SDK version instead of the one bundled with MSBuild.

--- a/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
+++ b/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
@@ -3,21 +3,23 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <Description><![CDATA[
-      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only: do not reference this package directly as it is explicitly not supported in that fashion.
+      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only:
+      do not reference this package directly as it is explicitly not supported in that fashion.
 
       This package is automatically downloaded when your MSBuild version does not match your SDK version.
-      Then your project uses the compiler version matching your SDK version instead of the one bundled with MSBuild.
+      Then the package is used to build your project with the compiler version matching your SDK version
+      instead of the one bundled with MSBuild.
 
-      If you want to disable this behavior, set property `BuildWithNetFrameworkHostedCompiler` to `false`
-      in your `.csproj` or `Directory.Build.props` file, for example:
+      If you want to download this package using the dotnet CLI, you can use the following command:
 
-      ```csproj
-      <Project>
-        <PropertyGroup>
-          <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
-        </ProperyGroup>
-      </Project>
       ```
+      dotnet restore /p:BuildWithNetFrameworkHostedCompiler=true
+      ```
+
+      If you want to disable automatic download and use of this package, set property `BuildWithNetFrameworkHostedCompiler` to `false`
+      (for example, in your `.csproj` or `Directory.Build.props` file).
+      However, be aware that you will be building with mismatched compiler and SDK versions.
+      That is explicitly not supported and can lead to errors (especially with analyzers and source generators).
     ]]></Description>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
+++ b/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <Description><![CDATA[
-      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only.
+      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only: do not reference this package directly.
 
       This package is automatically downloaded when your MSBuild version does not match your SDK version.
       Then your project uses the compiler version matching your SDK version instead of the one bundled with MSBuild.

--- a/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
+++ b/src/Microsoft.Net.Sdk.Compilers.Toolset/Microsoft.Net.Sdk.Compilers.Toolset.csproj
@@ -2,7 +2,23 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <Description>Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only.</Description>
+    <Description><![CDATA[
+      Transport package for Microsoft.Net.Compilers.Toolset.Framework assemblies. For internal use only.
+
+      This package is automatically downloaded when your MSBuild version does not match your SDK version.
+      Then your project uses the compiler version matching your SDK version instead of the one bundled with MSBuild.
+
+      If you want to disable this behavior, set property `BuildWithNetFrameworkHostedCompiler` to `false`
+      in your `.csproj` or `Directory.Build.props` file, for example:
+
+      ```csproj
+      <Project>
+        <PropertyGroup>
+          <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
+        </ProperyGroup>
+      </Project>
+      ```
+    ]]></Description>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
So when users are offline or don't have the nuget.org feed enabled, they know how to disable the package download when searching for its name online on nuget.org after getting an error like:

> error NU1101: Unable to find package Microsoft.Net.Sdk.Compilers.Toolset.

Related to https://github.com/dotnet/sdk/issues/41791.