### PR TITLE
Use PortableRid config value for self-contained publish test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/TestScenario.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/TestScenario.cs
@@ -59,11 +59,11 @@ public class TestScenario
         {
             dotNetHelper.ExecutePublish(projectName, Template, selfContained: false);
             dotNetHelper.ExecutePublish(projectName, Template, selfContained: true, rid: Config.TargetRid);
-            dotNetHelper.ExecutePublish(projectName, Template, selfContained: true, rid: $"linux-{Config.TargetArchitecture}");
+            dotNetHelper.ExecutePublish(projectName, Template, selfContained: true, rid: Config.PortableRid);
         }
         if (Commands.HasFlag(DotNetActions.PublishR2R))
         {
-            dotNetHelper.ExecutePublish(projectName, Template, selfContained: true, rid: $"linux-{Config.TargetArchitecture}", trimmed: true, readyToRun: true);
+            dotNetHelper.ExecutePublish(projectName, Template, selfContained: true, rid: Config.PortableRid, trimmed: true, readyToRun: true);
         }
         if (Commands.HasFlag(DotNetActions.Test))
         {


### PR DESCRIPTION
Fixes dotnet/source-build#4585

It's not clear what changed that caused the issue in dotnet/source-build#4585. But this fixes it by ensuring that the RID for the self-contained test is set to the `PortableRid` config value. This ensures that `linux-musl-<arch>` will be used in an Alpine environment.