### PR TITLE
[StaticWebAssets] Fix legacy package definitions design time builds

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -694,7 +694,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="UpdateExistingPackageStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="UpdateExistingPackageStaticWebAssets">
     <UpdatePackageStaticWebAssets Assets="@(StaticWebAsset)">
       <Output TaskParameter="UpdatedAssets" ItemName="_UpdatedPackageAssets" />
       <Output TaskParameter="OriginalAssets" ItemName="_OriginalPackageAssets" />


### PR DESCRIPTION
A target that was not running during design time builds, needs to run.

## Description

An error shows up in Visual Studio due to a failed build that is caused by a target that needs to run as part of the design build and wasn't running.

![image](https://github.com/user-attachments/assets/f0d7a487-f53e-4719-84ba-55784a805603)
![image](https://github.com/user-attachments/assets/178352bc-5bbd-471f-b0a7-b8be499bb289)

The issue only happens when the app references a package that was built with an older SDK as it contains an older definition for the assets in the package.

The build automatically upgrades assets from older versions to newer versions, however the target in charge of that wasn't running on Design time builds and is now required to do so after the fix we did for accelerated builds.

Fixes #https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2248967

## Customer Impact

Design time builds in Visual Studio produce an error when the application uses a package that contains older definitions for assets.

## Regression?

- [X] Yes
- [ ] No

Yes, 8.0

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix allows the required target to run on Design builds as needed.

## Verification

- [X] Manual (required)
- [ ] Automated

Validated the fix by modifying the SDK locally and validating that the error disappears.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props