### PR TITLE
Port to 9.0.1xx: Fix processing non-public classes and generic types in AssemblyScheduler.cs (#43377)

### DIFF
--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -267,13 +267,14 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         /// </summary>
         private static bool ShouldIncludeType(MetadataReader reader, TypeDefinition type, int testMethodCount)
         {
-            // xunit only handles public, non-abstract classes
+            // xunit only handles public, non-abstract, non-generic classes
             var isPublic =
-                TypeAttributes.Public == (type.Attributes & TypeAttributes.Public) ||
-                TypeAttributes.NestedPublic == (type.Attributes & TypeAttributes.NestedPublic);
+                TypeAttributes.Public == (type.Attributes & TypeAttributes.VisibilityMask) ||
+                TypeAttributes.NestedPublic == (type.Attributes & TypeAttributes.VisibilityMask);
             if (!isPublic ||
                 TypeAttributes.Abstract == (type.Attributes & TypeAttributes.Abstract) ||
-                TypeAttributes.Class != (type.Attributes & TypeAttributes.Class))
+                type.GetGenericParameters().Count != 0 ||
+                TypeAttributes.Class != (type.Attributes & TypeAttributes.ClassSemanticsMask))
             {
                 return false;
             }


### PR DESCRIPTION
While looking at why https://github.com/dotnet/sdk/pull/43295 is having issues running on Helix I noticed that we were passing ``-class "Microsoft.WebTools.AspireServer.UnitTests.MockFactory`1"`` to the test script which caused a parse error because of the backtick.

We shouldn't pass generic types since xunit can't do anything with it.

Additionally I noticed that we were passing some nested types even though they were internal. This is because we didn't check the visibility correctly, we must use `TypeAttributes.VisibilityMask` to check for just the visibility (the same also applies to checking for class). See https://learn.microsoft.com/en-us/dotnet/api/system.reflection.typeattributes?view=net-8.0&redirectedfrom=MSDN#examples