### PR TITLE
Add registry search for upgrade policy keys

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -87,7 +87,7 @@
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>3.2.2146</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftWindowsCsWin32PackageVersion>0.3.49-beta</MicrosoftWindowsCsWin32PackageVersion>
     <!-- This is the version of the zip archive for the WiX toolset and is different from the NuGet package version format. -->
-    <WixVersion>3.14.1.8722</WixVersion>
+    <WixVersion>3.14.1-9313.2537997</WixVersion>
   </PropertyGroup>
   <PropertyGroup Label="NUnit3.DotNetNew.Template version">
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->

--- a/src/Installer/redist-installer/packaging/windows/bundle.wxs
+++ b/src/Installer/redist-installer/packaging/windows/bundle.wxs
@@ -34,6 +34,11 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
+    <!-- Search references for upgrade policy keys -->
+    <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"
               Result="exists"

--- a/src/Installer/redist-installer/packaging/windows/generatebundle.ps1
+++ b/src/Installer/redist-installer/packaging/windows/generatebundle.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 param(
+    [Parameter(Mandatory=$true)][string]$UpgradePoliciesWxsFile,
     [Parameter(Mandatory=$true)][string]$WorkloadManifestWxsFile,
     [Parameter(Mandatory=$true)][string]$CLISDKMSIFile,
     [Parameter(Mandatory=$true)][string]$ASPNETRuntimeWixLibFile,
@@ -53,7 +54,9 @@ function RunCandleForBundle
         -dSDKProductBandVersion="$SDKProductBandVersion" `
         -dNugetVersion="$DotnetCLINugetVersion" `
         -dVersionMajor="$VersionMajor" `
+        -dMajorVersion="$VersionMajor" `
         -dVersionMinor="$VersionMinor" `
+        -dMinorVersion="$VersionMinor" `
         -dCLISDKMsiSourcePath="$CLISDKMSIFile" `
         -dDependencyKeyName="$DependencyKeyName" `
         -dUpgradeCode="$UpgradeCode" `
@@ -82,7 +85,7 @@ function RunCandleForBundle
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `
         -ext WixTagExtension.dll `
-        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile"
+        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile" "$UpgradePoliciesWxsFile"
 
     Write-Information "Candle output: $candleOutput"
 
@@ -102,6 +105,7 @@ function RunLightForBundle
     pushd "$WixRoot"
 
     $WorkloadManifestWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($WorkloadManifestWxsFile) + ".wixobj"
+    $UpgradePoliciesWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($UpgradePoliciesWxsFile) + ".wixobj"
 
     Write-Information "Running light for bundle.."
 
@@ -109,6 +113,7 @@ function RunLightForBundle
         -cultures:en-us `
         bundle.wixobj `
         $WorkloadManifestWixobjFile `
+        $UpgradePoliciesWixobjFile `
         $ASPNETRuntimeWixlibFile `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `

--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -319,9 +319,11 @@
     </ItemGroup>
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
+      <UpgradePoliciesSrcPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle\upgradePolicies.wxs</UpgradePoliciesSrcPath>
     </PropertyGroup>
 
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
+                      -UpgradePoliciesWxsFile '$(UpgradePoliciesSrcPath)' ^
                       -WorkloadManifestWxsFile '$(WorkloadManifestsWxsPath)' ^
                       -CLISDKMSIFile '$(SdkMSIInstallerFile)' ^
                       -ASPNETRuntimeWixLibFile '$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)' ^
@@ -358,6 +360,7 @@
     <ItemGroup>
         <BundleMsiWixSrcFiles Include="$(WixRoot)\bundle.wixobj" />
         <BundleMsiWixSrcFiles Include="$(WixRoot)\WorkloadManifests.wixobj" />
+        <BundleMsiWixSrcFiles Include="$(WixRoot)\upgradePolicies.wixobj" />
         <BundleMsiWixSrcFiles Include="$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)" />
     </ItemGroup>
     <CreateLightCommandPackageDrop
@@ -368,7 +371,7 @@
       InstallerFile="$(CombinedFrameworkSdkHostMSIInstallerFile)"
       WixExtensions="WixBalExtension;WixUtilExtension;WixTagExtension"
       WixSrcFiles="@(BundleMsiWixSrcFiles)"
-      AdditionalBasePaths="$(SdkPkgSourcesRootDirectory)">
+      AdditionalBasePaths="$(SdkPkgSourcesRootDirectory);$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
   </Target>


### PR DESCRIPTION
# Description
Add registry search operations to SDK installer bundles. The search operation will check for a global and version specific registry key. The version specific key takes precedence when present.

This is related to a customer request and part of a larger change. 

Unlike the runtime and desktop runtime, the SDK needs to explicitly pull in the additional source file.

# Risk
Medium/Low - this change modifies how bundles behave when upgrading. It is based off a modified copy of wixstdba (bootstrapper and UI layer) with changes to Burn (setup engine) and a copy of WiX v3 built from source.

# Testing
We've been testing the change for a while now. Verified against a private build of SDK. Log excerpt below. The test machine contained the version specific key for .NET 9.0 and shows that the override in the custom BA kicked in, opting to defer the removal. Once we have the installers in-hand, we'll do a more complete pass to look for any regressions.

```
[156C:175C][2024-09-18T14:44:44]i000: Setting numeric variable 'RemoveSpecificPreviousVersionRegistryKeyExists' to value 1
[156C:175C][2024-09-18T14:44:44]i052: Condition 'RemoveSpecificPreviousVersionRegistryKeyExists=1' evaluates to true.
[156C:175C][2024-09-18T14:44:44]i000: Setting string variable 'RemoveUpgradeRelatedBundle' to value 'nextSession'
[156C:175C][2024-09-18T14:44:44]i102: Detected related bundle: {c8110f4c-9390-43c5-840a-23131dd048ac}, type: Upgrade, scope: PerMachine, version: 9.1.24.45212, operation: MajorUpgrade
[156C:175C][2024-09-18T14:46:24]i000: Deferring removal of upgrade related bundle until the next session.
[156C:175C][2024-09-18T14:46:24]i202: Planned bundle: {c8110f4c-9390-43c5-840a-23131dd048ac}, ba requested state: NextSessionAbsent over default: Absent
```

ARP shows both the RC1 and custom build RC2 SDKs installed

![image](https://github.com/user-attachments/assets/20c9d39c-c3a5-4bc1-9d1f-f572f862c779)

And the RunOnce key for the removal is present to uninstall RC1

![image](https://github.com/user-attachments/assets/c51fc5e4-85c5-4add-8d40-652f44942a00)
