### PR TITLE
Remove locale from diagnostic-ids link

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
     /// <param name="baselineAllErrors">If true, baselines all errors.</param>
     public class SuppressionEngine(string? noWarn = null, bool baselineAllErrors = false) : ISuppressionEngine
     {
-        protected const string DiagnosticIdDocumentationComment = " https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids ";
+        protected const string DiagnosticIdDocumentationComment = " https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids ";
         private readonly HashSet<Suppression> _baselineSuppressions = [];
         private readonly HashSet<Suppression> _suppressions = [];
         private readonly HashSet<string> _noWarn = string.IsNullOrEmpty(noWarn) ? [] : new HashSet<string>(noWarn!.Split(';'));


### PR DESCRIPTION
I just noticed that we include a locale in the diagnostic-ids link emitted by APICompat. We should remove that as the doc page is also available in other locals.

Explicitly targeting release/9.0.1xx to still get this into .NET 9.