### PR TITLE
Use Defender on Linux in VMR pipeline

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -55,6 +55,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+     EnableDefenderForLinux: true
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
We're occasionally seeing infrastructure errors from antimalware scans on Linux in the VMR build, let's try opting in to the Defender preview to see if it's more stable.