### PR TITLE
[Main] Re-Bootstrap Source Build to .NET 9.0.100-preview.7.24380.1

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -23,8 +23,8 @@
       of a .NET major or minor release, prebuilts may be needed. When the release is mature, prebuilts
       are not necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSdkVersion>9.0.100-preview.7.24373.1</PrivateSourceBuiltSdkVersion>
-    <PrivateSourceBuiltArtifactsVersion>9.0.100-preview.7.24373.1</PrivateSourceBuiltArtifactsVersion>
+    <PrivateSourceBuiltSdkVersion>9.0.100-preview.7.24380.1</PrivateSourceBuiltSdkVersion>
+    <PrivateSourceBuiltArtifactsVersion>9.0.100-preview.7.24380.1</PrivateSourceBuiltArtifactsVersion>
     <!-- command-line-api dependencies -->
     <SystemCommandLineVersion>2.0.0-beta4.24126.1</SystemCommandLineVersion>
     <!-- msbuild dependencies -->

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.7.24373.6"
+    "dotnet": "9.0.100-preview.7.24380.2"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",


### PR DESCRIPTION
Port of the rebootstrap PR in preview7 (https://github.com/dotnet/sdk/pull/42469) to main.

Needed to consume https://github.com/dotnet/runtime/pull/105572. See https://github.com/dotnet/sdk/pull/42425#issuecomment-2256321965 where it was commented that the sdk version source-build was using did not include the fix.

I crosschecked the arcade toolset version and it's up to date.