### PR TITLE
Fix the minimum supported version for targeting net9

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -31,7 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
         <UnsupportedTargetFrameworkVersion>9.0</UnsupportedTargetFrameworkVersion>
-        <MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>17.8</MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>
+        <MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>17.12</MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>
     </PropertyGroup>
 
     <!-- .NET Standard -->


### PR DESCRIPTION
**Summary**

In .net 7 we created a specialized warning for when customers were using VS installs to target .net 8. Previously, the warning you got told you to upgrade your SDK but we got complaints from customers as you really need to update your VS and your SDK. We did not correctly update the version for this message when using 8 to target 9.

**Customer Impact** 

Customers using 17.11 to target .net 9 will be told their sdk needs to be updated rather than being told their VS needs to be updated.

**Regression**

No, it's always been wrong since we branched.

**Testing**

![image](https://github.com/user-attachments/assets/a8659e61-356a-465a-8e5c-2c4ec77516a8)


**Risk**

Very low
