### PR TITLE
Enabled NativeAOT for Arm in SourceBuild/content/repo-projects/sdk.proj

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
@@ -8,8 +8,6 @@
     <BuildArgs>$(BuildArgs) /p:PortableRid=$(PortableRid)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:TargetRid=$(TargetRid)</BuildArgs>
 
-    <!-- Just like mono, arm does not support NativeAot -->
-    <BuildArgs Condition="'$(BuildArchitecture)' == 'arm'">$(BuildArgs) /p:NativeAotSupported=false</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)v $(LogVerbosity)</BuildArgs>
 
     <!--


### PR DESCRIPTION
NativeAOT is supported on arm in .NET 9