### PR TITLE
[release/6.0.4xx] Add CompilerVisibleProperty needed for analyzer in Windows SDK projection

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -45,6 +45,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>
   </PropertyGroup>
 
+  <!-- Used by analyzers in the Microsoft.Windows.SDK.NET.Ref package. -->
+  <PropertyGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">
+    <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
+    <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
+    <CsWinRTCcwLookupTableGeneratorEnabled Condition="'$(CsWinRTCcwLookupTableGeneratorEnabled)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">true</CsWinRTCcwLookupTableGeneratorEnabled>
+    <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">1</CsWinRTAotWarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">
+    <CompilerVisibleProperty Include="CsWinRTAotOptimizerEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTAotExportsEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTRcwFactoryFallbackGeneratorForceOptIn" />
+    <CompilerVisibleProperty Include="CsWinRTRcwFactoryFallbackGeneratorForceOptOut" />
+    <CompilerVisibleProperty Include="CsWinRTCcwLookupTableGeneratorEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTMergeReferencedActivationFactories" />
+    <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
+  </ItemGroup>
+
   <Target Name="_ErrorOnUnresolvedWindowsSDKAssemblyConflict"
           AfterTargets="ResolveAssemblyReferences"
           Condition=" '@(ResolveAssemblyReferenceUnresolvedAssemblyConflicts)' != '' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -50,7 +50,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
     <CsWinRTCcwLookupTableGeneratorEnabled Condition="'$(CsWinRTCcwLookupTableGeneratorEnabled)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">true</CsWinRTCcwLookupTableGeneratorEnabled>
-    <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">1</CsWinRTAotWarningLevel>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">


### PR DESCRIPTION
The latest update to the Windows SDK projection does have an analyzer that relies on a couple of properties.  This PR makes them visible to the analyzer and sets the defaults.  The change are conditional on `IncludeWindowsSDKRefFrameworkReferences` which should scope it to scenarios where the package is used.