### PR TITLE
Clean up error experience when downloading non-tools

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
@@ -16,7 +16,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null);
+            PackageSourceMapping packageSourceMapping = null,
+            bool isTool = false);
 
         Task<string> GetPackageUrl(PackageId packageId,
             NuGetVersion packageVersion = null,

--- a/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
+++ b/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
@@ -126,6 +126,9 @@
   <data name="IsNotFoundInNuGetFeeds" xml:space="preserve">
     <value>{0} is not found in NuGet feeds {1}.</value>
   </data>
+  <data name="NotATool" xml:space="preserve">
+    <value>Package {0} is not a dotnet tool.</value>
+  </data>
   <data name="DownloadVersionFailed" xml:space="preserve">
     <value>Downloading {0} version {1} failed.</value>
   </data>

--- a/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
+++ b/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
@@ -127,7 +127,7 @@
     <value>{0} is not found in NuGet feeds {1}.</value>
   </data>
   <data name="NotATool" xml:space="preserve">
-    <value>Package {0} is not a dotnet tool.</value>
+    <value>Package {0} is not a .NET tool.</value>
   </data>
   <data name="DownloadVersionFailed" xml:space="preserve">
     <value>Downloading {0} version {1} failed.</value>

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -111,12 +111,12 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
                     if (!ToolPackageInstance.IsToolPackage(doc))
                     {
-                        throw new ToolPackageException(string.Format(LocalizableStrings.NotATool, packageId));
+                        throw new GracefulException(string.Format(LocalizableStrings.NotATool, packageId));
                     }
                 }
                 else
                 {
-                    throw new ToolPackageException(string.Format(LocalizableStrings.NotATool, packageId));
+                    throw new GracefulException(string.Format(LocalizableStrings.NotATool, packageId));
                 }
             }
 

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
             SourceRepository repository = GetSourceRepository(source);
 
-            if (isTool && await repository.GetResourceAsync<PackageSearchResourceV3>(cancellationToken).ConfigureAwait(false) is var searchResource)
+            if (isTool && await repository.GetResourceAsync<PackageSearchResourceV3>(cancellationToken).ConfigureAwait(false) is PackageSearchResourceV3 searchResource)
             {
                 var results = await searchResource.SearchAsync(packageId.ToString(), new SearchFilter(includePrerelease: includePreview, filter: SearchFilterType.IsLatestVersion)
                 {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
                 if (!results.Any())
                 {
-                    throw new ToolPackageException(string.Format(LocalizableStrings.NotATool, packageId));
+                    throw new GracefulException(string.Format(LocalizableStrings.NotATool, packageId));
                 }
             }
 

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -109,9 +109,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
                     XDocument doc = XDocument.Parse(nuspec);
 
-                    if (!doc.Root.Descendants().Where(
-                        e => e.Name.LocalName == "packageType" &&
-                        e.Attributes().Where(a => a.Name.LocalName == "name" && a.Value == "DotnetTool").Any()).Any())
+                    if (!ToolPackageInstance.IsToolPackage(doc))
                     {
                         throw new ToolPackageException(string.Format(LocalizableStrings.NotATool, packageId));
                     }

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -93,13 +93,14 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
             SourceRepository repository = GetSourceRepository(source);
 
-                        if (isTool && await repository.GetResourceAsync<PackageSearchResourceV3>(cancellationToken).ConfigureAwait(false) is var searchResource)
+            if (isTool && await repository.GetResourceAsync<PackageSearchResourceV3>(cancellationToken).ConfigureAwait(false) is var searchResource)
             {
                 var results = await searchResource.SearchAsync(packageId.ToString(), new SearchFilter(includePrerelease: includePreview, filter: SearchFilterType.IsLatestVersion)
                 {
                     PackageTypes = [NuGet.Packaging.Core.PackageType.DotnetTool.Name]
                 }, skip: 0, take: 10, log: _verboseLogger, cancellationToken: cancellationToken).ConfigureAwait(false);
-                if (results.Count() == 0)
+
+                if (!results.Any())
                 {
                     throw new ToolPackageException(string.Format(LocalizableStrings.NotATool, packageId));
                 }

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Přeskakuje se ověření podpisu balíčku NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">"{0}" wurde in NuGet-Feeds "{1}" nicht gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Die Überprüfung der NuGet-Paketsignatur wird übersprungen.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">No se encuentra {0} en las fuentes de NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Omitiendo la comprobación de la firma del paquete NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0} est introuvable dans les flux NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">La vérification de la signature du package NuGet est ignorée.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0} non è stato trovato nei feed NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">La verifica della firma del pacchetto NuGet verrà ignorata.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0} が NuGet フィード {1} に見つかりません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet パッケージ署名の認証をスキップしています。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">NuGet 피드 {1} 에서 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet 패키지 서명 확인을 건너뛰는 중입니다.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Pomijanie weryfikacji podpisu pakietu NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0} não foi encontrado no NuGet feeds {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Ignorando a verificação de assinatura do pacote NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0} не найдено в веб-каналах NuGet {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Пропуск проверки подписи пакета NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">{0}, {1} NuGet akışlarında bulunamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet paket imzası doğrulaması atlanıyor.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">在 NuGet 源 {1} 中找不到 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">正在跳过 NuGet 包签名验证。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="needs-review-translation">在 NuGet 摘要 {1} 中找不到 {0}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NotATool">
+        <source>Package {0} is not a dotnet tool.</source>
+        <target state="new">Package {0} is not a dotnet tool.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">正在略過 NuGet 套件簽章驗證。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NotATool">
-        <source>Package {0} is not a dotnet tool.</source>
-        <target state="new">Package {0} is not a dotnet tool.</target>
+        <source>Package {0} is not a .NET tool.</source>
+        <target state="new">Package {0} is not a .NET tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     {
                         if (!ToolPackageInstance.IsToolPackage(package.Nuspec.Xml))
                         {
-                            throw new ToolPackageException(string.Format(NuGetPackageDownloader.LocalizableStrings.NotATool, packageId));
+                            throw new GracefulException(string.Format(NuGetPackageDownloader.LocalizableStrings.NotATool, packageId));
                         }
 
                         if (isGlobalTool)

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -134,13 +134,21 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     {
                         DownloadAndExtractPackage(packageId, nugetPackageDownloader, toolDownloadDir.Value, packageVersion, packageSourceLocation, includeUnlisted: givenSpecificVersion).GetAwaiter().GetResult();
                     }
-                    else if(isGlobalTool)
+                    else
                     {
-                        throw new ToolPackageException(
-                            string.Format(
-                                CommonLocalizableStrings.ToolPackageConflictPackageId,
-                                packageId,
-                                packageVersion.ToNormalizedString()));
+                        if (!ToolPackageInstance.IsToolPackage(package.Nuspec.Xml))
+                        {
+                            throw new ToolPackageException(string.Format(NuGetPackageDownloader.LocalizableStrings.NotATool, packageId));
+                        }
+
+                        if (isGlobalTool)
+                        {
+                            throw new ToolPackageException(
+                                string.Format(
+                                    CommonLocalizableStrings.ToolPackageConflictPackageId,
+                                    packageId,
+                                    packageVersion.ToNormalizedString()));
+                        }
                     }
                                        
                     CreateAssetFile(packageId, packageVersion, toolDownloadDir, assetFileDirectory, _runtimeJsonPath, targetFramework);

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -284,7 +284,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             bool includeUnlisted = false
             )
         {
-            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted).ConfigureAwait(false);
+            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted, isTool: true).ConfigureAwait(false);
 
             // look for package on disk and read the version
             NuGetVersion version;

--- a/src/Cli/dotnet/ToolPackage/ToolPackageInstance.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageInstance.cs
@@ -23,6 +23,17 @@ namespace Microsoft.DotNet.ToolPackage
 
             return new ToolPackageInstance(id, version, packageDirectory, assetsJsonParentDirectory);
         }
+
+        /// <summary>
+        /// Validates that the nuspec XML represents a .NET tool package.
+        /// </summary>
+        /// <param name="nuspec">The nuspec XML to check.</param>
+        /// <returns><see langword="true"/> if the nuspec represents a .NET tool package; otherwise, <see langword="false"/>.</returns>
+        public static bool IsToolPackage(XDocument nuspec) =>
+            nuspec.Root.Descendants().Where(
+                e => e.Name.LocalName == "packageType" &&
+                e.Attributes().Where(a => a.Name.LocalName == "name" && a.Value == "DotnetTool").Any()).Any();
+
         private const string PackagedShimsDirectoryConvention = "shims";
 
         public IEnumerable<string> Warnings => _toolConfiguration.Value.Warnings;

--- a/test/dotnet-new.Tests/CommonTemplatesTests.cs
+++ b/test/dotnet-new.Tests/CommonTemplatesTests.cs
@@ -12,6 +12,8 @@ using TestLoggerFactory = Microsoft.NET.TestFramework.TestLoggerFactory;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
+    // Temporary workaround for possible threading issues related to accessing VS COM objects.
+    [Collection("C1")]
     public class CommonTemplatesTests : BaseIntegrationTest, IClassFixture<SharedHomeDirectory>
     {
         private readonly SharedHomeDirectory _fixture;

--- a/test/dotnet-new.Tests/CommonTemplatesTests.cs
+++ b/test/dotnet-new.Tests/CommonTemplatesTests.cs
@@ -12,8 +12,6 @@ using TestLoggerFactory = Microsoft.NET.TestFramework.TestLoggerFactory;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
-    // Temporary workaround for possible threading issues related to accessing VS COM objects.
-    [Collection("C1")]
     public class CommonTemplatesTests : BaseIntegrationTest, IClassFixture<SharedHomeDirectory>
     {
         private readonly SharedHomeDirectory _fixture;

--- a/test/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
+++ b/test/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null)
+            PackageSourceMapping packageSourceMapping = null,
+            bool isTool = false)
         {
             var mockPackagePath = Path.Combine(MockPackageDir, $"{packageId}.{packageVersion}.nupkg");
             File.WriteAllText(mockPackagePath, string.Empty);

--- a/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
+++ b/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null)
+            PackageSourceMapping packageSourceMapping = null,
+            bool isTool = false)
         {
             DownloadCallParams.Add((packageId, packageVersion, downloadFolder, packageSourceLocation));
 


### PR DESCRIPTION
Fixes #37010

This is the new error experience:
![image](https://github.com/user-attachments/assets/239f15df-04bc-470e-933d-e95cde962cd9)

This roughly works, but the current version feels pretty hacky to me, and I'm not a fan of that. In particular, where did magic 139 come from? Apparently it's the "failed to find a tool" message length, but I didn't see how I could access the real message, so that was the best I could do for now.