### PR TITLE
Increase license scan file timeout

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -134,7 +134,7 @@ public class LicenseScanTests : TestBase
         Assert.NotNull(Config.LicenseScanPath);
 
         // Indicates how long until a timeout occurs for scanning a given file
-        const int FileScanTimeoutSeconds = 240;
+        const int FileScanTimeoutSeconds = 300;
 
         string scancodeResultsPath = Path.Combine(Config.LogsDirectory, "scancode-results.json");
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4581