### PR TITLE
Avoid downloading of Microsoft.Net.Sdk.Compilers.Toolset when building in dogfood environment

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -46,6 +46,9 @@ try {
   $env:PATH = "$TestDotnetRoot;$env:Path"
   $env:DOTNET_ROOT = $TestDotnetRoot
 
+  # Avoid downloading Microsoft.Net.Sdk.Compilers.Toolset from feed
+  $env:BuildWithNetFrameworkHostedCompiler = $false
+
   if ($command -eq $null -and $env:DOTNET_SDK_DOGFOOD_SHELL -ne $null) {
     $command = , $env:DOTNET_SDK_DOGFOOD_SHELL
   }

--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -47,6 +47,7 @@ try {
   $env:DOTNET_ROOT = $TestDotnetRoot
 
   # Avoid downloading Microsoft.Net.Sdk.Compilers.Toolset from feed
+  # Locally built SDK package version is Major.Minor.0-dev, which won't be available.
   $env:BuildWithNetFrameworkHostedCompiler = $false
 
   if ($command -eq $null -and $env:DOTNET_SDK_DOGFOOD_SHELL -ne $null) {


### PR DESCRIPTION
Otherwise the targets are attempting to download 9.0.0-dev version of the package, which is going to fail.