### PR TITLE
Allow roslyn binary into VMR

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -86,6 +86,7 @@ src/roslyn/src/Compilers/Test/Resources/Core/**/*.dll
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.exe
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.Dll
 src/roslyn/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/Resources/WindowsProxy.winmd
+src/roslyn/src/Workspaces/CoreTest/Resources/*
 src/roslyn/src/Workspaces/MSBuildTest/Resources/Dlls/*.dll
 src/roslyn/**/CodeAnalysisTest/**/*.res
 src/roslyn/**/CodeAnalysisTest/**/*.blah


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4587

see https://github.com/dotnet/source-build/issues/4587#issuecomment-2323839755, add these two roslyn binaries as allowed VMR binary