### PR TITLE
Disable stage-2 builds

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -104,7 +104,7 @@ stages:
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 
-      # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+      # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
       # - template: ../jobs/vmr-build.yml
       #   parameters:
       #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -124,7 +124,7 @@ stages:
       #     reuseBuildArtifactsFrom:
       #     - ${{ format('{0}_Online_MsftSdk_x64', variables.centOSStreamName) }}
 
-      # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+      # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
       # - template: ../jobs/vmr-build.yml
       #   parameters:
       #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -201,7 +201,7 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+        # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -220,7 +220,7 @@ stages:
         #     useMonoRuntime: false              # 🚫
         #     withPreviousSDK: true              # ✅
 
-        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+        # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -307,7 +307,7 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+        # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -327,7 +327,7 @@ stages:
         #     reuseBuildArtifactsFrom:
         #     - ${{ format('{0}_Offline_MsftSdk_x64', variables.fedoraName) }}
 
-        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
+        # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -28,6 +28,11 @@ parameters:
   type: boolean
   default: false
 
+# True when Stage-2 source-only builds are enabled
+- name: enableStage2Builds
+  type: boolean
+  default: false
+
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -104,42 +109,44 @@ stages:
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 
-      - template: ../jobs/vmr-build.yml
-        parameters:
-          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
-          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-          vmrBranch: ${{ variables.VmrBranch }}
-          architecture: x64
-          pool: ${{ parameters.pool_Linux }}
-          container: ${{ variables.centOSStreamContainer }}
-          buildFromArchive: false            # 🚫
-          buildSourceOnly: true              # ✅
-          enablePoison: false                # 🚫
-          excludeOmniSharpTests: true        # ✅
-          runOnline: true                    # ✅
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
+      - ${{ if parameters.enableStage2Builds }}:
+        - template: ../jobs/vmr-build.yml
+          parameters:
+            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+            buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
+            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+            vmrBranch: ${{ variables.VmrBranch }}
+            architecture: x64
+            pool: ${{ parameters.pool_Linux }}
+            container: ${{ variables.centOSStreamContainer }}
+            buildFromArchive: false            # 🚫
+            buildSourceOnly: true              # ✅
+            enablePoison: false                # 🚫
+            excludeOmniSharpTests: true        # ✅
+            runOnline: true                    # ✅
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
+            reuseBuildArtifactsFrom: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
 
-      - template: ../jobs/vmr-build.yml
-        parameters:
-          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-          buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.alpinePreviousName) }}
-          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-          vmrBranch: ${{ variables.VmrBranch }}
-          architecture: x64
-          artifactsRid: ${{ variables.alpinePreviousX64Rid }}
-          pool: ${{ parameters.pool_Linux }}
-          container: ${{ variables.alpinePreviousContainer }}
-          targetRid: ${{ variables.alpinePreviousX64Rid }}
-          buildFromArchive: false            # 🚫
-          buildSourceOnly: true              # ✅
-          enablePoison: true                 # ✅
-          excludeOmniSharpTests: true        # ✅
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: true              # ✅
+      - ${{ if parameters.enableStage2Builds }}:
+        - template: ../jobs/vmr-build.yml
+          parameters:
+            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+            buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.alpinePreviousName) }}
+            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+            vmrBranch: ${{ variables.VmrBranch }}
+            architecture: x64
+            artifactsRid: ${{ variables.alpinePreviousX64Rid }}
+            pool: ${{ parameters.pool_Linux }}
+            container: ${{ variables.alpinePreviousContainer }}
+            targetRid: ${{ variables.alpinePreviousX64Rid }}
+            buildFromArchive: false            # 🚫
+            buildSourceOnly: true              # ✅
+            enablePoison: true                 # ✅
+            excludeOmniSharpTests: true        # ✅
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: true              # ✅
 
       ### Additional jobs for full build ###
       - ${{ if in(parameters.scope, 'full') }}:
@@ -198,41 +205,43 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            artifactsRid: ${{ variables.centOSStreamX64Rid }}
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: true                    # ✅
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: true              # ✅
+        - ${{ if parameters.enableStage2Builds }}:
+          - template: ../jobs/vmr-build.yml
+            parameters:
+              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+              buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
+              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+              vmrBranch: ${{ variables.VmrBranch }}
+              architecture: x64
+              artifactsRid: ${{ variables.centOSStreamX64Rid }}
+              pool: ${{ parameters.pool_Linux }}
+              container: ${{ variables.centOSStreamContainer }}
+              buildFromArchive: false            # 🚫
+              buildSourceOnly: true              # ✅
+              enablePoison: false                # 🚫
+              excludeOmniSharpTests: false       # 🚫
+              runOnline: true                    # ✅
+              useMonoRuntime: false              # 🚫
+              withPreviousSDK: true              # ✅
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            artifactsRid: ${{ variables.centOSStreamX64Rid }}
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: true              # ✅
+        - ${{ if parameters.enableStage2Builds }}:
+          - template: ../jobs/vmr-build.yml
+            parameters:
+              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+              buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
+              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+              vmrBranch: ${{ variables.VmrBranch }}
+              architecture: x64
+              artifactsRid: ${{ variables.centOSStreamX64Rid }}
+              pool: ${{ parameters.pool_Linux }}
+              container: ${{ variables.centOSStreamContainer }}
+              buildFromArchive: false            # 🚫
+              buildSourceOnly: true              # ✅
+              enablePoison: false                # 🚫
+              excludeOmniSharpTests: true        # ✅
+              runOnline: false                   # 🚫
+              useMonoRuntime: false              # 🚫
+              withPreviousSDK: true              # ✅
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -302,41 +311,43 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedoraContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
+        - ${{ if parameters.enableStage2Builds }}:
+          - template: ../jobs/vmr-build.yml
+            parameters:
+              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+              buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
+              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+              vmrBranch: ${{ variables.VmrBranch }}
+              architecture: x64
+              pool: ${{ parameters.pool_Linux }}
+              container: ${{ variables.fedoraContainer }}
+              buildFromArchive: false            # 🚫
+              buildSourceOnly: true              # ✅
+              enablePoison: false                # 🚫
+              excludeOmniSharpTests: false       # 🚫
+              runOnline: false                   # 🚫
+              useMonoRuntime: false              # 🚫
+              withPreviousSDK: false             # 🚫
+              reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: true             # ✅
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: true               # ✅
-            withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
+        - ${{ if parameters.enableStage2Builds }}:
+          - template: ../jobs/vmr-build.yml
+            parameters:
+              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+              buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
+              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+              vmrBranch: ${{ variables.VmrBranch }}
+              architecture: x64
+              pool: ${{ parameters.pool_Linux }}
+              container: ${{ variables.centOSStreamContainer }}
+              buildFromArchive: true             # ✅
+              buildSourceOnly: true              # ✅
+              enablePoison: false                # 🚫
+              excludeOmniSharpTests: true        # ✅
+              runOnline: false                   # 🚫
+              useMonoRuntime: true               # ✅
+              withPreviousSDK: false             # 🚫
+              reuseBuildArtifactsFrom: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -28,11 +28,6 @@ parameters:
   type: boolean
   default: false
 
-# True when Stage-2 source-only builds are enabled
-- name: enableStage2Builds
-  type: boolean
-  default: false
-
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -109,45 +104,43 @@ stages:
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 
-      - ${{ if parameters.enableStage2Builds }}:
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: true                    # ✅
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom:
-            - ${{ format('{0}_Online_MsftSdk_x64', variables.centOSStreamName) }}
+      # - template: ../jobs/vmr-build.yml
+      #   parameters:
+      #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      #     buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
+      #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      #     vmrBranch: ${{ variables.VmrBranch }}
+      #     architecture: x64
+      #     pool: ${{ parameters.pool_Linux }}
+      #     container: ${{ variables.centOSStreamContainer }}
+      #     buildFromArchive: false            # 🚫
+      #     buildSourceOnly: true              # ✅
+      #     enablePoison: false                # 🚫
+      #     excludeOmniSharpTests: true        # ✅
+      #     runOnline: true                    # ✅
+      #     useMonoRuntime: false              # 🚫
+      #     withPreviousSDK: false             # 🚫
+      #     reuseBuildArtifactsFrom:
+      #     - ${{ format('{0}_Online_MsftSdk_x64', variables.centOSStreamName) }}
 
-      - ${{ if parameters.enableStage2Builds }}:
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.alpinePreviousName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            artifactsRid: ${{ variables.alpinePreviousX64Rid }}
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.alpinePreviousContainer }}
-            targetRid: ${{ variables.alpinePreviousX64Rid }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: true                 # ✅
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: true              # ✅
+      # - template: ../jobs/vmr-build.yml
+      #   parameters:
+      #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      #     buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.alpinePreviousName) }}
+      #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      #     vmrBranch: ${{ variables.VmrBranch }}
+      #     architecture: x64
+      #     artifactsRid: ${{ variables.alpinePreviousX64Rid }}
+      #     pool: ${{ parameters.pool_Linux }}
+      #     container: ${{ variables.alpinePreviousContainer }}
+      #     targetRid: ${{ variables.alpinePreviousX64Rid }}
+      #     buildFromArchive: false            # 🚫
+      #     buildSourceOnly: true              # ✅
+      #     enablePoison: true                 # ✅
+      #     excludeOmniSharpTests: true        # ✅
+      #     runOnline: false                   # 🚫
+      #     useMonoRuntime: false              # 🚫
+      #     withPreviousSDK: true              # ✅
 
       ### Additional jobs for full build ###
       - ${{ if in(parameters.scope, 'full') }}:
@@ -206,43 +199,41 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        - ${{ if parameters.enableStage2Builds }}:
-          - template: ../jobs/vmr-build.yml
-            parameters:
-              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-              buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
-              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-              vmrBranch: ${{ variables.VmrBranch }}
-              architecture: x64
-              artifactsRid: ${{ variables.centOSStreamX64Rid }}
-              pool: ${{ parameters.pool_Linux }}
-              container: ${{ variables.centOSStreamContainer }}
-              buildFromArchive: false            # 🚫
-              buildSourceOnly: true              # ✅
-              enablePoison: false                # 🚫
-              excludeOmniSharpTests: false       # 🚫
-              runOnline: true                    # ✅
-              useMonoRuntime: false              # 🚫
-              withPreviousSDK: true              # ✅
+        # - template: ../jobs/vmr-build.yml
+        #   parameters:
+        #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+        #     buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
+        #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        #     vmrBranch: ${{ variables.VmrBranch }}
+        #     architecture: x64
+        #     artifactsRid: ${{ variables.centOSStreamX64Rid }}
+        #     pool: ${{ parameters.pool_Linux }}
+        #     container: ${{ variables.centOSStreamContainer }}
+        #     buildFromArchive: false            # 🚫
+        #     buildSourceOnly: true              # ✅
+        #     enablePoison: false                # 🚫
+        #     excludeOmniSharpTests: false       # 🚫
+        #     runOnline: true                    # ✅
+        #     useMonoRuntime: false              # 🚫
+        #     withPreviousSDK: true              # ✅
 
-        - ${{ if parameters.enableStage2Builds }}:
-          - template: ../jobs/vmr-build.yml
-            parameters:
-              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-              buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
-              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-              vmrBranch: ${{ variables.VmrBranch }}
-              architecture: x64
-              artifactsRid: ${{ variables.centOSStreamX64Rid }}
-              pool: ${{ parameters.pool_Linux }}
-              container: ${{ variables.centOSStreamContainer }}
-              buildFromArchive: false            # 🚫
-              buildSourceOnly: true              # ✅
-              enablePoison: false                # 🚫
-              excludeOmniSharpTests: true        # ✅
-              runOnline: false                   # 🚫
-              useMonoRuntime: false              # 🚫
-              withPreviousSDK: true              # ✅
+        # - template: ../jobs/vmr-build.yml
+        #   parameters:
+        #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+        #     buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
+        #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        #     vmrBranch: ${{ variables.VmrBranch }}
+        #     architecture: x64
+        #     artifactsRid: ${{ variables.centOSStreamX64Rid }}
+        #     pool: ${{ parameters.pool_Linux }}
+        #     container: ${{ variables.centOSStreamContainer }}
+        #     buildFromArchive: false            # 🚫
+        #     buildSourceOnly: true              # ✅
+        #     enablePoison: false                # 🚫
+        #     excludeOmniSharpTests: true        # ✅
+        #     runOnline: false                   # 🚫
+        #     useMonoRuntime: false              # 🚫
+        #     withPreviousSDK: true              # ✅
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -312,45 +303,43 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
-        - ${{ if parameters.enableStage2Builds }}:
-          - template: ../jobs/vmr-build.yml
-            parameters:
-              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-              buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
-              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-              vmrBranch: ${{ variables.VmrBranch }}
-              architecture: x64
-              pool: ${{ parameters.pool_Linux }}
-              container: ${{ variables.fedoraContainer }}
-              buildFromArchive: false            # 🚫
-              buildSourceOnly: true              # ✅
-              enablePoison: false                # 🚫
-              excludeOmniSharpTests: false       # 🚫
-              runOnline: false                   # 🚫
-              useMonoRuntime: false              # 🚫
-              withPreviousSDK: false             # 🚫
-              reuseBuildArtifactsFrom:
-              - ${{ format('{0}_Offline_MsftSdk_x64', variables.fedoraName) }}
+        # - template: ../jobs/vmr-build.yml
+        #   parameters:
+        #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+        #     buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
+        #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        #     vmrBranch: ${{ variables.VmrBranch }}
+        #     architecture: x64
+        #     pool: ${{ parameters.pool_Linux }}
+        #     container: ${{ variables.fedoraContainer }}
+        #     buildFromArchive: false            # 🚫
+        #     buildSourceOnly: true              # ✅
+        #     enablePoison: false                # 🚫
+        #     excludeOmniSharpTests: false       # 🚫
+        #     runOnline: false                   # 🚫
+        #     useMonoRuntime: false              # 🚫
+        #     withPreviousSDK: false             # 🚫
+        #     reuseBuildArtifactsFrom:
+        #     - ${{ format('{0}_Offline_MsftSdk_x64', variables.fedoraName) }}
 
-        - ${{ if parameters.enableStage2Builds }}:
-          - template: ../jobs/vmr-build.yml
-            parameters:
-              # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-              buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
-              isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-              vmrBranch: ${{ variables.VmrBranch }}
-              architecture: x64
-              pool: ${{ parameters.pool_Linux }}
-              container: ${{ variables.centOSStreamContainer }}
-              buildFromArchive: true             # ✅
-              buildSourceOnly: true              # ✅
-              enablePoison: false                # 🚫
-              excludeOmniSharpTests: true        # ✅
-              runOnline: false                   # 🚫
-              useMonoRuntime: true               # ✅
-              withPreviousSDK: false             # 🚫
-              reuseBuildArtifactsFrom:
-              - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
+        # - template: ../jobs/vmr-build.yml
+        #   parameters:
+        #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+        #     buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
+        #     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        #     vmrBranch: ${{ variables.VmrBranch }}
+        #     architecture: x64
+        #     pool: ${{ parameters.pool_Linux }}
+        #     container: ${{ variables.centOSStreamContainer }}
+        #     buildFromArchive: true             # ✅
+        #     buildSourceOnly: true              # ✅
+        #     enablePoison: false                # 🚫
+        #     excludeOmniSharpTests: true        # ✅
+        #     runOnline: false                   # 🚫
+        #     useMonoRuntime: true               # ✅
+        #     withPreviousSDK: false             # 🚫
+        #     reuseBuildArtifactsFrom:
+        #     - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -104,6 +104,7 @@ stages:
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 
+      # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
       # - template: ../jobs/vmr-build.yml
       #   parameters:
       #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -123,6 +124,7 @@ stages:
       #     reuseBuildArtifactsFrom:
       #     - ${{ format('{0}_Online_MsftSdk_x64', variables.centOSStreamName) }}
 
+      # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
       # - template: ../jobs/vmr-build.yml
       #   parameters:
       #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -199,6 +201,7 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
+        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -217,6 +220,7 @@ stages:
         #     useMonoRuntime: false              # 🚫
         #     withPreviousSDK: true              # ✅
 
+        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -303,6 +307,7 @@ stages:
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
+        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -322,6 +327,7 @@ stages:
         #     reuseBuildArtifactsFrom:
         #     - ${{ format('{0}_Offline_MsftSdk_x64', variables.fedoraName) }}
 
+        # Disabled until 9.0 GA - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
         #   parameters:
         #     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline


### PR DESCRIPTION
Resolves: https://github.com/dotnet/source-build/issues/4586

Stage 2 builds are currently failing as is always the case during transition to a new release. The failures were originally introduced with https://github.com/dotnet/sdk/pull/42969. We could modify those properties, to enable PVP version flow, and get stage 2 builds running, but that would only work for a short time, until `runtime` and `aspnetcore` move to 10.0 versioning. At that point building 9.0 projects could break, as `_NET90RuntimePackVersion` and other 9.0 'packs' properties in `src/Installer/redist-installer/targets/GenerateBundledVersions.targets` would reference 10.0 'packs'.

Stage-2 builds can be enabled after 9.0 GA, at which point we will add 9.0 targeting pack to SBRP and update the properties introduced in https://github.com/dotnet/sdk/pull/42969 to reference it.

Note that the diff is rather silly. My changes are simple. I am adding a new parameter `enableStage2Builds` and conditioning each of the stage-2 jobs, to only run if this parameter is set to `true`.