### PR TITLE
Fix .net 8.0 test templates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -367,9 +367,9 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>becc4bd157cd6608b51a5ffe414a5d2de6330272</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.8.0" Version="1.1.0-rc.24202.1">
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.8.0" Version="1.1.0-rc.24059.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
-      <Sha>49c9ad01f057b3c6352bbec12b117acc2224493c</Sha>
+      <Sha>7d2f2719628e6744f3172a2d48e0d1f600b360c0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.9.0" Version="1.1.0-rc.24365.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,7 +116,7 @@
     <!-- Dependency from https://github.com/dotnet/test-templates -->
     <!-- Supported versions -->
     <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.1.0-rc.24069.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates80PackageVersion>1.1.0-rc.24202.1</MicrosoftDotNetTestProjectTemplates80PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates80PackageVersion>1.1.0-rc.24059.1</MicrosoftDotNetTestProjectTemplates80PackageVersion>
     <MicrosoftDotNetTestProjectTemplates90PackageVersion>1.1.0-rc.24365.1</MicrosoftDotNetTestProjectTemplates90PackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
The template inserted inside the .NET 9.0 for .NET 8.0 tfm is broken.
This is visible on vendors testing because on the machine there's only .NET 9 preview installed, otherwise the template can be picked up from the .NET 8.0 SDK.
This PR revert the template we ship for .NET 9 to the last good one shipped inside .NET 8.0.4xx 

Version.Details.xml https://github.com/dotnet/installer/blob/release/8.0.4xx/eng/Version.Details.xml#L122-L125
Version.props https://github.com/dotnet/installer/blob/release/8.0.4xx/eng/Versions.props#L60

To test the fix I've build the package and overridden the `C:\Program Files\dotnet\templates\8.0.7\microsoft.dotnet.test.projecttemplates.8.0.1.1.0-rc.24202.1` package installed with the "only" .NET 9 SDK on vendors repro machine.
I did a manual test on vendors machine with 9.0 8.0 7.0 6.0 and looks good.

cc: @pavelhorak @Evangelink @nohwnd
