### PR TITLE
Add Dev Device ID

### DIFF
--- a/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
+++ b/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32;
+
+namespace Microsoft.DotNet.Cli.Telemetry
+{
+    internal static class DeviceIdGetter
+    {
+        public static string GetDeviceId()
+        {
+            string deviceId = GetCachedDeviceId();
+
+            // Check if the device Id is already cached
+            if (string.IsNullOrEmpty(deviceId))
+            {
+                // Generate a new guid
+                deviceId = Guid.NewGuid().ToString("D").ToLowerInvariant();
+
+                // Cache the new device Id
+                CacheDeviceId(deviceId);
+            }
+
+            return deviceId;
+        }
+
+        private static string GetCachedDeviceId()
+        {
+            string deviceId = null;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Get device Id from Windows registry
+                using (var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
+                {
+                    deviceId = key?.GetValue("deviceid") as string;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Get device Id from Linux cache file
+                string cacheFilePath;
+                string xdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                if (!string.IsNullOrEmpty(xdgCacheHome))
+                {
+                    cacheFilePath = Path.Combine(xdgCacheHome, "Microsoft", "DeveloperTools", "deviceid");
+                }
+                else
+                {
+                    cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "deviceid");
+                }
+
+                if (File.Exists(cacheFilePath))
+                {
+                    deviceId = File.ReadAllText(cacheFilePath);
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // Get device Id from macOS cache file
+                string cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Microsoft", "DeveloperTools", "deviceid");
+                if (File.Exists(cacheFilePath))
+                {
+                    deviceId = File.ReadAllText(cacheFilePath);
+                }
+            }
+
+            return deviceId;
+        }
+
+        private static void CacheDeviceId(string deviceId)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Cache device Id in Windows registry
+                using (var key = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
+                {
+                    key.SetValue("deviceid", deviceId);
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Cache device Id in Linux cache file
+                string cacheFilePath;
+                string xdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                if (!string.IsNullOrEmpty(xdgCacheHome))
+                {
+                    cacheFilePath = Path.Combine(xdgCacheHome, "Microsoft", "DeveloperTools", "deviceId");
+                }
+                else
+                {
+                    cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "deviceid");
+                }
+
+                File.WriteAllText(cacheFilePath, deviceId);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // Cache device Id in macOS cache file
+                string cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Microsoft", "DeveloperTools", "deviceid");
+                File.WriteAllText(cacheFilePath, deviceId);
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
+++ b/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 catch
                 {
                     // If caching fails, return empty string to avoid sending a non-stored id
-                    deviceId = ""
+                    deviceId = "";
                 }
             }
 

--- a/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
+++ b/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
@@ -18,7 +18,15 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 deviceId = Guid.NewGuid().ToString("D").ToLowerInvariant();
 
                 // Cache the new device Id
-                CacheDeviceId(deviceId);
+                try
+                {
+                    CacheDeviceId(deviceId);
+                }
+                catch
+                {
+                    // If caching fails, return empty string to avoid sending a non-stored id
+                    deviceId = ""
+                }
             }
 
             return deviceId;
@@ -92,14 +100,25 @@ namespace Microsoft.DotNet.Cli.Telemetry
                     cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "deviceid");
                 }
 
-                File.WriteAllText(cacheFilePath, deviceId);
+                CreateDirectoryAndWriteToFile(cacheFilePath, deviceId);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 // Cache device Id in macOS cache file
                 string cacheFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Microsoft", "DeveloperTools", "deviceid");
-                File.WriteAllText(cacheFilePath, deviceId);
+
+                CreateDirectoryAndWriteToFile(cacheFilePath, deviceId);
             }
+        }
+
+        private static void CreateDirectoryAndWriteToFile(string filePath, string content)
+        {
+            string directory = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(filePath, content);
         }
     }
 }

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             Func<string> getCurrentDirectory = null,
             Func<string, string> hasher = null,
             Func<string> getMACAddress = null,
+            Func<string> getDeviceId = null,
             IDockerContainerDetector dockerContainerDetector = null,
             IUserLevelCacheWriter userLevelCacheWriter = null,
             ICIEnvironmentDetector ciEnvironmentDetector = null)
@@ -21,6 +22,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             _getCurrentDirectory = getCurrentDirectory ?? Directory.GetCurrentDirectory;
             _hasher = hasher ?? Sha256Hasher.Hash;
             _getMACAddress = getMACAddress ?? MacAddressGetter.GetMacAddress;
+            _getDeviceId = getDeviceId ?? DeviceIdGetter.GetDeviceId;
             _dockerContainerDetector = dockerContainerDetector ?? new DockerContainerDetectorForTelemetry();
             _userLevelCacheWriter = userLevelCacheWriter ?? new UserLevelCacheWriter();
             _ciEnvironmentDetector = ciEnvironmentDetector ?? new CIEnvironmentDetectorForTelemetry();
@@ -31,6 +33,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private Func<string> _getCurrentDirectory;
         private Func<string, string> _hasher;
         private Func<string> _getMACAddress;
+        private Func<string> _getDeviceId;
         private IUserLevelCacheWriter _userLevelCacheWriter;
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
@@ -40,6 +43,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private const string ProductVersion = "Product Version";
         private const string TelemetryProfile = "Telemetry Profile";
         private const string CurrentPathHash = "Current Path Hash";
+        private const string DeviceId = "DeviceId";
         private const string MachineId = "Machine ID";
         private const string MachineIdOld = "Machine ID Old";
         private const string DockerContainer = "Docker Container";
@@ -81,6 +85,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                             CliFolderPathCalculator.DotnetUserProfileFolderPath,
                             $"{MachineIdCacheKey}.v1.dotnetUserLevelCache"),
                         GetMachineId)},
+                {DeviceId, _getDeviceId()},
                 {KernelVersion, GetKernelVersion()},
                 {InstallationType, ExternalTelemetryProperties.GetInstallationType()},
                 {ProductType, ExternalTelemetryProperties.GetProductType()},

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private const string ProductVersion = "Product Version";
         private const string TelemetryProfile = "Telemetry Profile";
         private const string CurrentPathHash = "Current Path Hash";
-        private const string DeviceId = "DeviceId";
+        private const string DeviceId = "devdeviceid";
         private const string MachineId = "Machine ID";
         private const string MachineIdOld = "Machine ID Old";
         private const string DockerContainer = "Docker Container";

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -34,10 +34,26 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
+        public void TelemetryCommonPropertiesShouldReturnDevDeviceId()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(getDeviceId: () => "plaintext", userLevelCacheWriter: new NothingCache());
+            unitUnderTest.GetTelemetryCommonProperties()["DevDeviceId"].Should().Be("plaintext");
+        }
+
+        [Fact]
         public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotGetMacAddress()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
             var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Machine ID"];
+
+            Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
+        }
+
+        [Fact]
+        public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotDevDeviceId()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(getDeviceId: () => null, userLevelCacheWriter: new NothingCache());
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["DevDeviceId"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
         }

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldReturnDevDeviceId()
         {
             var unitUnderTest = new TelemetryCommonProperties(getDeviceId: () => "plaintext", userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["DevDeviceId"].Should().Be("plaintext");
+            unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"].Should().Be("plaintext");
         }
 
         [Fact]
@@ -52,8 +52,8 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotDevDeviceId()
         {
-            var unitUnderTest = new TelemetryCommonProperties(getDeviceId: () => null, userLevelCacheWriter: new NothingCache());
-            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["DevDeviceId"];
+            var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
         }


### PR DESCRIPTION
Fixes #42804 
I followed the spec for where we should cache the ID from. I confirmed that it was getting populated with a guid in the telemetry common properties and on windows was saved in the cache. This is all assuming I got the locations correct. Ping me offline for the spec and I can link it for review.