### PR TITLE
Pass official build id props via /p:

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -13,7 +13,7 @@
     <RunEachTargetSeparately Condition="'$(BuildInParallel)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">true</RunEachTargetSeparately>
   </PropertyGroup>
 
-  <Import Project="$(GitInfoRepoPropsFile)" Condition="Exists('$(GitInfoRepoPropsFile)')" />
+  <Import Project="$(GitInfoRepoPropsFile)" Condition="Exists('$(GitInfoRepoPropsFile)') and '$(UseOfficialBuildVersioning)' != 'false'" />
 
   <PropertyGroup>
     <!-- Fake, to satisfy the SDK. -->
@@ -84,6 +84,7 @@
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
+    <BuildArgs Condition="'$(OfficialBuildId)' != ''">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
@@ -136,19 +137,6 @@
          See https://github.com/dotnet/source-build/issues/541 -->
     <EnvironmentVariables Include="MSBUILDDISABLENODEREUSE=1" />
 
-  </ItemGroup>
-
-  <!--
-    Apply official build versioning to match Microsoft build. These are based on build date, so
-    need to be parsed from Maestro++ auto-update and passed through.
-  -->
-  <ItemGroup Condition="'$(UseOfficialBuildVersioning)' != 'false'">
-    <EnvironmentVariables Include="OfficialBuildId=$(OfficialBuildId)" />
-    <EnvironmentVariables Include="BUILD_BUILDNUMBER=$(OfficialBuildId)" />
-
-    <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
-    <EnvironmentVariables Include="PreReleaseVersionLabel=$(PreReleaseVersionLabel)" />
-    <EnvironmentVariables Include="PackageVersionStamp=$(PreReleaseVersionLabel)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR does a bit of cleanup on some of the version props we were passing around.
- Let the repo determine the pre-release version label (vs. gitinfo)
- Pass the official build id via /p: and eliminate other env var passings, which I do not believe are in use any longer.
- Conditionalize gitinfo import on using MS official versioning

The upshot of all this is that there should be no change to the default builds and if you pass /p:OfficialBuildId=OBID and /p:UseOfficialBuildVersioning=false, you'll get a stack with all of the package date suffixes.