### PR TITLE
fix bug in workload history recorder

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            return workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            return workloadInfoHelper.ManifestProvider.GetWorkloadVersion().Version;
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Cli
 
             if (showVersion)
             {
-                reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion()}");
+                reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion().Version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         {
             var resolver = _workloadResolverFunc();
             var currentWorkloadVersion = resolver.GetWorkloadVersion();
-            currentWorkloadVersion = currentWorkloadVersion.Contains("manifest") ? string.Empty : currentWorkloadVersion;
+            var versionString = currentWorkloadVersion.WorkloadInstallType == WorkloadVersion.Type.LooseManifest ? string.Empty : currentWorkloadVersion.Version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = currentWorkloadVersion
+                WorkloadSetVersion = versionString
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadInfo = resolver.GetWorkloadVersion();
+            var currentWorkloadVersion = resolver.GetWorkloadVersion();
+            currentWorkloadVersion = currentWorkloadVersion.Contains("manifest") ? string.Empty : currentWorkloadVersion;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = resolver.GetWorkloadVersion()
+                WorkloadSetVersion = currentWorkloadVersion
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                     }
                     else
                     {
-                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion() ?? "unknown"));
+                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion().Version ?? "unknown"));
                     }
 
                     Reporter.WriteLine();

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -14,8 +14,20 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         string GetSdkFeatureBand();
 
-        string? GetWorkloadVersion();
+        WorkloadVersion GetWorkloadVersion();
 
         Dictionary<string, WorkloadSet> GetAvailableWorkloadSets();
+    }
+
+    public record WorkloadVersion
+    {
+        public enum Type
+        {
+            WorkloadSet,
+            LooseManifest
+        }
+
+        public string? Version;
+        public Type WorkloadInstallType;
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         string GetManifestFeatureBand(string manifestId);
         IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
-        string? GetWorkloadVersion();
+        WorkloadVersion GetWorkloadVersion();
         IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads);
         WorkloadManifest GetManifestFromWorkload(WorkloadId workloadId);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -243,18 +243,26 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
         }
 
-        public string? GetWorkloadVersion()
+        public WorkloadVersion GetWorkloadVersion()
         {
             if (_globalJsonWorkloadSetVersion != null)
             {
-                return _globalJsonWorkloadSetVersion;
+                return new WorkloadVersion()
+                {
+                    Version = _globalJsonWorkloadSetVersion,
+                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
+                };
             }
 
             ThrowExceptionIfManifestsNotAvailable();
 
             if (_workloadSet?.Version is not null)
             {
-                return _workloadSet?.Version!;
+                return new WorkloadVersion()
+                {
+                    Version = _workloadSet.Version,
+                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
+                };
             }
 
             using (SHA256 sha256Hash = SHA256.Create())
@@ -271,7 +279,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     sb.Append(bytes[b].ToString("x2"));
                 }
 
-                return $"{_sdkVersionBand.ToStringWithoutPrerelease()}-manifests.{sb}";
+                return new WorkloadVersion()
+                {
+                    Version = $"{_sdkVersionBand.ToStringWithoutPrerelease()}-manifests.{sb}",
+                    WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+                };
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -53,7 +53,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         }
 
         public string GetSdkFeatureBand() => _sdkVersionBand;
-        public string? GetWorkloadVersion() => _sdkVersionBand.ToString() + ".2";
+        public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion
+        {
+            Version = _sdkVersionBand + ".2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        };
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             InitializeManifests();
         }
 
-        public string? GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
+        public WorkloadVersion GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
 
         private void LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         {
@@ -778,7 +778,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public string? GetWorkloadVersion() => _sdkFeatureBand.ToString() + ".2";
+            public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion
+            {
+                Version = _sdkFeatureBand + ".2",
+                WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+            };
         }
     }
 

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -40,7 +40,11 @@ namespace ManifestReaderTests
 
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion
+                                                           {
+                                                               Version = "8.0.100.2",
+                                                               WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+                                                           };
     }
 
     internal class InMemoryFakeManifestProvider : IWorkloadManifestProvider, IEnumerable<(string id, string content)>
@@ -67,6 +71,10 @@ namespace ManifestReaderTests
         IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion
+        {
+            Version = "8.0.100.2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        };
     }
 }

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -93,14 +93,14 @@ namespace ManifestReaderTests
 
             if (useWorkloadSet)
             {
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Version.Should().Be("8.0.200");
             }
             else
             {
                 string[] manifests = sdkDirectoryWorkloadManifestProvider.GetManifests().OrderBy(m => m.ManifestId).Select(m => $"{m.ManifestId}.{m.ManifestFeatureBand}.{m.ManifestVersion}").ToArray();
                 manifests.Length.Should().Be(1);
                 manifests.Should().Contain("android.8.0.200.33.0.2-rc.1");
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200-manifests.4ba11739");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Version.Should().Be("8.0.200-manifests.4ba11739");
             }
 
             Directory.Delete(Path.Combine(_manifestRoot, "8.0.100"), recursive: true);

--- a/test/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/test/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -48,6 +48,10 @@ namespace ManifestReaderTests
         }
 
         public string GetSdkFeatureBand() => SdkFeatureBand.ToString();
-        public string GetWorkloadVersion() => SdkFeatureBand.ToString() + ".2";
+        public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion
+        {
+            Version = GetSdkFeatureBand() + ".2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        };
     }
 }

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,11 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public string GetWorkloadVersion() => "12.0.400.2";
+        public WorkloadVersion GetWorkloadVersion() => new WorkloadVersion()
+        {
+            Version = "12.0.400.2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        };
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();


### PR DESCRIPTION
Without this, it interprets the hashed form of the version as a workload set version