### PR TITLE
Enable 9.0.1xx branch for SDKDiffTests and LicenseScanTest

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -17,6 +17,8 @@ resources:
     trigger:
       branches:
         include:
+          - refs/heads/release/9.0.1xx
+          - refs/heads/release/9.0.1xx-rc*
           - refs/heads/release/*.0.1xx-preview*
           - refs/heads/internal/release/*.0.1xx*
 

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -8,6 +8,8 @@ schedules:
     # Previews don't have internal/release branches so they must be run from non-internal release branches.
     include:
     - main
+    - release/9.0.1xx
+    - release/9.0.1xx-rc*
     - release/*.0.1xx-preview*
     - internal/release/*.0.1xx*
 
@@ -18,6 +20,8 @@ trigger:
   branches:
     include:
     - main
+    - release/9.0.1xx
+    - release/9.0.1xx-rc*
     - release/*.0.1xx-preview*
     - internal/release/*.0.1xx*
   paths:


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4559

There are two new branches under 'release' folder that have been added to VMR pipelilne:
[release/9.0.1xx](https://dev.azure.com/dnceng/internal/_build/results?buildId=2516801) (internal Microsoft link)
[release/9.0.1xx-rc1](https://dev.azure.com/dnceng/internal/_build/results?buildId=2515935) (internal Microsoft link)