### PR TITLE
Support --no-restore option in dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -175,6 +175,9 @@
   <data name="CmdNoBuildDescription" xml:space="preserve">
     <value>Do not build the project before testing. Implies --no-restore.</value>
   </data>
+  <data name="CmdNoRestoreDescription" xml:space="preserve">
+    <value>Do not execute an implicit restore.</value>
+  </data>
   <data name="CmdResultsDirectoryDescription" xml:space="preserve">
     <value>The directory where the test results will be placed.
 The specified directory will be created if it does not exist.</value>

--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -176,7 +176,10 @@
     <value>Do not build the project before testing. Implies --no-restore.</value>
   </data>
   <data name="CmdNoRestoreDescription" xml:space="preserve">
-    <value>Do not execute an implicit restore.</value>
+    <value>Add the reference without performing restore preview and compatibility check.</value>
+  </data>
+  <data name="CmdArchitectureDescription" xml:space="preserve">
+    <value>The target architecture '{0}' on which tests will run.</value>
   </data>
   <data name="CmdResultsDirectoryDescription" xml:space="preserve">
     <value>The directory where the test results will be placed.

--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -176,7 +176,7 @@
     <value>Do not build the project before testing. Implies --no-restore.</value>
   </data>
   <data name="CmdNoRestoreDescription" xml:space="preserve">
-    <value>Add the reference without performing restore preview and compatibility check.</value>
+    <value>Do not execute an implicit restore.</value>
   </data>
   <data name="CmdArchitectureDescription" xml:space="preserve">
     <value>The target architecture '{0}' on which tests will run.</value>

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildConnectionHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildConnectionHandler.cs
@@ -6,15 +6,15 @@ using System.IO.Pipes;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Test;
 
-namespace Microsoft.DotNet.Cli.commands.dotnet_test
+namespace Microsoft.DotNet.Cli
 {
     internal sealed class MSBuildConnectionHandler : IDisposable
     {
+        private readonly string[] _args;
+        private readonly TestApplicationActionQueue _actionQueue;
+
         private readonly PipeNameDescription _pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
         private readonly List<NamedPipeServer> _namedPipeConnections = new();
-        private readonly string[] _args;
-
-        private TestApplicationActionQueue _actionQueue;
 
         public MSBuildConnectionHandler(string[] args, TestApplicationActionQueue actionQueue)
         {
@@ -82,10 +82,12 @@ namespace Microsoft.DotNet.Cli.commands.dotnet_test
 
         public int RunWithMSBuild(ParseResult parseResult)
         {
-            bool containsNoBuild = parseResult.UnmatchedTokens.Any(token => token == CliConstants.NoBuildOptionKey);
+            bool containsNoBuild = parseResult.HasOption(TestCommandParser.NoBuild);
+            bool containsNoRestore = parseResult.HasOption(TestCommandParser.NoRestore) || containsNoBuild;
+
             List<string> msbuildCommandLineArgs =
             [
-                    $"-t:{(containsNoBuild ? string.Empty : "Build;")}_GetTestsProject",
+                    $"-t:{(containsNoRestore ? string.Empty : "Restore;")}{(containsNoBuild ? string.Empty : "Build;")}_GetTestsProject",
                     $"-p:GetTestsProjectPipeName={_pipeNameDescription.Name}",
                     "-verbosity:q"
             ];

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -37,6 +37,12 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.Zero
         };
 
+        public static readonly CliOption<string> NoRestore = new("--no-restore")
+        {
+            Description = LocalizableStrings.CmdNoRestoreDescription,
+            Arity = ArgumentArity.Zero
+        };
+
         public static readonly CliOption<string> SettingsOption = new ForwardedOption<string>("--settings", "-s")
         {
             Description = LocalizableStrings.CmdSettingsDescription,
@@ -222,6 +228,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(TestModules);
             command.Options.Add(TestModulesRootDirectory);
             command.Options.Add(NoBuild);
+            command.Options.Add(NoRestore);
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -43,6 +43,12 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.Zero
         };
 
+        public static readonly CliOption<string> Architecture = new("--arch")
+        {
+            Description = LocalizableStrings.CmdArchitectureDescription,
+            Arity = ArgumentArity.ExactlyOne
+        };
+
         public static readonly CliOption<string> SettingsOption = new ForwardedOption<string>("--settings", "-s")
         {
             Description = LocalizableStrings.CmdSettingsDescription,
@@ -229,6 +235,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(TestModulesRootDirectory);
             command.Options.Add(NoBuild);
             command.Options.Add(NoRestore);
+            command.Options.Add(Architecture);
 
             return command;
         }

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Tools.Test;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal sealed class TestModulesFilterHandler
+    {
+        private readonly string[] _args;
+
+        private readonly TestApplicationActionQueue _actionQueue;
+
+        public TestModulesFilterHandler(string[] args, TestApplicationActionQueue actionQueue)
+        {
+            _args = args;
+            _actionQueue = actionQueue;
+        }
+
+        public bool RunWithTestModulesFilter(ParseResult parseResult)
+        {
+            // If the module path pattern(s) was provided, we will use that to filter the test modules
+            string testModules = parseResult.GetValue(TestCommandParser.TestModules);
+
+            // If the root directory was provided, we will use that to search for the test modules
+            // Otherwise, we will use the current directory
+            string rootDirectory = Directory.GetCurrentDirectory();
+            if (parseResult.HasOption(TestCommandParser.TestModulesRootDirectory))
+            {
+                rootDirectory = parseResult.GetValue(TestCommandParser.TestModulesRootDirectory);
+
+                // If the root directory is not valid, we simply return
+                if (string.IsNullOrEmpty(rootDirectory) || !Directory.Exists(rootDirectory))
+                {
+                    VSTestTrace.SafeWriteTrace(() => $"The provided root directory does not exist: {rootDirectory}");
+                    return false;
+                }
+            }
+
+            var testModulePaths = GetMatchedModulePaths(testModules, rootDirectory);
+
+            // If no matches were found, we simply return
+            if (!testModulePaths.Any())
+            {
+                VSTestTrace.SafeWriteTrace(() => $"No test modules found for the given test module pattern: {testModules} with root directory: {rootDirectory}");
+                return false;
+            }
+
+            foreach (string testModule in testModulePaths)
+            {
+                var testApp = new TestApplication(testModule, _args);
+                // Write the test application to the channel
+                _actionQueue.Enqueue(testApp);
+                testApp.OnCreated();
+            }
+
+            return true;
+        }
+
+        private static IEnumerable<string> GetMatchedModulePaths(string testModules, string rootDirectory)
+        {
+            var testModulePatterns = testModules.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            Matcher matcher = new();
+            matcher.AddIncludePatterns(testModulePatterns);
+
+            return MatcherExtensions.GetResultsInFullPath(matcher, rootDirectory);
+        }
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -26,6 +26,12 @@ namespace Microsoft.DotNet.Cli
 
         public int Run(ParseResult parseResult)
         {
+            if (parseResult.HasOption(TestCommandParser.Architecture))
+            {
+                VSTestTrace.SafeWriteTrace(() => $"The --arch option is not yet supported.");
+                return ExitCodes.GenericFailure;
+            }
+
             // User can decide what the degree of parallelism should be
             // If not specified, we will default to the number of processors
             if (!int.TryParse(parseResult.GetValue(TestCommandParser.MaxParallelTestModules), out int degreeOfParallelism))

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Umožní shromažďovat výpisy stavu systému při očekávaných i neočekávaných ukončeních hostitele testů.</target>
@@ -114,8 +119,8 @@ Příklady:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -113,6 +113,11 @@ Příklady:
         <target state="translated">Spustit testy bez zobrazení nápisu Microsoft Testplatform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -119,8 +119,8 @@ Příklady:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -113,6 +113,11 @@ Beispiele:
         <target state="translated">Test(s) ohne Anzeige des Microsoft-Testplattformbanners ausführen</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Aktiviert die Erfassung von Absturzabbildern bei einer erwarteten und einer unerwarteten Beendigung des Testhosts.</target>
@@ -114,8 +119,8 @@ Beispiele:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -119,8 +119,8 @@ Beispiele:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Habilita la recopilación del volcado de memoria en la salida del host de prueba esperada e inesperada.</target>
@@ -116,8 +121,8 @@ Ejemplos:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -121,8 +121,8 @@ Ejemplos:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -115,6 +115,11 @@ Ejemplos:
         <target state="translated">Ejecutar pruebas, sin mostrar la pancarta de Microsoft Testplatform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Active la collecte des données de vidage sur plantage en cas de sortie attendue et inattendue de testhost.</target>
@@ -114,8 +119,8 @@ Exemples :
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -113,6 +113,11 @@ Exemples :
         <target state="translated">Exécute le ou les tests, sans afficher la bannière Microsoft Testplatform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -119,8 +119,8 @@ Exemples :
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -113,6 +113,11 @@ Esempi:
         <target state="translated">Esegui test senza visualizzare il banner di Microsoft Testplatform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -119,8 +119,8 @@ Esempi:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Abilita la raccolta del dump di arresto anomalo in caso di chiusura prevista e imprevista dell'host di test.</target>
@@ -114,8 +119,8 @@ Esempi:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -113,6 +113,11 @@ Examples:
         <target state="translated">Microsoft Testplatform バナーを表示せずにテストを実行する</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">TestHost の予期されるおよび予期されない終了時にクラッシュ ダンプを収集することを有効にします。</target>
@@ -114,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -119,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -119,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">예상된 테스트 호스트 종료와 예기치 않은 테스트 호스트 종료 시 크래시 덤프 수집을 사용하도록 설정합니다.</target>
@@ -114,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -113,6 +113,11 @@ Examples:
         <target state="translated">Microsoft Testplatform 배너를 표시하지 않고 테스트 실행</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -119,8 +119,8 @@ Przykłady:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -113,6 +113,11 @@ Przykłady:
         <target state="translated">Uruchom testy bez wyświetlania baneru platformy testowej firmy Microsoft</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Włącza zbieranie zrzutów awaryjnych po oczekiwanym i nieoczekiwanym zakończenia działania przez host testowy.</target>
@@ -114,8 +119,8 @@ Przykłady:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -119,8 +119,8 @@ Exemplos:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -113,6 +113,11 @@ Exemplos:
         <target state="translated">Executar testes, sem exibir a faixa do Microsoft Testplatform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Habilita a coleta de despejo de memória nas saídas esperada e inesperada do host de teste.</target>
@@ -114,8 +119,8 @@ Exemplos:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Включает сбор аварийного дампа при ожидаемом и неожиданном завершении работы узла тестирования.</target>
@@ -114,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -119,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -113,6 +113,11 @@ Examples:
         <target state="translated">Запуск тестов без отображения баннера Testplatform Майкрософт</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -113,6 +113,11 @@ Bu bağımsız değişken, birden çok değişken sağlamak için birden çok ke
         <target state="translated">Testleri Microsoft Testplatform bandını görüntülemeden çalıştır</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -119,8 +119,8 @@ Bu bağımsız değişken, birden çok değişken sağlamak için birden çok ke
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Hem beklenen hem de beklenmeyen test ana bilgisayarı çıkışında kilitlenme bilgi dökümünün toplanmasını sağlar.</target>
@@ -114,8 +119,8 @@ Bu bağımsız değişken, birden çok değişken sağlamak için birden çok ke
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -119,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">允许在预期和意外的 testhost 退出时收集故障转储。</target>
@@ -114,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -113,6 +113,11 @@ Examples:
         <target state="translated">运行测试，而不显示 Microsoft Testplatform 版权标志</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -113,6 +113,11 @@ Examples:
         <target state="translated">執行測試，但不顯示 Microsoft Testplatform 橫幅</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdSettingsFile">
         <source>SETTINGS_FILE</source>
         <target state="translated">SETTINGS_FILE</target>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -119,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Add the reference without performing restore preview and compatibility check.</source>
-        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
+        <source>Do not execute an implicit restore.</source>
+        <target state="new">Do not execute an implicit restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">The additional msbuild parameters to pass.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdArchitectureDescription">
+        <source>The target architecture '{0}' on which tests will run.</source>
+        <target state="new">The target architecture '{0}' on which tests will run.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">允許在測試主機如預期或未預期地結束時收集損毀傾印。</target>
@@ -114,8 +119,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="CmdNoRestoreDescription">
-        <source>Do not execute an implicit restore.</source>
-        <target state="new">Do not execute an implicit restore.</target>
+        <source>Add the reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add the reference without performing restore preview and compatibility check.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSettingsFile">


### PR DESCRIPTION
Also avoid test execution and display "The --arch option is not yet supported" when using --arch.