### PR TITLE
Remove unused property from Microsoft.NET.CrossGen.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -330,11 +330,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
   </Target>
 
-  <PropertyGroup>
-    <MicrosoftNETCrossgenBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tasks\net7.0\Microsoft.NET.Sdk.Crossgen.dll</MicrosoftNETCrossgenBuildTasksAssembly>
-    <MicrosoftNETCrossgenBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tasks\net472\Microsoft.NET.Sdk.Crossgen.dll</MicrosoftNETCrossgenBuildTasksAssembly>
-  </PropertyGroup>
-
   <!--
     ============================================================
                                         CreateReadyToRunImages


### PR DESCRIPTION
The SDK doesn't ship Microsoft.NET.Sdk.Crossgen.dll.

@davidwrighton I saw you introduced this in https://github.com/dotnet/sdk/commit/dd30cabf1018e392c45f71222258fe04473c988e but from what I can see this is unused?