### PR TITLE
Revert "Replace obsolete nuget api in Microsoft.DotNet.PackageValidation"

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Package.cs
@@ -94,11 +94,11 @@ namespace Microsoft.DotNet.PackageValidation
             _contentItemCollection = new ContentItemCollection();
             _contentItemCollection.Load(packageAssets);
 
-            PackageAssets = GetContentItemsFromPattern(_conventions.Patterns.AnyTargettedFile);
-            RefAssets = GetContentItemsFromPattern(_conventions.Patterns.CompileRefAssemblies);
-            LibAssets = GetContentItemsFromPattern(_conventions.Patterns.CompileLibAssemblies);
+            PackageAssets = _contentItemCollection.FindItems(_conventions.Patterns.AnyTargettedFile);
+            RefAssets = _contentItemCollection.FindItems(_conventions.Patterns.CompileRefAssemblies);
+            LibAssets = _contentItemCollection.FindItems(_conventions.Patterns.CompileLibAssemblies);
             CompileAssets = RefAssets.Any() ? RefAssets : LibAssets;
-            RuntimeAssets = GetContentItemsFromPattern(_conventions.Patterns.RuntimeAssemblies);
+            RuntimeAssets = _contentItemCollection.FindItems(_conventions.Patterns.RuntimeAssemblies);
             RuntimeSpecificAssets = RuntimeAssets.Where(t => t.Path.StartsWith("runtimes")).ToArray();
             Rids = RuntimeSpecificAssets.Select(t => (string)t.Properties["rid"])
                 .Distinct()
@@ -108,13 +108,6 @@ namespace Microsoft.DotNet.PackageValidation
                 .Distinct()
                 .ToArray();
             AssemblyReferences = assemblyReferences;
-
-            IEnumerable<ContentItem> GetContentItemsFromPattern(PatternSet pattern)
-            {
-                List<ContentItemGroup> itemGroups = new();
-                _contentItemCollection.PopulateItemGroups(pattern, itemGroups);
-                return itemGroups.SelectMany(i => i.Items).ToArray();
-            }
         }
 
         public static void InitializeRuntimeGraph(string runtimeGraph)


### PR DESCRIPTION
Reverts dotnet/sdk#42508

It turns out that this was discussed a while ago when the `FindItems` API was made obsolete the first time and we actually concluded that it _should not_ be obsolete: https://github.com/dotnet/sdk/issues/23301

@nkolev92 would you mind adding a comment to `FindItems` so that we don't try to obsolete a third time? 😄 