### PR TITLE
Add storage location to key vault config

### DIFF
--- a/src/SourceBuild/content/.vault-config/vmr-pipeline-secrets.yaml
+++ b/src/SourceBuild/content/.vault-config/vmr-pipeline-secrets.yaml
@@ -1,5 +1,11 @@
 # Partially copied from https://github.com/dotnet/arcade/blob/dfc6882da43decb37f12e0d9011ce82b25225578/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
 
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    name: SourceBuildKeyVault
+    subscription: 941d4baa-5ef2-462e-b4b1-505791294610
+
 secrets:
   BotAccount-dotnet-sb-bot:
     type: github-account


### PR DESCRIPTION
The key vault config is misconfigured because it is missing `storageLocation`. Without this, it causes the following error when running secret-manager on this config file: 
```
error : Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.DncEng.SecretManager.SecretManifest.CreateStorage(Storage data) in /_/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManifest.cs:line 96
```

This fixes it by adding the appropriate config to target `SourceBuildKeyVault`.