### PR TITLE
Re-enable a torn SDK test

### DIFF
--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Restore.Tests
                 .HaveStdOutContaining(Path.Combine(toolsetPackageDir, toolsetPackageVersion, "csc.exe") + " /noconfig");
         }
 
-        [FullMSBuildOnlyFact(Skip = "Skip until we can figure out how to fix the test with the package off globally")]
+        [FullMSBuildOnlyFact]
         public void It_downloads_Microsoft_Net_Compilers_Toolset_Framework_when_MSBuild_is_torn()
         {
             const string testProjectName = "NetCoreApp";


### PR DESCRIPTION
Follow up on https://github.com/dotnet/sdk/pull/42822.