### PR TITLE
Fix TestResultMessagesSerializer

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/BaseSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/BaseSerializer.cs
@@ -294,4 +294,6 @@ internal abstract class BaseSerializer
         Type type when type == typeof(bool) => sizeof(bool),
         _ => 0,
     };
+
+    public static bool IsNullOrEmpty<T>(T[]? list) => list is null || list.Length == 0;
 }

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         private static ushort GetFieldCount(CommandLineOptionMessages commandLineOptionMessages) =>
             (ushort)((commandLineOptionMessages.ModulePath is null ? 0 : 1) +
-            (commandLineOptionMessages.CommandLineOptionMessageList is null ? 0 : 1));
+            (IsNullOrEmpty(commandLineOptionMessages.CommandLineOptionMessageList) ? 0 : 1));
 
         private static ushort GetFieldCount(CommandLineOptionMessage commandLineOptionMessage) =>
             (ushort)((commandLineOptionMessage.Name is null ? 0 : 1) +

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         private static ushort GetFieldCount(DiscoveredTestMessages discoveredTestMessages) =>
             (ushort)((discoveredTestMessages.ExecutionId is null ? 0 : 1) +
-            (discoveredTestMessages.DiscoveredMessages is null ? 0 : 1));
+            (IsNullOrEmpty(discoveredTestMessages.DiscoveredMessages) ? 0 : 1));
 
         private static ushort GetFieldCount(DiscoveredTestMessage discoveredTestMessage) =>
             (ushort)((discoveredTestMessage.Uid is null ? 0 : 1) +

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         private static ushort GetFieldCount(FileArtifactMessages fileArtifactMessages) =>
             (ushort)((fileArtifactMessages.ExecutionId is null ? 0 : 1) +
-            (fileArtifactMessages.FileArtifacts is null ? 0 : 1));
+            (IsNullOrEmpty(fileArtifactMessages.FileArtifacts) ? 0 : 1));
 
         private static ushort GetFieldCount(FileArtifactMessage fileArtifactMessage) =>
             (ushort)((fileArtifactMessage.FullPath is null ? 0 : 1) +

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -284,7 +284,7 @@ namespace Microsoft.DotNet.Tools.Test
                 return;
             }
 
-            WriteShort(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList);
+            WriteShort(stream, TestResultMessagesFieldsId.FailedTestMessageList);
 
             // We will reserve an int (4 bytes)
             // so that we fill the size later, once we write the payload
@@ -292,17 +292,17 @@ namespace Microsoft.DotNet.Tools.Test
 
             long before = stream.Position;
             WriteInt(stream, failedTestResultMessages.Length);
-            foreach (FailedTestResultMessage successfulTestResultMessage in failedTestResultMessages)
+            foreach (FailedTestResultMessage failedTestResultMessage in failedTestResultMessages)
             {
-                WriteShort(stream, GetFieldCount(successfulTestResultMessage));
+                WriteShort(stream, GetFieldCount(failedTestResultMessage));
 
-                WriteField(stream, FailedTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
-                WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
-                WriteField(stream, FailedTestResultMessageFieldsId.State, successfulTestResultMessage.State);
-                WriteField(stream, FailedTestResultMessageFieldsId.Reason, successfulTestResultMessage.Reason);
-                WriteField(stream, FailedTestResultMessageFieldsId.ErrorMessage, successfulTestResultMessage.ErrorMessage);
-                WriteField(stream, FailedTestResultMessageFieldsId.ErrorStackTrace, successfulTestResultMessage.ErrorStackTrace);
-                WriteField(stream, FailedTestResultMessageFieldsId.SessionUid, successfulTestResultMessage.SessionUid);
+                WriteField(stream, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
+                WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
+                WriteField(stream, FailedTestResultMessageFieldsId.State, failedTestResultMessage.State);
+                WriteField(stream, FailedTestResultMessageFieldsId.Reason, failedTestResultMessage.Reason);
+                WriteField(stream, FailedTestResultMessageFieldsId.ErrorMessage, failedTestResultMessage.ErrorMessage);
+                WriteField(stream, FailedTestResultMessageFieldsId.ErrorStackTrace, failedTestResultMessage.ErrorStackTrace);
+                WriteField(stream, FailedTestResultMessageFieldsId.SessionUid, failedTestResultMessage.SessionUid);
             }
 
             // NOTE: We are able to seek only if we are using a MemoryStream
@@ -312,8 +312,8 @@ namespace Microsoft.DotNet.Tools.Test
 
         private static ushort GetFieldCount(TestResultMessages testResultMessages) =>
             (ushort)((testResultMessages.ExecutionId is null ? 0 : 1) +
-            (testResultMessages.SuccessfulTestMessages is null ? 0 : 1) +
-            (testResultMessages.FailedTestMessages is null ? 0 : 1));
+            (IsNullOrEmpty(testResultMessages.SuccessfulTestMessages) ? 0 : 1) +
+            (IsNullOrEmpty(testResultMessages.FailedTestMessages) ? 0 : 1));
 
         private static ushort GetFieldCount(SuccessfulTestResultMessage successfulTestResultMessage) =>
             (ushort)((successfulTestResultMessage.Uid is null ? 0 : 1) +


### PR DESCRIPTION
Failing tests in the test project were preventing dotnet test to run normally.