### PR TITLE
Exclude Directory.Build.rsp from .gitignore template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -88,6 +88,8 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
 *.sbr
 *.tlb
 *.tli

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -88,6 +88,8 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
 *.sbr
 *.tlb
 *.tli


### PR DESCRIPTION
`Directory.Build.rsp` is a [documented file][1] that allows setting default arguments to command line builds. However, our .gitignore template ignores _all_ `*.rsp` files. which causes confusion:

1. Devs write an .rsp file and if they aren't being attentive forget to commit it
2. Adding it to git requires `git add --force`, which some devs mistake for a destructive or not-recommended action

Thus, explicitly allow the `Directory.Build.rsp` file.

[1]: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files?view=vs-2022#directorybuildrsp