### PR TITLE
Add -pack support for the build CLI so that the zips/msi/packages aren't built by default

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,10 @@
 @echo off
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -nativeToolsOnMachine -msbuildEngine dotnet %*"
+
+echo %* | findstr /C:"-pack" >nul
+if %errorlevel%==0 (
+    set PackInstaller=
+) else (
+    set PackInstaller=/p:PackInstaller=false
+)
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -nativeToolsOnMachine -msbuildEngine dotnet %PackInstaller% %*"
 exit /b %ErrorLevel%

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,10 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-. "$ScriptRoot/eng/common/build.sh" --build --restore "$@"
+if [[ "$@" != *"-pack"* ]]; then
+  packInstallerFlag="/p:PackInstaller=false"
+else
+  packInstallerFlag=
+fi
+
+. "$ScriptRoot/eng/common/build.sh --build --restore " $packInstallerFlag "$@"

--- a/build.sh
+++ b/build.sh
@@ -14,4 +14,4 @@ else
   packInstallerFlag=
 fi
 
-. "$ScriptRoot/eng/common/build.sh --build --restore " $packInstallerFlag "$@"
+. "$ScriptRoot/eng/common/build.sh" --build --restore $packInstallerFlag "$@"

--- a/src/Installer/redist-installer/redist-installer.csproj
+++ b/src/Installer/redist-installer/redist-installer.csproj
@@ -42,15 +42,15 @@
   <Import Project="targets\GenerateBundledVersions.targets" />
   <Import Project="targets\Crossgen.targets" />
   <Import Project="targets\GenerateLayout.targets" />
-  <Import Project="targets\GenerateMSBuildExtensions.targets" />
+  <Import Project="targets\GenerateMSBuildExtensions.targets" Condition="'$(PackInstaller)' != 'false'"/>
   <Import Project="targets\FileExtensions.targets" />
-  <Import Project="targets\GenerateArchives.targets" />
+  <Import Project="targets\GenerateArchives.targets" Condition="'$(PackInstaller)' != 'false'"/>
   <Import Project="targets\GenerateMSIs.targets" />
-  <Import Project="targets\LinuxNativeInstallerDependencyVersions.targets" />
-  <Import Project="targets\GenerateDebs.targets" />
-  <Import Project="targets\GenerateRPMs.targets" />
-  <Import Project="targets\GeneratePKG.targets" />
-  <Import Project="targets\GenerateInstallers.targets" />
+  <Import Project="targets\LinuxNativeInstallerDependencyVersions.targets" Condition="'$(PackInstaller)' != 'false'"/>
+  <Import Project="targets\GenerateDebs.targets" Condition="'$(PackInstaller)' != 'false'"/>
+  <Import Project="targets\GenerateRPMs.targets" Condition="'$(PackInstaller)' != 'false'"/>
+  <Import Project="targets\GeneratePKG.targets" Condition="'$(PackInstaller)' != 'false'"/>
+  <Import Project="targets\GenerateInstallers.targets" Condition="'$(PackInstaller)' != 'false'"/>
   <Import Project="targets\Badge.targets" />
 
 </Project>


### PR DESCRIPTION
Initial stab at adding back the packinstaller flag a different way. I had previously added this in installer but it ended up not working in CI and was removed. Trying to add it back here to eliminate a few targets from running unless you specify -pack locally (but default to running them in all other situations). I believe only the root build.sh and build.cmd files are used by devs rather than any CI or PR builds.