### PR TITLE
[release/8.0.4xx] Add CompilerVisibleProperty needed for analyzer in Windows SDK projection

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -45,6 +45,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">$(TargetPlatformVersion)</TargetPlatformMinVersion>
   </PropertyGroup>
 
+  <!-- Used by analyzers in the Microsoft.Windows.SDK.NET.Ref package. -->
+  <PropertyGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">
+    <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
+    <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
+    <CsWinRTCcwLookupTableGeneratorEnabled Condition="'$(CsWinRTCcwLookupTableGeneratorEnabled)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">true</CsWinRTCcwLookupTableGeneratorEnabled>
+    <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">1</CsWinRTAotWarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">
+    <CompilerVisibleProperty Include="CsWinRTAotOptimizerEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTAotExportsEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTRcwFactoryFallbackGeneratorForceOptIn" />
+    <CompilerVisibleProperty Include="CsWinRTRcwFactoryFallbackGeneratorForceOptOut" />
+    <CompilerVisibleProperty Include="CsWinRTCcwLookupTableGeneratorEnabled" />
+    <CompilerVisibleProperty Include="CsWinRTMergeReferencedActivationFactories" />
+    <CompilerVisibleProperty Include="CsWinRTAotWarningLevel" />
+  </ItemGroup>
+
   <Target Name="_ErrorOnUnresolvedWindowsSDKAssemblyConflict"
           AfterTargets="ResolveAssemblyReferences"
           Condition=" '@(ResolveAssemblyReferenceUnresolvedAssemblyConflicts)' != '' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -50,7 +50,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CsWinRTAotOptimizerEnabled Condition="'$(CsWinRTAotOptimizerEnabled)' == '' and $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 6">true</CsWinRTAotOptimizerEnabled>
     <CsWinRTAotExportsEnabled Condition="'$(CsWinRTAotExportsEnabled)' == '' and '$(CsWinRTAotOptimizerEnabled)' == 'true' and '$(PublishAot)' == 'true'">true</CsWinRTAotExportsEnabled>
     <CsWinRTCcwLookupTableGeneratorEnabled Condition="'$(CsWinRTCcwLookupTableGeneratorEnabled)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">true</CsWinRTCcwLookupTableGeneratorEnabled>
-    <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == '' and '$(CsWinRTGenerateProjection)' != 'true'">1</CsWinRTAotWarningLevel>
+    <CsWinRTAotWarningLevel Condition="'$(CsWinRTAotWarningLevel)' == '' and '$(CsWinRTGenerateProjection)' != 'true' and ('$(PublishAot)' == 'true' or '$(IsAotCompatible)' == 'true')">1</CsWinRTAotWarningLevel>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'">


### PR DESCRIPTION
**Summary**

Our latest update to the Windows SDK projection package `Microsoft.Windows.SDK.NET.Ref` in the installer repo contains an analyzer that needs access to a couple MSBuild properties.  To allow that, this PR sets the default for these properties and exposes them to the analyzer using `CompilerVisibleProperty`.  This is only done in the scenarios when our package gets included as determined by `IncludeWindowsSDKRefFrameworkReferences` being set to true (i.e. someone targeting net8.0-windows10.0.22621.0 or similar Windows OS version TFM).

**Customer Impact** 

The impact is without this PR, the analyzer will just use the defaults and prevent consumers from being able to configure the behavior without themselves adding `CompilerVisibleProperty`.  And without the analyzer itself, they will not get the improvements that have been made for this scenario to be AOT compatible which the upcoming WindowsAppSDK release is relying on.

**Regression**

No, our package didn't include an analyzer in the past.

**Testing**

For the changes in this PR itself, these are only setting defaults on scenario specific properties when not set and just declaring them as exposed to an analyzer.

But for in general together with the projection package update, these changes have been in public preview for the last 2 months and have been exercised as part of public WindowsAppSDK 1.6 experimental and preview releases.  In those preview releases, a reference to the `Microsoft.Windows.CsWinRT` package was required which set the equivalent but for the stable release we are putting those changes here as developers don't typically reference that package unless they are a component owner building a projection.

**Risk**

These changes are just exposing scenario specific properties, so are low risk.  And overall, the projection package and these properties are only set when the Windows OS version specific TFM is used (i.e. net8.0-windows10.0.22621.0 or similar).