### PR TITLE
Correctly handle different architectures for devdeviceID

### DIFF
--- a/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
+++ b/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
@@ -39,10 +39,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Get device Id from Windows registry
-                using (var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
-                {
-                    deviceId = key?.GetValue("deviceid") as string;
-                }
+                deviceId = Registry.GetValue(@"HKEY_CURRENT_USER\SOFTWARE\Microsoft\DeveloperTools", "deviceid", null) as string;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
@@ -81,7 +78,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Cache device Id in Windows registry
-                using (var key = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
+                using (var key = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default).CreateSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
                 {
                     key.SetValue("deviceid", deviceId);
                 }

--- a/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
+++ b/src/Cli/dotnet/Telemetry/DevDeviceIDGetter.cs
@@ -39,8 +39,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Get device Id from Windows registry matching the OS architecture
-                RegistryView registryView = Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Registry32;
-                using (var key = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, registryView).OpenSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
+                using (var key = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64).OpenSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
                 {
                     deviceId = key?.GetValue("deviceid") as string;
                 }
@@ -82,8 +81,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Cache device Id in Windows registry matching the OS architecture
-                RegistryView registryView = Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Registry32;
-                using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, registryView))
+                using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64))
                 {
                     using(var key = baseKey.CreateSubKey(@"SOFTWARE\Microsoft\DeveloperTools"))
                     {

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -50,12 +50,16 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotDevDeviceId()
+        public void TelemetryCommonPropertiesShouldEnsureDevDeviceIDIsCached()
         {
             var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
             var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
+            var secondAssignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"];
+
+            Guid.TryParse(secondAssignedMachineId, out var _).Should().BeTrue("it should be a guid");
+            secondAssignedMachineId.Should().Be(assignedMachineId, "it should match the previously assigned guid");
         }
 
         [Fact]


### PR DESCRIPTION
**Summary**

DevDeviceID was introduced in RC2 as a way to be consistent with Visual Studio on how to track individual devices. There was a bug in the initial implementation where on windows, we would use the SDK architecture version of the registry for reading and storing the cached value

**Customer Impact** 

x86 SDKs would have a completely unique devdevice ID to the x64 version on the same box. The spec calls for the same id regardless of architecture.

**Regression**

No, implemented incorrectly.

**Testing**

Minimal. Update the test to ensure we have caching

**Risk**

Very low