### PR TITLE
Explicity set UseConsolidatedMvcViews to false.

### DIFF
--- a/src/RazorSdk/Tool/DiscoverCommand.cs
+++ b/src/RazorSdk/Tool/DiscoverCommand.cs
@@ -142,7 +142,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
 
             var version = RazorLanguageVersion.Parse(Version.Value());
-            var configuration = new RazorConfiguration(version, Configuration.Value(), Extensions: []);
+            var configuration = new RazorConfiguration(version, Configuration.Value(), Extensions: [], UseConsolidatedMvcViews: false);
 
             var result = ExecuteCore(
                 configuration: configuration,

--- a/src/RazorSdk/Tool/GenerateCommand.cs
+++ b/src/RazorSdk/Tool/GenerateCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
 
             var version = RazorLanguageVersion.Parse(Version.Value());
-            var configuration = new RazorConfiguration(version, Configuration.Value(), Extensions: []);
+            var configuration = new RazorConfiguration(version, Configuration.Value(), Extensions: [], UseConsolidatedMvcViews: false);
 
             var sourceItems = GetSourceItems(
                 Sources.Values, Outputs.Values, RelativePaths.Values,


### PR DESCRIPTION
As part of https://github.com/dotnet/razor/pull/10795 we're changing the default to true. This opts RZC back to false.