### PR TITLE
T00001 - Insecure temporary file creation methods should not be used

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         // Virtual for testing.
         public virtual async ValueTask<EvaluationResult?> TryCreateAsync(CancellationToken cancellationToken)
         {
-            var watchList = Path.GetTempFileName();
+            var watchList = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             try
             {
                 var projectDir = Path.GetDirectoryName(rootProjectFile);


### PR DESCRIPTION
[OWASP](https://owasp.org/www-community/vulnerabilities/Insecure_Temporary_File) - Insecure Temporary File