### PR TITLE
Move WindowsProxy.winmd from allowed-sb-binaries.txt to allowed-vmr-binaries.txt

### DIFF
--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -47,9 +47,6 @@ src/razor/**/SampleApp/**/fonts/**/*.eot
 src/razor/**/SampleApp/**/fonts/**/*.otf
 src/razor/**/SampleApp/**/fonts/**/*.woff
 
-# roslyn
-src/roslyn/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/Resources/WindowsProxy.winmd
-
 # runtime
 src/runtime/src/libraries/System.Diagnostics.EventLog/src/Messages/EventLogMessages.res # Icon
 src/runtime/src/libraries/System.Speech/src/**/*.upsmap # https://github.com/dotnet/runtime/issues/81692

--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -85,6 +85,7 @@ src/roslyn/src/Compilers/Test/Resources/Core/**/*.obj
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.dll
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.exe
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.Dll
+src/roslyn/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/Resources/WindowsProxy.winmd
 src/roslyn/src/Workspaces/MSBuildTest/Resources/Dlls/*.dll
 src/roslyn/**/CodeAnalysisTest/**/*.res
 src/roslyn/**/CodeAnalysisTest/**/*.blah


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/issues/66718#issuecomment-2304123252 This file shouldn't be included in a source-build tarball.

/cc @dviererbe 