### PR TITLE
Send "workload set not installed" messages

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -46,7 +46,9 @@ namespace Microsoft.DotNet.Cli
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
             (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-            return version.Version + (error is not null ? ' ' + error : string.Empty);
+
+            // The explicit space here is intentional, as it's easy to miss in localization and crucial for parsing
+            return version.Version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,7 +45,13 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            return workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            if (error is not null)
+            {
+                Reporter.Output.WriteLine(error);
+            }
+
+            return version;
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -58,7 +64,13 @@ namespace Microsoft.DotNet.Cli
 
             if (showVersion)
             {
-                reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion()}");
+                (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                if (error is not null)
+                {
+                    reporter.WriteLine(error);
+                }
+
+                reporter.WriteLine($" Workload version: {version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,10 +45,10 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
 
             // The explicit space here is intentional, as it's easy to miss in localization and crucial for parsing
-            return version.Version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
+            return version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -62,8 +62,8 @@ namespace Microsoft.DotNet.Cli
             string error = null;
             if (showVersion)
             {
-                (WorkloadVersion version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-                reporter.WriteLine($" Workload version: {version.Version}");
+                (string version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                reporter.WriteLine($" Workload version: {version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,13 +45,8 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-            if (error is not null)
-            {
-                Reporter.Output.WriteLine(error);
-            }
-
-            return version;
+            (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            return version.Version + (error is not null ? ' ' + error : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -62,15 +57,11 @@ namespace Microsoft.DotNet.Cli
             reporter ??= Utils.Reporter.Output;
             string dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
 
+            string error = null;
             if (showVersion)
             {
-                (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-                if (error is not null)
-                {
-                    reporter.WriteLine(error);
-                }
-
-                reporter.WriteLine($" Workload version: {version}");
+                (WorkloadVersion version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                reporter.WriteLine($" Workload version: {version.Version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;
@@ -108,6 +99,11 @@ namespace Microsoft.DotNet.Cli
                 reporter.WriteLine($"       {WorkloadInstallType.GetWorkloadInstallType(new SdkFeatureBand(workloadFeatureBand), dotnetPath).ToString(),align}"
                 );
                 reporter.WriteLine("");
+            }
+
+            if (error is not null)
+            {
+                reporter.WriteLine(error);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadInfo = resolver.GetWorkloadVersion();
+            var currentWorkloadVersion = resolver.GetWorkloadVersion();
+            var versionString = currentWorkloadVersion.version.WorkloadInstallType == WorkloadVersion.Type.LooseManifest ? string.Empty : currentWorkloadVersion.version.Version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = resolver.GetWorkloadVersion().version
+                WorkloadSetVersion = versionString
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = resolver.GetWorkloadVersion()
+                WorkloadSetVersion = resolver.GetWorkloadVersion().version
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,8 +54,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadVersion = resolver.GetWorkloadVersion();
-            var versionString = currentWorkloadVersion.version.WorkloadInstallType == WorkloadVersion.Type.LooseManifest ? string.Empty : currentWorkloadVersion.version.Version;
+            var currentWorkloadVersion = resolver.GetWorkloadVersion().version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -63,7 +62,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = versionString
+                WorkloadSetVersion = currentWorkloadVersion
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/list/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/LocalizableStrings.resx
@@ -134,6 +134,9 @@
   <data name="WorkloadSetFromGlobalJsonInstalled" xml:space="preserve">
     <value>Found workload version {0} pinned in the global.json file at {1}.</value>
   </data>
+  <data name="WorkloadVersionNotInstalledShort" xml:space="preserve">
+    <value>(not installed)</value>
+  </data>
   <data name="WorkloadSetFromGlobalJsonNotInstalled" xml:space="preserve">
     <value>Found workload version {0} pinned in the global.json file at {1}, but it was not installed. Running `dotnet workload install`, `dotnet workload update`, or `dotnet workload restore` may fix this.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                     }
                     else
                     {
-                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion() ?? "unknown"));
+                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion().version ?? "unknown"));
                     }
 
                     Reporter.WriteLine();

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Aktualizace jsou k dispozici pro následující úlohy: {0}. Pokud chcete získat nejnovější verzi, spusťte aktualizaci úlohy dotnet (`dotnet workload update`).</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Updates sind für die folgenden Workloads verfügbar: {0}. Führen Sie „dotnet workload update“ aus, um die neueste Updates zu erhalten.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Hay actualizaciones disponibles para las siguientes cargas de trabajo: {0}. Ejecute "dotnet workload update" para obtener la versión más reciente.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Des mises à jour sont disponibles pour les charges de travail suivantes : {0}. Exécutez `dotnet workload update` pour obtenir la dernière version.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Gli aggiornamenti sono disponibili per i carichi di lavoro seguenti: {0}. Per ottenere la versione più recente, eseguire 'dotnet workload update'.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">次のワークロードについて更新プログラムを入手可能です: {0}。最新版を取得するには、`dotnet workload update` を実行します。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">다음 워크로드에 대한 업데이트를 사용할 수 있습니다. {0}. 최신 버전을 받으려면 `dotnet workload update`를 실행하세요.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Aktualizacje są dostępne dla następujących obciążeń: {0}. Uruchom polecenie `dotnet workload update`, aby uzyskać najnowszą wersję.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">As atualizações estão disponíveis para as seguintes cargas de trabalho(s): {0}. Execute `dotnet workload update` para obter o mais recente.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Обновления доступны для следующих рабочих нагрузок: {0}. Чтобы получить последнюю версию, запустите `dotnet workload update`.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Şu iş yükleri için güncelleştirmeler var: {0}. En son sürümü almak için `dotnet workload update` çalıştırın.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">以下工作负载有可用的更新: {0}。请运行 `dotnet workload update` 以获取最新版本。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">以下工作負載有可用的更新: {0}。執行 `dotnet workload update` 以取得最新更新。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         string GetSdkFeatureBand();
 
-        string? GetWorkloadVersion();
+        (string? version, string? error) GetWorkloadVersion();
 
         Dictionary<string, WorkloadSet> GetAvailableWorkloadSets();
     }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         string GetManifestFeatureBand(string manifestId);
         IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
-        string? GetWorkloadVersion();
+        (string? version, string? error) GetWorkloadVersion();
         IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads);
         WorkloadManifest GetManifestFromWorkload(WorkloadId workloadId);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -257,10 +257,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet?.Version is not null)
             {
-                // This not only means workload sets were enabled but also that we found a workload set. We should still
-                // notify the user if the only workload set we could find was the baseline manifest.
-                string? baselineMessage = _workloadSet.IsBaselineWorkloadSet ? string.Format(Strings.OnlyBaselineManifestFound, _workloadSet.Version) : null;
-                return (_workloadSet.Version, baselineMessage);
+                return (new WorkloadVersion()
+                {
+                    Version = _workloadSet.Version,
+                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
+                }, null);
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkOrUserLocalPath), "default.json");

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -257,11 +257,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet?.Version is not null)
             {
-                return (new WorkloadVersion()
-                {
-                    Version = _workloadSet.Version,
-                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
-                }, null);
+                return (_workloadSet.Version, null);
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkOrUserLocalPath), "default.json");

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -201,9 +201,6 @@
     <value>Workload version {0}, which was specified in {1}, was not found. Run "dotnet workload restore" to install this workload version.</value>
     <comment>{Locked="dotnet workload restore"}</comment>
   </data>
-  <data name="OnlyBaselineManifestFound" xml:space="preserve">
-    <value>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</value>
-  </data>
   <data name="ShouldInstallAWorkloadSet" xml:space="preserve">
     <value>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</value>
   </data>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -201,6 +201,12 @@
     <value>Workload version {0}, which was specified in {1}, was not found. Run "dotnet workload restore" to install this workload version.</value>
     <comment>{Locked="dotnet workload restore"}</comment>
   </data>
+  <data name="OnlyBaselineManifestFound" xml:space="preserve">
+    <value>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</value>
+  </data>
+  <data name="ShouldInstallAWorkloadSet" xml:space="preserve">
+    <value>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</value>
+  </data>
   <data name="WorkloadVersionNotFound" xml:space="preserve">
     <value>Workload version {0} was not found.</value>
   </data>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         }
 
         public string GetSdkFeatureBand() => _sdkVersionBand;
-        public string? GetWorkloadVersion() => _sdkVersionBand.ToString() + ".2";
+        public (string? version, string? error) GetWorkloadVersion() => (_sdkVersionBand.ToString() + ".2", null);
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,7 +778,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand.ToString() + ".2", null);
+            public (WorkloadVersion, string? error) GetWorkloadVersion() => (new WorkloadVersion
+            {
+                Version = _sdkFeatureBand + ".2",
+                WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+            }, null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,11 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (WorkloadVersion version, string? error) GetWorkloadVersion() => (new WorkloadVersion
-            {
-                Version = _sdkFeatureBand + ".2",
-                WorkloadInstallType = WorkloadVersion.Type.LooseManifest
-            }, null);
+            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand + ".2", null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             InitializeManifests();
         }
 
-        public string? GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
+        public (string? version, string? error) GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
 
         private void LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         {
@@ -778,7 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public string? GetWorkloadVersion() => _sdkFeatureBand.ToString() + ".2";
+            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand.ToString() + ".2", null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,7 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (WorkloadVersion, string? error) GetWorkloadVersion() => (new WorkloadVersion
+            public (WorkloadVersion version, string? error) GetWorkloadVersion() => (new WorkloadVersion
             {
                 Version = _sdkFeatureBand + ".2",
                 WorkloadInstallType = WorkloadVersion.Type.LooseManifest

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Chybějící verze pro sadu úloh {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Přesměrování úlohy {0} má jiné klíče než redirect-to.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Chybějící verze pro sadu úloh {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Přesměrování úlohy {0} má jiné klíče než redirect-to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Version für Workloadpaket "{0}" fehlt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Die Umleitungsworkload „{0}“ hat andere Schlüssel als „redirect-to“.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Version für Workloadpaket "{0}" fehlt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Die Umleitungsworkload „{0}“ hat andere Schlüssel als „redirect-to“.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Falta la versión del paquete de carga de trabajo "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La carga de trabajo de redireccionamiento '{0}' tiene claves distintas que las de 'redirect-to'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Falta la versión del paquete de carga de trabajo "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La carga de trabajo de redireccionamiento '{0}' tiene claves distintas que las de 'redirect-to'</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Version manquante pour le pack de charges de travail '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La charge de travail de redirection « {0} » a des clés autres que « redirection vers ».</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Version manquante pour le pack de charges de travail '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La charge de travail de redirection « {0} » a des clés autres que « redirection vers ».</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Versione mancante per il pacchetto '{0}' del carico di lavoro</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Il carico di lavoro '{0}' di reindirizzamento ha chiavi diverse da ' Redirect-to '</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Versione mancante per il pacchetto '{0}' del carico di lavoro</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Il carico di lavoro '{0}' di reindirizzamento ha chiavi diverse da ' Redirect-to '</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -112,9 +112,19 @@
         <target state="translated">ワークロード パック '{0}' のバージョンがありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">リダイレクト ワークロード '{0}' に 'redirect-to' 以外のキーがあります</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -112,11 +112,6 @@
         <target state="translated">ワークロード パック '{0}' のバージョンがありません</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">リダイレクト ワークロード '{0}' に 'redirect-to' 以外のキーがあります</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -112,9 +112,19 @@
         <target state="translated">워크로드 팩 '{0}'에 대한 버전이 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">리디렉션 워크로드 '{0}'에 'redirect-to' 이외의 다른 키가 있습니다</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -112,11 +112,6 @@
         <target state="translated">워크로드 팩 '{0}'에 대한 버전이 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">리디렉션 워크로드 '{0}'에 'redirect-to' 이외의 다른 키가 있습니다</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Brak wersji dla pakietu obciążenia „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Obciążenie przekierowania „{0}” ma klucze inne niż „redirect-to”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Brak wersji dla pakietu obciążenia „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Obciążenie przekierowania „{0}” ma klucze inne niż „redirect-to”</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Versão do pacote de carga de trabalho '{0}' ausente</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">A carga de trabalho de redirecionamento '{0}' tem chaves diferentes além de 'redirecionar-para'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Versão do pacote de carga de trabalho '{0}' ausente</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">A carga de trabalho de redirecionamento '{0}' tem chaves diferentes além de 'redirecionar-para'</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Отсутствует версия для пакета рабочей нагрузки "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Перенаправление рабочей нагрузки "{0}" содержит ключи, отличные от "redirect-to"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Отсутствует версия для пакета рабочей нагрузки "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Перенаправление рабочей нагрузки "{0}" содержит ключи, отличные от "redirect-to"</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -112,9 +112,19 @@
         <target state="translated">'{0}' iş yükü paketi için sürüm eksik</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">'{0}' yeniden yönlendirme iş yükünde 'redirect-to' dışında anahtarlar var</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -112,11 +112,6 @@
         <target state="translated">'{0}' iş yükü paketi için sürüm eksik</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">'{0}' yeniden yönlendirme iş yükünde 'redirect-to' dışında anahtarlar var</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -112,9 +112,19 @@
         <target state="translated">工作负载包“{0}”版本缺失</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重定向工作负荷“{0}”具有“重定向到”以外的键</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -112,11 +112,6 @@
         <target state="translated">工作负载包“{0}”版本缺失</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重定向工作负荷“{0}”具有“重定向到”以外的键</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -112,9 +112,19 @@
         <target state="translated">缺少工作負載套件 '{0}' 的版本</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重新導向工作負載 '{0}' 具有 'redirect-to' 以外的其他金鑰</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -112,11 +112,6 @@
         <target state="translated">缺少工作負載套件 '{0}' 的版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重新導向工作負載 '{0}' 具有 'redirect-to' 以外的其他金鑰</target>

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -40,7 +40,7 @@ namespace ManifestReaderTests
 
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
     }
 
     internal class InMemoryFakeManifestProvider : IWorkloadManifestProvider, IEnumerable<(string id, string content)>
@@ -67,6 +67,6 @@ namespace ManifestReaderTests
         IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
     }
 }

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -93,14 +93,14 @@ namespace ManifestReaderTests
 
             if (useWorkloadSet)
             {
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200");
             }
             else
             {
                 string[] manifests = sdkDirectoryWorkloadManifestProvider.GetManifests().OrderBy(m => m.ManifestId).Select(m => $"{m.ManifestId}.{m.ManifestFeatureBand}.{m.ManifestVersion}").ToArray();
                 manifests.Length.Should().Be(1);
                 manifests.Should().Contain("android.8.0.200.33.0.2-rc.1");
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200-manifests.4ba11739");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200-manifests.4ba11739");
             }
 
             Directory.Delete(Path.Combine(_manifestRoot, "8.0.100"), recursive: true);

--- a/test/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/test/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -48,6 +48,6 @@ namespace ManifestReaderTests
         }
 
         public string GetSdkFeatureBand() => SdkFeatureBand.ToString();
-        public string GetWorkloadVersion() => SdkFeatureBand.ToString() + ".2";
+        public (string version, string error) GetWorkloadVersion() => (SdkFeatureBand.ToString() + ".2", null);
     }
 }

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,11 +39,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public (WorkloadVersion version, string error) GetWorkloadVersion() => (new WorkloadVersion()
-        {
-            Version = "12.0.400.2",
-            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
-        }, null);
+        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,11 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
+        public (WorkloadVersion version, string error) GetWorkloadVersion() => (new WorkloadVersion()
+        {
+            Version = "12.0.400.2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        }, null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public string GetWorkloadVersion() => "12.0.400.2";
+        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/42527

Specifically when the user runs `dotnet workload --version` or `dotnet workload --info` after requesting a workload set via the global.json but it isn't installed, finding only the baseline manifest, or switching to WorkloadInstallType.WorkloadSets and not finding a workload set.

Sample output:
```
PS C:\bugs\temp> dotnet workload config --update-mode workload-set
Successfully updated workload install mode to use workload-set.
PS C:\bugs\temp> dotnet workload --version
Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.
9.0.100-manifests.4bec43ae

PS C:\bugs\temp> dotnet workload --info
Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.
 Workload version: 9.0.100-manifests.4bec43ae
Configured to use workload sets when installing new manifests.
There are no installed workloads to display.

PS C:\bugs\temp> dotnet --info
.NET SDK:
 Version:           9.0.100-dev
 Commit:            7047bd2f34
Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.
 Workload version:  9.0.100-manifests.4bec43ae
 MSBuild version:   17.12.0-preview-24407-03+6bc91d5e2
```

```
PS C:\bugs\temp> dotnet workload --version
Workload version 9.0.100, which was specified in C:\bugs\temp\global.json, was not found. Run "dotnet workload restore" to install this workload version.
9.0.100
```

@baronfel, what do you think of these messages?

I'm also a bit undecided as to whether this is a bug or not:
![image](https://github.com/user-attachments/assets/58b68953-7b4c-47b0-96a3-38dde8cf84a4)

(Not including the stack trace part—that should disappear with https://github.com/dotnet/sdk/pull/42630.)

But I'm a bit undecided as to what it should look like if a user specifies a particular workload set in a global.json then tries to run something like dotnet --info. It normally prints out the installed workload manifest versions, among other things, and that should lead to the FileNotFoundException it throws, but it feels weird to have that in the middle of the info spew. Thoughts?

This will conflict with https://github.com/dotnet/sdk/pull/42536