### PR TITLE
[8.0.1xx] No .deps.json for net472 Container task

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)"/>
     <PackageVersion Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistPackageVersion)" />
     <PackageVersion Include="Microsoft.NET.HostModel" Version="$(MicrosoftNETHostModelVersion)" />
     <PackageVersion Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" Version="$(MicrosoftNETSdkRazorSourceGeneratorsTransportPackageVersion)" />
     <PackageVersion Include="Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -509,5 +509,9 @@
       <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.IO.Redist" Version="6.0.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e77011b31a3e5c47d931248a64b47f9b2d47853d</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,7 @@
     <PreReleaseVersionLabel Condition="'$(StabilizePackageVersion)' == 'true' and !$(VersionPrefix.EndsWith('00'))">servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration Condition="'$(StabilizePackageVersion)' != 'true'">
     </PreReleaseVersionIteration>
+    <MicrosoftIORedistPackageVersion>6.0.1</MicrosoftIORedistPackageVersion>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>

--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -9,8 +9,8 @@
       $(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage
     </TargetsForTfmSpecificBuildOutput>
 
-    <!-- Tell the SDK to generate a deps.json file -->
-    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <!-- Tell the SDK to generate a deps.json file to be used by .NET SDK MSBuild -->
+    <GenerateDependencyFile Condition=" '$(TargetFramework)' != 'net472'">true</GenerateDependencyFile>
 
     <!-- Allow the packaging project to use the name `Microsoft.NET.Build.Containers` for the nuget package -->
     <Packageid>.</Packageid>


### PR DESCRIPTION
### Summary

Resolve CG alerts for Containers integration by removing a useless `.deps.json` file.

MSBuild only respects a .deps.json in the net8.0 engine, so there's no need to create it for a net472 task. It includes references that aren't part of the SDK, like the downlevel `System.Text.Json` that is provided by MSBuild/Visual Studio, so removing it can avoid false positives from dependency scanners.

Fixes #42279 (for 8.0.1xx)

### Customer Impact

Avoid spurious CG-scanner alerts related to references in MSBuild task.

### Regression?

No, longstanding behavior that is of interest because of a new vulnerability causing false-positive scan alerts.

### Testing

Existing repo testing.

### Risk

Low--the deleted file was not used at build time. No SDK outputs reference the updated `Microsoft.IO.Redist` assembly.