### PR TITLE
Disable fingerprinting in the VanillaWasm test

### DIFF
--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
@@ -10,7 +10,14 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         {
             var testAsset = "VanillaWasm";
             var targetFramework = "net8.0";
-            var testInstance = CreateAspNetSdkTestAsset(testAsset);
+            var testInstance = CreateAspNetSdkTestAsset(testAsset)
+                .WithProjectChanges((p, doc) =>
+                {
+                    var itemGroup = new XElement("PropertyGroup");
+                    var fingerprintAssets = new XElement("WasmFingerprintAssets", false);
+                    itemGroup.Add(fingerprintAssets);
+                    doc.Root.Add(itemGroup);
+                });
 
             var build = CreateBuildCommand(testInstance);
             ExecuteCommand(build)


### PR DESCRIPTION
The test won't work with fingerprinting so turn it off always event if the sdk doesn't support it yet