### PR TITLE
Find baseline workload set in 8.0.100 folder

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -123,6 +123,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             _installStateFilePath = null;
             _useManifestsFromInstallState = true;
             var availableWorkloadSets = GetAvailableWorkloadSets(_sdkVersionBand);
+            var workloadSets80100 = GetAvailableWorkloadSets(new SdkFeatureBand("8.0.100"));
 
             bool TryGetWorkloadSet(string workloadSetVersion, out WorkloadSet? workloadSet)
             {
@@ -140,6 +141,13 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     {
                         return true;
                     }
+                }
+
+                // The baseline workload sets were merged with a fixed 8.0.100 feature band. That means they will always be here
+                // regardless of where they would otherwise belong. This is a workaround for that.
+                if (workloadSets80100.TryGetValue(workloadSetVersion, out workloadSet))
+                {
+                    return true;
                 }
 
                 workloadSet = null;


### PR DESCRIPTION
**Summary**
This effectively contains one commit that went into main previously but never made it into 8.0.4xx despite needing it.

This was missed for multiple reasons:
1. The commit is already in main/9.0-previews, and the change that led to the user-visible issue was only merged in 8.0.4xx, which limits its impact.
2. It does not reproduce until sdk and installer are put together, which means it wasn't even testable with the 8.0.4xx SDK unless it was inserted into the installer repo.
3. It does not reproduce with MSI-based installs, as their layout is different.

Fixes #42357 and #42358

**Customer Impact**
The impact of the bug is that any operation involving workload garbage collection will fail. More specifically, all workload sets are always considered 'workload sets to keep,' including the baseline workload set, during garbage collection. That baseline workload set is not in the correct folder, however, which means that although we can 'discover' it when we do an initial 'find all workload sets' step, when we move to resolve it, we can't find it. This then throws an exception. This PR enables us to find it. Though a workaround, this should work for 8.0.4xx in the long term; main has both this workaround and a better long-term fix.

**Regression?**
This is a fix for a regression in 8.0.4xx.

**Testing**
I built this change, overlaid it on an SDK with the baseline workload set, verified that that workload set was discovered during garbage collection and resolved as intended, and verified that the remainder of the operation completed successfully.

**Risk**
The risk of this fix is low. It permits a code path that otherwise was not otherwise available.