### PR TITLE
use stage 2 MSBuild version instead of stage 0 for msbuild disjoint c…

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -1247,7 +1247,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <MinimumMSBuildVersionFile>$(RedistLayoutPath)sdk/$(Version)/minimumMSBuildVersion</MinimumMSBuildVersionFile>
       <BundledMSBuildPropsFileName>Microsoft.NETCoreSdk.BundledMSBuildInformation.props</BundledMSBuildPropsFileName>
-      <BundledMSBuildVersion>$(MSBuildVersion)</BundledMSBuildVersion>
+      <_ShippingMSBuildVersion>$(MicrosoftBuildVersion)</_ShippingMSBuildVersion>
+      <_ShippingMSBuildVersion Condition="$(_ShippingMSBuildVersion.Contains('-'))">$(MicrosoftBuildVersion.Split('-')[0])</_ShippingMSBuildVersion>
+      <BundledMSBuildVersion>$(_ShippingMSBuildVersion)</BundledMSBuildVersion>
     </PropertyGroup>
 
     <Error Text="No MSBuild version file found under '$(RedistLayoutPath)sdk/$(Version)'" Condition="!Exists('$(MinimumMSBuildVersionFile)')" />


### PR DESCRIPTION
…hecks


## Testing

```xml
<Project InitialTargets="TestSplicing">
    <Target Name="TestSplicing">
        <PropertyGroup>
            <MicrosoftBuildVersion>17.12.0-preview-24374-02</MicrosoftBuildVersion>
            <_ShippingMSBuildVersion>$(MicrosoftBuildVersion)</_ShippingMSBuildVersion>
            <_ShippingMSBuildVersion Condition="$(_ShippingMSBuildVersion.Contains('-'))">$(MicrosoftBuildVersion.Split('-')[0])</_ShippingMSBuildVersion>
            <BundledMSBuildVersion>$(_ShippingMSBuildVersion)</BundledMSBuildVersion>
        </PropertyGroup>
    </Target>
</Project>
```

put that in a file and run it with `dotnet build -bl`, then check the binlog. You should see properties like this:

![image](https://github.com/user-attachments/assets/5c3211d4-8497-4855-8a93-968d966adeb3)
