### PR TITLE
T00002 - Insecure temporary file creation methods should not be used

### DIFF
--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -337,7 +337,7 @@ namespace Microsoft.DotNet.CommandFactory
                 LocalizableStrings.GeneratingDepsJson,
                 depsPath));
 
-            var tempDepsFile = Path.GetTempFileName();
+            var tempDepsFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
             var args = new List<string>();
 


### PR DESCRIPTION
[OWASP](https://owasp.org/www-community/vulnerabilities/Insecure_Temporary_File) - Insecure Temporary File