### PR TITLE
[VMR] Add "buildPass" parameter to vmr-build jobs templates

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -258,7 +258,9 @@ jobs:
         versionSpec: 20.x
 
     - script: |
-        call build.cmd -ci -cleanWhileBuilding -prepareMachine %devArgument% /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} ${{ parameters.extraProperties }}
+        set extraBuildProperties=
+        if not [${{ parameters.buildPass }}]==[] set extraBuildProperties=%extraBuildProperties% /p:DotNetBuildPass=${{ parameters.buildPass }}
+        call build.cmd -ci -cleanWhileBuilding -prepareMachine %devArgument% /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} %extraBuildProperties% ${{ parameters.extraProperties }}
       displayName: Build
       workingDirectory: ${{ variables.sourcesPath }}
       env:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -151,10 +151,10 @@ jobs:
       value: $(vmrPath)
 
   - ${{ if ne(parameters.buildPass, '') }}:
-    - name: _artifactsSuffix
+    - name: artifactsSuffix
       value: '_buildpass${{ parameters.buildPass }}'
   - ${{ else }}:
-    - name: _artifactsSuffix
+    - name: artifactsSuffix
       value: ''
 
   templateContext:
@@ -168,7 +168,7 @@ jobs:
 
     - output: pipelineArtifact
       path: $(Build.ArtifactStagingDirectory)/publishing
-      artifact: $(Agent.JobName)_Artifacts$(_artifactsSuffix)
+      artifact: $(Agent.JobName)_Artifacts$(artifactsSuffix)
       displayName: Publish Artifacts
       sbomEnabled: true
 
@@ -579,6 +579,6 @@ jobs:
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(Build.ArtifactStagingDirectory)/publishing
-      artifact: $(Agent.JobName)_Artifacts$(_artifactsSuffix)
+      artifact: $(Agent.JobName)_Artifacts$(artifactsSuffix)
       displayName: Publish Artifacts
       continueOnError: true

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -14,6 +14,7 @@ parameters:
 
 - name: buildPass
   type: string
+  default: ''
 
 - name: container
   type: string

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -12,6 +12,9 @@ parameters:
 - name: buildName
   type: string
 
+- name: buildPass
+  type: string
+
 - name: container
   type: string
   default: ''
@@ -146,6 +149,13 @@ jobs:
     - name: sourcesPath
       value: $(vmrPath)
 
+  - ${{ if ne(parameters.buildPass, '') }}:
+    - name: _artifactsSuffix
+      value: '_buildpass${{ parameters.buildPass }}'
+  - ${{ else }}:
+    - name: _artifactsSuffix
+      value: ''
+
   templateContext:
     outputs:
     - output: pipelineArtifact
@@ -157,7 +167,7 @@ jobs:
 
     - output: pipelineArtifact
       path: $(Build.ArtifactStagingDirectory)/publishing
-      artifact: $(Agent.JobName)_Artifacts
+      artifact: $(Agent.JobName)_Artifacts$(_artifactsSuffix)
       displayName: Publish Artifacts
       sbomEnabled: true
 
@@ -346,6 +356,10 @@ jobs:
 
         if [[ ! -z '${{ parameters.targetArchitecture }}' ]]; then
           extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArchitecture }}"
+        fi
+
+        if [[ -n "${{ parameters.buildPass }}" ]]; then
+          extraBuildProperties="$extraBuildProperties /p:DotNetBuildPass=${{ parameters.buildPass }}"
         fi
 
         if [[ -n "${{ parameters.extraProperties }}" ]]; then
@@ -564,6 +578,6 @@ jobs:
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(Build.ArtifactStagingDirectory)/publishing
-      artifact: $(Agent.JobName)_Artifacts
+      artifact: $(Agent.JobName)_Artifacts$(_artifactsSuffix)
       displayName: Publish Artifacts
       continueOnError: true


### PR DESCRIPTION
This is treating buildPass as a string rather than a number, as the spec explicitly uses the phrasing "if set", and number in AzDO needs to be a valid (non-null) value.

Closes: https://github.com/dotnet/source-build/issues/4217