### PR TITLE
Update triggers for SB sdk diff and license scan pipelines

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -18,6 +18,7 @@ resources:
       branches:
         include:
           - refs/heads/release/*.0.1xx-preview*
+          - refs/heads/release/9.0.1xx*
           - refs/heads/internal/release/*.0.1xx*
 
 pr: none

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -18,7 +18,7 @@ resources:
       branches:
         include:
           - refs/heads/release/*.0.1xx-preview*
-          - refs/heads/release/9.0.1xx*
+          - refs/heads/release/9.0.1xx
           - refs/heads/internal/release/*.0.1xx*
 
 pr: none

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -9,7 +9,7 @@ schedules:
     include:
     - main
     - release/*.0.1xx-preview*
-    - release/9.0.1xx*
+    - release/9.0.1xx
     - internal/release/*.0.1xx*
 
 pr: none
@@ -20,7 +20,7 @@ trigger:
     include:
     - main
     - release/*.0.1xx-preview*
-    - release/9.0.1xx*
+    - release/9.0.1xx
     - internal/release/*.0.1xx*
   paths:
     include:

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -9,6 +9,7 @@ schedules:
     include:
     - main
     - release/*.0.1xx-preview*
+    - release/9.0.1xx*
     - internal/release/*.0.1xx*
 
 pr: none
@@ -19,6 +20,7 @@ trigger:
     include:
     - main
     - release/*.0.1xx-preview*
+    - release/9.0.1xx*
     - internal/release/*.0.1xx*
   paths:
     include:


### PR DESCRIPTION
The SB sdk diff and license scan pipelines are not being run for the release/9.0.1xx branch. There will be no corresponding builds from the internal/release/9.0.1xx branch until 9.0 GAs. In the meantime, we still want to get runs for this branch.

This updates the triggers to account for this branch. This will need to be removed after GA because we don't want to run this pipeline on the public builds during servicing. I'll follow this up with an issue to get these changes reverted.