### PR TITLE
Add "not installed" and other messages for workloads

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.Installer.Windows
         {
             return Send(new InstallRequestMessage
             {
-                RequestType = InstallRequestType.RecordWorkloadSetInGlobalJson,
+                RequestType = InstallRequestType.GetGlobalJsonWorkloadSetVersions,
                 SdkFeatureBand = sdkFeatureBand.ToString(),
             });
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,13 +45,8 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-            if (error is not null)
-            {
-                Reporter.Output.WriteLine(error);
-            }
-
-            return version;
+            (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            return version.Version + (error is not null ? ' ' + error : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -62,15 +57,11 @@ namespace Microsoft.DotNet.Cli
             reporter ??= Utils.Reporter.Output;
             string dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
 
+            string error = null;
             if (showVersion)
             {
-                (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-                if (error is not null)
-                {
-                    reporter.WriteLine(error);
-                }
-
-                reporter.WriteLine($" Workload version: {version}");
+                (WorkloadVersion version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                reporter.WriteLine($" Workload version: {version.Version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;
@@ -108,6 +99,11 @@ namespace Microsoft.DotNet.Cli
                 reporter.WriteLine($"       {WorkloadInstallType.GetWorkloadInstallType(new SdkFeatureBand(Utils.Product.Version), dotnetPath).ToString(),align}"
                 );
                 reporter.WriteLine("");
+            }
+
+            if (error is not null)
+            {
+                reporter.WriteLine(error);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,10 +45,10 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            var versionInfo = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
 
             // The explicit space here is intentional, as it's easy to miss in localization and crucial for parsing
-            return version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
+            return versionInfo.Version + (versionInfo.VersionNotInstalledMessage is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -59,53 +59,67 @@ namespace Microsoft.DotNet.Cli
             reporter ??= Utils.Reporter.Output;
             string dotnetPath = dotnetDir ?? Path.GetDirectoryName(Environment.ProcessPath);
 
-            string error = null;
+            
+
+            var versionInfo = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+
+            void WriteUpdateModeAndAnyError(string indent = "")
+            {
+                var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;
+                var workloadSetsString = useWorkloadSets == true ? "workload sets" : "loose manifests";
+                reporter.WriteLine(indent + string.Format(CommonStrings.WorkloadManifestInstallationConfiguration, workloadSetsString));
+
+                var additionalMessage = versionInfo.VersionNotInstalledMessage ?? versionInfo.UpdateModeMessage;
+                if (additionalMessage != null)
+                {
+                    reporter.WriteLine(indent + additionalMessage);
+                }
+            }
+            
             if (showVersion)
             {
-                (string version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-                reporter.WriteLine($" Workload version: {version}");
+                reporter.WriteLine($" Workload version: {GetWorkloadsVersion()}");
+                
+                WriteUpdateModeAndAnyError(indent: " ");
             }
-
-            var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;
-            var workloadSetsString = useWorkloadSets == true ? "workload sets" : "loose manifests";
-            reporter.WriteLine(string.Format(CommonStrings.WorkloadManifestInstallationConfiguration, workloadSetsString));
 
             if (installedWorkloads.Count == 0)
             {
                 reporter.WriteLine(CommonStrings.NoWorkloadsInstalledInfoWarning);
-                return;
+            }
+            else
+            {
+                var manifestInfoDict = workloadInfoHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
+
+                foreach (var workload in installedWorkloads.AsEnumerable())
+                {
+                    var workloadManifest = workloadInfoHelper.WorkloadResolver.GetManifestFromWorkload(new WorkloadId(workload.Key));
+                    var workloadFeatureBand = manifestInfoDict[workloadManifest.Id].ManifestFeatureBand;
+
+                    const int align = 10;
+                    const string separator = "   ";
+
+                    reporter.WriteLine($" [{workload.Key}]");
+
+                    reporter.Write($"{separator}{CommonStrings.WorkloadSourceColumn}:");
+                    reporter.WriteLine($" {workload.Value,align}");
+
+                    reporter.Write($"{separator}{CommonStrings.WorkloadManifestVersionColumn}:");
+                    reporter.WriteLine($"    {workloadManifest.Version + '/' + workloadFeatureBand,align}");
+
+                    reporter.Write($"{separator}{CommonStrings.WorkloadManifestPathColumn}:");
+                    reporter.WriteLine($"       {workloadManifest.ManifestPath,align}");
+
+                    reporter.Write($"{separator}{CommonStrings.WorkloadInstallTypeColumn}:");
+                    reporter.WriteLine($"       {WorkloadInstallType.GetWorkloadInstallType(new SdkFeatureBand(Utils.Product.Version), dotnetPath).ToString(),align}"
+                    );
+                    reporter.WriteLine("");
+                }
             }
 
-            var manifestInfoDict = workloadInfoHelper.WorkloadResolver.GetInstalledManifests().ToDictionary(info => info.Id, StringComparer.OrdinalIgnoreCase);
-
-            foreach (var workload in installedWorkloads.AsEnumerable())
+            if (!showVersion)
             {
-                var workloadManifest = workloadInfoHelper.WorkloadResolver.GetManifestFromWorkload(new WorkloadId(workload.Key));
-                var workloadFeatureBand = manifestInfoDict[workloadManifest.Id].ManifestFeatureBand;
-
-                const int align = 10;
-                const string separator = "   ";
-
-                reporter.WriteLine($" [{workload.Key}]");
-
-                reporter.Write($"{separator}{CommonStrings.WorkloadSourceColumn}:");
-                reporter.WriteLine($" {workload.Value,align}");
-
-                reporter.Write($"{separator}{CommonStrings.WorkloadManifestVersionColumn}:");
-                reporter.WriteLine($"    {workloadManifest.Version + '/' + workloadFeatureBand,align}");
-
-                reporter.Write($"{separator}{CommonStrings.WorkloadManifestPathColumn}:");
-                reporter.WriteLine($"       {workloadManifest.ManifestPath,align}");
-
-                reporter.Write($"{separator}{CommonStrings.WorkloadInstallTypeColumn}:");
-                reporter.WriteLine($"       {WorkloadInstallType.GetWorkloadInstallType(new SdkFeatureBand(Utils.Product.Version), dotnetPath).ToString(),align}"
-                );
-                reporter.WriteLine("");
-            }
-
-            if (error is not null)
-            {
-                reporter.WriteLine(error);
+                WriteUpdateModeAndAnyError();
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -46,7 +46,9 @@ namespace Microsoft.DotNet.Cli
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
             (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-            return version.Version + (error is not null ? ' ' + error : string.Empty);
+
+            // The explicit space here is intentional, as it's easy to miss in localization and crucial for parsing
+            return version.Version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,7 +45,13 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            return workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            if (error is not null)
+            {
+                Reporter.Output.WriteLine(error);
+            }
+
+            return version;
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -58,7 +64,13 @@ namespace Microsoft.DotNet.Cli
 
             if (showVersion)
             {
-                reporter.WriteLine($" Workload version: {workloadInfoHelper.ManifestProvider.GetWorkloadVersion()}");
+                (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                if (error is not null)
+                {
+                    reporter.WriteLine(error);
+                }
+
+                reporter.WriteLine($" Workload version: {version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -45,10 +45,10 @@ namespace Microsoft.DotNet.Cli
         {
             workloadInfoHelper ??= new WorkloadInfoHelper(false);
 
-            (WorkloadVersion version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+            (string version, string error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
 
             // The explicit space here is intentional, as it's easy to miss in localization and crucial for parsing
-            return version.Version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
+            return version + (error is not null ? ' ' + Workloads.Workload.List.LocalizableStrings.WorkloadVersionNotInstalledShort : string.Empty);
         }
 
         internal static void ShowWorkloadsInfo(ParseResult parseResult = null, WorkloadInfoHelper workloadInfoHelper = null, IReporter reporter = null, string dotnetDir = null, bool showVersion = true)
@@ -62,8 +62,8 @@ namespace Microsoft.DotNet.Cli
             string error = null;
             if (showVersion)
             {
-                (WorkloadVersion version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
-                reporter.WriteLine($" Workload version: {version.Version}");
+                (string version, error) = workloadInfoHelper.ManifestProvider.GetWorkloadVersion();
+                reporter.WriteLine($" Workload version: {version}");
             }
 
             var useWorkloadSets = InstallStateContents.FromPath(Path.Combine(WorkloadInstallType.GetInstallStateFolder(workloadInfoHelper._currentSdkFeatureBand, workloadInfoHelper.UserLocalPath), "default.json")).UseWorkloadSets;

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandParser.cs
@@ -81,6 +81,7 @@ namespace Microsoft.DotNet.Cli
                 reporter.WriteLine($" Workload version: {GetWorkloadsVersion()}");
                 
                 WriteUpdateModeAndAnyError(indent: " ");
+                reporter.WriteLine();
             }
 
             if (installedWorkloads.Count == 0)

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadVersion = resolver.GetWorkloadVersion().version;
+            var currentWorkloadVersion = resolver.GetWorkloadVersion().Version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadInfo = resolver.GetWorkloadVersion();
+            var currentWorkloadVersion = resolver.GetWorkloadVersion();
+            var versionString = currentWorkloadVersion.version.WorkloadInstallType == WorkloadVersion.Type.LooseManifest ? string.Empty : currentWorkloadVersion.version.Version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = resolver.GetWorkloadVersion().version
+                WorkloadSetVersion = versionString
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = resolver.GetWorkloadVersion()
+                WorkloadSetVersion = resolver.GetWorkloadVersion().version
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadHistoryRecorder.cs
@@ -54,8 +54,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         private WorkloadHistoryState GetWorkloadState()
         {
             var resolver = _workloadResolverFunc();
-            var currentWorkloadVersion = resolver.GetWorkloadVersion();
-            var versionString = currentWorkloadVersion.version.WorkloadInstallType == WorkloadVersion.Type.LooseManifest ? string.Empty : currentWorkloadVersion.version.Version;
+            var currentWorkloadVersion = resolver.GetWorkloadVersion().version;
             return new WorkloadHistoryState()
             {
                 ManifestVersions = resolver.GetInstalledManifests().ToDictionary(manifest => manifest.Id.ToString(), manifest => $"{manifest.Version}/{manifest.ManifestFeatureBand}"),
@@ -63,7 +62,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                                                        .GetInstalledWorkloads(new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand()))
                                                        .Select(id => id.ToString())
                                                        .ToList(),
-                WorkloadSetVersion = versionString
+                WorkloadSetVersion = currentWorkloadVersion
             };
 
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs
@@ -122,7 +122,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 throw new GracefulException(string.Format(LocalizableStrings.CannotCombineSkipManifestAndVersion,
                     WorkloadInstallCommandParser.SkipManifestUpdateOption.Name, InstallingWorkloadCommandParser.VersionOption.Name), isUserError: true);
             }
-            else if (_skipManifestUpdate && SpecifiedWorkloadSetVersionInGlobalJson)
+            else if ((_skipManifestUpdate && SpecifiedWorkloadSetVersionInGlobalJson) &&
+                !IsRunningRestore)  //  When running restore, we first update workloads, then query the projects to figure out what workloads should be installed, then run the install command.
+                                    //  When we run the install command we set skipManifestUpdate to true as an optimization to avoid trying to update twice
             {
                 throw new GracefulException(string.Format(LocalizableStrings.CannotUseSkipManifestWithGlobalJsonWorkloadVersion,
                     WorkloadInstallCommandParser.SkipManifestUpdateOption.Name, _globalJsonPath), isUserError: true);

--- a/src/Cli/dotnet/commands/dotnet-workload/list/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/LocalizableStrings.resx
@@ -134,6 +134,9 @@
   <data name="WorkloadSetFromGlobalJsonInstalled" xml:space="preserve">
     <value>Found workload version {0} pinned in the global.json file at {1}.</value>
   </data>
+  <data name="WorkloadVersionNotInstalledShort" xml:space="preserve">
+    <value>(not installed)</value>
+  </data>
   <data name="WorkloadSetFromGlobalJsonNotInstalled" xml:space="preserve">
     <value>Found workload version {0} pinned in the global.json file at {1}, but it was not installed. Running `dotnet workload install`, `dotnet workload update`, or `dotnet workload restore` may fix this.</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                     }
                     else
                     {
-                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion() ?? "unknown"));
+                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion().version ?? "unknown"));
                     }
 
                     Reporter.WriteLine();

--- a/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/WorkloadListCommand.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
                     }
                     else
                     {
-                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion().version ?? "unknown"));
+                        Reporter.WriteLine(string.Format(LocalizableStrings.WorkloadSetVersion, _workloadListHelper.WorkloadResolver.GetWorkloadVersion().Version ?? "unknown"));
                     }
 
                     Reporter.WriteLine();

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Aktualizace jsou k dispozici pro následující úlohy: {0}. Pokud chcete získat nejnovější verzi, spusťte aktualizaci úlohy dotnet (`dotnet workload update`).</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Updates sind für die folgenden Workloads verfügbar: {0}. Führen Sie „dotnet workload update“ aus, um die neueste Updates zu erhalten.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Hay actualizaciones disponibles para las siguientes cargas de trabajo: {0}. Ejecute "dotnet workload update" para obtener la versión más reciente.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Des mises à jour sont disponibles pour les charges de travail suivantes : {0}. Exécutez `dotnet workload update` pour obtenir la dernière version.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Gli aggiornamenti sono disponibili per i carichi di lavoro seguenti: {0}. Per ottenere la versione più recente, eseguire 'dotnet workload update'.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">次のワークロードについて更新プログラムを入手可能です: {0}。最新版を取得するには、`dotnet workload update` を実行します。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">다음 워크로드에 대한 업데이트를 사용할 수 있습니다. {0}. 최신 버전을 받으려면 `dotnet workload update`를 실행하세요.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Aktualizacje są dostępne dla następujących obciążeń: {0}. Uruchom polecenie `dotnet workload update`, aby uzyskać najnowszą wersję.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">As atualizações estão disponíveis para as seguintes cargas de trabalho(s): {0}. Execute `dotnet workload update` para obter o mais recente.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Обновления доступны для следующих рабочих нагрузок: {0}. Чтобы получить последнюю версию, запустите `dotnet workload update`.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Şu iş yükleri için güncelleştirmeler var: {0}. En son sürümü almak için `dotnet workload update` çalıştırın.</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">以下工作负载有可用的更新: {0}。请运行 `dotnet workload update` 以获取最新版本。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">以下工作負載有可用的更新: {0}。執行 `dotnet workload update` 以取得最新更新。</target>
         <note>{Locked="dotnet workload update"}</note>
       </trans-unit>
+      <trans-unit id="WorkloadVersionNotInstalledShort">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
             recorder.Run(() =>
             {
                 // First update manifests and install a workload set as necessary
-                new WorkloadUpdateCommand(_result, recorder: recorder).Execute();
+                new WorkloadUpdateCommand(_result, recorder: recorder, isRestoring: true).Execute();
 
                 var allProjects = DiscoverAllProjects(Directory.GetCurrentDirectory(), _slnOrProjectArgument).Distinct();
                 List<WorkloadId> allWorkloadId = RunTargetToGetWorkloadIds(allProjects);
@@ -64,6 +64,8 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
                     IsRunningRestore = true
                 }.Execute();
             });
+
+            workloadInstaller.Shutdown();
             
             return 0;
         }

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
         private readonly bool _fromPreviousSdk;
         private WorkloadHistoryRecorder _recorder;
         private readonly bool _isRestoring;
+        private readonly bool _shouldShutdownInstaller;
         public WorkloadUpdateCommand(
             ParseResult parseResult,
             IReporter reporter = null,
@@ -48,6 +49,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                                 _sdkFeatureBand, _workloadResolver, Verbosity, _userProfileDir, VerifySignatures, PackageDownloader,
                                 _dotnetPath, TempDirectoryPath, packageSourceLocation: _packageSourceLocation, RestoreActionConfiguration,
                                 elevationRequired: !_printDownloadLinkOnly && !_printRollbackDefinitionOnly && string.IsNullOrWhiteSpace(_downloadToCacheOption));
+
+            _shouldShutdownInstaller = _workloadInstallerFromConstructor != null;
+
 
             _workloadManifestUpdater = _workloadManifestUpdaterFromConstructor ?? new WorkloadManifestUpdater(resolvedReporter, _workloadResolver, PackageDownloader, _userProfileDir,
                 _workloadInstaller.GetWorkloadInstallationRecordRepository(), _workloadInstaller, _packageSourceLocation, sdkFeatureBand: _sdkFeatureBand);
@@ -132,7 +136,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 }
             }
 
-            _workloadInstaller.Shutdown();
+            if (_shouldShutdownInstaller)
+            {
+                _workloadInstaller.Shutdown();
+            }
             return _workloadInstaller.ExitCode;
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         string GetSdkFeatureBand();
 
-        string? GetWorkloadVersion();
+        (string? version, string? error) GetWorkloadVersion();
 
         Dictionary<string, WorkloadSet> GetAvailableWorkloadSets();
     }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadManifestProvider.cs
@@ -14,8 +14,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         string GetSdkFeatureBand();
 
-        (string? version, string? error) GetWorkloadVersion();
+        WorkloadVersionInfo GetWorkloadVersion();
 
         Dictionary<string, WorkloadSet> GetAvailableWorkloadSets();
+
+        public readonly record struct WorkloadVersionInfo(string Version, string? VersionNotInstalledMessage = null, string? UpdateModeMessage = null);
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         string GetManifestFeatureBand(string manifestId);
         IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
-        (string? version, string? error) GetWorkloadVersion();
+        IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion();
         IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads);
         WorkloadManifest GetManifestFromWorkload(WorkloadId workloadId);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/IWorkloadResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         string GetManifestFeatureBand(string manifestId);
         IEnumerable<WorkloadManifestInfo> GetInstalledManifests();
         string GetSdkFeatureBand();
-        string? GetWorkloadVersion();
+        (string? version, string? error) GetWorkloadVersion();
         IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads);
         WorkloadManifest GetManifestFromWorkload(WorkloadId workloadId);
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -257,10 +257,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet?.Version is not null)
             {
-                // This not only means workload sets were enabled but also that we found a workload set. We should still
-                // notify the user if the only workload set we could find was the baseline manifest.
-                string? baselineMessage = _workloadSet.IsBaselineWorkloadSet ? string.Format(Strings.OnlyBaselineManifestFound, _workloadSet.Version) : null;
-                return (_workloadSet.Version, baselineMessage);
+                return (new WorkloadVersion()
+                {
+                    Version = _workloadSet.Version,
+                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
+                }, null);
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkOrUserLocalPath), "default.json");

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -257,11 +257,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (_workloadSet?.Version is not null)
             {
-                return (new WorkloadVersion()
-                {
-                    Version = _workloadSet.Version,
-                    WorkloadInstallType = WorkloadVersion.Type.WorkloadSet
-                }, null);
+                return (_workloadSet.Version, null);
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkOrUserLocalPath), "default.json");

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.NET.Sdk.Localization;
+using static Microsoft.NET.Sdk.WorkloadManifestReader.IWorkloadManifestProvider;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
@@ -243,21 +244,21 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
         }
 
-        public (string? version, string? error) GetWorkloadVersion()
+        public WorkloadVersionInfo GetWorkloadVersion()
         {
             if (_globalJsonWorkloadSetVersion != null)
             {
                 // _exceptionToThrow is set to null here if and only if the workload set is not installed.
                 // If this came from --info or workload --version, the error won't be thrown, but we should still
                 // suggest running `dotnet workload restore` to the user.
-                return (_globalJsonWorkloadSetVersion, _exceptionToThrow?.Message);
+                return new WorkloadVersionInfo(_globalJsonWorkloadSetVersion, _exceptionToThrow?.Message);
             }
 
             ThrowExceptionIfManifestsNotAvailable();
 
             if (_workloadSet?.Version is not null)
             {
-                return (_workloadSet.Version, null);
+                return new WorkloadVersionInfo(_workloadSet.Version);
             }
 
             var installStateFilePath = Path.Combine(WorkloadInstallType.GetInstallStateFolder(_sdkVersionBand, _sdkOrUserLocalPath), "default.json");
@@ -280,7 +281,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     sb.Append(bytes[b].ToString("x2"));
                 }
 
-                return ($"{_sdkVersionBand.ToStringWithoutPrerelease()}-manifests.{sb}", shouldRestoreMessage);
+                return new WorkloadVersionInfo($"{_sdkVersionBand.ToStringWithoutPrerelease()}-manifests.{sb}", null, UpdateModeMessage: shouldRestoreMessage);
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -201,9 +201,6 @@
     <value>Workload version {0}, which was specified in {1}, was not found. Run "dotnet workload restore" to install this workload version.</value>
     <comment>{Locked="dotnet workload restore"}</comment>
   </data>
-  <data name="OnlyBaselineManifestFound" xml:space="preserve">
-    <value>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</value>
-  </data>
   <data name="ShouldInstallAWorkloadSet" xml:space="preserve">
     <value>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</value>
   </data>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Strings.resx
@@ -201,6 +201,12 @@
     <value>Workload version {0}, which was specified in {1}, was not found. Run "dotnet workload restore" to install this workload version.</value>
     <comment>{Locked="dotnet workload restore"}</comment>
   </data>
+  <data name="OnlyBaselineManifestFound" xml:space="preserve">
+    <value>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</value>
+  </data>
+  <data name="ShouldInstallAWorkloadSet" xml:space="preserve">
+    <value>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</value>
+  </data>
   <data name="WorkloadVersionNotFound" xml:space="preserve">
     <value>Workload version {0} was not found.</value>
   </data>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         }
 
         public string GetSdkFeatureBand() => _sdkVersionBand;
-        public (string? version, string? error) GetWorkloadVersion() => (_sdkVersionBand.ToString() + ".2", null);
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo(_sdkVersionBand.ToString() + ".2");
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/TempDirectoryWorkloadManifestProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         }
 
         public string GetSdkFeatureBand() => _sdkVersionBand;
-        public string? GetWorkloadVersion() => _sdkVersionBand.ToString() + ".2";
+        public (string? version, string? error) GetWorkloadVersion() => (_sdkVersionBand.ToString() + ".2", null);
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,7 +778,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand.ToString() + ".2", null);
+            public (WorkloadVersion, string? error) GetWorkloadVersion() => (new WorkloadVersion
+            {
+                Version = _sdkFeatureBand + ".2",
+                WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+            }, null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,11 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (WorkloadVersion version, string? error) GetWorkloadVersion() => (new WorkloadVersion
-            {
-                Version = _sdkFeatureBand + ".2",
-                WorkloadInstallType = WorkloadVersion.Type.LooseManifest
-            }, null);
+            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand + ".2", null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             InitializeManifests();
         }
 
-        public string? GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
+        public (string? version, string? error) GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
 
         private void LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         {
@@ -778,7 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public string? GetWorkloadVersion() => _sdkFeatureBand.ToString() + ".2";
+            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand.ToString() + ".2", null);
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -778,7 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (WorkloadVersion, string? error) GetWorkloadVersion() => (new WorkloadVersion
+            public (WorkloadVersion version, string? error) GetWorkloadVersion() => (new WorkloadVersion
             {
                 Version = _sdkFeatureBand + ".2",
                 WorkloadInstallType = WorkloadVersion.Type.LooseManifest

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             InitializeManifests();
         }
 
-        public (string? version, string? error) GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => _manifestProvider.GetWorkloadVersion();
 
         private void LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         {
@@ -778,7 +778,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => new();
             public IEnumerable<ReadableWorkloadManifest> GetManifests() => Enumerable.Empty<ReadableWorkloadManifest>();
             public string GetSdkFeatureBand() => _sdkFeatureBand;
-            public (string? version, string? error) GetWorkloadVersion() => (_sdkFeatureBand + ".2", null);
+            public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo(_sdkFeatureBand + ".2");
         }
     }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Chybějící verze pro sadu úloh {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Přesměrování úlohy {0} má jiné klíče než redirect-to.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.cs.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Chybějící verze pro sadu úloh {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Přesměrování úlohy {0} má jiné klíče než redirect-to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Version für Workloadpaket "{0}" fehlt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Die Umleitungsworkload „{0}“ hat andere Schlüssel als „redirect-to“.</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.de.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Version für Workloadpaket "{0}" fehlt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Die Umleitungsworkload „{0}“ hat andere Schlüssel als „redirect-to“.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Falta la versión del paquete de carga de trabajo "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La carga de trabajo de redireccionamiento '{0}' tiene claves distintas que las de 'redirect-to'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.es.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Falta la versión del paquete de carga de trabajo "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La carga de trabajo de redireccionamiento '{0}' tiene claves distintas que las de 'redirect-to'</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Version manquante pour le pack de charges de travail '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La charge de travail de redirection « {0} » a des clés autres que « redirection vers ».</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.fr.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Version manquante pour le pack de charges de travail '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">La charge de travail de redirection « {0} » a des clés autres que « redirection vers ».</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Versione mancante per il pacchetto '{0}' del carico di lavoro</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Il carico di lavoro '{0}' di reindirizzamento ha chiavi diverse da ' Redirect-to '</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.it.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Versione mancante per il pacchetto '{0}' del carico di lavoro</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Il carico di lavoro '{0}' di reindirizzamento ha chiavi diverse da ' Redirect-to '</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -112,9 +112,19 @@
         <target state="translated">ワークロード パック '{0}' のバージョンがありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">リダイレクト ワークロード '{0}' に 'redirect-to' 以外のキーがあります</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ja.xlf
@@ -112,11 +112,6 @@
         <target state="translated">ワークロード パック '{0}' のバージョンがありません</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">リダイレクト ワークロード '{0}' に 'redirect-to' 以外のキーがあります</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -112,9 +112,19 @@
         <target state="translated">워크로드 팩 '{0}'에 대한 버전이 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">리디렉션 워크로드 '{0}'에 'redirect-to' 이외의 다른 키가 있습니다</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ko.xlf
@@ -112,11 +112,6 @@
         <target state="translated">워크로드 팩 '{0}'에 대한 버전이 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">리디렉션 워크로드 '{0}'에 'redirect-to' 이외의 다른 키가 있습니다</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Brak wersji dla pakietu obciążenia „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Obciążenie przekierowania „{0}” ma klucze inne niż „redirect-to”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pl.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Brak wersji dla pakietu obciążenia „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Obciążenie przekierowania „{0}” ma klucze inne niż „redirect-to”</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Versão do pacote de carga de trabalho '{0}' ausente</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">A carga de trabalho de redirecionamento '{0}' tem chaves diferentes além de 'redirecionar-para'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.pt-BR.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Versão do pacote de carga de trabalho '{0}' ausente</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">A carga de trabalho de redirecionamento '{0}' tem chaves diferentes além de 'redirecionar-para'</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -112,9 +112,19 @@
         <target state="translated">Отсутствует версия для пакета рабочей нагрузки "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Перенаправление рабочей нагрузки "{0}" содержит ключи, отличные от "redirect-to"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.ru.xlf
@@ -112,11 +112,6 @@
         <target state="translated">Отсутствует версия для пакета рабочей нагрузки "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">Перенаправление рабочей нагрузки "{0}" содержит ключи, отличные от "redirect-to"</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -112,9 +112,19 @@
         <target state="translated">'{0}' iş yükü paketi için sürüm eksik</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">'{0}' yeniden yönlendirme iş yükünde 'redirect-to' dışında anahtarlar var</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.tr.xlf
@@ -112,11 +112,6 @@
         <target state="translated">'{0}' iş yükü paketi için sürüm eksik</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">'{0}' yeniden yönlendirme iş yükünde 'redirect-to' dışında anahtarlar var</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -112,9 +112,19 @@
         <target state="translated">工作负载包“{0}”版本缺失</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重定向工作负荷“{0}”具有“重定向到”以外的键</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hans.xlf
@@ -112,11 +112,6 @@
         <target state="translated">工作负载包“{0}”版本缺失</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重定向工作负荷“{0}”具有“重定向到”以外的键</target>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -112,9 +112,19 @@
         <target state="translated">缺少工作負載套件 '{0}' 的版本</target>
         <note />
       </trans-unit>
+      <trans-unit id="OnlyBaselineManifestFound">
+        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
+        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重新導向工作負載 '{0}' 具有 'redirect-to' 以外的其他金鑰</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShouldInstallAWorkloadSet">
+        <source>Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</source>
+        <target state="new">Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedTokenAtOffset">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/xlf/Strings.zh-Hant.xlf
@@ -112,11 +112,6 @@
         <target state="translated">缺少工作負載套件 '{0}' 的版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="OnlyBaselineManifestFound">
-        <source>Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</source>
-        <target state="new">Workload version {0} was found. This is the baseline version. If you recently switched to using workload versions, consider running "dotnet workload update" to install the latest version.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RedirectWorkloadHasOtherKeys">
         <source>Redirect workload '{0}' has keys other than 'redirect-to'</source>
         <target state="translated">重新導向工作負載 '{0}' 具有 'redirect-to' 以外的其他金鑰</target>

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -40,7 +40,7 @@ namespace ManifestReaderTests
 
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
     }
 
     internal class InMemoryFakeManifestProvider : IWorkloadManifestProvider, IEnumerable<(string id, string content)>
@@ -67,6 +67,6 @@ namespace ManifestReaderTests
         IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public string? GetWorkloadVersion() => "8.0.100.2";
+        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
     }
 }

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/FakeManifestProvider.cs
@@ -40,7 +40,7 @@ namespace ManifestReaderTests
 
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo("8.0.100.2");
     }
 
     internal class InMemoryFakeManifestProvider : IWorkloadManifestProvider, IEnumerable<(string id, string content)>
@@ -67,6 +67,6 @@ namespace ManifestReaderTests
         IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "8.0.100";
         public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => throw new NotImplementedException();
-        public (string? version, string? error) GetWorkloadVersion() => ("8.0.100.2", null);
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo("8.0.100.2");
     }
 }

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -93,14 +93,14 @@ namespace ManifestReaderTests
 
             if (useWorkloadSet)
             {
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200");
             }
             else
             {
                 string[] manifests = sdkDirectoryWorkloadManifestProvider.GetManifests().OrderBy(m => m.ManifestId).Select(m => $"{m.ManifestId}.{m.ManifestFeatureBand}.{m.ManifestVersion}").ToArray();
                 manifests.Length.Should().Be(1);
                 manifests.Should().Contain("android.8.0.200.33.0.2-rc.1");
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Should().Be("8.0.200-manifests.4ba11739");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200-manifests.4ba11739");
             }
 
             Directory.Delete(Path.Combine(_manifestRoot, "8.0.100"), recursive: true);

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -93,14 +93,14 @@ namespace ManifestReaderTests
 
             if (useWorkloadSet)
             {
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Version.Should().Be("8.0.200");
             }
             else
             {
                 string[] manifests = sdkDirectoryWorkloadManifestProvider.GetManifests().OrderBy(m => m.ManifestId).Select(m => $"{m.ManifestId}.{m.ManifestFeatureBand}.{m.ManifestVersion}").ToArray();
                 manifests.Length.Should().Be(1);
                 manifests.Should().Contain("android.8.0.200.33.0.2-rc.1");
-                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().version.Should().Be("8.0.200-manifests.4ba11739");
+                sdkDirectoryWorkloadManifestProvider.GetWorkloadVersion().Version.Should().Be("8.0.200-manifests.4ba11739");
             }
 
             Directory.Delete(Path.Combine(_manifestRoot, "8.0.100"), recursive: true);

--- a/test/dotnet-MsiInstallation.Tests/Framework/TestExtensions.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/TestExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.MsiInstallerTests.Framework
+{
+    public static class TestExtensions
+    {
+        public static AndConstraint<CommandResultAssertions> PassWithoutWarning(this CommandResultAssertions assertions)
+        {
+            return assertions.Pass()
+                .And.NotHaveStdOutContaining("Warning: ")
+                .And.NotHaveStdErrContaining("Warning: ");
+        }
+    }
+}

--- a/test/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                     VM.WriteFile($@"c:\SdkTesting\rollback-{rollbackID}.json", manifestContents),
                     VM.CreateRunCommand("dotnet", "workload", "update", "--from-rollback-file", $@"c:\SdkTesting\rollback-{rollbackID}.json", "--skip-sign-check"))
                 .Execute();
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
             return result;
         }
 
@@ -213,10 +213,10 @@ namespace Microsoft.DotNet.MsiInstallerTests
             InstallSdk();
 
             VM.WriteFile($@"c:\SdkTesting\rollback-rc1.json", RollbackRC1)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             VM.CreateRunCommand("dotnet", "workload", "install", "wasm-tools", "--from-rollback-file", $@"c:\SdkTesting\rollback-rc1.json")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             TestWasmWorkload();
         }
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             VM.CreateRunCommand("dotnet", "workload", "update")
                 .Execute()
-                .Should().Pass();
+                .Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().NotBe(workloadVersion);
 
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             //AddNuGetSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-d215c528/nuget/v3/index.json");
 
             //VM.CreateRunCommand("powershell", "-Command", "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }")
-            //    .Execute().Should().Pass();
+            //    .Execute().Should().PassWithoutWarning();
 
             InstallWorkload("aspire", skipManifestUpdate: true);
 
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithWorkingDirectory(@"c:\SdkTesting")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
         }
 
 
@@ -289,13 +289,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithWorkingDirectory(@"c:\SdkTesting")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             var result = VM.CreateRunCommand("dotnet", "publish", "/p:RunAotCompilation=true")
                 .WithWorkingDirectory(@"c:\SdkTesting\BlazorWasm")
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             //  When publishing a blazorwasm project without the wasm-tools workload installed, the following message is displayed:
             //  Publishing without optimizations. Although it's optional for Blazor, we strongly recommend using `wasm-tools` workload! You can install it by running `dotnet workload install wasm-tools` from the command line.
@@ -364,7 +364,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return result.StdOut;            
         }

--- a/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             result.Should().HaveStdOutContaining("aspire");
         }
@@ -39,12 +39,12 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithWorkingDirectory(@"C:\SdkTesting")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             //  build (or any restoring) command should check for and notify of updates
             VM.CreateRunCommand("dotnet", "build")
                 .WithWorkingDirectory(@"C:\SdkTesting\LibraryTest")
-                .Execute().Should().Pass()
+                .Execute().Should().PassWithoutWarning()
                 .And.HaveStdOutContaining("Workload updates are available");
 
             //  Workload list should list the specific workloads that have updates
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute()
                 .Should()
-                .Pass()
+                .PassWithoutWarning()
                 .And
                 .HaveStdOutContaining("Updates are available for the following workload(s): aspire");
         }

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             var originalRollback = GetRollback();
 
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             var newRollback = GetRollback();
 
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             rollbackAfterUpdate = GetRollback();
             updatedWorkloadVersion = GetWorkloadVersion();
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithDescription("Switch mode to workload-set")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(updatedWorkloadVersion);
 
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
 
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews", "--source", @"c:\SdkTesting\EmptySource")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             var newRollback = GetRollback();
 
@@ -157,13 +157,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--version", versionToInstall, "--include-previews")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             VM.CreateRunCommand("dotnet", "workload", "search")
                 .WithIsReadOnly(true)
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(versionToInstall);
 
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             originalRollback = GetRollback(SdkTestingDirectory);
 
-            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{versionToUpdateTo}""}}}}").Execute().Should().Pass();
+            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{versionToUpdateTo}""}}}}").Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion(SdkTestingDirectory).Should().Be(versionToUpdateTo);
 
@@ -285,13 +285,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
             var testProjectFolder = Path.Combine(SdkTestingDirectory, "ConsoleApp");
             VM.CreateRunCommand("dotnet", "new", "console", "-o", "ConsoleApp")
                 .WithWorkingDirectory(SdkTestingDirectory)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             SetupWorkloadSetInGlobalJson(out var originalRollback);
 
             VM.CreateRunCommand("dotnet", "workload", "restore")
                 .WithWorkingDirectory(testProjectFolder)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
 
@@ -306,7 +306,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             SetupWorkloadSetInGlobalJson(out var originalRollback);
 
             string[] args = command.Equals("install") ? ["dotnet", "workload", "install", "aspire"] : ["dotnet", "workload", command];
-            VM.CreateRunCommand(args).WithWorkingDirectory(SdkTestingDirectory).Execute().Should().Pass();
+            VM.CreateRunCommand(args).WithWorkingDirectory(SdkTestingDirectory).Execute().Should().PassWithoutWarning();
             GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
         }
 
@@ -344,12 +344,12 @@ namespace Microsoft.DotNet.MsiInstallerTests
             originalVersion.Should().NotBe(WorkloadSetVersion1);
 
             VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1, "--include-previews")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
 
             VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--version", WorkloadSetVersion2)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
@@ -365,13 +365,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
             originalVersion.Should().NotBe(WorkloadSetVersion1);
 
             VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1, "--include-previews")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
 
             VM.CreateRunCommand("dotnet", "workload", "install", "aspire")
                 .WithWorkingDirectory(SdkTestingDirectory)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
 
@@ -393,10 +393,10 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateActionGroup($"Disable {WorkloadSetVersion2}",
                     VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg", $"Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.bak"),
                     VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg", $"Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.bak"))
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
 
@@ -404,7 +404,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateActionGroup($"Enable {WorkloadSetVersion2}",
                     VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.bak", $"Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg"),
                     VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.bak", $"Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg"))
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             InstallWorkload("aspire", skipManifestUpdate: false);
 
@@ -438,7 +438,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             //  Update to latest workload set version
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
 
@@ -451,22 +451,22 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             //  Downgrade to earlier workload set version
             VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1)
-                .Execute().Should().Pass();
+                .Execute().Should().PassWithoutWarning();
 
             //  Later workload set version should be GC'd
             VM.GetRemoteDirectory(workloadSet2Path).Should().NotExist();
 
             //  Now, pin older workload set version in global.json
-            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{WorkloadSetVersion1}""}}}}").Execute().Should().Pass();
+            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{WorkloadSetVersion1}""}}}}").Execute().Should().PassWithoutWarning();
 
             //  Install pinned version
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
                .WithWorkingDirectory(SdkTestingDirectory)
-               .Execute().Should().Pass();
+               .Execute().Should().PassWithoutWarning();
 
             //  Update globally installed version to later version
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-               .Execute().Should().Pass();
+               .Execute().Should().PassWithoutWarning();
 
             //  Check workload versions in global context and global.json directory
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
@@ -477,11 +477,11 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.GetRemoteDirectory(workloadSet1Path).Should().Exist();
 
             //  Now, remove pinned workload set from global.json
-            VM.WriteFile("C:\\SdkTesting\\global.json", "{}").Execute().Should().Pass();
+            VM.WriteFile("C:\\SdkTesting\\global.json", "{}").Execute().Should().PassWithoutWarning();
 
             //  Run workload update to do a GC
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-               .Execute().Should().Pass();
+               .Execute().Should().PassWithoutWarning();
 
             //  Workload set 1 should have been GC'd
             VM.GetRemoteDirectory(workloadSet1Path).Should().NotExist();
@@ -513,7 +513,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             var searchVersionResult = VM.CreateRunCommand("dotnet", "workload", "search", "version")
                 .WithIsReadOnly(true)
                 .Execute(); ;
-            searchVersionResult.Should().Pass();
+            searchVersionResult.Should().PassWithoutWarning();
 
             //  Without source set up, there should be no workload sets found
             searchVersionResult.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
@@ -527,7 +527,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             searchVersionResult = VM.CreateRunCommand("dotnet", "workload", "search", "version")
                 .WithIsReadOnly(true)
                 .Execute();
-            searchVersionResult.Should().Pass();
+            searchVersionResult.Should().PassWithoutWarning();
             var actualVersions = searchVersionResult.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
             actualVersions.Should().Equal(WorkloadSetVersion2, WorkloadSetVersion1);
 
@@ -537,7 +537,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute();
 
-            searchVersionResult.Should().Pass();
+            searchVersionResult.Should().PassWithoutWarning();
 
             var searchResultJson = JsonNode.Parse(searchVersionResult.StdOut);
             var searchResultWorkloadSet = WorkloadSet.FromDictionaryForJson(JsonSerializer.Deserialize<Dictionary<string, string>>(searchResultJson["manifestVersions"]), new SdkFeatureBand(SdkInstallerVersion));
@@ -546,7 +546,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews", "--version", WorkloadSetVersion2)
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
 
             GetRollback().ManifestVersions.Should().BeEquivalentTo(searchResultWorkloadSet.ManifestVersions);
         }
@@ -558,7 +558,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return result.StdOut;
         }
@@ -568,7 +568,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return result.StdOut;
         }
@@ -580,7 +580,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .WithDescription($"Add {source} to NuGet.config")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
         }
     }
 }

--- a/test/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/test/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -48,6 +48,6 @@ namespace ManifestReaderTests
         }
 
         public string GetSdkFeatureBand() => SdkFeatureBand.ToString();
-        public string GetWorkloadVersion() => SdkFeatureBand.ToString() + ".2";
+        public (string version, string error) GetWorkloadVersion() => (SdkFeatureBand.ToString() + ".2", null);
     }
 }

--- a/test/dotnet-workload-install.Tests/MockManifestProvider.cs
+++ b/test/dotnet-workload-install.Tests/MockManifestProvider.cs
@@ -48,6 +48,6 @@ namespace ManifestReaderTests
         }
 
         public string GetSdkFeatureBand() => SdkFeatureBand.ToString();
-        public (string version, string error) GetWorkloadVersion() => (SdkFeatureBand.ToString() + ".2", null);
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo(SdkFeatureBand.ToString() + ".2");
     }
 }

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,11 +39,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public (WorkloadVersion version, string error) GetWorkloadVersion() => (new WorkloadVersion()
-        {
-            Version = "12.0.400.2",
-            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
-        }, null);
+        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,11 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
+        public (WorkloadVersion version, string error) GetWorkloadVersion() => (new WorkloadVersion()
+        {
+            Version = "12.0.400.2",
+            WorkloadInstallType = WorkloadVersion.Type.LooseManifest
+        }, null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo("12.0.400.2");
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         public string GetSdkFeatureBand() => "12.0.400";
-        public string GetWorkloadVersion() => "12.0.400.2";
+        public (string version, string error) GetWorkloadVersion() => ("12.0.400.2", null);
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/42527.

This PR is an update to #42683, I rebased the changes so I couldn't push to @Forgind's original branch.

Sample output when SDK is in workload set update mode but no workload set is installed:

```
C:\SdkTesting>dotnet workload --version
9.0.100-manifests.91e63147


C:\SdkTesting>dotnet workload --info
 Workload version: 9.0.100-manifests.91e63147
 Configured to use workload sets when installing new manifests.
 Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.

 [aspire]
   Installation Source: SDK 9.0.100-preview.6
   Manifest Version:    9.0.0-preview.4.24456.4/8.0.100
   Manifest Path:       C:\Program Files\dotnet\sdk-manifests\8.0.100\microsoft.net.sdk.aspire\9.0.0-preview.4.24456.4\WorkloadManifest.json
   Install Type:              Msi



C:\SdkTesting>dotnet --info
.NET SDK:
 Version:           9.0.100-preview.6.24328.19
 Commit:            b7dcdeb43c
 Workload version:  9.0.100-manifests.91e63147
 MSBuild version:   17.12.0-preview-24461-13+3b9f2e956

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22631
 OS Platform: Windows
 RID:         win-x64
 Base Path:   C:\Program Files\dotnet\sdk\9.0.100-preview.6.24328.19\

.NET workloads installed:
 [aspire]
   Installation Source: SDK 9.0.100-preview.6
   Manifest Version:    9.0.0-preview.4.24456.4/8.0.100
   Manifest Path:       C:\Program Files\dotnet\sdk-manifests\8.0.100\microsoft.net.sdk.aspire\9.0.0-preview.4.24456.4\WorkloadManifest.json
   Install Type:              Msi

Configured to use workload sets when installing new manifests.
Workloads are configured to install and update using workload versions, but none were found. Run "dotnet workload restore" to install a workload version.

Host:
  Version:      9.0.0-rc.2.24459.11
  Architecture: x64
  Commit:       static

.NET SDKs installed:
  9.0.100-preview.6.24328.19 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 9.0.0-preview.6.24328.4 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 9.0.0-preview.6.24327.7 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 9.0.0-rc.2.24459.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 9.0.0-preview.6.24327.6 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Other architectures found:
  None

Environment variables:
  Not set

global.json file:
  Not found

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download
```

Sample output when global.json specifies a workload set that isn't installed:

```
C:\SdkTesting\ConsoleApp>dotnet workload --version
9.0.100-preview.6.24352.3 (not installed)


C:\SdkTesting\ConsoleApp>dotnet workload --info
 Workload version: 9.0.100-preview.6.24352.3 (not installed)
 Configured to use loose manifests when installing new manifests.
 Workload version 9.0.100-preview.6.24352.3, which was specified in C:\SdkTesting\global.json, was not found. Run "dotnet workload restore" to install this workload version.

There are no installed workloads to display.


C:\SdkTesting\ConsoleApp>dotnet --info
.NET SDK:
 Version:           9.0.100-preview.6.24328.19
 Commit:            b7dcdeb43c
 Workload version:  9.0.100-preview.6.24352.3 (not installed)
 MSBuild version:   17.12.0-preview-24461-13+3b9f2e956

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22631
 OS Platform: Windows
 RID:         win-x64
 Base Path:   C:\Program Files\dotnet\sdk\9.0.100-preview.6.24328.19\

.NET workloads installed:
There are no installed workloads to display.
Configured to use loose manifests when installing new manifests.
Workload version 9.0.100-preview.6.24352.3, which was specified in C:\SdkTesting\global.json, was not found. Run "dotnet workload restore" to install this workload version.

Host:
  Version:      9.0.0-rc.2.24459.11
  Architecture: x64
  Commit:       static

.NET SDKs installed:
  9.0.100-preview.6.24328.19 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 9.0.0-preview.6.24328.4 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 9.0.0-preview.6.24327.7 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 9.0.0-rc.2.24459.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 9.0.0-preview.6.24327.6 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Other architectures found:
  None

Environment variables:
  Not set

global.json file:
  C:\SdkTesting\global.json

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download
```