### PR TITLE
[9.0.1xx] Proto/enable buildcheck telemetry rc2

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -18,6 +18,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
         internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
         internal const string BuildTelemetryEventName = "build";
         internal const string LoggingConfigurationTelemetryEventName = "loggingConfiguration";
+        internal const string BuildcheckAcquisitionFailureEventName = "buildcheck/acquisitionfailure";
+        internal const string BuildcheckRunEventName = "buildcheck/run";
+        internal const string BuildcheckRuleStatsEventName = "buildcheck/rule";
 
         internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
         internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
@@ -137,6 +140,21 @@ namespace Microsoft.DotNet.Tools.MSBuild
                     TrackEvent(telemetry, $"msbuild/{LoggingConfigurationTelemetryEventName}", args.Properties,
                         toBeHashed: Array.Empty<string>(),
                         toBeMeasured: new[] { "FileLoggersCount" });
+                    break;
+                case BuildcheckAcquisitionFailureEventName:
+                    TrackEvent(telemetry, $"msbuild/{BuildcheckAcquisitionFailureEventName}", args.Properties,
+                        toBeHashed: new[] { "AssemblyName", "ExceptionType", "ExceptionMessage" },
+                        toBeMeasured: Array.Empty<string>());
+                    break;
+                case BuildcheckRunEventName:
+                    TrackEvent(telemetry, $"msbuild/{BuildcheckRunEventName}", args.Properties,
+                        toBeHashed: Array.Empty<string>(),
+                        toBeMeasured: new[] { "RulesCount", "CustomRulesCount", "ViolationsCount", "TotalRuntimeInMilliseconds" });
+                    break;
+                case BuildcheckRuleStatsEventName:
+                    TrackEvent(telemetry, $"msbuild/{BuildcheckRuleStatsEventName}", args.Properties,
+                        toBeHashed: new[] { "RuleId", "CheckFriendlyName" },
+                        toBeMeasured: new[] { "DefaultSeverityId", "ViolationMessagesCount", "ViolationWarningsCount", "ViolationErrorsCount", "TotalRuntimeInMilliseconds" });
                     break;
                 // Pass through events that don't need special handling
                 case SdkTaskBaseCatchExceptionTelemetryEventName:

--- a/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -149,12 +149,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 case BuildcheckRunEventName:
                     TrackEvent(telemetry, $"msbuild/{BuildcheckRunEventName}", args.Properties,
                         toBeHashed: Array.Empty<string>(),
-                        toBeMeasured: new[] { "RulesCount", "CustomRulesCount", "ViolationsCount", "TotalRuntimeInMilliseconds" });
+                        toBeMeasured: new[] { "TotalRuntimeInMilliseconds" });
                     break;
                 case BuildcheckRuleStatsEventName:
                     TrackEvent(telemetry, $"msbuild/{BuildcheckRuleStatsEventName}", args.Properties,
                         toBeHashed: new[] { "RuleId", "CheckFriendlyName" },
-                        toBeMeasured: new[] { "DefaultSeverityId", "ViolationMessagesCount", "ViolationWarningsCount", "ViolationErrorsCount", "TotalRuntimeInMilliseconds" });
+                        toBeMeasured: new[] { "TotalRuntimeInMilliseconds" });
                     break;
                 // Pass through events that don't need special handling
                 case SdkTaskBaseCatchExceptionTelemetryEventName:


### PR DESCRIPTION
Contributes to https://github.com/dotnet/msbuild/issues/10634

### Context
MSBuild is adding new tlemetry events - those needs to be recognized and handled in logger in sdk.