### PR TITLE
Setup private feeds for tests

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -383,6 +383,18 @@ jobs:
 
     # Only run tests if enabled
     - ${{ if eq(parameters.runTests, 'True') }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(sourcesPath)/src/sdk/eng/common/SetupNugetSources.sh
+            arguments: $(sourcesPath)/src/sdk/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+        - script: cp "$(sourcesPath)/src/sdk/NuGet.config" "$(sourcesPath)/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/online.NuGet.Config"
+          displayName: Copy Test NuGet Config for Smoke Tests
+
       - script: |
           set -ex
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -383,6 +383,8 @@ jobs:
 
     # Only run tests if enabled
     - ${{ if eq(parameters.runTests, 'True') }}:
+      # Setup the NuGet sources used by the tests to use private feeds. This is necessary when testing internal-only product
+      # builds where the packages are only available in the private feeds. This allows the tests to restore from those feeds.
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - task: Bash@3
           displayName: Setup Private Feeds Credentials


### PR DESCRIPTION
Previous refactoring of the VMR pipeline mistakenly removed the pipeline steps which setup the private feed credentials for the NuGet.config used by tests. This causes the error described in https://github.com/dotnet/source-build/issues/4583#issuecomment-2312465352.

This is resolved by adding back the pipeline steps that were removed. One difference here is that now we also run the scenario tests in addition to the source build smoke tests. The scenario tests have the same issue as they just copy in the NuGet.config file from the sdk repo. To resolve both of these, the sdk repo's NuGet.config file is directly updated by the `SetupNuGetSources.sh`. That updated file then is used as the source for both test suites.

Fixes https://github.com/dotnet/source-build/issues/4583

Note that this won't fix RC1 builds. There's no time to get this change in for RC1. But that branch has been privately verified with this fix.