### PR TITLE
Avoid "missing toolset" error in design-time builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -250,7 +250,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', 'Microsoft.Net.Compilers.Toolset.Framework'))' == 'true'" />
   </Target>
 
-  <Target Name="_CheckMicrosoftNetSdkCompilersToolsetPackageExists" Condition="'$(_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage)' == 'true'" BeforeTargets="CoreCompile">
+  <Target Name="_CheckMicrosoftNetSdkCompilersToolsetPackageExists"
+          Condition="'$(_NeedToDownloadMicrosoftNetSdkCompilersToolsetPackage)' == 'true' and '$(DesignTimeBuild)' != 'true'"
+          BeforeTargets="CoreCompile">
     <!-- If users did not run restore or it failed to download the Microsoft.Net.Sdk.Compilers.Toolset package
          (but they proceeded to build, e.g., in Visual Studio), display an error with suggestions how to fix the problem. -->
     <NETSdkError ResourceName="MicrosoftNetSdkCompilersToolsetNotFound"


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2172605
Part of https://github.com/dotnet/sdk/issues/41791.

### Summary

A new error trying to detect builds run with a split SDK/compiler inadvertently triggered when projects are opened in some cases, blocking NuGet restore and build in VS scenarios.

### Customer Impact

Opening a .NET SDK project in Visual Studio can fail to restore packages and load the project with `NETSDK1216`.

### Regression?

Yes, introduced in 2a0c0f0d52e8598c3a78cc0f470a06c68963e5fd.

### Testing

Manual execution of scenario.

### Risk

Low--avoids executing a new target that provides error information about a failed-to-restore state in cases where it shouldn't run. The target never existed before so it definitely didn't run in design-time builds then.