### PR TITLE
Add false positive license scan to exclusions list

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -52,7 +52,6 @@ public class LicenseScanTests : TestBase
         "apsl-2.0", // https://opensource.org/license/apsl-2-0-php/
         "blueoak-1.0.0", // https://blueoakcouncil.org/license/1.0.0
         "boost-1.0", // https://opensource.org/license/bsl-1-0/
-        "bsd-2-clause-views", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-2-clause-views.LICENSE
         "bsd-new", // https://opensource.org/license/BSD-3-clause/
         "bsd-original", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-original.LICENSE
         "bsd-original-uc", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-original-uc.LICENSE

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -250,3 +250,4 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resourc
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/*.xaml|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|mpl-2.0
+src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/*.xaml|bsd-2-clause-views


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/42352 made me realize that `bsd-2-clause-views` should not have been added to the list of allowed licenses (added in https://github.com/dotnet/sdk/pull/42288). This PR is to revert that change and add the detected file to the list of exclusions under `False Positives`.