### PR TITLE
Revert "[release/8.0.4xx] Fix NullReferenceException for `dotnet tool update -g --all`"

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tool.Common;
-using Microsoft.Extensions.EnvironmentAbstractions;
 using CreateShellShimRepository = Microsoft.DotNet.Tools.Tool.Install.CreateShellShimRepository;
 
 namespace Microsoft.DotNet.Tools.Tool.Update
@@ -44,17 +43,16 @@ namespace Microsoft.DotNet.Tools.Tool.Update
                         localToolsResolverCache,
                         reporter);
 
-            _global = result.GetValue(ToolInstallCommandParser.GlobalOption);
-            _toolPath = result.GetValue(ToolInstallCommandParser.ToolPathOption);
-            DirectoryPath? location = string.IsNullOrWhiteSpace(_toolPath) ? null : new DirectoryPath(_toolPath);
             _toolUpdateGlobalOrToolPathCommand =
                 toolUpdateGlobalOrToolPathCommand
                 ?? new ToolUpdateGlobalOrToolPathCommand(
                     result,
                     createToolPackageStoreDownloaderUninstaller,
                     createShellShimRepository,
-                    reporter,
-                    ToolPackageFactory.CreateToolPackageStoreQuery(location));
+                    reporter);
+
+            _global = result.GetValue(ToolInstallCommandParser.GlobalOption);
+            _toolPath = result.GetValue(ToolInstallCommandParser.ToolPathOption);
         }
 
 


### PR DESCRIPTION
Reverts dotnet/sdk#43550 -- this change was not yet approved and it needs to get approval before we can merge it. We need to merge this PR and then remerge the other one after approval. I doubt it's 'early enough' that we can just leave it and get it approved after the fact.