### PR TITLE
[Web SDK] Avoid copying packages.lock.json to the output folder

### DIFF
--- a/src/StaticWebAssetsSdk/Sdk/Sdk.StaticWebAssets.StaticAssets.ProjectSystem.props
+++ b/src/StaticWebAssetsSdk/Sdk/Sdk.StaticWebAssets.StaticAssets.ProjectSystem.props
@@ -22,6 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**\packages.lock.json</DefaultItemExcludes>
     <DefaultWebContentItemExcludes>$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/55568

Validated this manually.