### PR TITLE
Update the stale limit by a year

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       daysBeforeStale:
         required: true
-        default: "2192"
+        default: "1827"
       daysBeforeClose:
         required: true
         default: "30"


### PR DESCRIPTION
We've successfully had the stale bot running since May. Bringing in the date by a year adds in around 100 new issues that would be stale so I'm proposing we do that. We should keep bringing this in slowly and get feedback until this is maybe 2-3 years I was thinking.