### PR TITLE
[Wasm] Fix request filters for blazor.boot.json

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             if (request.Headers.TryGetValue("Sec-Fetch-Dest", out var values) &&
                 !StringValues.IsNullOrEmpty(values) &&
-                !string.Equals(values[0], "document", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(values[0], "empty", StringComparison.OrdinalIgnoreCase))
             {
                 // See https://github.com/dotnet/aspnetcore/issues/37326.
                 // Only inject scripts that are destined for a browser page.
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             for (var i = 0; i < acceptHeaders.Count; i++)
             {
-                if (acceptHeaders[i].IsSubsetOf(_applicationJsonMediaType))
+                if (acceptHeaders[i].MatchesAllTypes || acceptHeaders[i].IsSubsetOf(_applicationJsonMediaType))
                 {
                     return true;
                 }

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
@@ -282,6 +282,30 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             Assert.True(result);
         }
 
+        [Fact]
+        public void IsWebassemblyBootRequest_ReturnsTrue_ForGetRequestsThatAcceptAnyContentType()
+        {
+            // Arrange
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = "/_framework/blazor.boot.json",
+                    Method = HttpMethods.Get,
+                    Headers =
+                    {
+                        ["Accept"] = "*/*",
+                    },
+                },
+            };
+
+            // Act
+            var result = BrowserRefreshMiddleware.IsWebAssemblyBootRequest(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
         [Theory]
         [InlineData("/_framework/blazor.boot.json")]
         [InlineData("/Blazor.boot.json")]
@@ -385,9 +409,9 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         }
 
         [Theory]
-        [InlineData("document")]
-        [InlineData("Document")]
-        public void IsWebassemblyBootRequest_ReturnsTrue_IfRequestFetchMetadataRequestHeaderIsDocument(string headerValue)
+        [InlineData("empty")]
+        [InlineData("Empty")]
+        public void IsWebassemblyBootRequest_ReturnsTrue_IfRequestFetchMetadataRequestHeaderIsEmptyValue(string headerValue)
         {
             // Arrange
             var context = new DefaultHttpContext
@@ -415,7 +439,8 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         [InlineData("frame")]
         [InlineData("iframe")]
         [InlineData("serviceworker")]
-        public void IsWebassemblyBootRequest_ReturnsFalse_IfRequestFetchMetadataRequestHeaderIsNotDocument(string headerValue)
+        [InlineData("document")]
+        public void IsWebassemblyBootRequest_ReturnsFalse_IfRequestFetchMetadataRequestHeaderIsEmptyValue(string headerValue)
         {
             // Arrange
             var context = new DefaultHttpContext


### PR DESCRIPTION
The browser sends `sec-fetch-dest: empty` and Accept `*/*`