### PR TITLE
Do not sync `internal/release/8.0.402` into VMR

### DIFF
--- a/eng/pipelines/vmr-sync-internal.yml
+++ b/eng/pipelines/vmr-sync-internal.yml
@@ -9,6 +9,7 @@ trigger:
     - internal/release/*.0.2xx
     - internal/release/*.0.3xx
     - internal/release/*.0.4xx
+    - internal/release/8.0.4*
 
 resources:
   repositories:


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/3967