### PR TITLE
VMR: Exit when error happens in Prepare BuildLogs step

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -472,7 +472,7 @@ jobs:
 
     # Don't use CopyFiles@2 as it encounters permissions issues because it indexes all files in the source directory graph.
     - script: |
-        set -x
+        set -ex
 
         targetFolder=$(Build.StagingDirectory)/BuildLogs/
         mkdir -p ${targetFolder}


### PR DESCRIPTION
While doing some experiments I noticed that errors in the Prepare BuildLogs step don't fail the build.