### PR TITLE
Stable sort workloads list

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 
                     table.AddColumn(InformationStrings.WorkloadSourceColumn, workload => workload.Value);
 
-                    table.PrintRows(installedWorkloads.AsEnumerable(), l => Reporter.WriteLine(l));
+                    table.PrintRows(installedWorkloads.AsEnumerable().OrderBy(workload => workload.Key), l => Reporter.WriteLine(l));
                 }
 
                 Reporter.WriteLine();


### PR DESCRIPTION
Make the sorting of `dotnet workload list` stable.

See https://github.com/dotnet/sdk/issues/42211#issuecomment-2236207607.
