### PR TITLE
Add parsing and flag for `-bl` for MSbuild-related commands

### DIFF
--- a/src/Cli/dotnet/CommonLocalizableStrings.resx
+++ b/src/Cli/dotnet/CommonLocalizableStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -735,5 +735,8 @@ The default is 'false.' However, when targeting .NET 7 or lower, the default is 
   </data>
   <data name="ToolSettingsNotFound" xml:space="preserve">
     <value>Tool settings file does not exist for the tool {0}.</value>
+  </data>
+  <data name="BinaryLoggerOptionDescription" xml:space="preserve">
+    <value>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -201,17 +201,15 @@ namespace Microsoft.DotNet.Cli
         public static readonly CliOption<BinlogArgs?> BinaryLoggerOption = new ForwardedOption<BinlogArgs?>("-bl", "--bl")
         {
             Arity = ArgumentArity.ZeroOrOne,
-            //TODO: loc
-            Description = "Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.",
+            Description = CommonLocalizableStrings.BinaryLoggerOptionDescription,
             CustomParser = (arg) => ParseBinlogArgs(arg)
         }.ForwardAsSingle(value =>
         {
             return value switch
             {
-                { binlogFilePathOrPattern: string pattern, projectImports: BinlogProjectImports imports } => $"-bl:{pattern};ProjectImports={imports}",
-                { binlogFilePathOrPattern: null, projectImports: BinlogProjectImports imports } => $"-bl:ProjectImports={imports}",
-                { binlogFilePathOrPattern: string pattern, projectImports: null } => $"-bl:{pattern}",
-                _ => "-bl"
+                null => "-bl",
+                { binlogFilePathOrPattern: null, projectImports: null } => "-bl",
+                BinlogArgs args => $"-bl:{args.ToMSBuildArgString()}"
             };
         });
 

--- a/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.ArchitectureOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
 
             command.SetAction(BuildCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.ArtifactsPathOption);
             command.Options.Add(NoLogoOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
 
             command.SetAction(CleanCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(ConfigurationOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
             RestoreCommandParser.AddImplicitRestoreOptions(command, includeRuntimeOption: true, includeNoDependenciesOption: true);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
 
             command.SetAction(PackCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -84,6 +84,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.ArchitectureOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
 
             command.SetAction(PublishCommand.Run);
 

--- a/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DotNet.Cli
             }
 
             command.Options.Add(CommonOptions.ArchitectureOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
             command.SetAction(RestoreCommand.Run);
 
             return command;

--- a/src/Cli/dotnet/commands/dotnet-run/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/Program.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Tools.Run
                 interactive: parseResult.HasOption(RunCommandParser.InteractiveOption),
                 verbosity: parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
                 restoreArgs: parseResult.OptionValuesToBeForwarded(RunCommandParser.GetCommand()).ToArray(),
+                binlogArgs: parseResult.GetValue(CommonOptions.BinaryLoggerOption),
                 args: parseResult.GetValue(RunCommandParser.ApplicationArguments)
             );
 

--- a/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -81,6 +81,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
             command.Options.Add(CommonOptions.ArtifactsPathOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
 
             command.Arguments.Add(ApplicationArguments);
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -246,6 +246,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(CommonOptions.ArchitectureOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.DisableBuildServersOption);
+            command.Options.Add(CommonOptions.BinaryLoggerOption);
             command.SetAction(TestCommand.Run);
 
             return command;

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Cesta k artefaktům. Veškerý výstup z projektu, včetně výstupu sestavení, publikování a balíčku, se přesune do podsložek v zadané cestě.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Nepovedlo se vyřešit aktuální identifikátor modulu runtime.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Der Artefaktpfad. Die gesamte Ausgabe des Projekts, einschließlich Build-, Veröffentlichungs- und Paketausgabe, wird in Unterordnern unter dem angegebenen Pfad angezeigt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Fehler beim Auflösen des aktuellen Runtimebezeichners.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Ruta de acceso de los artefactos. Todas las salidas del proyecto, incluidas las salidas de compilación, publicación y empaquetado, se incluirán en subcarpetas en la ruta de acceso especificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">No se ha podido resolver el identificador en el tiempo de ejecución actual.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Le chemin des artefacts. Toutes les sorties du projet, y compris les sorties de build, de publication et de pack, iront dans des sous-dossiers sous le chemin spécifié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Échec de la résolution de l’identificateur d’exécution actuel</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Percorso degli artefatti. Tutto l'output del progetto, inclusi l'output di compilazione, pubblicazione e pacchetto, verrà inserito nelle sottocartelle nel percorso specificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">La risoluzione dell'identificatore di runtime corrente non è riuscita.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">成果物のパス。ビルド、発行、パック出力などのプロジェクトからの出力はすべて、指定されたパスの下のサブフォルダーに格納されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">現在のランタイム識別子を解決できませんでした。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">아티팩트 경로입니다. 빌드, 게시 및 팩 출력을 포함한 프로젝트의 모든 출력이 지정된 경로 아래의 하위 폴더로 이동합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">현재 런타임 식별자를 확인하지 못했습니다.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Ścieżka artefaktów. Wszystkie dane wyjściowe z projektu, w tym dane wyjściowe kompilacji, publikowania i pakowania, będą trafiać do podfolderów w określonej ścieżce.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Rozpoznawanie bieżącego identyfikatora środowiska uruchomieniowego nie powiodło się.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">O caminho dos artefatos. Toda a saída do projeto, incluindo compilação, publicação e saída do pacote, irá para subpastas no caminho especificado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Falha ao resolver o identificador de tempo de execução atual.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Путь к артефактам. Все выходные данные проекта, включая выходные данные сборки, публикации и упаковки, будут направляться во вложенные папки по указанному пути.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Не удалось разрешить текущий идентификатор среды выполнения.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Yapıtlar yolu. Derleme, yayımlama ve paket çıkışı dahil olmak üzere projedeki tüm çıkışlar belirtilen yol altındaki alt klasörlerde bulunur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">Geçerli çalışma zamanı tanımlayıcısı çözümlenemedi.</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">工件路径。项目中的所有输出(包括生成、发布和打包输出)都将放到指定路径下的子文件夹中。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">解决当前运行时标识符失败。</target>

--- a/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">成品路徑。來自專案的所有輸出 (包括建置、發佈和封裝輸出)，都會進入指定路徑下的子資料夾。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryLoggerOptionDescription">
+        <source>Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</source>
+        <target state="new">Serializes build events to a compressed binary file. See https://learn.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#switches-for-loggers for more details.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotResolveRuntimeIdentifier">
         <source>Resolving the current runtime identifier failed.</source>
         <target state="translated">解析目前執行階段識別碼失敗。</target>


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/43310 by explicitly modeling the flag (including argument parsing as described/implemented by MSBuild).

cc @rainersigwald for more MSBuild arg bindings