### PR TITLE
Use NuGetAudit property to condition NuGet source auditing

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveInternetSourcesFromNuGetConfig.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveInternetSourcesFromNuGetConfig.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
         /// </summary>
         public string[] KeepFeedPrefixes { get; set; } = [];
 
-        private readonly string[] Sections = [ "packageSources", "auditSources" ];
+        private readonly string[] Sections = [ "packageSources" ];
 
         public override bool Execute()
         {

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -165,8 +165,9 @@
     <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EnvironmentVariables Include="DotNetBuildFromSource=true" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+  <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <EnvironmentVariables Include="DotNetBuildFromSource=true" />
+    <EnvironmentVariables Include="NuGetAudit=false" Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">


### PR DESCRIPTION
This PR changes the way we condition NuGet source auditing in source-build.

Previously we've used https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveInternetSourcesFromNuGetConfig.cs as implemented in https://github.com/dotnet/sdk/pull/42740

Now, we are using `NuGetAudit` property as documented at https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#configuring-nuget-audit

We're passing this as environment variable so it is available in all repo builds, including those that use custom build commands.