### PR TITLE
Remove the extra set of testexecutiondirectory

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -10,9 +10,6 @@ set PATH=%DOTNET_ROOT%;%PATH%
 set DOTNET_MULTILEVEL_LOOKUP=0
 set TestFullMSBuild=%1
 
-set TestExecutionDirectory=%CD%\testExecutionDirectory
-mkdir %TestExecutionDirectory%
-
 REM Use powershell to call partical Arcade logic to get full framework msbuild path and assign it
 if "%TestFullMSBuild%"=="true" (
     FOR /F "tokens=*" %%g IN ('PowerShell -ExecutionPolicy ByPass -File "%HELIX_CORRELATION_PAYLOAD%\t\eng\print-full-msbuild-path.ps1"') do (SET DOTNET_SDK_TEST_MSBUILD_PATH=%%g)


### PR DESCRIPTION
Per analysis of this file, the test execution directory is set and then it's reset to a random value. The initial value doesn't appear to be used so let's remove it to prevent confusion in the future.