### PR TITLE
Hot Reload: Handle file deletions correctly

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -26,9 +26,11 @@ internal sealed class StartupHook
         // When launching the application process dotnet-watch sets Hot Reload environment variables via CLI environment directives (dotnet [env:X=Y] run).
         // Currently, the CLI parser sets the env variables to the dotnet.exe process itself, rather then to the target process.
         // This may cause the dotnet.exe process to connect to the named pipe and break it for the target process.
-        if (Path.ChangeExtension(processPath, ".exe") != Path.ChangeExtension(s_targetProcessPath, ".exe"))
+        var processExe = Path.ChangeExtension(processPath, ".exe");
+        var expectedExe = Path.ChangeExtension(s_targetProcessPath, ".exe");
+        if (!string.Equals(processExe, expectedExe, Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
         {
-            Log($"Ignoring process '{processPath}', expecting '{s_targetProcessPath}'");
+            Log($"Ignoring process '{processExe}', expecting '{expectedExe}'");
             return;
         }
 

--- a/src/BuiltInTools/dotnet-watch/FileItem.cs
+++ b/src/BuiltInTools/dotnet-watch/FileItem.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Watcher.Internal;
+
 namespace Microsoft.DotNet.Watcher
 {
-    internal readonly struct FileItem
+    internal readonly record struct FileItem
     {
         public string FilePath { get; init; }
 
@@ -14,7 +16,7 @@ namespace Microsoft.DotNet.Watcher
 
         public string? StaticWebAssetPath { get; init; }
 
-        public bool IsNewFile { get; init; }
+        public ChangeKind Change { get; init; }
 
         public bool IsStaticFile => StaticWebAssetPath != null;
     }

--- a/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             return [context.RootProjectOptions.Command, .. context.RootProjectOptions.CommandArguments];
         }
 
-        public async ValueTask<EvaluationResult> EvaluateAsync(FileItem? changedFile, CancellationToken cancellationToken)
+        public async ValueTask<EvaluationResult> EvaluateAsync(ChangedFile? changedFile, CancellationToken cancellationToken)
         {
             if (context.EnvironmentOptions.SuppressMSBuildIncrementalism)
             {
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return _evaluationResult = await CreateEvaluationResult(cancellationToken);
             }
 
-            if (_evaluationResult == null || RequiresMSBuildRevaluation(changedFile))
+            if (_evaluationResult == null || RequiresMSBuildRevaluation(changedFile?.Item))
             {
                 RequiresRevaluation = true;
             }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Diagnostics;
 using Microsoft.Build.Graph;
+using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -13,14 +14,14 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         private const string BuildTargetName = "GenerateComputedBuildStaticWebAssets";
 
-        public async ValueTask HandleFileChangesAsync(IReadOnlyList<FileItem> files, CancellationToken cancellationToken)
+        public async ValueTask HandleFileChangesAsync(IReadOnlyList<ChangedFile> files, CancellationToken cancellationToken)
         {
             var projectsToRefresh = new HashSet<ProjectGraphNode>();
             var hasApplicableFiles = false;
 
             for (int i = 0; i < files.Count; i++)
             {
-                var file = files[i];
+                var file = files[i].Item;
 
                 if (!file.FilePath.EndsWith(".razor.css", StringComparison.Ordinal) &&
                     !file.FilePath.EndsWith(".cshtml.css", StringComparison.Ordinal))

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis.StackTraceExplorer;
+using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -18,13 +19,13 @@ namespace Microsoft.DotNet.Watcher.Tools
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
-        public async ValueTask<bool> HandleFileChangesAsync(IReadOnlyList<FileItem> files, CancellationToken cancellationToken)
+        public async ValueTask<bool> HandleFileChangesAsync(IReadOnlyList<ChangedFile> files, CancellationToken cancellationToken)
         {
             var allFilesHandled = true;
             var refreshRequests = new Dictionary<BrowserRefreshServer, List<string>>();
             for (int i = 0; i < files.Count; i++)
             {
-                var file = files[i];
+                var file = files[i].Item;
 
                 if (file.StaticWebAssetPath is null)
                 {

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Watcher
                 HotReloadFileSetWatcher? fileSetWatcher = null;
                 EvaluationResult? evaluationResult = null;
                 RunningProject? rootRunningProject = null;
-                Task<FileItem[]?>? fileSetWatcherTask = null;
+                Task<ChangedFile[]?>? fileSetWatcherTask = null;
 
                 try
                 {
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Watcher
                         // When a new file is added we need to run design-time build to find out
                         // what kind of the file it is and which project(s) does it belong to (can be linked, web asset, etc.).
                         // We don't need to rebuild and restart the application though.
-                        if (changedFiles.Any(f => f.IsNewFile))
+                        if (changedFiles.Any(f => f.Change is ChangeKind.Add))
                         {
                             Context.Reporter.Verbose("File addition triggered re-evaluation.");
 
@@ -195,9 +195,9 @@ namespace Microsoft.DotNet.Watcher
                             // update files in the change set with new evaluation info:
                             for (int i = 0; i < changedFiles.Length; i++)
                             {
-                                if (evaluationResult.Files.TryGetValue(changedFiles[i].FilePath, out var evaluatedFile))
+                                if (evaluationResult.Files.TryGetValue(changedFiles[i].Item.FilePath, out var evaluatedFile))
                                 {
-                                    changedFiles[i] = evaluatedFile;
+                                    changedFiles[i] = changedFiles[i] with { Item = evaluatedFile };
                                 }
                             }
 
@@ -336,24 +336,43 @@ namespace Microsoft.DotNet.Watcher
             }
         }
 
-        private void ReportFileChanges(IReadOnlyList<FileItem> fileItems)
+        private void ReportFileChanges(IReadOnlyList<ChangedFile> changedFiles)
         {
-            Report(added: true);
-            Report(added: false);
+            Report(kind: ChangeKind.Add);
+            Report(kind: ChangeKind.Update);
+            Report(kind: ChangeKind.Delete);
 
-            void Report(bool added)
+            void Report(ChangeKind kind)
             {
-                var items = fileItems.Where(item => item.IsNewFile == added).ToArray();
+                var items = changedFiles.Where(item => item.Change == kind).ToArray();
                 if (items is not [])
                 {
-                    Context.Reporter.Output(GetMessage(items, added));
+                    Context.Reporter.Output(GetMessage(items, kind));
                 }
             }
 
-            string GetMessage(IReadOnlyList<FileItem> items, bool added)
-                => items is [var item]
-                    ? (added ? "File added: " : "File changed: ") + GetRelativeFilePath(item.FilePath)
-                    : (added ? "Files added: " : "Files changed: ") + string.Join(", ", items.Select(f => GetRelativeFilePath(f.FilePath)));
+            string GetMessage(IReadOnlyList<ChangedFile> items, ChangeKind kind)
+                => items is [{Item: var item }]
+                    ? GetSingularMessage(kind) + ": " + GetRelativeFilePath(item.FilePath)
+                    : GetPlurarMessage(kind) + ": " + string.Join(", ", items.Select(f => GetRelativeFilePath(f.Item.FilePath)));
+
+            static string GetSingularMessage(ChangeKind kind)
+                => kind switch
+                {
+                    ChangeKind.Update => "File updated",
+                    ChangeKind.Add => "File added",
+                    ChangeKind.Delete => "File deleted",
+                    _ => throw new InvalidOperationException()
+                };
+
+            static string GetPlurarMessage(ChangeKind kind)
+                => kind switch
+                {
+                    ChangeKind.Update => "Files updated",
+                    ChangeKind.Add => "Files added",
+                    ChangeKind.Delete => "Files deleted",
+                    _ => throw new InvalidOperationException()
+                };
         }
 
         private async ValueTask<EvaluationResult> EvaluateRootProjectAsync(CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/ChangeKind.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/ChangeKind.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Watcher.Internal;
+
+internal enum ChangeKind
+{
+    Update,
+    Add,
+    Delete
+}
+
+internal readonly record struct ChangedFile(FileItem Item, ChangeKind Change);

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IFileSystemWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IFileSystemWatcher.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 {
     internal interface IFileSystemWatcher : IDisposable
     {
-        event EventHandler<(string filePath, bool newFile)> OnFileChange;
+        event EventHandler<(string filePath, ChangeKind kind)> OnFileChange;
 
         event EventHandler<Exception> OnError;
 

--- a/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/HotReloadFileSetWatcher.cs
@@ -3,6 +3,7 @@
 
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Internal
@@ -10,12 +11,13 @@ namespace Microsoft.DotNet.Watcher.Internal
     internal sealed class HotReloadFileSetWatcher(IReadOnlyDictionary<string, FileItem> fileSet, DateTime buildCompletionTime, IReporter reporter) : IDisposable
     {
         private static readonly TimeSpan s_debounceInterval = TimeSpan.FromMilliseconds(50);
+        private static readonly DateTime s_fileNotExistFileTime = DateTime.FromFileTime(0);
 
         private readonly FileWatcher _fileWatcher = new(fileSet, reporter);
         private readonly object _changedFilesLock = new();
-        private readonly ConcurrentDictionary<string, FileItem> _changedFiles = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, ChangedFile> _changedFiles = new(StringComparer.Ordinal);
 
-        private TaskCompletionSource<FileItem[]?>? _tcs;
+        private TaskCompletionSource<ChangedFile[]?>? _tcs;
         private bool _initialized;
         private bool _disposed;
 
@@ -65,7 +67,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                         continue;
                     }
 
-                    FileItem[] changedFiles;
+                    ChangedFile[] changedFiles;
                     lock (_changedFilesLock)
                     {
                         changedFiles = _changedFiles.Values.ToArray();
@@ -82,7 +84,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
             }, default, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
-            void FileChangedCallback(string path, bool newFile)
+            void FileChangedCallback(string path, ChangeKind kind)
             {
                 // only handle file changes:
                 if (Directory.Exists(path))
@@ -90,43 +92,66 @@ namespace Microsoft.DotNet.Watcher.Internal
                     return;
                 }
 
-                try
+                if (kind != ChangeKind.Delete)
                 {
-                    // TODO: Deleted files will be ignored https://github.com/dotnet/sdk/issues/42535
-
-                    // Do not report changes to files that happened during build:
-                    var creationTime = File.GetCreationTimeUtc(path);
-                    var writeTime = File.GetLastWriteTimeUtc(path);
-                    if (creationTime.Ticks < buildCompletionTime.Ticks && writeTime.Ticks < buildCompletionTime.Ticks)
+                    try
                     {
-                        reporter.Verbose($"Ignoring file updated during build: '{path}' ({FormatTimestamp(creationTime)},{FormatTimestamp(writeTime)} < {FormatTimestamp(buildCompletionTime)}).");
+                        // Do not report changes to files that happened during build:
+                        var creationTime = File.GetCreationTimeUtc(path);
+                        var writeTime = File.GetLastWriteTimeUtc(path);
+
+                        if (creationTime == s_fileNotExistFileTime || writeTime == s_fileNotExistFileTime)
+                        {
+                            // file might have been deleted since we received the event
+                            kind = ChangeKind.Delete;
+                        }
+                        else if (creationTime.Ticks < buildCompletionTime.Ticks && writeTime.Ticks < buildCompletionTime.Ticks)
+                        {
+                            reporter.Verbose(
+                                $"Ignoring file change during build: {kind} '{path}' " +
+                                $"(created {FormatTimestamp(creationTime)} and written {FormatTimestamp(writeTime)} before {FormatTimestamp(buildCompletionTime)}).");
+
+                            return;
+                        }
+                        else if (writeTime > creationTime)
+                        {
+                            reporter.Verbose($"File change: {kind} '{path}' (written {FormatTimestamp(writeTime)} after {FormatTimestamp(buildCompletionTime)}).");
+                        }
+                        else
+                        {
+                            reporter.Verbose($"File change: {kind} '{path}' (created {FormatTimestamp(creationTime)} after {FormatTimestamp(buildCompletionTime)}).");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        reporter.Verbose($"Ignoring file '{path}' due to access error: {e.Message}.");
                         return;
                     }
                 }
-                catch (Exception e)
+
+                if (kind == ChangeKind.Delete)
                 {
-                    reporter.Verbose($"Ignoring file '{path}' due to access error: {e.Message}.");
-                    return;
+                    reporter.Verbose($"File '{path}' deleted after {FormatTimestamp(buildCompletionTime)}.");
                 }
 
-                if (newFile)
+                if (kind == ChangeKind.Add)
                 {
                     lock (_changedFilesLock)
                     {
-                        _changedFiles.TryAdd(path, new FileItem { FilePath = path, IsNewFile = newFile });
+                        _changedFiles.TryAdd(path, new ChangedFile(new FileItem { FilePath = path }, kind));
                     }
                 }
                 else if (fileSet.TryGetValue(path, out var fileItem))
                 {
                     lock (_changedFilesLock)
                     {
-                        _changedFiles.TryAdd(path, fileItem);
+                        _changedFiles.TryAdd(path, new ChangedFile(fileItem, kind));
                     }
                 }
             }
         }
 
-        public Task<FileItem[]?> GetChangedFilesAsync(CancellationToken cancellationToken, bool forceWaitForNewUpdate = false)
+        public Task<ChangedFile[]?> GetChangedFilesAsync(CancellationToken cancellationToken, bool forceWaitForNewUpdate = false)
         {
             EnsureInitialized();
 
@@ -142,6 +167,6 @@ namespace Microsoft.DotNet.Watcher.Internal
         }
 
         internal static string FormatTimestamp(DateTime time)
-            => time.ToString("yyyy-MM-dd HH:mm:ss.fffffff");
+            => time.ToString("HH:mm:ss.fffffff");
     }
 }

--- a/test/dotnet-watch.Tests/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcherTests.cs
@@ -1,53 +1,43 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.DotNet.Watcher.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
-    public class FileWatcherTests
+    public class FileWatcherTests(ITestOutputHelper output)
     {
-        public FileWatcherTests(ITestOutputHelper output)
-        {
-            _output = output;
-            _testAssetManager = new TestAssetsManager(output);
-        }
-
         private readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
         private readonly TimeSpan NegativeTimeout = TimeSpan.FromSeconds(5);
-        private readonly ITestOutputHelper _output;
-        private readonly TestAssetsManager _testAssetManager;
+        private readonly TestAssetsManager _testAssetManager = new TestAssetsManager(output);
 
         private async Task TestOperation(
             string dir,
-            (string, bool)[] expectedChanges,
+            (string path, ChangeKind kind)[] expectedChanges,
             bool usePolling,
             Action operation)
         {
-            // On Unix the native file watcher may surface events from
-            // the recent past. Delay to avoid those.
-            // On Unix the file write time is in 1s increments;
-            // if we don't wait, there's a chance that the polling
-            // watcher will not detect the change
-            await Task.Delay(1250);
-
             using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling);
             if (watcher is DotnetFileWatcher dotnetWatcher)
             {
-                dotnetWatcher.Logger = m => _output.WriteLine(m);
+                dotnetWatcher.Logger = m => output.WriteLine(m);
             }
 
             var changedEv = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var filesChanged = new HashSet<(string, bool)>();
+            var filesChanged = new HashSet<(string path, ChangeKind kind)>();
 
-            var testFileFullPath = Path.Combine(dir, "foo");
-
-            EventHandler<(string path, bool newFile)> handler = null;
+            EventHandler<(string path, ChangeKind kind)> handler = null;
             handler = (_, f) =>
             {
-                filesChanged.Add(f);
+                if (filesChanged.Add(f))
+                {
+                    output.WriteLine($"Observed new {f.kind}: '{f.path}' ({filesChanged.Count} out of {expectedChanges.Length})");
+                }
+                else
+                {
+                    output.WriteLine($"Already seen {f.kind}: '{f.path}'");
+                }
 
                 if (filesChanged.Count == expectedChanges.Length)
                 {
@@ -88,15 +78,46 @@ namespace Microsoft.DotNet.Watcher.Tools
                 expectedChanges: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !usePolling
                 ? new[]
                 {
-                    (testFileFullPath, false),
-                    (testFileFullPath, true),
+                    (testFileFullPath, ChangeKind.Update),
+                    (testFileFullPath, ChangeKind.Add),
                 }
                 : new[]
                 {
-                    (testFileFullPath, true),
+                    (testFileFullPath, ChangeKind.Add),
                 },
                 usePolling,
                 () => File.WriteAllText(testFileFullPath, string.Empty));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task NewFileInNewDirectory(bool usePolling)
+        {
+            var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+
+            var newDir = Path.Combine(dir, "Dir");
+            var newFile = Path.Combine(newDir, "foo");
+
+            await TestOperation(
+                dir,
+                expectedChanges: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !usePolling
+                ? new[]
+                {
+                    (newDir, ChangeKind.Add),
+                    (newFile, ChangeKind.Update),
+                    (newFile, ChangeKind.Add),
+                }
+                : new[]
+                {
+                    (newDir, ChangeKind.Add),
+                },
+                usePolling,
+                () =>
+                {
+                    Directory.CreateDirectory(newDir);
+                    File.WriteAllText(newFile, string.Empty);
+                });
         }
 
         [Theory]
@@ -111,14 +132,13 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await TestOperation(
                 dir,
-                expectedChanges: [(testFileFullPath, false)],
+                expectedChanges: [(testFileFullPath, ChangeKind.Update)],
                 usePolling,
                 () => File.WriteAllText(testFileFullPath, string.Empty));
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [CombinatorialData]
         public async Task MoveFile(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -129,18 +149,19 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await TestOperation(
                 dir,
-                expectedChanges: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !usePolling
-                ? new[]
-                {
-                    (srcFile, false),
-                    (srcFile, true),
-                    (dstFile, true),
-                }
-                : new[]
-                {
-                    (srcFile, false),
-                    (dstFile, true),
-                },
+                expectedChanges: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !usePolling ?
+                [
+                    // On OSX events from before we started observing are reported as well.
+                    (srcFile, ChangeKind.Update),
+                    (srcFile, ChangeKind.Add),
+                    (srcFile, ChangeKind.Delete),
+                    (dstFile, ChangeKind.Add),
+                ]
+                :
+                [
+                    (srcFile, ChangeKind.Delete),
+                    (dstFile, ChangeKind.Add),
+                ],
                 usePolling,
                 () => File.Move(srcFile, dstFile));
 
@@ -160,8 +181,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             await TestOperation(
                 dir,
                 expectedChanges: [
-                    (subdir, false),
-                    (testFileFullPath, false)
+                    (subdir, ChangeKind.Update),
+                    (testFileFullPath, ChangeKind.Update)
                 ],
                 usePolling: true,
                 () => File.WriteAllText(testFileFullPath, string.Empty));
@@ -246,7 +267,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await TestOperation(
                 dir,
-                expectedChanges: [(testFileFullPath, false)],
+                expectedChanges: [(testFileFullPath, ChangeKind.Update)],
                 usePolling: true,
                 () => File.WriteAllText(testFileFullPath, string.Empty));
         }
@@ -274,9 +295,9 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             var changedEv = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             var expectedPath = Path.Combine(directory, Path.GetRandomFileName());
-            EventHandler<(string, bool)> handler = (_, f) =>
+            EventHandler<(string, ChangeKind)> handler = (_, f) =>
             {
-                _output.WriteLine("File changed: " + f);
+                output.WriteLine("File changed: " + f);
                 try
                 {
                     if (string.Equals(f.Item1, expectedPath, StringComparison.OrdinalIgnoreCase))
@@ -331,13 +352,43 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             await TestOperation(
                 dir,
-                expectedChanges: [
-                    (subdir, false),
-                    (f1, false),
-                    (f2, false),
-                    (f3, false),
+                expectedChanges: usePolling ?
+                [
+                    (subdir, ChangeKind.Delete),
+                    (f1, ChangeKind.Delete),
+                    (f2, ChangeKind.Delete),
+                    (f3, ChangeKind.Delete),
+                ]
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                [
+                    (subdir, ChangeKind.Update),
+                    (subdir, ChangeKind.Delete),
+                    (f1, ChangeKind.Update),
+                    (f1, ChangeKind.Add),
+                    (f1, ChangeKind.Delete),
+                    (f2, ChangeKind.Update),
+                    (f2, ChangeKind.Add),
+                    (f2, ChangeKind.Delete),
+                    (f3, ChangeKind.Update),
+                    (f3, ChangeKind.Add),
+                    (f3, ChangeKind.Delete),
+                ]
+                : RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                [
+                    (subdir, ChangeKind.Update),
+                    (subdir, ChangeKind.Delete),
+                    (f1, ChangeKind.Delete),
+                    (f2, ChangeKind.Delete),
+                    (f3, ChangeKind.Delete),
+                ]
+                :
+                [
+                    (subdir, ChangeKind.Delete),
+                    (f1, ChangeKind.Delete),
+                    (f2, ChangeKind.Delete),
+                    (f3, ChangeKind.Delete),
                 ],
-                usePolling: true,
+                usePolling,
                 () => Directory.Delete(subdir, recursive: true));
         }
     }

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -120,5 +120,112 @@ namespace Microsoft.DotNet.Watcher.Tests
             //UpdateSourceFile(Path.Combine(testAsset.Path, "Pages", "Index.razor"), newSource);
             //await App.AssertOutputLineStartsWith(MessageDescriptor.HotReloadSucceeded);
         }
+
+        [Theory]
+        [InlineData(true, Skip = "https://github.com/dotnet/sdk/issues/43320")]
+        [InlineData(false)]
+        public async Task RenameSourceFile(bool useMove)
+        {
+            Logger.WriteLine("RenameSourceFile started");
+
+            var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
+                .WithSource();
+
+            var dependencyDir = Path.Combine(testAsset.Path, "Dependency");
+            var oldFilePath = Path.Combine(dependencyDir, "Foo.cs");
+            var newFilePath = Path.Combine(dependencyDir, "Renamed.cs");
+
+            var source = """
+                using System;
+                using System.IO;
+                using System.Runtime.CompilerServices;
+
+                public class Lib
+                {
+                    public static void Print() => PrintFileName();
+
+                    public static void PrintFileName([CallerFilePathAttribute] string filePath = null)
+                    {
+                        Console.WriteLine($"> {Path.GetFileName(filePath)}");
+                    }
+                }
+                """;
+
+            File.WriteAllText(oldFilePath, source);
+
+            App.Start(testAsset, [], "AppWithDeps");
+
+            await App.AssertWaitingForChanges();
+
+            // rename the file:
+            if (useMove)
+            {
+                File.Move(oldFilePath, newFilePath);
+            }
+            else
+            {
+                File.Delete(oldFilePath);
+                File.WriteAllText(newFilePath, source);
+            }
+
+            Logger.WriteLine($"Renamed '{oldFilePath}' to '{newFilePath}'.");
+
+            await App.AssertOutputLineStartsWith("> Renamed.cs");
+        }
+
+        [Theory]
+        [InlineData(true, Skip = "https://github.com/dotnet/sdk/issues/43320")]
+        [InlineData(false)]
+        public async Task RenameDirectory(bool useMove)
+        {
+            Logger.WriteLine("RenameSourceFile started");
+
+            var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
+                .WithSource();
+
+            var dependencyDir = Path.Combine(testAsset.Path, "Dependency");
+            var oldSubdir = Path.Combine(dependencyDir, "Subdir");
+            var newSubdir = Path.Combine(dependencyDir, "NewSubdir");
+
+            var source = """
+                using System;
+                using System.IO;
+                using System.Runtime.CompilerServices;
+
+                public class Lib
+                {
+                    public static void Print() => PrintDirectoryName();
+
+                    public static void PrintDirectoryName([CallerFilePathAttribute] string filePath = null)
+                    {
+                        Console.WriteLine($"> {Path.GetFileName(Path.GetDirectoryName(filePath))}");
+                    }
+                }
+                """;
+
+            File.Delete(Path.Combine(dependencyDir, "Foo.cs"));
+            Directory.CreateDirectory(oldSubdir);
+            File.WriteAllText(Path.Combine(oldSubdir, "Foo.cs"), source);
+
+            App.Start(testAsset, [], "AppWithDeps");
+
+            await App.AssertWaitingForChanges();
+
+            // rename the directory:
+            if (useMove)
+            {
+                Directory.Move(oldSubdir, newSubdir);
+            }
+            else
+            {
+                Directory.Delete(oldSubdir, recursive: true);
+                Directory.CreateDirectory(newSubdir);
+                File.WriteAllText(Path.Combine(newSubdir, "Foo.cs"), source);
+            }
+
+            Logger.WriteLine($"Renamed '{oldSubdir}' to '{newSubdir}'.");
+
+            await App.AssertOutputLineStartsWith("> NewSubdir");
+        }
     }
 }

--- a/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
+++ b/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -27,7 +28,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new() { FilePath = "Test.csproj" }, CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Test.csproj" }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
         }
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new() { FilePath = "Controller.cs" }, CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
 
             Assert.False(evaluator.RequiresRevaluation);
             Assert.Equal(1, counter);
@@ -77,7 +78,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new() { FilePath = "Controller.cs" }, CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
             Assert.Equal(2, counter);
@@ -118,7 +119,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             evaluator.RequiresRevaluation = false;
             evaluator.Timestamps["Proj.csproj"] = new DateTime(1007);
 
-            await evaluator.EvaluateAsync(new() { FilePath = "Controller.cs" }, CancellationToken.None);
+            await evaluator.EvaluateAsync(new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
         }


### PR DESCRIPTION
Fixes file watcher and workspace updating to support file deletes.

Fixes https://github.com/dotnet/sdk/issues/42535
