### PR TITLE
manually port the loc build update

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -105,7 +105,7 @@ extends:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          locBranch: release/8.0.4xx
+          locBranch: release/9.0.1xx
           ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
             timeoutInMinutes: 90
             windowsJobParameterSets:


### PR DESCRIPTION
Since our pipelines were rewritten in 9.0.1xx, this change didn't flow automatically: https://github.com/dotnet/sdk/pull/42746