### PR TITLE
[Preview 7] Report better error when `Microsoft.Net.Sdk.Compilers.Toolset` package is not downloaded

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -952,5 +952,9 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1215: Targeting .NET Standard prior to 2.0 is no longer recommended. See {0} for more details.</value>
     <comment>{StrBegin="NETSDK1215: "}</comment>
   </data>
-  <!-- The latest message added is TargetFrameworkIsNotRecommended. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="MicrosoftNetSdkCompilersToolsetNotFound" xml:space="preserve">
+    <value>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</value>
+    <comment>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</comment>
+  </data>
+  <!-- The latest message added is MicrosoftNetSdkCompilersToolsetNotFound. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: Knihovna JIT {0} se nenašla.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Projekt byl obnoven pomocí aplikace {0} verze {1}, ale s aktuálním nastavením by se místo toho použít verze {2}. Tento problém vyřešíte tak, že zkontrolujete, že se pro obnovení a následné operace, například sestavení nebo publikování, používá stejné nastavení. Obvykle k tomuto problému může dojít, pokud je vlastnost RuntimeIdentifier nastavena při sestavování nebo publikování, ale ne při obnovování. Další informace najdete na stránce https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: Die JIT-Bibliothek "{0}" wurde nicht gefunden.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Das Projekt wurde mit {0}, Version {1} wiederhergestellt, aber mit den aktuellen Einstellungen würde stattdessen Version {2} verwendet werden. Um dieses Problem zu beheben, müssen Sie sicherstellen, dass für die Wiederherstellung und für nachfolgende Vorgänge wie das Kompilieren oder Veröffentlichen dieselben Einstellungen verwendet werden. Dieses Problem tritt typischerweise auf, wenn die RuntimeIdentifier-Eigenschaft bei der Kompilierung oder Veröffentlichung, aber nicht bei der Wiederherstellung festgelegt wird. Weitere Informationen finden Sie unter https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: No se encontró la biblioteca JIT "{0}".</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: El proyecto fue restaurado utilizando la versión {0} {1}, pero con la configuración actual, la versión {2} se utilizaría en su lugar. Para resolver este problema, asegúrese de que la misma configuración se utiliza para restaurar y para operaciones posteriores como compilar o publicar. Normalmente, este problema puede producirse si la `propiedad RuntimeIdentifier se establece durante la compilación o la publicación pero no durante la restauración. Para obtener más información, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: la bibliothèque JIT '{0}' est introuvable.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Le projet a été restauré avec la version {0} {1}, mais avec les paramètres actuels, la version {2} serait utilisée à la place. Pour résoudre ce problème, assurez-vous que les mêmes paramètres sont utilisés pour la restauration et pour les opérations ultérieures telles que la génération et la publication. Généralement, ce problème peut se produire si la propriété RuntimeIdentifier est définie au cours de la génération ou de la publication, mais pas pendant la restauration. Pour plus d’informations, consultez https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: la libreria '{0}' di JIT non è stata trovata.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: per il ripristino del progetto è stato usato {0} versione {1}, ma con le impostazioni correnti viene usata la versione {2}. Per risolvere il problema, assicurarsi di usare le stesse impostazioni per il ripristino e per le operazioni successive, quali compilazione o pubblicazione. In genere questo problema può verificarsi se la proprietà RuntimeIdentifier viene impostata durante la compilazione o la pubblicazione, ma non durante il ripristino. Per altre informazioni, vedere https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: JIT ライブラリ '{0}' が見つかりません。</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: プロジェクトは {0} バージョン {1} を使用して復元されましたが、現在の設定では、バージョン {2} が代わりに使用されます。この問題を解決するには、復元およびこれ以降の操作 (ビルドや公開など) で同じ設定を使用していることをご確認ください。通常この問題は、ビルドや公開の実行時に RuntimeIdentifier プロパティを設定したが、復元時には設定していない場合に発生することがあります。詳しくは、https://aka.ms/dotnet-runtime-patch-selection を参照してください。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: JIT 라이브러리 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: {0} 버전 {1}을(를) 사용하여 프로젝트가 복원되었지만, 현재 설정에서는 버전 {2}을(를) 대신 사용합니다. 이 문제를 해결하려면 복원 및 후속 작업(예: 빌드 또는 게시)에 동일한 설정을 사용해야 합니다. 일반적으로 이 문제는 RuntimeIdentifier 속성이 빌드 또는 게시 중에 설정되었지만, 복원 중에는 설정되지 않은 경우에 발생할 수 있습니다. 자세한 내용은 https://aka.ms/dotnet-runtime-patch-selection을 참조하세요.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: nie znaleziono biblioteki JIT "{0}".</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Projekt został przywrócony przy użyciu pakietu {0} w wersji {1}, ale w przypadku bieżących ustawień zamiast niej zostałaby użyta wersja {2}. Aby rozwiązać ten problem, upewnij się, że te same ustawienia są używane do przywracania i dla kolejnych operacji, takich jak kompilacja lub publikowanie. Ten problem zazwyczaj występuje, gdy właściwość RuntimeIdentifier jest ustawiona podczas kompilacji lub publikowania, ale nie podczas przywracania. Aby uzyskać więcej informacji, zobacz https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: biblioteca JIT '{0}' não encontrada.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: o projeto foi restaurado usando o {0} versão {1}, mas, com as configurações atuais, a versão {2} seria usada. Para resolver esse problema, verifique se as mesmas configurações são usadas para restauração e para operações subsequentes, como compilação ou publicação. Normalmente, esse problema poderá ocorrer se a propriedade RuntimeIdentifier for definida durante a compilação ou a publicação, mas não durante a restauração. Para obter mais informações, consulte https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: библиотека JIT "{0}" не найдена.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Проект был восстановлен с использованием {0} версии {1}, но с текущими параметрами вместо этой версии будет использована версия {2}. Чтобы устранить эту проблему, убедитесь, что для восстановления и последующих операций (таких как сборка или публикация) используются одинаковые параметры. Обычно эта проблема возникает, когда свойство RuntimeIdentifier устанавливается во время сборки или публикации, но не во время восстановления. Дополнительные сведения см. на странице https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: JIT kitaplığı '{0}' bulunamadı.</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: Proje, {0} sürüm {1} kullanılarak geri yüklendi, ancak geçerli ayarlarla, bunun yerine sürüm {2} kullanılması gerekiyordu. Bu sorunu çözmek amacıyla, geri yükleme için ve derleme veya yayımlama gibi sonraki işlemler için aynı ayarların kullanıldığından emin olun. Bu sorun genellikle RuntimeIdentifier özelliği derleme veya yayımlama sırasında ayarlandığında ancak geri yükleme sırasında ayarlanmadığında oluşur. Daha fazla bilgi için bkz. https://aka.ms/dotnet-runtime-patch-selection.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: 找不到 JIT 库“{0}”。</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: 项目是使用 {0} 版本 {1} 还原的, 但使用当前设置, 将改用版本 {2}。要解决此问题, 请确保将相同的设置用于还原和后续操作 (如生成或发布)。通常, 如果 RuntimeIdentifier 属性是在生成或发布过程中设置的, 而不是在还原过程中进行的, 则会发生此问题。有关详细信息, 请参阅 https://aka.ms/dotnet-runtime-patch-selection。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -583,6 +583,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1157: 找不到 JIT 程式庫 '{0}'。</target>
         <note>{StrBegin="NETSDK1157: "}</note>
       </trans-unit>
+      <trans-unit id="MicrosoftNetSdkCompilersToolsetNotFound">
+        <source>NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</source>
+        <target state="new">NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version {0} of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.</target>
+        <note>{StrBegin="NETSDK1216: "}{Locked="Microsoft.Net.Sdk.Compilers.Toolset"} {0} is a NuGet package version and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="MismatchedPlatformPackageVersion">
         <source>NETSDK1061: The project was restored using {0} version {1}, but with current settings, version {2} would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.</source>
         <target state="translated">NETSDK1061: 專案是使用 {0} 版本 {1} 還原的，但依照目前設定，使用的版本會是 {2}。若要解決此問題，請確認用於還原與後續作業 (例如建置或發佈) 的設定相同。一般而言，若在建置或發佈期間設定了 RuntimeIdentifier，但在還原期間未加以設定，就可能發生這個問題。如需詳細資訊，請參閱 https://aka.ms/dotnet-runtime-patch-selection。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -242,12 +242,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageDownload Include="Microsoft.Net.Sdk.Compilers.Toolset" Version="[$(NETCoreSdkVersion)]" />
   </ItemGroup>
 
-  <Target Name="_CheckMicrosoftNetSdkCompilersToolsetPackageReference" Condition="'$(MSBuildRuntimeType)' == 'Full'" BeforeTargets="CollectPackageReferences">
+  <Target Name="_CheckMicrosoftNetCompilersToolsetFrameworkPackageReference" Condition="'$(MSBuildRuntimeType)' == 'Full'" BeforeTargets="CollectPackageReferences">
     <!-- Users should not be setting Microsoft.Net.Compilers.Toolset.Framework directly.
          If they do, and BuildWithNetFrameworkHostedCompiler is also set, the former will override the latter.
          This makes it more explicit that that is not supported. -->
     <NETSdkWarning ResourceName="CannotDirectlyReferenceMicrosoftNetCompilersToolsetFramework"
         Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', 'Microsoft.Net.Compilers.Toolset.Framework'))' == 'true'" />
+  </Target>
+
+  <Target Name="_CheckMicrosoftNetSdkCompilersToolsetPackageExists" Condition="'$(_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage)' == 'true'" BeforeTargets="CoreCompile">
+    <!-- If users did not run restore or it failed to download the Microsoft.Net.Sdk.Compilers.Toolset package
+         (but they proceeded to build, e.g., in Visual Studio), display an error with suggestions how to fix the problem. -->
+    <NETSdkError ResourceName="MicrosoftNetSdkCompilersToolsetNotFound"
+        Condition="!Exists('$(RoslynTargetsPath)')"
+        FormatArguments="$(NETCoreSdkVersion)" />
   </Target>
 
   <!-- TODO: this target should not check GeneratePackageOnBuild.


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/42216.