### PR TITLE
Set props & envs to diagnose null ref issue

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -344,6 +344,12 @@ jobs:
           extraBuildProperties="$extraBuildProperties ${{ parameters.extraProperties }}"
         fi
 
+        # Needed to diagnose https://github.com/dotnet/dnceng/issues/3305. These should be removed once the issue is resolved.
+        extraBuildProperties="$extraBuildProperties /p:Features=debug-analyzers"
+        export DOTNET_DbgEnableMiniDump=1
+        export DOTNET_DbgMiniDumpType=2
+        export DOTNET_DbgMiniDumpName=/vmr/artifacts/log/Release/%p.dmp
+
         buildArgs="$(additionalBuildArgs) $customBuildArgs $extraBuildProperties"
 
         # Only use Docker when a container is specified
@@ -482,6 +488,9 @@ jobs:
           find artifacts/prebuilt-report/ -exec rsync -R {} -t ${targetFolder} \;
           find artifacts/log/binary-report/ -exec rsync -R {} -t ${targetFolder} \;
         fi
+
+        # Needed to diagnose https://github.com/dotnet/dnceng/issues/3305. Remove once the issue is resolved.
+        find src/ -type f -name "*.dmp" -exec rsync -R {} -t ${targetFolder} \;
 
         find src/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
         find src/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -489,9 +489,6 @@ jobs:
           find artifacts/log/binary-report/ -exec rsync -R {} -t ${targetFolder} \;
         fi
 
-        # Needed to diagnose https://github.com/dotnet/dnceng/issues/3305. Remove once the issue is resolved.
-        find src/ -type f -name "*.dmp" -exec rsync -R {} -t ${targetFolder} \;
-
         find src/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
         find src/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -344,12 +344,6 @@ jobs:
           extraBuildProperties="$extraBuildProperties ${{ parameters.extraProperties }}"
         fi
 
-        # Needed to diagnose https://github.com/dotnet/dnceng/issues/3305. These should be removed once the issue is resolved.
-        extraBuildProperties="$extraBuildProperties /p:Features=debug-analyzers"
-        export DOTNET_DbgEnableMiniDump=1
-        export DOTNET_DbgMiniDumpType=2
-        export DOTNET_DbgMiniDumpName=/vmr/artifacts/log/Release/%p.dmp
-
         buildArgs="$(additionalBuildArgs) $customBuildArgs $extraBuildProperties"
 
         # Only use Docker when a container is specified

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -84,6 +84,8 @@
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
+    <!-- TODO Remove once https://github.com/dotnet/dnceng/issues/3305 is resolved -->
+    <BuildArgs>$(BuildArgs) /p:Features="$(Features)"</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -84,8 +84,8 @@
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
-    <!-- TODO Remove once https://github.com/dotnet/dnceng/issues/3305 is resolved -->
-    <BuildArgs>$(BuildArgs) /p:Features="$(Features)"</BuildArgs>
+    <!-- TODO: Needed to debug null ref issue. Remove once https://github.com/dotnet/dnceng/issues/3305 is resolved -->
+    <BuildArgs>$(BuildArgs) /p:Features=debug-analyzers</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
@@ -138,6 +138,10 @@
          See https://github.com/dotnet/source-build/issues/541 -->
     <EnvironmentVariables Include="MSBUILDDISABLENODEREUSE=1" />
 
+    <!-- TODO: Needed to debug null ref issue. Remove once https://github.com/dotnet/dnceng/issues/3305 is resolved -->
+    <EnvironmentVariables Include="DOTNET_DbgEnableMiniDump=1" />
+    <EnvironmentVariables Include="DOTNET_DbgMiniDumpType=2" />
+    <EnvironmentVariables Include="DOTNET_DbgMiniDumpName=$(ArtifactsLogDir)%p.dmp" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Related to https://github.com/dotnet/dnceng/issues/3305

This PR sets the `Features` prop to `debug-analyzers` and 3 envs to help debug the null ref issue linked above.

The dumps will be published as build artifacts as part of https://github.com/dotnet/sdk/blob/2cc1c059be27e6d1c9e0eed540738afe2ff2a8d4/eng/pipelines/templates/jobs/vmr-build.yml#L471