### PR TITLE
Stop using IReadOnlyList when it's always single

### DIFF
--- a/src/Cli/dotnet/ToolPackage/IToolPackage.cs
+++ b/src/Cli/dotnet/ToolPackage/IToolPackage.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ToolPackage
 
         DirectoryPath PackageDirectory { get; }
 
-        IReadOnlyList<RestoredCommand> Commands { get; }
+        RestoredCommand Command { get; }
 
         IEnumerable<string> Warnings { get; }
 

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -209,23 +209,20 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             ToolPackageInstance toolPackageInstance
             )
         {
-            foreach (var command in toolPackageInstance.Commands)
+            var runtimeConfigFilePath = Path.ChangeExtension(toolPackageInstance.Command.Executable.Value, ".runtimeconfig.json");
+
+            // Update the runtimeconfig.json file
+            if (File.Exists(runtimeConfigFilePath))
             {
-                var runtimeConfigFilePath = Path.ChangeExtension(command.Executable.Value, ".runtimeconfig.json");
+                string existingJson = File.ReadAllText(runtimeConfigFilePath);
 
-                // Update the runtimeconfig.json file
-                if (File.Exists(runtimeConfigFilePath))
+                var jsonObject = JObject.Parse(existingJson);
+                var runtimeOptions = jsonObject["runtimeOptions"] as JObject;
+                if (runtimeOptions != null)
                 {
-                    string existingJson = File.ReadAllText(runtimeConfigFilePath);
-
-                    var jsonObject = JObject.Parse(existingJson);
-                    var runtimeOptions = jsonObject["runtimeOptions"] as JObject;
-                    if (runtimeOptions != null)
-                    {
-                        runtimeOptions["rollForward"] = "Major";
-                        string updateJson = jsonObject.ToString();
-                        File.WriteAllText(runtimeConfigFilePath, updateJson);
-                    }
+                    runtimeOptions["rollForward"] = "Major";
+                    string updateJson = jsonObject.ToString();
+                    File.WriteAllText(runtimeConfigFilePath, updateJson);
                 }
             }
         }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/LocalToolsResolverCacheExtensions.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/LocalToolsResolverCacheExtensions.cs
@@ -30,20 +30,17 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                     nameof(targetFrameworkToInstall));
             }
 
-            foreach (var restoredCommand in toolDownloadedPackage.Commands)
-            {
-                localToolsResolverCache.Save(
-                    new Dictionary<RestoredCommandIdentifier, RestoredCommand>
-                    {
-                        [new RestoredCommandIdentifier(
-                                toolDownloadedPackage.Id,
-                                toolDownloadedPackage.Version,
-                                NuGetFramework.Parse(targetFrameworkToInstall),
-                                Constants.AnyRid,
-                                restoredCommand.Name)] =
-                            restoredCommand
-                    });
-            }
+            localToolsResolverCache.Save(
+                new Dictionary<RestoredCommandIdentifier, RestoredCommand>
+                {
+                    [new RestoredCommandIdentifier(
+                            toolDownloadedPackage.Id,
+                            toolDownloadedPackage.Version,
+                            NuGetFramework.Parse(targetFrameworkToInstall),
+                            Constants.AnyRid,
+                            toolDownloadedPackage.Command.Name)] =
+                        toolDownloadedPackage.Command
+                });
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -177,11 +177,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 {
                     RunWithHandlingUninstallError(() =>
                     {
-                        foreach (RestoredCommand command in oldPackageNullable.Commands)
-                        {
-                            shellShimRepository.RemoveShim(command.Name);
-                        }
-
+                        shellShimRepository.RemoveShim(oldPackageNullable.Command.Name);
                         toolPackageUninstaller.Uninstall(oldPackageNullable.PackageDirectory);
                     }, packageId);
                 }
@@ -215,10 +211,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                     }
                     string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;
 
-                    foreach (RestoredCommand command in newInstalledPackage.Commands)
-                    {
-                        shellShimRepository.CreateShim(command.Executable, command.Name, newInstalledPackage.PackagedShims);
-                    }
+                    shellShimRepository.CreateShim(newInstalledPackage.Command.Executable, newInstalledPackage.Command.Name, newInstalledPackage.PackagedShims);
 
                     foreach (string w in newInstalledPackage.Warnings)
                     {
@@ -368,8 +361,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 {
                     _reporter.WriteLine(
                         string.Format(
-                            Install.LocalizableStrings.InstallationSucceeded,
-                            string.Join(", ", newInstalledPackage.Commands.Select(c => c.Name)),
+                            LocalizableStrings.InstallationSucceeded,
+                            newInstalledPackage.Command.Name,
                             newInstalledPackage.Id,
                             newInstalledPackage.Version.ToNormalizedString()).Green());
                 }

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                     manifestFile,
                     packageId,
                     toolDownloadedPackage.Version,
-                    toolDownloadedPackage.Commands.Select(c => c.Name).ToArray());
+                    [toolDownloadedPackage.Command.Name]);
                 _reporter.WriteLine(
                     string.Format(
                         Update.LocalizableStrings.UpdateLocalToolSucceeded,
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 manifestFile,
                 toolDownloadedPackage.Id,
                 toolDownloadedPackage.Version,
-                toolDownloadedPackage.Commands.Select(c => c.Name).ToArray(),
+                [toolDownloadedPackage.Command.Name],
                 _allowRollForward);
 
             _localToolsResolverCache.SaveToolPackage(
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             _reporter.WriteLine(
                 string.Format(
                     LocalizableStrings.LocalToolInstallationSucceeded,
-                    string.Join(", ", toolDownloadedPackage.Commands.Select(c => c.Name)),
+                    toolDownloadedPackage.Command.Name,
                     toolDownloadedPackage.Id,
                     toolDownloadedPackage.Version.ToNormalizedString(),
                     manifestFile.Value).Green());

--- a/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools.Tool.List
                 p => p.Version.ToNormalizedString());
             table.AddColumn(
                 LocalizableStrings.CommandsColumn,
-                p => string.Join(CommandDelimiter, p.Commands.Select(c => c.Name)));
+                p => p.Command.Name.ToString());
 
             table.PrintRows(packageEnumerable, l => _reporter.WriteLine(l));
         }
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Tools.Tool.List
                 {
                     PackageId = p.Id.ToString(),
                     Version = p.Version.ToNormalizedString(),
-                    Commands = p.Commands.Select(c => c.Name.Value).ToArray()
+                    Commands = [p.Command.Name.Value]
                 }).ToArray()
             };
             var jsonText = System.Text.Json.JsonSerializer.Serialize(jsonData, JsonHelper.NoEscapeSerializerOptions);

--- a/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
@@ -91,9 +91,9 @@ namespace Microsoft.DotNet.Tools.Tool.List
         {
             try
             {
-                // Attempt to read the commands collection
+                // Attempt to read the command
                 // If it fails, print a warning and treat as no commands
-                return package.Commands.Count >= 0;
+                return package.Command is not null;
             }
             catch (Exception ex) when (ex is ToolConfigurationException)
             {

--- a/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tools.Tool.List
         public IEnumerable<IToolPackage> GetPackages(DirectoryPath? toolPath, PackageId? packageId)
         {
             return _createToolPackageStore(toolPath).EnumeratePackages()
-                .Where((p) => PackageHasCommands(p) && PackageIdMatches(p, packageId))
+                .Where((p) => PackageHasCommand(p) && PackageIdMatches(p, packageId))
                 .OrderBy(p => p.Id)
                 .ToArray();
         }
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Tools.Tool.List
             return !packageId.HasValue || package.Id.Equals(packageId);
         }
 
-        private bool PackageHasCommands(IToolPackage package)
+        private bool PackageHasCommand(IToolPackage package)
         {
             try
             {

--- a/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -133,24 +133,24 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                         package.PackageId, verbosity: _verbosity, ToVersionRangeWithOnlyOneVersion(package.Version), targetFramework
                         );
 
-                if (!ManifestCommandMatchesActualInPackage(package.CommandNames, toolPackage.Commands))
+                if (!ManifestCommandMatchesActualInPackage(package.CommandNames, [toolPackage.Command]))
                 {
                     return ToolRestoreResult.Failure(
                         string.Format(LocalizableStrings.CommandsMismatch,
                             JoinBySpaceWithQuote(package.CommandNames.Select(c => c.Value.ToString())),
                             package.PackageId,
-                            JoinBySpaceWithQuote(toolPackage.Commands.Select(c => c.Name.ToString()))));
+                            toolPackage.Command.Name));
                 }
 
                 return ToolRestoreResult.Success(
-                    saveToCache: toolPackage.Commands.Select(command => (
-                        new RestoredCommandIdentifier(
+                    saveToCache: 
+                        [(new RestoredCommandIdentifier(
                             toolPackage.Id,
                             toolPackage.Version,
                             NuGetFramework.Parse(targetFramework),
                             Constants.AnyRid,
-                            command.Name),
-                        command)).ToArray(),
+                            toolPackage.Command.Name),
+                        toolPackage.Command)],
                     message: string.Format(
                         LocalizableStrings.RestoreSuccessful,
                         package.PackageId,

--- a/src/Cli/dotnet/commands/dotnet-tool/uninstall/ToolUninstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/uninstall/ToolUninstallGlobalOrToolPathCommand.cs
@@ -95,11 +95,8 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
                     TransactionScopeOption.Required,
                     TimeSpan.Zero))
                 {
-                    foreach (var command in package.Commands)
-                    {
-                        shellShimRepository.RemoveShim(command.Name);
-                    }
-
+                    shellShimRepository.RemoveShim(package.Command.Name);
+                 
                     toolPackageUninstaller.Uninstall(package.PackageDirectory);
 
                     scope.Complete();

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                <root>/packageid/version/packageid/version/tools/framework/rid/mytool.dll
                                        /project.assets.json
              */
-            var assetJsonPath = package.Commands[0].Executable
+            var assetJsonPath = package.Command.Executable
                 .GetDirectoryPath()
                 .GetParentPath()
                 .GetParentPath()
@@ -813,7 +813,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
                 action.Should().NotThrow<ToolConfigurationException>();
 
-                fileSystem.File.Exists(package.Commands[0].Executable.Value).Should().BeTrue($"{package.Commands[0].Executable.Value} should exist");
+                fileSystem.File.Exists(package.Command.Executable.Value).Should().BeTrue($"{package.Command.Executable.Value} should exist");
 
                 uninstaller.Uninstall(package.PackageDirectory);
             }
@@ -842,10 +842,10 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .Should()
                 .Equal(TestPackageVersion);
 
-            package.Commands.Count.Should().Be(1);
-            fileSystem.File.Exists(package.Commands[0].Executable.Value).Should()
-                .BeTrue($"{package.Commands[0].Executable.Value} should exist");
-            package.Commands[0].Executable.Value.Should().Contain(store.Root.Value);
+            package.Command.Should().NotBeNull();
+            fileSystem.File.Exists(package.Command.Executable.Value).Should()
+                .BeTrue($"{package.Command.Executable.Value} should exist");
+            package.Command.Executable.Value.Should().Contain(store.Root.Value);
         }
 
         private static void AssertInstallRollBack(IFileSystem fileSystem, IToolPackageStore store)

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -45,13 +45,13 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     packageLocation: new PackageLocation(nugetConfig: nugetConfigPath),
                     targetFramework: _testTargetframework);
 
-                var commands = toolPackage.Commands;
+                var command = toolPackage.Command;
                 var expectedPackagesFolder = NuGetGlobalPackagesFolder.GetLocation();
-                commands[0].Executable.Value.Should().StartWith(expectedPackagesFolder);
+                command.Executable.Value.Should().StartWith(expectedPackagesFolder);
 
                 fileSystem.File
-                    .Exists(commands[0].Executable.Value)
-                    .Should().BeTrue($"{commands[0].Executable.Value} should exist");
+                    .Exists(command.Executable.Value)
+                    .Should().BeTrue($"{command.Executable.Value} should exist");
             }
             finally
             {
@@ -85,8 +85,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
             var expectedPackagesFolder = NuGetGlobalPackagesFolder.GetLocation();
 
-            var commands = toolPackage.Commands;
-            commands[0].Executable.Value.Should().StartWith(expectedPackagesFolder);
+            var command = toolPackage.Command;
+            command.Executable.Value.Should().StartWith(expectedPackagesFolder);
             toolPackage.Version.Should().Be(NuGetVersion.Parse(TestPackageVersion));
         }
 

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
@@ -174,8 +174,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                         {
                             Id = packageId,
                             Version = NuGetVersion.Parse(feedPackage.Version),
-                            Commands = new List<RestoredCommand> {
-                            new RestoredCommand(new ToolCommandName(feedPackage.ToolCommandName), "runner", executable) },
+                            Command = new RestoredCommand(new ToolCommandName(feedPackage.ToolCommandName), "runner", executable),
                             Warnings = Array.Empty<string>(),
                             PackagedShims = Array.Empty<FilePath>()
                         };
@@ -330,7 +329,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             public NuGetVersion Version { get; set; }
             public DirectoryPath PackageDirectory { get; set; }
 
-            public IReadOnlyList<RestoredCommand> Commands { get; set; }
+            public RestoredCommand Command { get; set; }
 
             public IEnumerable<string> Warnings { get; set; }
 

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageMock.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
     internal class ToolPackageMock : IToolPackage
     {
         private IFileSystem _fileSystem;
-        private Lazy<IReadOnlyList<RestoredCommand>> _commands;
+        private Lazy<RestoredCommand> _command;
         private IEnumerable<string> _warnings;
         private readonly IReadOnlyList<FilePath> _packagedShims;
 
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             Id = id;
             Version = version ?? throw new ArgumentNullException(nameof(version));
             PackageDirectory = packageDirectory;
-            _commands = new Lazy<IReadOnlyList<RestoredCommand>>(GetCommands);
+            _command = new Lazy<RestoredCommand>(GetCommand);
             _warnings = warnings ?? new List<string>();
             _packagedShims = packagedShims ?? new List<FilePath>();
             Frameworks = frameworks ?? new List<NuGetFramework>();
@@ -41,11 +41,11 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         public NuGetVersion Version { get; private set; }
         public DirectoryPath PackageDirectory { get; private set; }
 
-        public IReadOnlyList<RestoredCommand> Commands
+        public RestoredCommand Command
         {
             get
             {
-                return _commands.Value;
+                return _command.Value;
             }
         }
 
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
         public IEnumerable<NuGetFramework> Frameworks { get; private set; }
 
-        private IReadOnlyList<RestoredCommand> GetCommands()
+        private RestoredCommand GetCommand()
         {
             try
             {
@@ -78,13 +78,10 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                     name = root.GetProperty("Name").GetString();
                 }
 
-                return new RestoredCommand[]
-                {
-                    new RestoredCommand(
+                return new RestoredCommand(
                         new ToolCommandName(name),
                         "dotnet",
-                        PackageDirectory.WithFile(executablePath))
-                };
+                        PackageDirectory.WithFile(executablePath));
             }
             catch (IOException ex)
             {

--- a/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
@@ -164,16 +164,12 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockToolPackage(
                         "another.tool",
                         "2.7.3",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
                     )
                 });
 

--- a/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
@@ -345,7 +345,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             static string GetCommandString(IToolPackage package) => package.Command.Name.ToString();
 
             var packages = store.EnumeratePackages().Where(
-                (p) => PackageHasCommands(p) && ToolListGlobalOrToolPathCommand.PackageIdMatches(p, targetPackageId)
+                (p) => PackageHasCommand(p) && ToolListGlobalOrToolPathCommand.PackageIdMatches(p, targetPackageId)
                 ).OrderBy(package => package.Id);
             var columnDelimiter = PrintableTable<IToolPackageStoreQuery>.ColumnDelimiter;
 
@@ -383,7 +383,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             }
         }
 
-        private static bool PackageHasCommands(IToolPackage package)
+        private static bool PackageHasCommand(IToolPackage package)
         {
             try
             {

--- a/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListGlobalOrToolPathCommandTests.cs
@@ -111,9 +111,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     )
                 });
 
@@ -134,23 +132,17 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockToolPackage(
                         "another.tool",
                         "2.7.3",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockToolPackage(
                         "some.tool",
                         "1.0.0",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
                     )
                 });
 
@@ -216,12 +208,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool")),
-                            new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool")),
-                            new RestoredCommand(new ToolCommandName("baz"), "dotnet", new FilePath("tool"))
-                        }
-                    )
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool")))
                 });
 
             var command = CreateCommand(store.Object, "-g");
@@ -241,17 +228,13 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockBrokenPackage("another.tool", "2.7.3"),
                     CreateMockToolPackage(
                         "some.tool",
                         "1.0.0",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
                     )
                 });
 
@@ -267,13 +250,13 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                         "broken").Yellow()));
         }
 
-        private IToolPackage CreateMockToolPackage(string id, string version, IReadOnlyList<RestoredCommand> commands)
+        private IToolPackage CreateMockToolPackage(string id, string version, RestoredCommand command)
         {
             var package = new Mock<IToolPackage>(MockBehavior.Strict);
 
             package.SetupGet(p => p.Id).Returns(new PackageId(id));
             package.SetupGet(p => p.Version).Returns(NuGetVersion.Parse(version));
-            package.SetupGet(p => p.Commands).Returns(commands);
+            package.SetupGet(p => p.Command).Returns(command);
             return package.Object;
         }
 
@@ -287,23 +270,17 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                      CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockToolPackage(
                         "another.tool",
                         "2.7.3",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("bar"), "dotnet", new FilePath("tool"))
                     ),
                     CreateMockToolPackage(
                         "some.tool",
                         "1.0.0",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("fancy-foo"), "dotnet", new FilePath("tool"))
                     )
                 });
 
@@ -324,9 +301,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     CreateMockToolPackage(
                         "test.tool",
                         "1.3.5-preview",
-                        new[] {
-                            new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
-                        }
+                        new RestoredCommand(new ToolCommandName("foo"), "dotnet", new FilePath("tool"))
                     )
                 });
 
@@ -343,7 +318,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             package.SetupGet(p => p.Id).Returns(new PackageId(id));
             package.SetupGet(p => p.Version).Returns(NuGetVersion.Parse(version));
-            package.SetupGet(p => p.Commands).Throws(new ToolConfigurationException("broken"));
+            package.SetupGet(p => p.Command).Throws(new ToolConfigurationException("broken"));
             return package.Object;
         }
 
@@ -371,10 +346,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
         private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStoreQuery store, PackageId? targetPackageId = null)
         {
-            static string GetCommandsString(IToolPackage package)
-            {
-                return string.Join(ToolListGlobalOrToolPathCommand.CommandDelimiter, package.Commands.Select(c => c.Name));
-            }
+            static string GetCommandString(IToolPackage package) => package.Command.Name.ToString();
 
             var packages = store.EnumeratePackages().Where(
                 (p) => PackageHasCommands(p) && ToolListGlobalOrToolPathCommand.PackageIdMatches(p, targetPackageId)
@@ -388,7 +360,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             {
                 packageIdColumnWidth = Math.Max(packageIdColumnWidth, package.Id.ToString().Length);
                 versionColumnWidth = Math.Max(versionColumnWidth, package.Version.ToNormalizedString().Length);
-                commandsColumnWidth = Math.Max(commandsColumnWidth, GetCommandsString(package).Length);
+                commandsColumnWidth = Math.Max(commandsColumnWidth, GetCommandString(package).Length);
             }
 
             yield return string.Format(
@@ -411,7 +383,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     columnDelimiter,
                     package.Version.ToNormalizedString().PadRight(versionColumnWidth),
                     columnDelimiter,
-                    GetCommandsString(package).PadRight(commandsColumnWidth));
+                    GetCommandString(package).PadRight(commandsColumnWidth));
             }
         }
 
@@ -419,7 +391,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             try
             {
-                return package.Commands.Count >= 0;
+                return package.Command is not null;
             }
             catch (Exception ex) when (ex is ToolConfigurationException)
             {

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 .Contain(l =>
                     l.Contains(
                         string.Format(LocalizableStrings.CommandsMismatch,
-                            "\"different-command-nameA\" \"different-command-nameB\"", _packageIdA, "\"a\"")));
+                            "\"different-command-nameA\" \"different-command-nameB\"", _packageIdA, "a")));
         }
 
         [Fact]


### PR DESCRIPTION
A ToolCommandInstance never has more than one Command associated with it. We pretend otherwise throughout our code base.

Unfortunately, that was baked into the json for the tools manifest, so this change is imperfect; it would be ideal to remove that as well, but that would be a breaking change.