### PR TITLE
We're currently copying the test assets to the publish directory 

### DIFF
--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -24,6 +24,7 @@ dotnet new --debug:ephemeral-hive
 # We downloaded a special zip of files to the .nuget folder so add that as a source
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget add source $DOTNET_ROOT/.nuget --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget add source $TestExecutionDirectory/Testpackages --configfile $TestExecutionDirectory/NuGet.config
 #Remove feeds not needed for tests
 dotnet nuget remove source dotnet6-transport --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet6-internal-transport --configfile $TestExecutionDirectory/NuGet.config

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -24,13 +24,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\Program.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-
-    <!-- Note: These items are showing up in solution explorer even though Visible is set to false -->
-    <None Include="$(MSBuildThisFileDirectory)TestAssets\**\*.*" Exclude="$(MSBuildThisFileDirectory)TestAssets\TestPackages\dotnet-new\**\*" CopyToPublishDirectory="PreserveNewest" 
-          LinkBase="TestAssets" Visible="false" />
-  </ItemGroup>
-
   <Target Name="TestAsTool" DependsOnTargets="Pack;_InnerGetTestsToRun">
     <PropertyGroup>
       <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>

--- a/test/Microsoft.NET.TestFramework/TestContext.cs
+++ b/test/Microsoft.NET.TestFramework/TestContext.cs
@@ -198,6 +198,12 @@ namespace Microsoft.NET.TestFramework
                 testContext.NuGetFallbackFolder = Path.Combine(nugetFolder, "NuGetFallbackFolder");
                 testContext.NuGetExePath = Path.Combine(nugetFolder, $"nuget{Constants.ExeSuffix}");
                 testContext.NuGetCachePath = Path.Combine(nugetFolder, "packages");
+
+                var testPackages = Path.Combine(testContext.TestExecutionDirectory, "Testpackages");
+                if (Directory.Exists(testPackages))
+                {
+                    testContext.TestPackages = testPackages;
+                }
             }
 
             if (commandLine.SdkVersion != null)


### PR DESCRIPTION
for every single test project which is duplicating a lot of files in our PR builds.

This is also leading to some .tmp file missing copy issues from the parallel builds I'm not sure why these files are specifically included so let's try removing them and see what fails.