### PR TITLE
Exclude bincore directory in diff test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/SdkFileDiffExclusions.txt
@@ -88,6 +88,5 @@
 ./library-packs/|sb
 ./packs/runtime.banana-rid.Microsoft.DotNet.ILCompiler/|sb
 
-# https://github.com/dotnet/source-build/issues/4534
-./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll|sb
-./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll|sb
+# Exclude bincore directory due to too much noise - https://github.com/dotnet/source-build/issues/4534
+./sdk/x.y.z/Roslyn/bincore/


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4534

Excludes the entire bincore directory from the sdk diff tests.