### PR TITLE
[StaticWebAssets] Improve Up to date check logic

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
@@ -1,0 +1,68 @@
+<Project>
+  <PropertyGroup>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>
+      $(CollectUpToDateCheckInputDesignTimeDependsOn);
+      ResolveStaticWebAssetsConfiguration;
+      ResolveProjectStaticWebAssets;
+      CollectStaticWebAssetInputsDesignTime;
+    </CollectUpToDateCheckInputDesignTimeDependsOn>
+    <CollectUpToDateCheckOutputDesignTimeDependsOn>
+      $(CollectUpToDateCheckOutputDesignTimeDependsOn);
+      ResolveStaticWebAssetsConfiguration;
+      CollectStaticWebAssetOutputsDesignTime;
+    </CollectUpToDateCheckOutputDesignTimeDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CollectStaticWebAssetInputsDesignTime">
+
+    <ReadLinesFromFile
+      File="$(StaticWebAssetUpToDateCheckManifestPath)"
+      Condition="Exists('$(StaticWebAssetUpToDateCheckManifestPath)')"
+    >
+      <Output TaskParameter="Lines" ItemName="_StaticWebAssetUpToDateCheckInput" />
+    </ReadLinesFromFile>
+
+    <ReadLinesFromFile
+      File="$(StaticWebAssetReferencesUpToDateCheckManifestPath)"
+      Condition="Exists('$(StaticWebAssetReferencesUpToDateCheckManifestPath)')"
+    >
+      <Output TaskParameter="Lines" ItemName="_StaticWebAssetReferenceUpToDateCheckInput" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <_UpToDateCheckStaticWebAssetResolved Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_UpToDateCheckStaticWebAssetResolvedCandidate Include="@(_UpToDateCheckStaticWebAssetResolved->'%(OriginalItemSpec)')" />
+      <_StaticWebAssetUpToDateCheckInput Include="@(_UpToDateCheckStaticWebAssetResolvedCandidate->'%(FullPath)')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ExistingStaticWebAssetUpToDateCheckInput Include="@(_StaticWebAssetUpToDateCheckInput)" Condition="Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
+      <_NonExistingStaticWebAssetUpToDateCheckInput Include="@(_StaticWebAssetUpToDateCheckInput)" Condition="!Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(StaticWebAssetUpToDateCheckRemovedManifestPath)"
+      Lines="@(_NonExistingStaticWebAssetUpToDateCheckInput->Distinct())"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <UpToDateCheckInput Condition="'@(_NonExistingStaticWebAssetUpToDateCheckInput->Distinct())' != ''" Include="$(StaticWebAssetUpToDateCheckRemovedManifestPath)" Set="StaticWebAssets" />
+      <UpToDateCheckInput Include="@(_ExistingStaticWebAssetUpToDateCheckInput)" Set="StaticWebAssets" />
+      <UpToDateCheckInput Include="@(_StaticWebAssetReferenceUpToDateCheckInput)" Set="StaticWebAssets" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="CollectStaticWebAssetOutputsDesignTime">
+
+    <ItemGroup>
+      <UpToDateCheckOutput Include="$(StaticWebAssetBuildManifestPath)" Set="StaticWebAssets" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
@@ -35,22 +35,22 @@
 
     <ItemGroup>
       <_UpToDateCheckStaticWebAssetResolvedCandidate Include="@(_UpToDateCheckStaticWebAssetResolved->'%(OriginalItemSpec)')" />
-      <_StaticWebAssetUpToDateCheckInput Include="@(_UpToDateCheckStaticWebAssetResolvedCandidate->'%(FullPath)')" />
+      <_StaticWebAssetUpToDateCheckInput Include="@(_UpToDateCheckStaticWebAssetResolvedCandidate->Distinct()->'%(FullPath)')" />
     </ItemGroup>
 
     <ItemGroup>
-      <_ExistingStaticWebAssetUpToDateCheckInput Include="@(_StaticWebAssetUpToDateCheckInput)" Condition="Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
-      <_NonExistingStaticWebAssetUpToDateCheckInput Include="@(_StaticWebAssetUpToDateCheckInput)" Condition="!Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
+      <_ExistingStaticWebAssetUpToDateCheckInput Include="%(_StaticWebAssetUpToDateCheckInput.FullPath)" Condition="Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
+      <_NonExistingStaticWebAssetUpToDateCheckInput Include="%(_StaticWebAssetUpToDateCheckInput.FullPath)" Condition="!Exists('%(_StaticWebAssetUpToDateCheckInput.FullPath)')" />
     </ItemGroup>
 
     <WriteLinesToFile
       File="$(StaticWebAssetUpToDateCheckRemovedManifestPath)"
-      Lines="@(_NonExistingStaticWebAssetUpToDateCheckInput->Distinct())"
+      Lines="@(_NonExistingStaticWebAssetUpToDateCheckInput)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
-      <UpToDateCheckInput Condition="'@(_NonExistingStaticWebAssetUpToDateCheckInput->Distinct())' != ''" Include="$(StaticWebAssetUpToDateCheckRemovedManifestPath)" Set="StaticWebAssets" />
+      <UpToDateCheckInput Condition="'@(_NonExistingStaticWebAssetUpToDateCheckInput)' != ''" Include="$(StaticWebAssetUpToDateCheckRemovedManifestPath)" Set="StaticWebAssets" />
       <UpToDateCheckInput Include="@(_ExistingStaticWebAssetUpToDateCheckInput)" Set="StaticWebAssets" />
       <UpToDateCheckInput Include="@(_StaticWebAssetReferenceUpToDateCheckInput)" Set="StaticWebAssets" />
     </ItemGroup>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
@@ -46,11 +46,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectsConfiguration" />
     </MSBuild>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
       <_ReferenceManifestPath Include="@(_ReferencedProjectsConfiguration->'%(BuildManifestPath)')" Condition="'%(_ReferencedProjectsConfiguration.BuildManifestPath)' != ''" />
     </ItemGroup>
 
-    <WriteLinesToFile
+    <WriteLinesToFile Condition="'$(BuildingInsideVisualStudio)' == 'true'"
       File="$(StaticWebAssetReferencesUpToDateCheckManifestPath)"
       Lines="@(_ReferenceManifestPath)"
       Overwrite="false"

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
@@ -46,6 +46,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ReferencedProjectsConfiguration" />
     </MSBuild>
 
+    <ItemGroup>
+      <_ReferenceManifestPath Include="@(_ReferencedProjectsConfiguration->'%(BuildManifestPath)')" Condition="'%(_ReferencedProjectsConfiguration.BuildManifestPath)' != ''" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(StaticWebAssetReferencesUpToDateCheckManifestPath)"
+      Lines="@(_ReferenceManifestPath)"
+      Overwrite="false"
+      WriteOnlyWhenDifferent="true" />
+
     <MergeConfigurationProperties
       CandidateConfigurations="@(_ReferencedProjectsConfiguration)"
       ProjectReferences="@(_StaticWebAssetProjectReference)">
@@ -85,6 +95,8 @@ Copyright (c) .NET Foundation. All rights reserved.
           <GetPublishAssetsTargets>$(StaticWebAssetsGetPublishAssetsTargets)</GetPublishAssetsTargets>
           <AdditionalPublishProperties>$(StaticWebAssetsAdditionalPublishProperties)</AdditionalPublishProperties>
           <AdditionalPublishPropertiesToRemove>$(StaticWebAssetsAdditionalPublishPropertiesToRemove)</AdditionalPublishPropertiesToRemove>
+          <!-- Build manifest -->
+          <BuildManifestPath>$([System.IO.Path]::GetFullPath('$(StaticWebAssetBuildManifestPath)'))</BuildManifestPath>
         </_StaticWebAssetThisProjectConfiguration>
       </ItemGroup>
   </Target>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -101,7 +101,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     TaskName="Microsoft.AspNetCore.StaticWebAssets.Tasks.FilterStaticWebAssetEndpoints"
     AssemblyFile="$(StaticWebAssetsSdkBuildTasksAssembly)"
     Condition="'$(StaticWebAssetsSdkBuildTasksAssembly)' != ''" />
-  
+
   <UsingTask
     TaskName="Microsoft.AspNetCore.StaticWebAssets.Tasks.UpdateStaticWebAssetEndpoints"
     AssemblyFile="$(StaticWebAssetsSdkBuildTasksAssembly)"
@@ -285,7 +285,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- For preview only, to ease in the new implementation -->
     <PrepareForRunDependsOn>StaticWebAssetsPrepareForRun;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
 
-    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);ResolveBuildStaticWebAssets;GenerateStaticWebAssetsManifest;CopyStaticWebAssetsToOutputDirectory;WriteStaticWebAssetsUpToDateCheck</StaticWebAssetsPrepareForRunDependsOn>
+    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);ResolveBuildStaticWebAssets;GenerateStaticWebAssetsManifest;CopyStaticWebAssetsToOutputDirectory;</StaticWebAssetsPrepareForRunDependsOn>
+    <StaticWebAssetsPrepareForRunDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(StaticWebAssetsPrepareForRunDependsOn);WriteStaticWebAssetsUpToDateCheck;</StaticWebAssetsPrepareForRunDependsOn>
 
     <!-- This is a hook for features like scoped CSS and Blazor can ensure all the assets have been generated -->
     <GenerateComputedBuildStaticWebAssetsDependsOn>ResolveCoreStaticWebAssets;$(GenerateComputedBuildStaticWebAssetsDependsOn)</GenerateComputedBuildStaticWebAssetsDependsOn>
@@ -693,7 +694,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="UpdateExistingPackageStaticWebAssets" Condition="$(DesignTimeBuild) != 'true'" >
+  <Target Name="UpdateExistingPackageStaticWebAssets" Condition="$(DesignTimeBuild) != 'true'">
     <UpdatePackageStaticWebAssets Assets="@(StaticWebAsset)">
       <Output TaskParameter="UpdatedAssets" ItemName="_UpdatedPackageAssets" />
       <Output TaskParameter="OriginalAssets" ItemName="_OriginalPackageAssets" />
@@ -709,7 +710,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.References.targets" />
 
-  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.Design.targets" />
+  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.Design.targets" Condition="'$(DesignTimeBuild)' == 'true' and '$(BuildingInsideVisualStudio)' == 'true'" />
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets" />
 

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -285,7 +285,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- For preview only, to ease in the new implementation -->
     <PrepareForRunDependsOn>StaticWebAssetsPrepareForRun;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
 
-    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);ResolveBuildStaticWebAssets;GenerateStaticWebAssetsManifest;CopyStaticWebAssetsToOutputDirectory</StaticWebAssetsPrepareForRunDependsOn>
+    <StaticWebAssetsPrepareForRunDependsOn>$(StaticWebAssetsPrepareForRunDependsOn);ResolveBuildStaticWebAssets;GenerateStaticWebAssetsManifest;CopyStaticWebAssetsToOutputDirectory;WriteStaticWebAssetsUpToDateCheck</StaticWebAssetsPrepareForRunDependsOn>
 
     <!-- This is a hook for features like scoped CSS and Blazor can ensure all the assets have been generated -->
     <GenerateComputedBuildStaticWebAssetsDependsOn>ResolveCoreStaticWebAssets;$(GenerateComputedBuildStaticWebAssetsDependsOn)</GenerateComputedBuildStaticWebAssetsDependsOn>
@@ -457,6 +457,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_StaticWebAssetsGeneratedBuildPropsFileImportPath>..\build\$(PackageId).props</_StaticWebAssetsGeneratedBuildPropsFileImportPath>
       <_StaticWebAssetsGeneratedBuildMultiTargetingPropsFileImportPath>..\buildMultiTargeting\$(PackageId).props</_StaticWebAssetsGeneratedBuildMultiTargetingPropsFileImportPath>
 
+      <!-- Design -->
+      <StaticWebAssetUpToDateCheckManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.upToDateCheck.txt</StaticWebAssetUpToDateCheckManifestPath>
+      <StaticWebAssetReferencesUpToDateCheckManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.references.upToDateCheck.txt</StaticWebAssetReferencesUpToDateCheckManifestPath>
+      <StaticWebAssetUpToDateCheckRemovedManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.removed.txt</StaticWebAssetUpToDateCheckRemovedManifestPath>
+
     </PropertyGroup>
 
     <MakeDir
@@ -526,6 +531,39 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </Copy>
 
+  </Target>
+
+  <Target Name="WriteStaticWebAssetsUpToDateCheck" DependsOnTargets="_BuildCopyStaticWebAssetsPreserveNewest;_BuildCopyStaticWebAssetsAlways">
+
+    <ItemGroup>
+      <_UpToDateCheckStaticWebAssetCandidate Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />
+    </ItemGroup>
+
+    <ComputeReferenceStaticWebAssetItems
+      Assets="@(_UpToDateCheckStaticWebAssetCandidate)"
+      Patterns="@(DiscoveryPattern)"
+      ProjectMode="$(StaticWebAssetProjectMode)"
+      AssetKind="Build"
+      Source="$(PackageId)"
+    >
+      <Output TaskParameter="StaticWebAssets" ItemName="_UpToDateCheckStaticWebAssetResolved" />
+    </ComputeReferenceStaticWebAssetItems>
+
+    <ItemGroup>
+      <_UpToDateCheckStaticWebAssetResolvedCandidate Include="@(_UpToDateCheckStaticWebAssetResolved->'%(OriginalItemSpec)')" />
+      <_UpToDateCheckStaticWebAsset Include="@(_UpToDateCheckStaticWebAssetResolvedCandidate->Distinct())" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(StaticWebAssetUpToDateCheckManifestPath)"
+      Lines="@(_UpToDateCheckStaticWebAsset)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
+      Condition="'@(_UpToDateCheckStaticWebAsset)' != ''" />
+
+    <ItemGroup>
+      <FileWrites Include="$(StaticWebAssetUpToDateCheckManifestPath)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AddStaticWebAssetsManifest" DependsOnTargets="ResolveStaticWebAssetsConfiguration">
@@ -607,7 +645,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-
   <Target Name="ResolveCoreStaticWebAssets" DependsOnTargets="$(ResolveCoreStaticWebAssetsDependsOn)" />
 
   <Target Name="ResolveStaticWebAssetsInputs" DependsOnTargets="$(ResolveStaticWebAssetsInputsDependsOn)" />
@@ -656,7 +693,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="UpdateExistingPackageStaticWebAssets">
+  <Target Name="UpdateExistingPackageStaticWebAssets" Condition="$(DesignTimeBuild) != 'true'" >
     <UpdatePackageStaticWebAssets Assets="@(StaticWebAsset)">
       <Output TaskParameter="UpdatedAssets" ItemName="_UpdatedPackageAssets" />
       <Output TaskParameter="OriginalAssets" ItemName="_OriginalPackageAssets" />
@@ -671,6 +708,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.Publish.targets" />
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.References.targets" />
+
+  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.Design.targets" />
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets" />
 

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsDesignTimeTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsDesignTimeTest.cs
@@ -1,0 +1,161 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Sdk.Razor.Tests;
+
+public class StaticWebAssetsDesignTimeTest(ITestOutputHelper log) : AspNetSdkBaselineTest(log)
+{
+#if DEBUG
+    public const string Configuration = "Debug";
+#else
+    public const string Configuration = "Release";
+#endif
+
+    [Fact]
+    public void CollectUpToDateCheckInputOutputsDesignTime_ReportsAddedFiles()
+    {
+        // Arrange
+        var testAsset = "RazorAppWithP2PReference";
+        ProjectDirectory = AddIntrospection(CreateAspNetSdkTestAsset(testAsset));
+
+        var build = CreateBuildCommand(ProjectDirectory, "ClassLibrary");
+
+        build.Execute("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:build.binlog").Should().Pass();
+
+        File.WriteAllText(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "file.js"), "New File");
+
+        var msbuild = CreateMSBuildCommand(
+            ProjectDirectory,
+            "ClassLibrary",
+            "ResolveStaticWebAssetsConfiguration;ResolveProjectStaticWebAssets;CollectStaticWebAssetInputsDesignTime;CollectStaticWebAssetOutputsDesignTime");
+
+        msbuild.ExecuteWithoutRestore("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:design.binlog").Should().Pass();
+
+        // Check the contents of the input and output files
+        var inputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCInput.txt");
+        new FileInfo(inputFilePath).Should().Exist();
+        var inputFiles = File.ReadAllLines(inputFilePath);
+        inputFiles.Should().HaveCount(3);
+        inputFiles.Should().Contain(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "file.js"));
+        inputFiles.Should().Contain(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "project-transitive-dep.js"));
+        inputFiles.Should().Contain(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "project-transitive-dep.v4.js"));
+
+        var outputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCOutput.txt");
+        new FileInfo(outputFilePath).Should().Exist();
+        var outputFiles = File.ReadAllLines(outputFilePath);
+        outputFiles.Should().ContainSingle();
+        Path.GetFileName(outputFiles[0]).Should().Be("staticwebassets.build.json");
+    }
+
+    [Fact]
+    public void CollectUpToDateCheckInputOutputsDesignTime_ReportsRemovedFiles_Once()
+    {
+        // Arrange
+        var testAsset = "RazorAppWithP2PReference";
+        ProjectDirectory = AddIntrospection(CreateAspNetSdkTestAsset(testAsset));
+
+        var build = CreateBuildCommand(ProjectDirectory, "ClassLibrary");
+
+        build.Execute("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:build.binlog").Should().Pass();
+
+        File.Delete(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "project-transitive-dep.js"));
+
+        var msbuild = CreateMSBuildCommand(
+            ProjectDirectory,
+            "ClassLibrary",
+            "ResolveStaticWebAssetsConfiguration;ResolveProjectStaticWebAssets;CollectStaticWebAssetInputsDesignTime;CollectStaticWebAssetOutputsDesignTime");
+
+        msbuild.ExecuteWithoutRestore("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:design.binlog").Should().Pass();
+
+        // Check the contents of the input and output files
+        var inputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCInput.txt");
+        new FileInfo(inputFilePath).Should().Exist();
+        var inputFiles = File.ReadAllLines(inputFilePath);
+        inputFiles.Should().HaveCount(2);
+        inputFiles.Should().Contain(Path.Combine(build.GetIntermediateDirectory().FullName, "staticwebassets.removed.txt"));
+        inputFiles.Should().Contain(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "wwwroot", "js", "project-transitive-dep.v4.js"));
+
+        var outputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCOutput.txt");
+        new FileInfo(outputFilePath).Should().Exist();
+        var outputFiles = File.ReadAllLines(outputFilePath);
+        outputFiles.Should().ContainSingle();
+        Path.GetFileName(outputFiles[0]).Should().Be("staticwebassets.build.json");
+    }
+
+    [Fact]
+    public void CollectUpToDateCheckInputOutputsDesignTime_IncludesReferencedProjectsManifests()
+    {
+        // Arrange
+        var testAsset = "RazorAppWithP2PReference";
+        ProjectDirectory = AddIntrospection(CreateAspNetSdkTestAsset(testAsset));
+
+        var build = CreateBuildCommand(ProjectDirectory, "AppWithP2PReference");
+
+        build.Execute("/bl:build.binlog").Should().Pass();
+        build.Execute("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:build.binlog").Should().Pass();
+
+        var msbuild = CreateMSBuildCommand(
+            ProjectDirectory,
+            "AppWithP2PReference",
+            "ResolveStaticWebAssetsConfiguration;ResolveProjectStaticWebAssets;CollectStaticWebAssetInputsDesignTime;CollectStaticWebAssetOutputsDesignTime");
+
+        msbuild.ExecuteWithoutRestore("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:design.binlog").Should().Pass();
+
+        // Check the contents of the input and output files
+        var inputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCInput.txt");
+        new FileInfo(inputFilePath).Should().Exist();
+        var inputFiles = File.ReadAllLines(inputFilePath);
+        inputFiles.Should().HaveCount(1);        
+        inputFiles.Should().Contain(Path.Combine(ProjectDirectory.Path, "ClassLibrary", "obj", "Debug", DefaultTfm, "staticwebassets.build.json"));
+
+        var outputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCOutput.txt");
+        new FileInfo(outputFilePath).Should().Exist();
+        var outputFiles = File.ReadAllLines(outputFilePath);
+        outputFiles.Should().ContainSingle();
+        Path.GetFileName(outputFiles[0]).Should().Be("staticwebassets.build.json");
+    }
+
+    private MSBuildCommand CreateMSBuildCommand(TestAsset testAsset, string relativeProjectPath, string targets)
+    {
+        return (MSBuildCommand)new MSBuildCommand(testAsset.Log, targets, testAsset.TestRoot, relativeProjectPath)
+            .WithWorkingDirectory(testAsset.TestRoot);
+    }
+
+    private TestAsset AddIntrospection(TestAsset testAsset)
+    {
+        return testAsset
+            .WithProjectChanges((name, project) =>
+            {
+                project.Document.Root.LastNode.AddAfterSelf(
+                    XElement.Parse("""
+                        <Target Name="ReportInputOutputs" AfterTargets="CollectStaticWebAssetOutputsDesignTime">
+                            <ItemGroup>
+                                <_StaticWebAssetsUTDCInput Include="@(UpToDateCheckInput)" Condition="'%(UpToDateCheckInput.Set)' == 'StaticWebAssets'" />
+                                <_StaticWebAssetsUTDCOutput Include="@(UpToDateCheckOutput)" Condition="'%(UpToDateCheckOutput.Set)' == 'StaticWebAssets'" />
+                            </ItemGroup>
+
+                            <WriteLinesToFile Condition="'@(_StaticWebAssetsUTDCInput)' != ''"
+                                File="$(IntermediateOutputPath)\StaticWebAssetsUTDCInput.txt"
+                                Lines="@(_StaticWebAssetsUTDCInput->'%(FullPath)')"
+                                Overwrite="true"
+                                Encoding="UTF-8"
+                                />
+
+                            <WriteLinesToFile Condition="'@(_StaticWebAssetsUTDCOutput)' != ''"
+                                File="$(IntermediateOutputPath)\StaticWebAssetsUTDCOutput.txt"
+                                Lines="@(_StaticWebAssetsUTDCOutput->'%(FullPath)')"
+                                Overwrite="true"
+                                Encoding="UTF-8"
+                                />
+                        </Target>
+                        """
+                        ));
+            });
+    }
+}


### PR DESCRIPTION
* Implements specific targets for the up-to-date check for static web assets.

#### Validated the scenarios manually, since this functionality is tied to VS:
* Add a file:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
* Update a file:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
* Remove a file:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
* Add a file on a dependent project:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
* Update a file on a dependent project:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
* Remove a file on a dependent project:
  * Build: Project is not up to date (build).
  * Build: Project becomes up to date (nothing to do).
