### PR TITLE
Change Windows PR build image

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -37,7 +37,7 @@ stages:
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals 1es-windows-2022-open
+        demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
         os: windows
       helixTargetQueue: windows.amd64.vs2022.pre.open
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -37,7 +37,7 @@ stages:
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
+        demands: ImageOverride -equals windows.vs2022.amd64.open
         os: windows
       helixTargetQueue: windows.amd64.vs2022.pre.open
 


### PR DESCRIPTION
## Summary

There is currently an issue with the VS version used in the current build image for TemplateEngine tests. This happens on the build image because the TemplateEngine tests do not run on Helix. Therefore, let's try changing the build image to a preview image to see if it resolves the test problems with the VS version used on the stable image.