### PR TITLE
Create a transport package for VS and VS authoring for analyzers

### DIFF
--- a/src/Installer/core-sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Installer/core-sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -16,15 +16,31 @@ namespace Microsoft.DotNet.Cli.Build
             StringBuilder sb = new StringBuilder(SWR_HEADER);
 
             AddFolder(sb,
-                      @"RuntimeAnalyzers",
-                      @"MSBuild");
+                      @"AspNetCoreAnalyzers",
+                      @"SDK\AspNetCoreAnalyzers");
+
+            AddFolder(sb,
+                      @"NetCoreAnalyzers",
+                      @"SDK\NetCoreAnalyzers");
+
+            AddFolder(sb,
+                      @"WindowsDesktopAnalyzers",
+                      @"SDK\WindowsDesktopAnalyzers");
+
+            AddFolder(sb,
+                      @"SDKAnalyzers",
+                      @"SDK\SDKAnalyzers");
+
+            AddFolder(sb,
+                      @"WebSDKAnalyzers",
+                      @"SDK\WebSDKAnalyzers");
 
             File.WriteAllText(OutputFile, sb.ToString());
 
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = true)
         {
             string sourceFolder = Path.Combine(RuntimeAnalyzersLayoutDirectory, relativeSourcePath);
             var files = Directory.GetFiles(sourceFolder)
@@ -33,7 +49,17 @@ namespace Microsoft.DotNet.Cli.Build
             if (files.Any(f => !Path.GetFileName(f).Equals("_._")))
             {
                 sb.Append(@"folder ""InstallDir:\");
-                sb.Append(swrInstallDir);
+                // remove the version number and everything until we get to the real analyzers folder
+                Console.WriteLine(swrInstallDir);
+
+                var startIndex = swrInstallDir.IndexOf("analyzers", StringComparison.OrdinalIgnoreCase);
+                var endIndex = swrInstallDir.IndexOf("analyzers", startIndex + 1, StringComparison.OrdinalIgnoreCase);
+                var tempinstalldir = swrInstallDir;
+                if (startIndex >= 0 && endIndex >= 0)
+                {
+                    tempinstalldir = swrInstallDir.Remove(startIndex + 9, endIndex - startIndex );
+                }
+                sb.Append(tempinstalldir);
                 sb.AppendLine(@"\""");
 
                 foreach (var file in files)

--- a/src/Installer/core-sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Installer/core-sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GenerateRuntimeAnalyzersSWR : Task
+    {
+        [Required]
+        public string RuntimeAnalyzersLayoutDirectory { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public override bool Execute()
+        {
+            StringBuilder sb = new StringBuilder(SWR_HEADER);
+
+            AddFolder(sb,
+                      @"RuntimeAnalyzers",
+                      @"MSBuild");
+
+            File.WriteAllText(OutputFile, sb.ToString());
+
+            return true;
+        }
+
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false)
+        {
+            string sourceFolder = Path.Combine(RuntimeAnalyzersLayoutDirectory, relativeSourcePath);
+            var files = Directory.GetFiles(sourceFolder)
+                            .Where(f => !Path.GetExtension(f).Equals(".pdb", StringComparison.OrdinalIgnoreCase) && !Path.GetExtension(f).Equals(".swr", StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+            if (files.Any(f => !Path.GetFileName(f).Equals("_._")))
+            {
+                sb.Append(@"folder ""InstallDir:\");
+                sb.Append(swrInstallDir);
+                sb.AppendLine(@"\""");
+
+                foreach (var file in files)
+                {
+                    sb.Append(@"  file source=""$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\");
+                    sb.Append(Path.Combine(relativeSourcePath, Path.GetFileName(file)));
+                    sb.Append('"');
+
+                    if (ngenAssemblies && file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append(@" vs.file.ngenApplications=""[installDir]\Common7\IDE\vsn.exe""");
+                    }
+
+                    sb.AppendLine();
+                }
+
+                sb.AppendLine();
+            }
+
+            foreach (var subfolder in Directory.GetDirectories(sourceFolder))
+            {
+                string subfolderName = Path.GetFileName(subfolder);
+                string newRelativeSourcePath = Path.Combine(relativeSourcePath, subfolderName);
+                string newSwrInstallDir = Path.Combine(swrInstallDir, subfolderName);
+
+                // Don't propagate ngenAssemblies to subdirectories.
+                AddFolder(sb, newRelativeSourcePath, newSwrInstallDir);
+            }
+        }
+
+        readonly string SWR_HEADER = @"use vs
+
+package name=Microsoft.Net.Core.SDK.RuntimeAnalyzers
+        version=$(ProductsBuildVersion)
+        vs.package.internalRevision=$(PackageInternalRevision)
+
+";
+    }
+}

--- a/src/Installer/redist-installer/packaging/windows/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.nuspec
+++ b/src/Installer/redist-installer/packaging/windows/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.nuspec
@@ -1,0 +1,17 @@
+﻿<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers</id>
+        <version>1.0.0</version>
+        <title>VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers</title>
+        <authors>Microsoft</authors>
+        <owners>Microsoft</owners>
+        <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>
+        <projectUrl>https://github.com/dotnet/sdk</projectUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Analyzers and generators from the runtime and SDK for VS insertion</description>
+        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="$PAYLOAD_FILES$\**\*" />
+    </files>
+</package>

--- a/src/Installer/redist-installer/redist-installer.csproj
+++ b/src/Installer/redist-installer/redist-installer.csproj
@@ -43,6 +43,7 @@
   <Import Project="targets\Crossgen.targets" />
   <Import Project="targets\GenerateLayout.targets" />
   <Import Project="targets\GenerateMSBuildExtensions.targets" />
+  <Import Project="targets\GenerateRuntimeAnalyzers.targets" />
   <Import Project="targets\FileExtensions.targets" />
   <Import Project="targets\GenerateArchives.targets" />
   <Import Project="targets\GenerateMSIs.targets" />

--- a/src/Installer/redist-installer/targets/BuildCoreSdkTasks.targets
+++ b/src/Installer/redist-installer/targets/BuildCoreSdkTasks.targets
@@ -32,6 +32,7 @@
   <UsingTask TaskName="ExtractArchiveToDirectory" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateDefaultRuntimeFrameworkVersion" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateMSBuildExtensionsSWR" AssemblyFile="$(CoreSdkTaskDll)" />
+  <UsingTask TaskName="GenerateRuntimeAnalyzersSWR" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateMsiVersionFromFullVersion" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateSdkRuntimeIdentifierChain" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GetDependencyInfo" AssemblyFile="$(CoreSdkTaskDll)" />

--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -37,6 +37,10 @@
       <SdkMSBuildExtensionsNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.$(FullNugetVersion).nupkg</SdkMSBuildExtensionsNupkgFile>
       <SdkMSBuildExtensionsSwrFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr</SdkMSBuildExtensionsSwrFile>
 
+      <SdkRuntimeAnalyzersNuspecFile>$(SdkPkgSourcesRootDirectory)/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.nuspec</SdkRuntimeAnalyzersNuspecFile>
+      <SdkRuntimeAnalyzersNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.$(FullNugetVersion).nupkg</SdkRuntimeAnalyzersNupkgFile>
+      <SdkRuntimeAnalyzersSwrFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.swr</SdkRuntimeAnalyzersSwrFile>
+
       <VSTemplateLocatorLayoutPath>$(ArtifactsDir)bin/VSTemplateLocator/$(Configuration)</VSTemplateLocatorLayoutPath>
       <VSTemplateLocatorNuspecFile>$(SdkPkgSourcesRootDirectory)/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.nuspec</VSTemplateLocatorNuspecFile>
       <VSTemplateLocatorNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.$(FullNugetVersion).nupkg</VSTemplateLocatorNupkgFile>
@@ -497,6 +501,27 @@
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
   </Target>
 
+<Target Name="GenerateRuntimeAnalyzersNupkg"
+  DependsOnTargets="GenerateLayout;GenerateRuntimeAnalyzers;MsiTargetsSetupInputOutputs"
+  Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' "
+  Inputs="$(RuntimeAnalyzersLayoutDirectory)/**/*;
+            $(SdkRuntimeAnalyzersNuspecFile);
+            $(GenerateNupkgPowershellScript)"
+  Outputs="$(SdkRuntimeAnalyzersNupkgFile);$(SdkRuntimeAnalyzersSwrFile)">
+<GenerateRuntimeAnalyzersSWR RuntimeAnalyzersLayoutDirectory="$(RuntimeAnalyzersLayoutDirectory)"
+                          OutputFile="$(SdkRuntimeAnalyzersSwrFile)" />
+
+<!-- Include the swr file in the nuget package for VS authoring -->
+<Copy SourceFiles="$(SdkRuntimeAnalyzersSwrFile)" DestinationFolder="$(RuntimeAnalyzersLayoutDirectory)" />
+
+<Exec Command="powershell -NoProfile -NoLogo $(GenerateNupkgPowershellScript) ^
+              '$(ArtifactsDir)' ^
+              '$(RuntimeAnalyzersLayoutDirectory.TrimEnd('\'))' ^
+              '$(FullNugetVersion)' ^
+              '$(SdkRuntimeAnalyzersNuspecFile)' ^
+              '$(SdkRuntimeAnalyzersNupkgFile)'" />
+</Target>
+
   <!--
     This project references assets from multiple architectures, so it can't be built until we have a join point job that can pull assets from multiple legs.
     https://github.com/dotnet/source-build/issues/4336
@@ -530,6 +555,7 @@
                             GenerateVSToolsNupkg;
                             GenerateVSToolsResolverNupkg;
                             GenerateSdkMSBuildExtensionsNupkg;
+                            GenerateRuntimeAnalyzersNupkg;
                             GenerateVSTemplateLocatorNupkg"
         Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' != 'arm' " />
 

--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -502,7 +502,7 @@
   </Target>
 
 <Target Name="GenerateRuntimeAnalyzersNupkg"
-  DependsOnTargets="GenerateLayout;GenerateRuntimeAnalyzers;MsiTargetsSetupInputOutputs"
+  DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs"
   Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' "
   Inputs="$(RuntimeAnalyzersLayoutDirectory)/**/*;
             $(SdkRuntimeAnalyzersNuspecFile);

--- a/src/Installer/redist-installer/targets/GenerateRuntimeAnalyzers.targets
+++ b/src/Installer/redist-installer/targets/GenerateRuntimeAnalyzers.targets
@@ -1,22 +1,7 @@
 <Project>
 
   <PropertyGroup>
-      <RuntimeAnalyzersLayoutDirectory>$(BaseOutputPath)$(Configuration)\RuntimeAnalyzersLayout\</RuntimeAnalyzersLayoutDirectory>
-      <RuntimeAnalyzersOutputPath>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</RuntimeAnalyzersOutputPath>
+      <RuntimeAnalyzersLayoutDirectory>$(ArtifactsBinDir)$(Configuration)\RuntimeAnalyzers</RuntimeAnalyzersLayoutDirectory>
   </PropertyGroup>
-
-  <Target Name="GenerateRuntimeAnalyzers" DependsOnTargets="GenerateBundledVersionsProps">
-    <ItemGroup>
-      <!-- The VSRuntimeAnalyzersContent item is for the files that will be included in the VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers
-           package and inserted into Visual Studio -->
-      <VSRuntimeAnalyzersContent Include="$(RuntimeAnalyzersOutputPath)\RuntimeAnalyzers\**\*.*" />
-
-      <VSRuntimeAnalyzersContent Update="@(VSMSBuildExtensionsContent)">
-        <DestinationPath>$(RuntimeAnalyzersLayoutDirectory)/%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
-      </VSRuntimeAnalyzersContent>
-     </ItemGroup>
-
-    <Copy SourceFiles="@(VSRuntimeAnalyzersContent)" DestinationFiles="%(VSRuntimeAnalyzersContent.DestinationPath)" />
-  </Target>
 
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateRuntimeAnalyzers.targets
+++ b/src/Installer/redist-installer/targets/GenerateRuntimeAnalyzers.targets
@@ -1,0 +1,22 @@
+<Project>
+
+  <PropertyGroup>
+      <RuntimeAnalyzersLayoutDirectory>$(BaseOutputPath)$(Configuration)\RuntimeAnalyzersLayout\</RuntimeAnalyzersLayoutDirectory>
+      <RuntimeAnalyzersOutputPath>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</RuntimeAnalyzersOutputPath>
+  </PropertyGroup>
+
+  <Target Name="GenerateRuntimeAnalyzers" DependsOnTargets="GenerateBundledVersionsProps">
+    <ItemGroup>
+      <!-- The VSRuntimeAnalyzersContent item is for the files that will be included in the VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers
+           package and inserted into Visual Studio -->
+      <VSRuntimeAnalyzersContent Include="$(RuntimeAnalyzersOutputPath)\RuntimeAnalyzers\**\*.*" />
+
+      <VSRuntimeAnalyzersContent Update="@(VSMSBuildExtensionsContent)">
+        <DestinationPath>$(RuntimeAnalyzersLayoutDirectory)/%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
+      </VSRuntimeAnalyzersContent>
+     </ItemGroup>
+
+    <Copy SourceFiles="@(VSRuntimeAnalyzersContent)" DestinationFiles="%(VSRuntimeAnalyzersContent.DestinationPath)" />
+  </Target>
+
+</Project>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -27,6 +27,7 @@
   <Import Project="targets\GenerateArchive.targets" />
   <Import Project="targets\OverlaySdkOnLKG.targets" Condition="'$(DotNetBuild)' != 'true'" />
   <Import Project="targets\MSBuildExtensions.targets" />
+  <Import Project="targets\RuntimeAnalyzers.targets" />
 
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -130,6 +130,13 @@
 
   </Target>
 
+  <Target Name="PublishRuntimeAnalyzers"
+          DependsOnTargets="GenerateRuntimeAnalyzers"
+          BeforeTargets="Build">
+    <Copy SourceFiles="@(RuntimeAnalyzersContent)"
+          DestinationFiles="@(RuntimeAnalyzersContent->'$(OutputPath)\RuntimeAnalyzers\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+
   <Target Name="PublishNetSdks"
           BeforeTargets="Build">
     <ItemGroup>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -134,7 +134,7 @@
           DependsOnTargets="GenerateRuntimeAnalyzers"
           BeforeTargets="Build">
     <Copy SourceFiles="@(RuntimeAnalyzersContent)"
-          DestinationFiles="@(RuntimeAnalyzersContent->'$(OutputPath)\RuntimeAnalyzers\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+          DestinationFiles="@(RuntimeAnalyzersContent->'$(ArtifactsBinDir)$(Configuration)\RuntimeAnalyzers\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="PublishNetSdks"

--- a/src/Layout/redist/targets/MSBuildExtensions.targets
+++ b/src/Layout/redist/targets/MSBuildExtensions.targets
@@ -22,9 +22,6 @@
       <MSBuildExtensionsContent Include="$(MSBuildExtensionsSourceRoot)\msbuildExtensions-ver\**\*.*"
                           DeploymentSubpath="$(MSBuildExtensionsVersionSubfolder)/" />
 
-
-
-
     </ItemGroup>
 
   </Target>

--- a/src/Layout/redist/targets/RuntimeAnalyzers.targets
+++ b/src/Layout/redist/targets/RuntimeAnalyzers.targets
@@ -18,7 +18,6 @@
       <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(SDKAnalyzersSubPath)\**\*.*" DeploymentSubpath="SDKAnalyzers"/>
       <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(WebSDKAnalyzersSubPath)\**\*.*" DeploymentSubpath="WebSDKAnalyzers"/>
     </ItemGroup>
-
   </Target>
 
 </Project>

--- a/src/Layout/redist/targets/RuntimeAnalyzers.targets
+++ b/src/Layout/redist/targets/RuntimeAnalyzers.targets
@@ -1,0 +1,24 @@
+<Project>
+
+  <PropertyGroup>
+    <RuntimeAnalyzersSourceRoot>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</RuntimeAnalyzersSourceRoot>
+    <NetCoreRuntimeAnalyzersSubPath>packs\Microsoft.NetCore.App.Ref\9.*\analyzers</NetCoreRuntimeAnalyzersSubPath>
+    <WindowsDesktopRuntimeAnalyzersSubPath>packs\Microsoft.WindowsDesktop.App.Ref\9.*\analyzers</WindowsDesktopRuntimeAnalyzersSubPath>
+    <AspNetCoreRuntimeAnalyzersSubPath>packs\Microsoft.AspNetCore.App.Ref\9.*\analyzers</AspNetCoreRuntimeAnalyzersSubPath>
+    <SDKAnalyzersSubPath>sdk\9.*\Sdks\Microsoft.NET.Sdk\Analyzers</SDKAnalyzersSubPath>
+    <WebSDKAnalyzersSubPath>sdk\9.*\Sdks\Microsoft.NET.Sdk.Web\Analyzers</WebSDKAnalyzersSubPath>
+  </PropertyGroup>
+
+  <Target Name="GenerateRuntimeAnalyzers">
+
+    <ItemGroup>
+      <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(NetCoreRuntimeAnalyzersSubPath)\**\*.*" DeploymentSubpath="NetCoreAnalyzers"/>
+      <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(WindowsDesktopRuntimeAnalyzersSubPath)\**\*.*" DeploymentSubpath="WindowsDesktopAnalyzers"/>
+      <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(AspNetCoreRuntimeAnalyzersSubPath)\**\*.*" DeploymentSubpath="AspNetCoreAnalyzers"/>
+      <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(SDKAnalyzersSubPath)\**\*.*" DeploymentSubpath="SDKAnalyzers"/>
+      <RuntimeAnalyzersContent Include="$(RuntimeAnalyzersSourceRoot)$(WebSDKAnalyzersSubPath)\**\*.*" DeploymentSubpath="WebSDKAnalyzers"/>
+    </ItemGroup>
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
#42087

- Create a new nupkg to package up the analyzers and VS authoring
- Copy the analyzers into a separate folder to be included in the nupkg
- Create separate sub-folders for each category of analyzer pulling the contents from the analyzers folder
- Install into VS into the SDK\<analyzercategory> folder
- Mark all the files to be ngened
- Keep the existing folder structure

**Some examples:**
folder "InstallDir:\SDK\AspNetCoreAnalyzers\dotnet\cs\"
  file source="$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\AspNetCoreAnalyzers\9.0.0-preview.5.24306.11\analyzers\dotnet\cs\Microsoft.AspNetCore.App.Analyzers.dll" vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe"
  
folder "InstallDir:\SDK\NetCoreAnalyzers\dotnet\cs\"
  file source="$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\NetCoreAnalyzers\9.0.0-preview.5.24306.7\analyzers\dotnet\cs\System.Text.RegularExpressions.Generator.dll" vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe"

folder "InstallDir:\SDK\WindowsDesktopAnalyzers\dotnet\"
  file source="$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\WindowsDesktopAnalyzers\9.0.0-preview.5.24306.8\analyzers\dotnet\System.Windows.Forms.Analyzers.dll" vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe"
  
folder "InstallDir:\SDK\SDKAnalyzers\"
  file source="$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\SDKAnalyzers\9.0.100-dev\Sdks\Microsoft.NET.Sdk\analyzers\Microsoft.CodeAnalysis.NetAnalyzers.dll" vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe"

folder "InstallDir:\SDK\WebSDKAnalyzers\cs\"
  file source="$(PkgVS_Redist_Common_Net_Core_SDK_RuntimeAnalyzers)\WebSDKAnalyzers\9.0.100-dev\Sdks\Microsoft.NET.Sdk.Web\analyzers\cs\Microsoft.AspNetCore.Analyzers.dll" vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe"



