### PR TITLE
Only publish artifacts on success

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -159,7 +159,6 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/publishing
       artifact: $(Agent.JobName)_Artifacts
       displayName: Publish Artifacts
-      condition: always()
       sbomEnabled: true
 
     - ${{ if not(parameters.isBuiltFromVmr) }}:
@@ -548,7 +547,6 @@ jobs:
         assets/**
       TargetFolder: $(Build.ArtifactStagingDirectory)/publishing
     displayName: Copy artifacts to Artifact Staging Directory
-    condition: succeededOrFailed()
 
   # When building from source, the Private.SourceBuilt.Artifacts archive already contains the nuget packages
   - ${{ if ne(parameters.buildSourceOnly, 'true') }}:
@@ -557,11 +555,9 @@ jobs:
         SourceFolder: $(sourcesPath)/artifacts/packages
         TargetFolder: $(Build.ArtifactStagingDirectory)/publishing/packages
       displayName: Copy packages to Artifact Staging Directory
-      condition: succeededOrFailed()
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(Build.ArtifactStagingDirectory)/publishing
       artifact: $(Agent.JobName)_Artifacts
       displayName: Publish Artifacts
-      condition: succeededOrFailed()
       continueOnError: true


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4537?notification_referrer_id=NT_kwDOBAelGbQxMTc1MzUxMjQ3OTo2NzYwOTg4MQ#issuecomment-2272189775

The default step condition is `succeeded()`, so the steps without conditions will only run if the previous steps were successful.