### PR TITLE
Remove Node-Externals allowed binary

### DIFF
--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -38,7 +38,6 @@ src/aspnetcore/src/**/Samples/**/*.woff*
 src/aspnetcore/src/Components/benchmarkapps/BlazingPizza.Server/wwwroot/css/font/quicksand-v8-latin-*.woff*
 src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.*.js # JavaScript files with a null bytes
 src/aspnetcore/src/ProjectTemplates/Web.ProjectTemplates/**/app.db
-src/aspnetcore/src/submodules/Node-Externals/cache/**/* # https://github.com/dotnet/source-build/issues/4161
 
 # fsharp
 src/fsharp/src/fsi/fsi.res # Icon


### PR DESCRIPTION
This is no longer needed as it was removed with https://github.com/dotnet/aspnetcore/pull/56982

Fixes https://github.com/dotnet/source-build/issues/4161