### PR TITLE
[release/8.0.4xx] Fix NullReferenceException for `dotnet tool update -g --all`

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tool.Common;
+using Microsoft.Extensions.EnvironmentAbstractions;
 using CreateShellShimRepository = Microsoft.DotNet.Tools.Tool.Install.CreateShellShimRepository;
 
 namespace Microsoft.DotNet.Tools.Tool.Update
@@ -43,16 +44,17 @@ namespace Microsoft.DotNet.Tools.Tool.Update
                         localToolsResolverCache,
                         reporter);
 
+            _global = result.GetValue(ToolInstallCommandParser.GlobalOption);
+            _toolPath = result.GetValue(ToolInstallCommandParser.ToolPathOption);
+            DirectoryPath? location = string.IsNullOrWhiteSpace(_toolPath) ? null : new DirectoryPath(_toolPath);
             _toolUpdateGlobalOrToolPathCommand =
                 toolUpdateGlobalOrToolPathCommand
                 ?? new ToolUpdateGlobalOrToolPathCommand(
                     result,
                     createToolPackageStoreDownloaderUninstaller,
                     createShellShimRepository,
-                    reporter);
-
-            _global = result.GetValue(ToolInstallCommandParser.GlobalOption);
-            _toolPath = result.GetValue(ToolInstallCommandParser.ToolPathOption);
+                    reporter,
+                    ToolPackageFactory.CreateToolPackageStoreQuery(location));
         }
 
 


### PR DESCRIPTION
Summary

Running dotnet tool update -g -all would fail starting in 8.0.4xx. A fix is pending for that branch as well which has different code. This is due to a NullReferenceException -- when calling a delegate function it can return null in the global mode and thus did not check whether the member was null correctly.

Customer Impact

For customers upgrading from any .NET version before 8.0.4xx, customers and CI would be broken as well in any scenario that requires updating a global .NET Tool.

Regression

This was an existing behavior in 8.0.4xx where update --all has been totally broken with -g.

Testing

Manual testing has been done to confirm the behavior before and after. A test is not provided due to the nature of the change requiring the store, which is an online component and the issue is not exposable with the mocking code that is currently in place.

Risk

The risk is low; the behavior did not work before. It adds protection against the 'store' or source of places to get .NET tools from being null, which is the expected case with a global tool install.

--
Backports #43157 to .NET 8 and addresses #42598.

#43158 does not need backporting as the related optimization was not applied to .NET 8.