### PR TITLE
Support launchSettings.json workingDirectory with dotnet run

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public string CommandName { get; }
         public string CommandArgs => string.Join(" ", _commandArgs);
+        public string CommandWorkingDirectory => _workingDirectory;
 
         public BuiltInCommand(string commandName, IEnumerable<string> commandArgs, Func<string[], int> builtInCommand)
             : this(commandName, commandArgs, builtInCommand, new BuiltInCommandEnvironment())

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -182,6 +182,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public string CommandArgs => _process.StartInfo.Arguments;
 
+        public string CommandWorkingDirectory => _process.StartInfo.WorkingDirectory;
+
         public ICommand SetCommandArgs(string commandArgs)
         {
             _process.StartInfo.Arguments = commandArgs;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ICommand.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ICommand.cs
@@ -28,5 +28,7 @@ namespace Microsoft.DotNet.Cli.Utils
         string CommandName { get; }
 
         string CommandArgs { get; }
+
+        string CommandWorkingDirectory { get; }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
@@ -18,5 +18,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
         public string DotNetRunMessages { get; set; }
 
         public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public string WorkingDirectory { get; set; }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -82,6 +82,15 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                         }
                     }
                 }
+                else if (string.Equals(property.Name, nameof(ProjectLaunchSettingsModel.WorkingDirectory), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!TryGetStringValue(property.Value, out var workingDirectory))
+                    {
+                        return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.CouldNotConvertToString, property.Name));
+                    }
+
+                    config.WorkingDirectory = workingDirectory;
+                }
             }
 
             return new LaunchSettingsApplyResult(true, null, config);

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Tools.Run
                 {
                     targetCommand.SetCommandArgs(launchSettings.CommandLineArgs);
                 }
-                if (string.IsNullOrEmpty(targetCommand.CommandWorkingDirectory) && launchSettings.WorkingDirectory != null)
+                if (launchSettings.WorkingDirectory != null)
                 {
                     targetCommand.WorkingDirectory(launchSettings.WorkingDirectory);
                 }

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -109,6 +109,10 @@ namespace Microsoft.DotNet.Tools.Run
                 {
                     targetCommand.SetCommandArgs(launchSettings.CommandLineArgs);
                 }
+                if (string.IsNullOrEmpty(targetCommand.CommandWorkingDirectory) && launchSettings.WorkingDirectory != null)
+                {
+                    targetCommand.WorkingDirectory(launchSettings.WorkingDirectory);
+                }
             }
             return targetCommand;
         }

--- a/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/AppWithWorkingDirectoryInLaunchSettings.csproj
+++ b/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/AppWithWorkingDirectoryInLaunchSettings.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <RuntimeIdentifiers>$(LatestRuntimeIdentifiers)</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/Program.cs
+++ b/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MSBuildTestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var message = Environment.CurrentDirectory;
+            Console.WriteLine(message);
+        }
+    }
+}

--- a/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/Properties/launchSettings.json
+++ b/test/TestAssets/TestProjects/AppWithWorkingDirectoryInLaunchSettings/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "First":{
+      "commandName": "Project"
+    },
+    "Second":{
+      "commandName": "Project",
+      "workingDirectory": "launchSubfolder"
+    }
+  }
+}

--- a/test/dotnet-run.Tests/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunBuildsCsProj.cs
@@ -562,6 +562,53 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItUsesTheValueOfWorkingDirectoryIfTheProjectRunWorkingDirectoryIsNotSet()
+        {
+            var testAppName = "AppWithWorkingDirectoryInLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource();
+
+            var testProjectDirectory = testInstance.Path;
+
+            Directory.CreateDirectory(Path.Combine(testProjectDirectory, "launchSubfolder"));
+
+            var cmd = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--launch-profile", "Second");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("launchSubfolder");
+
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItPrefersTheValueOfProjectRunWorkingDirectoryIfSet()
+        {
+            var testAppName = "AppWithWorkingDirectoryInLaunchSettings";
+            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
+                            .WithSource()
+                            .WithProjectChanges(p => {
+                                var ns = p.Root.Name.Namespace;
+                                var propertyGroup = p.Root.Elements(ns + "PropertyGroup").First();
+                                propertyGroup.Add(new XElement(ns + "RunWorkingDirectory", "runSubfolder"));
+                            });
+
+            var testProjectDirectory = testInstance.Path;
+
+            Directory.CreateDirectory(Path.Combine(testProjectDirectory, "runSubfolder"));
+
+            var cmd = new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--launch-profile", "Second");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("runSubfolder");
+
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
         public void ItGivesAnErrorWhenTheLaunchProfileNotFound()
         {
             var testAppName = "AppWithLaunchSettings";

--- a/test/dotnet-run.Tests/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunBuildsCsProj.cs
@@ -562,7 +562,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItUsesTheValueOfWorkingDirectoryIfTheProjectRunWorkingDirectoryIsNotSet()
+        public void ItUsesTheValueOfWorkingDirectoryIfSet()
         {
             var testAppName = "AppWithWorkingDirectoryInLaunchSettings";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
@@ -583,7 +583,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItPrefersTheValueOfProjectRunWorkingDirectoryIfSet()
+        public void ItPrefersTheValueOfWorkingDirectoryFromLaunchSettingsOverProjectRunWorkingDirectory()
         {
             var testAppName = "AppWithWorkingDirectoryInLaunchSettings";
             var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
@@ -591,19 +591,19 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithProjectChanges(p => {
                                 var ns = p.Root.Name.Namespace;
                                 var propertyGroup = p.Root.Elements(ns + "PropertyGroup").First();
-                                propertyGroup.Add(new XElement(ns + "RunWorkingDirectory", "runSubfolder"));
+                                propertyGroup.Add(new XElement(ns + "RunWorkingDirectory", "expectThisSubfolderIsOverridden"));
                             });
 
             var testProjectDirectory = testInstance.Path;
 
-            Directory.CreateDirectory(Path.Combine(testProjectDirectory, "runSubfolder"));
+            Directory.CreateDirectory(Path.Combine(testProjectDirectory, "launchSubfolder"));
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute("--launch-profile", "Second");
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining("runSubfolder");
+                .And.HaveStdOutContaining("launchSubfolder");
 
             cmd.StdErr.Should().BeEmpty();
         }


### PR DESCRIPTION
This change adds support for the workingDirectory field of the launchSettings.json file to the dotnet run command. I believe this should also resolve #20885.

I followed the behavior of how commandLineArgs interacts with RunArguments in the project file where if RunArguments is defined then it overrides whatever is defined in the launchSettings.json.
In the same way, if RunWorkingDirectory is defined in the project file, it will override the workingDirectory in the launchSettings.json. The tests I added should confirm that behavior.