### PR TITLE
skip projects that don't support workloads during workload restore

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
@@ -52,7 +51,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
             {
                 {"SkipResolvePackageAssets", "true"}
             };
-
 
             var allWorkloadId = new List<WorkloadId>();
             foreach (string projectFile in allProjects)

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetWorkloadCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetWorkloadCommand.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.TestFramework.Commands;
+
+public class DotnetWorkloadCommand : DotnetCommand
+{
+    public DotnetWorkloadCommand(ITestOutputHelper log, params string[] args) : base(log)
+    {
+        Arguments.Add("workload");
+        Arguments.AddRange(args);
+    }
+}

--- a/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp.Docker/SampleApp.Docker.dcproj
+++ b/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp.Docker/SampleApp.Docker.dcproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.Docker.Sdk">
+    <PropertyGroup Label="Globals">
+        <ProjectVersion>2.1</ProjectVersion>
+        <DockerTargetOS>Windows</DockerTargetOS>
+        <ProjectGuid>154022c1-8014-4e9d-bd78-6ff46670ffa4</ProjectGuid>
+        <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
+        <DockerServiceUrl>{Scheme}://{ServiceIPAddress}{ServicePort}</DockerServiceUrl>
+        <DockerServiceName>webapplication1</DockerServiceName>
+        <DockerComposeBaseFilePath>DockerComposeFiles\mydockercompose</DockerComposeBaseFilePath>
+        <AdditionalComposeFilePaths>AdditionalComposeFiles\myadditionalcompose.yml</AdditionalComposeFilePaths>
+        <ProjectTypeGuids>E53339B2-1760-4266-BCC7-CA923CBCF16C</ProjectTypeGuids>
+    </PropertyGroup>
+    <ItemGroup>
+        <None Include="DockerComposeFiles\mydockercompose.override.yml">
+            <DependentUpon>DockerComposeFiles\mydockercompose.yml</DependentUpon>
+        </None>
+        <None Include="DockerComposeFiles\mydockercompose.yml" />
+        <None Include=".dockerignore" />
+    </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp/Program.cs
+++ b/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp/SampleApp.csproj
+++ b/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SampleApp/SampleApp.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SolutionWithAppAndDcProj.sln
+++ b/test/TestAssets/TestProjects/SolutionWithAppAndDcProj/SolutionWithAppAndDcProj.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "SampleApp\SampleApp.csproj", "{99463187-C4F6-4A68-82AD-2BBB08DBF872}"
+EndProject
+Project("E53339B2-1760-4266-BCC7-CA923CBCF16C") = "SampleApp.Docker", "SampleApp.Docker\SampleApp.Docker.dcproj", "{154022C1-8014-4E9D-BD78-6FF46670FFA4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{99463187-C4F6-4A68-82AD-2BBB08DBF872}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99463187-C4F6-4A68-82AD-2BBB08DBF872}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99463187-C4F6-4A68-82AD-2BBB08DBF872}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99463187-C4F6-4A68-82AD-2BBB08DBF872}.Release|Any CPU.Build.0 = Release|Any CPU
+		{154022C1-8014-4E9D-BD78-6FF46670FFA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{154022C1-8014-4E9D-BD78-6FF46670FFA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{154022C1-8014-4E9D-BD78-6FF46670FFA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{154022C1-8014-4E9D-BD78-6FF46670FFA4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/test/dotnet-workload-restore.Tests/GivenDotnetWorkloadRestore.cs
+++ b/test/dotnet-workload-restore.Tests/GivenDotnetWorkloadRestore.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Workload.Restore.Tests;
+
+public class GivenDotnetWorkloadRestore : SdkTest
+{
+    public GivenDotnetWorkloadRestore(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    public static string DcProjAssetName = "SolutionWithAppAndDcProj";
+
+    [Fact]
+    public void ProjectsThatDoNotSupportWorkloadsAreNotInspected()
+    {
+        var projectPath =
+            _testAssetsManager
+                .CopyTestAsset(DcProjAssetName)
+                .WithSource()
+                .Path;
+
+        new DotnetWorkloadCommand(Log, "restore")
+        .WithWorkingDirectory(projectPath)
+        .Execute()
+        .Should()
+        // if we did try to restore the dcproj in this TestAsset we would fail, so passing means we didn't!
+        .Pass();
+    }
+}


### PR DESCRIPTION
Fixes #42394 by not attempting to run the target if it isn't present in the project.

There's not an API-based version of 'SkipNonexistentTarget' like there is for the `MSBuild` intrinsic Task, this is what the engine itself does when that flag is present.