### PR TITLE
Sidestep telemetry null writing by writing empty strings

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -332,13 +332,13 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
 
     private void LogTelemetryData(InferenceTelemetryData telemetryData)
     {
-        var telemetryProperties = new Dictionary<string, string?>
+        var telemetryProperties = new Dictionary<string, string>
         {
             { nameof(telemetryData.InferencePerformed), telemetryData.InferencePerformed.ToString() },
             { nameof(telemetryData.TargetFramework), telemetryData.TargetFramework },
-            { nameof(telemetryData.BaseImage), telemetryData.BaseImage },
-            { nameof(telemetryData.BaseImageTag), telemetryData.BaseImageTag },
-            { nameof(telemetryData.ContainerFamily), telemetryData.ContainerFamily },
+            { nameof(telemetryData.BaseImage), telemetryData.BaseImage ?? "" },
+            { nameof(telemetryData.BaseImageTag), telemetryData.BaseImageTag ?? "" },
+            { nameof(telemetryData.ContainerFamily), telemetryData.ContainerFamily ?? "" },
             { nameof(telemetryData.ProjectType), telemetryData.ProjectType.ToString() },
             { nameof(telemetryData.PublishMode), telemetryData.PublishMode.ToString() },
             { nameof(telemetryData.IsInvariant), telemetryData.IsInvariant.ToString() },

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -388,12 +388,12 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     private class Telemetry(Microsoft.Build.Utilities.TaskLoggingHelper Log, PublishTelemetryContext context)
     {
-        private IDictionary<string, string?> ContextProperties() => new Dictionary<string, string?>
+        private IDictionary<string, string> ContextProperties() => new Dictionary<string, string>
             {
-                { nameof(context.RemotePullType), context.RemotePullType?.ToString() },
-                { nameof(context.LocalPullType), context.LocalPullType?.ToString() },
-                { nameof(context.RemotePushType), context.RemotePushType?.ToString() },
-                { nameof(context.LocalPushType), context.LocalPushType?.ToString() }
+                { nameof(context.RemotePullType), context.RemotePullType?.ToString() ?? "" },
+                { nameof(context.LocalPullType), context.LocalPullType?.ToString()  ?? "" },
+                { nameof(context.RemotePushType), context.RemotePushType?.ToString() ?? "" },
+                { nameof(context.LocalPushType), context.LocalPushType?.ToString() ?? "" }
             };
 
         public void LogPublishSuccess()
@@ -428,7 +428,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         {
             var props = ContextProperties();
             props.Add("error", "rid_mismatch");
-            props.Add("target_rid", desiredRid);
+            props.Add("target_rid", desiredRid ?? "");
             props.Add("available_rids", string.Join(",", availableRids));
             Log.LogTelemetry("sdk/container/publish/error", props);
         }


### PR DESCRIPTION
Another potential fix for [azdo#2174440](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2174440).

If we take this fix we could ask users to use a PackageReference instead of needing to hotfix the SDK.

We can publish this package and known-issue the release with:

```xml
<ItemGroup>
    <PackageReference Include="Microsoft.NET.Build.Containers" Version="<whatever we end up with>" />
  </ItemGroup>
```

but users will still have the following inescapable error:

```
C:\Program Files\dotnet\sdk\9.0.100-preview.6.24328.19\Containers\build\Microsoft.NET.Build.Containers.targets(217,5): warning : The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers because it is no longer needed.
```

To get around this warning, we could hijack the detection in the SDK temporarily:

```xml

  <ItemGroup>
    <PackageDownload Include="Microsoft.NET.Build.Containers" Version="[8.0.303]" />
  </ItemGroup>
  <!-- import directly to avoid the PackageReference that triggers warning from SDK and define using tasks before SDK imports targets -->
  <Import Project="$(NuGetPackageRoot)\Microsoft.NET.Build.Containers\8.0.303\build\Microsoft.NET.Build.Containers.props" />
  <PropertyGroup>
    <!-- Define ContainersTargets dir to make the SDK load the targets from the nuget package too (and not it's own). -->
    <_ContainersTargetsDir>$(NuGetPackageRoot)\Microsoft.NET.Build.Containers\8.0.303\build\</_ContainersTargetsDir>
  </PropertyGroup>
```
