### PR TITLE
Update SDK diff pipeline schedule

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -1,6 +1,6 @@
 schedules:
-- cron: "0 11 * * 1-5"
-  displayName: Run on weekdays at 11am UTC
+- cron: "0 12 * * 1-5"
+  displayName: Run on weekdays at 12pm UTC
   branches:
     include:
     - main


### PR DESCRIPTION
Increase the starting time of the SB SDK diff pipeline to ensure it runs after the scheduled VMR build.

The VMR build starts at 08:00 UTC but is now taking about 3.5 hrs to run. The SDK diff pipeline is scheduled to start at 11:00 UTC so it starts before the VMR build is done. This leads to misalignment, causing "today's" SDK diff pipeline run to report on "yesterday's" VMR build.