### PR TITLE
Fix the formatting of the onelocbuildconditional

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -82,7 +82,7 @@ parameters:
 
 jobs:
 ### ONELOCBUILD ###
-- ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/${{ parameters.locBranch }}')) }}:
+- ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', parameters.locBranch))) }}:
   - template: /eng/common/${{ parameters.oneESCompat.templateFolderName }}/job/onelocbuild.yml
     parameters:
       CreatePr: true


### PR DESCRIPTION
It looks like you can't use {{}} inside an existing {{}} which was causing this if check to fail always.