### PR TITLE
Don't forward along binlog arguments to runnable applications

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/Program.cs
@@ -24,27 +24,33 @@ namespace Microsoft.DotNet.Tools.Run
                 parseResult = ModifyParseResultForShorthandProjectOption(parseResult);
             }
 
-            // if the application arguments contain the binlog arg then we need to remove it from the application arguments and apply it to the restore args
+            // if the application arguments contain any binlog args then we need to remove them from the application arguments and apply
+            // them to the restore args.
             // this is because we can't model the binlog command structure in MSbuild in the System.CommandLine parser, but we need
             // bl information to synchronize the restore and build logger configurations
             var applicationArguments = parseResult.GetValue(RunCommandParser.ApplicationArguments).ToList();
-            var binlogIndex = applicationArguments.FindIndex(arg =>
-                arg.StartsWith("/bl:") || arg.Equals("/bl")
-                || arg.StartsWith("--binaryLogger:") || arg.Equals("--binaryLogger")
-                || arg.StartsWith("-bl:") || arg.Equals("-bl")
-            );
 
-            string binlogArgument = null;
-            if (binlogIndex != -1)
+            var binlogArgs = new List<string>();
+            var nonBinLogArgs = new List<string>();
+            foreach (var arg in applicationArguments)
             {
-                binlogArgument = applicationArguments[binlogIndex];
-                applicationArguments.RemoveAt(binlogIndex);
+
+                if (arg.StartsWith("/bl:") || arg.Equals("/bl")
+                    || arg.StartsWith("--binaryLogger:") || arg.Equals("--binaryLogger")
+                    || arg.StartsWith("-bl:") || arg.Equals("-bl"))
+                {
+                    binlogArgs.Add(arg);
+                }
+                else
+                {
+                    nonBinLogArgs.Add(arg);
+                }
             }
 
             var restoreArgs = parseResult.OptionValuesToBeForwarded(RunCommandParser.GetCommand()).ToList();
-            if (binlogArgument != null)
+            if (binlogArgs.Count > 0)
             {
-                restoreArgs.Add(binlogArgument);
+                restoreArgs.AddRange(binlogArgs);
             }
 
             var command = new RunCommand(
@@ -56,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Run
                 interactive: parseResult.HasOption(RunCommandParser.InteractiveOption),
                 verbosity: parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
                 restoreArgs: restoreArgs.ToArray(),
-                args: applicationArguments.ToArray()
+                args: nonBinLogArgs.ToArray()
             );
 
             return command;


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/43310

In https://github.com/dotnet/sdk/pull/42240 I introduced a regression in behavior for applications in `dotnet run`. The `-bl` argument would get forwarded along as application arguments, not arguments to the implicit build/restore that `dotnet run` performs.

A 'proper' way of handling this would be to [model the `-bl` argument syntax in S.CL](https://github.com/dotnet/sdk/pull/43322), but this is currently impossible due to design differences between MSBuild's CLI syntax and S.CL.

So instead we filter out the `-bl` argument from the application arguments if it exists (along with any of its arguments) and apply it to the restore arguments. We have to do special handling of the binlog file name because binlogs are not appendable and we're actually doing two 'build' operations here - one managed entirely by MSBuild, and one managed by the CLI. As a result, we need to provide different names to the binlogs used in each case.

One odd case that I found is that for some reason I cannot use the same `binaryLogger` for the evaluation phase and the execution phase of the `dotnet run` protocol - I split this into two binlogs to illustrate the problem. Would love some feedback from @JanKrivanek / @rainersigwald et al about how I'm holding it wrong here.