### PR TITLE
Fix GetTargetPath hook point

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.NonCrossTargeting.targets
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/build/Microsoft.DotNet.ApiCompat.ValidateAssemblies.NonCrossTargeting.targets
@@ -50,8 +50,8 @@
   <!-- Annotate the TargetPath item to make the ApiCompatContractAssembly property accessible in the the cross-targeting build. -->
   <Target Name="ApiCompatAnnotateTargetPathWithTargetPlatformMoniker"
           Condition="'$(ApiCompatValidateAssemblies)' == 'true'"
-          DependsOnTargets="GetApiCompatContractAssembly;GetReferencesForApiCompatValidateAssemblies"
-          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+          DependsOnTargets="GetApiCompatContractAssembly;GetReferencesForApiCompatValidateAssemblies;GetTargetPathWithTargetPlatformMoniker"
+          BeforeTargets="GetTargetPath">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker ApiCompatContractAssembly="$(ApiCompatContractAssembly)"
                                            ApiCompatAssemblyReferences="@(ApiCompatAssemblyReferences, ',')"


### PR DESCRIPTION
Same as https://github.com/dotnet/runtime/pull/106553

I noticed that in some environments, the existing hook point (AfterTargets=GetTargetPathWithTargetPlatformMoniker) doesn't run before GetTargetPath. That resulted in some project compiling against the src instead of the ref assembly.

DependsOnTargets + BeforeTargets="GetTargetPath" is is more correct anyway and works as exected.