### PR TITLE
[release/9.0.1xx] Cloak sRGB.icm from VMR

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -199,7 +199,11 @@
         },
         {
             "name": "wpf",
-            "defaultRemote": "https://github.com/dotnet/wpf"
+            "defaultRemote": "https://github.com/dotnet/wpf",
+            "exclude": [
+                // Non-OSS license - https://github.com/dotnet/source-build/issues/4590
+                "src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Resources/ColorProfiles/sRGB.icm"
+            ]
         },
         {
             "name": "windowsdesktop",


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4590

This sRGB.icm does not have a license that is considered to be "free". Removing it from the VMR to be in compliance with source build requirements.