### PR TITLE
dotnet-format batch replace EndOfLine instead of one by one

### DIFF
--- a/src/BuiltInTools/dotnet-format/Formatters/EndOfLineFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/Formatters/EndOfLineFormatter.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
                 }
 
                 var newSourceText = sourceText;
+                var changes = new　List<TextChange>();
                 for (var lineIndex = 0; lineIndex < newSourceText.Lines.Count; lineIndex++)
                 {
                     var line = newSourceText.Lines[lineIndex];
@@ -50,9 +51,10 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
                         continue;
                     }
 
-                    var newLineChange = new TextChange(lineEndingSpan, endOfLine);
-                    newSourceText = newSourceText.WithChanges(newLineChange);
+                    changes.Add(new TextChange(lineEndingSpan, endOfLine));
                 }
+
+                newSourceText = newSourceText.WithChanges(changes);
 
                 return newSourceText;
             });


### PR DESCRIPTION
The original implementation takes quadratic time when the file is filled with different EOLs. For a large file (90k lines) it takes more than five minutes to just replace those EOLs.