### PR TITLE
[Wasm] Moves wasm reload logic out of ASP.NET Core and into the SDK

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -12,16 +12,27 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
     public class BrowserRefreshMiddleware
     {
         private static readonly MediaTypeHeaderValue _textHtmlMediaType = new("text/html");
+        private static readonly MediaTypeHeaderValue _applicationJsonMediaType = new("application/json");
+        private readonly string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
+        private readonly string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
+
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
+
+        private static string? GetNonEmptyEnvironmentVariableValue(string name)
+            => Environment.GetEnvironmentVariable(name) is { Length: > 0 } value ? value : null;
 
         public BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger) =>
             (_next, _logger) = (next, logger);
 
         public async Task InvokeAsync(HttpContext context)
         {
-            // We only need to support this for requests that could be initiated by a browser.
-            if (IsBrowserDocumentRequest(context))
+            if (IsWebAssemblyBootRequest(context))
+            {
+                AttachWebAssemblyHeaders(context);
+                await _next(context);
+            }
+            else if (IsBrowserDocumentRequest(context))
             {
                 // Use a custom StreamWrapper to rewrite output on Write/WriteAsync
                 using var responseStreamWrapper = new ResponseStreamWrapper(context, _logger);
@@ -57,6 +68,86 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             {
                 await _next(context);
             }
+        }
+
+        private void AttachWebAssemblyHeaders(HttpContext context)
+        {
+            context.Response.OnStarting(() =>
+            {
+                if (!context.Response.Headers.ContainsKey("DOTNET-MODIFIABLE-ASSEMBLIES"))
+                {
+                    if(_dotnetModifiableAssemblies != null)
+                    {
+                        context.Response.Headers.Add("DOTNET-MODIFIABLE-ASSEMBLIES", _dotnetModifiableAssemblies);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES environment variable is not set. The browser refresh feature may not work as expected.");
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES header is already set.");
+                }
+
+                if (!context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"))
+                {
+                    if (_aspnetcoreBrowserTools != null)
+                    {
+                        context.Response.Headers.Add("ASPNETCORE-BROWSER-TOOLS", _aspnetcoreBrowserTools);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("__ASPNETCORE_BROWSER_TOOLS environment variable is not set. The browser refresh feature may not work as expected.");
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug("ASPNETCORE_BROWSER_TOOLS header is already set.");
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+
+        internal static bool IsWebAssemblyBootRequest(HttpContext context)
+        {
+            var request = context.Request;
+            if (!HttpMethods.IsGet(request.Method))
+            {
+                return false;
+            }
+
+            if (request.Headers.TryGetValue("Sec-Fetch-Dest", out var values) &&
+                !StringValues.IsNullOrEmpty(values) &&
+                !string.Equals(values[0], "document", StringComparison.OrdinalIgnoreCase))
+            {
+                // See https://github.com/dotnet/aspnetcore/issues/37326.
+                // Only inject scripts that are destined for a browser page.
+                return false;
+            }
+
+            if (!request.Path.HasValue ||
+                !string.Equals(Path.GetFileName(request.Path.Value), "blazor.boot.json", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var typedHeaders = request.GetTypedHeaders();
+            if (typedHeaders.Accept is not IList<MediaTypeHeaderValue> acceptHeaders)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < acceptHeaders.Count; i++)
+            {
+                if (acceptHeaders[i].IsSubsetOf(_applicationJsonMediaType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static bool IsBrowserDocumentRequest(HttpContext context)

--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -82,12 +82,12 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                     }
                     else
                     {
-                        _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES environment variable is not set. The browser refresh feature may not work as expected.");
+                        _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES environment variable is not set, likely because hot reload is not enabled. The browser refresh feature may not work as expected.");
                     }
                 }
                 else
                 {
-                    _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES header is already set.");
+                    _logger.LogDebug("DOTNET-MODIFIABLE-ASSEMBLIES header is already set.");
                 }
 
                 if (!context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"))
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 }
                 else
                 {
-                    _logger.LogDebug("ASPNETCORE_BROWSER_TOOLS header is already set.");
+                    _logger.LogDebug("ASPNETCORE-BROWSER-TOOLS header is already set.");
                 }
 
                 return Task.CompletedTask;

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
@@ -203,6 +206,333 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             Assert.False(result);
         }
 
+        [Theory]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        [InlineData("head")]
+        [InlineData("Put")]
+        public void IsWebassemblyBootRequest_ReturnsFalse_ForNonGetRequests(string method)
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = method,
+                    Headers =
+                    {
+                        ["Accept"] = "application/html",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsWebassemblyBootRequest_ReturnsFalse_IfRequestDoesNotAcceptJson()
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "text/html",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsWebassemblyBootRequest_ReturnsTrue_ForGetRequestsThatAcceptJson()
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "text/html,application/json;q=0.9",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("/_framework/blazor.boot.json")]
+        [InlineData("/Blazor.boot.json")]
+        public void IsWebassemblyBootRequest_ReturnsTrue_ForFileNameRequestsToBlazorBootJson(string path)
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = path,
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("/_framework/other.txt")]
+        [InlineData("/other.txt")]
+        [InlineData("/Blazor.boot.json/other.txt")]
+        public void IsWebassemblyBootRequest_ReturnsFalse_ForRequestsToOtherPathsThanBlazorBootJson(string path)
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = path,
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsWebassemblyBootRequest_ReturnsTrue_IfRequestDoesNotHaveFetchMetadataRequestHeader()
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json"
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsWebassemblyBootRequest_ReturnsTrue_IfRequestFetchMetadataRequestHeaderIsEmpty()
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json",
+                        ["Sec-Fetch-Dest"] = string.Empty,
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("document")]
+        [InlineData("Document")]
+        public void IsWebassemblyBootRequest_ReturnsTrue_IfRequestFetchMetadataRequestHeaderIsDocument(string headerValue)
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json",
+                        ["Sec-Fetch-Dest"] = headerValue,
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("frame")]
+        [InlineData("iframe")]
+        [InlineData("serviceworker")]
+        public void IsWebassemblyBootRequest_ReturnsFalse_IfRequestFetchMetadataRequestHeaderIsNotDocument(string headerValue)
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "application/json",
+                        ["Sec-Fetch-Dest"] = headerValue,
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_AttachesHeadersToResponse()
+        {
+            var stream = new MemoryStream();
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = "GET",
+                    Headers = { ["Accept"] = "application/json" },
+                },
+                Response =
+                {
+                    Body = stream
+                },
+            };
+
+            var response = new TestHttpResponseFeature
+            {
+                Body = stream,
+                Headers = new HeaderDictionary()
+            };
+            context.Features.Set<IHttpResponseFeature>(response);
+            context.Features.Set<IHttpResponseBodyFeature>(response);
+
+            var middleware = new BrowserRefreshMiddleware(async (context) =>
+            {
+
+                context.Response.ContentType = "application/json";
+                await context.Response.StartAsync();
+                await context.Response.WriteAsync("{ }");
+            }, NullLogger<BrowserRefreshMiddleware>.Instance);
+
+            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateDotnetModifiableAssemblies(middleware) = "true";
+            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateAspnetcoreBrowserTools(middleware) = "true";
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.True(context.Response.Headers.ContainsKey("DOTNET-MODIFIABLE-ASSEMBLIES"));
+            Assert.True(context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"));
+        }
+
+        [Fact]
+        public async Task InvokeAsync_DoesNotAttachHeaders_WhenAlreadyAttached()
+        {
+            var stream = new MemoryStream();
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = "GET",
+                    Headers = { ["Accept"] = "application/json" },
+                },
+                Response =
+                {
+                    Body = stream
+                },
+            };
+
+            var response = new TestHttpResponseFeature
+            {
+                Body = stream,
+                Headers = new HeaderDictionary()
+            };
+            context.Features.Set<IHttpResponseFeature>(response);
+            context.Features.Set<IHttpResponseBodyFeature>(response);
+
+            var middleware = new BrowserRefreshMiddleware(async (context) =>
+            {
+
+                context.Response.ContentType = "application/json";
+                context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", "true");
+                context.Response.Headers.Append("ASPNETCORE-BROWSER-TOOLS", "true");
+                await context.Response.StartAsync();
+                await context.Response.WriteAsync("{ }");
+            }, NullLogger<BrowserRefreshMiddleware>.Instance);
+
+            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateDotnetModifiableAssemblies(middleware) = "true";
+            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateAspnetcoreBrowserTools(middleware) = "true";
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.True(context.Response.Headers.ContainsKey("DOTNET-MODIFIABLE-ASSEMBLIES"));
+            Assert.Equal("true", context.Response.Headers["DOTNET-MODIFIABLE-ASSEMBLIES"]);
+            Assert.True(context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"));
+            Assert.Equal("true", context.Response.Headers["ASPNETCORE-BROWSER-TOOLS"]);
+        }
+
         [Fact]
         public async Task InvokeAsync_AddsScriptToThePage()
         {
@@ -241,6 +571,62 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             // Assert
             var responseContent = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal("<html><body><h1>Hello world</h1><script src=\"/_framework/aspnetcore-browser-refresh.js\"></script></body></html>", responseContent);
+        }
+
+        private static class UnsafeBrowserRefreshMiddlewareAccessor
+        {
+            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_dotnetModifiableAssemblies")]
+            extern internal static ref string GetSetPrivateDotnetModifiableAssemblies(BrowserRefreshMiddleware middleware);
+
+            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_aspnetcoreBrowserTools")]
+            extern internal static ref string GetSetPrivateAspnetcoreBrowserTools(BrowserRefreshMiddleware middleware);
+        }
+
+        private class TestHttpResponseFeature : IHttpResponseFeature, IHttpResponseBodyFeature
+        {
+            private (Func<object, Task> callback, object state)[] _callbacks = [];
+            private bool _hasStarted;
+
+            public int StatusCode { get; set; }
+            public string? ReasonPhrase { get; set; }
+            public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+            public Stream Body { get; set; } = new MemoryStream();
+
+            public bool HasStarted => _hasStarted;
+
+            public Stream Stream => Body;
+
+            public PipeWriter Writer => PipeWriter.Create(Body);
+
+            public Task CompleteAsync() => Task.CompletedTask;
+
+            public void DisableBuffering() { }
+
+            public void OnCompleted(Func<object, Task> callback, object state) => throw new NotImplementedException();
+
+            public void OnStarting(Func<object, Task> callback, object state)
+            {
+                _callbacks = [(callback, state)];
+            }
+
+            public Task SendFileAsync(string path, long offset, long? count, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public async Task StartAsync(CancellationToken cancellationToken = default)
+            {
+                if(_hasStarted)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                foreach (var (callback, state) in _callbacks)
+                {
+                    await callback(state);
+                }
+
+                await Stream.FlushAsync();
+
+                _hasStarted = true;
+            }
         }
     }
 }


### PR DESCRIPTION
* Moves the logic from https://github.com/dotnet/aspnetcore/blob/eb626ad8577ac295416f645ee020f6f4024d4565/src/Components/WebAssembly/Server/src/ComponentWebAssemblyConventions.cs#L17-L52 into the SDK directly.
* For reference, the JS logic for this feature lives in https://github.com/dotnet/runtime/blob/6931b3b729ec050f935f958122d3cc66bb46fdcf/src/mono/browser/runtime/loader/config.ts#L319-L343

We only attach the headers to any file whose name is "blazor.boot.json".