### PR TITLE
Fix SelfContained build/publish when FrameworkReference with profile is combined with FrameworkReference without profile

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -31,14 +31,13 @@ namespace Microsoft.NET.Build.Tasks
 
             // Find any RuntimeFrameworks that matches with FrameworkReferences, so that we can apply that RuntimeFrameworks profile to the corresponding RuntimePack.
             // This is done in 2 parts, First part (see comments for 2nd part further below), we match the RuntimeFramework with the FrameworkReference by using the following metadata.
-            // RuntimeFrameworks.GetMetadata("FrameworkName")==FrameworkReferences.ItemSpec AND RuntimeFrameworks.GetMetadata("Profile") is not empty
+            // RuntimeFrameworks.GetMetadata("FrameworkName")==FrameworkReferences.ItemSpec
             // For example, A WinForms app that uses useWindowsForms (and useWPF will be set to false) has the following values that will result in a match of the below RuntimeFramework.
             // FrameworkReferences with an ItemSpec "Microsoft.WindowsDesktop.App.WindowsForms" will match with 
             // RuntimeFramework with an ItemSpec => "Microsoft.WindowsDesktop.App", GetMetadata("FrameworkName") => "Microsoft.WindowsDesktop.App.WindowsForms", GetMetadata("Profile") => "WindowsForms"
             List<ITaskItem> matchingRuntimeFrameworks = RuntimeFrameworks != null ? FrameworkReferences
                     .SelectMany(fxReference => RuntimeFrameworks.Where(rtFx =>
-                        fxReference.ItemSpec.Equals(rtFx.GetMetadata(MetadataKeys.FrameworkName), StringComparison.OrdinalIgnoreCase) &&
-                        !string.IsNullOrEmpty(rtFx.GetMetadata("Profile"))))
+                        fxReference.ItemSpec.Equals(rtFx.GetMetadata(MetadataKeys.FrameworkName), StringComparison.OrdinalIgnoreCase)))
                         .ToList() : null;
 
             HashSet<string> frameworkReferenceNames = new(FrameworkReferences.Select(item => item.ItemSpec), StringComparer.OrdinalIgnoreCase);
@@ -91,6 +90,13 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         profiles.Add("Xaml");
                     }
+                }
+
+                //  If we have a runtime framework with an empty profile, it means that we should use all of the contents of the runtime pack,
+                //  so we can clear the profile list
+                if (profiles.Contains(string.Empty))
+                {
+                    profiles.Clear();
                 }
 
                 string runtimePackRoot = runtimePack.GetMetadata(MetadataKeys.PackageDirectory);


### PR DESCRIPTION
Fixes #43461.  This was an issue with how profiles were handled for self-contained apps

## Customer impact

In some situations, a self-contained app that should include both WPF and Windows Forms assemblies would be missing either WPF or Windows Forms assemblies, causing the application to crash on startup.  In #43461, this was reported with a combination of Microsoft, DevExpress, and other third-party packages.  In general, this could happen with any app that sets both `UseWindowsForms` and `UseWPF` to true, and references a NuGet package that depends only on Windows Forms (or only on WPF).

## Regression

Yes, in .NET 9 we added the ability for runtime packs to have profiles, so that self-contained (and especially AOT) apps could include the Windows Forms implementation but not WPF, or vice versa.  This was added in https://github.com/dotnet/sdk/pull/39402.  This new logic didn't correctly handle the case where there was a `FrameworkReference` to a profile and also a `FrameworkReference` without a profile, which should cause the entire framework to be include.

## Testing
- Verified that repro supplied with bug passes after fix
- Added automated test to cover scenario

## Risk
Low - fairly simple change to code that was added for .NET 9.
