### PR TITLE
[release/9.0.1xx] Publish prebuilt reports for each repo

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -464,6 +464,10 @@ jobs:
         CopyWithRelativeFolders "src/"                       $targetFolder "*.binlog"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.log"
 
+        if (Test-Path "src/**/artifacts/sb/prebuilt-report/") {
+            CopyWithRelativeFolders "src/**/artifacts/sb/prebuilt-report/" $targetFolder "*"
+        }
+
         if (Test-Path "artifacts/scenario-tests/") {
             CopyWithRelativeFolders "artifacts/scenario-tests/" $targetFolder "*.binlog"
             echo "##vso[task.setvariable variable=hasScenarioTestResults]true"
@@ -517,6 +521,10 @@ jobs:
 
         find src/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
         find src/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;
+
+        if [ $(find src/**/artifacts/sb/prebuilt-report/ -type d | wc -l) -gt 0 ]; then
+          find src/**/artifacts/sb/prebuilt-report/ -type f -exec rsync -R {} -t ${targetFolder} \;
+        fi
 
         # check if we have assets to publish
         if [ -n "$(ls -A 'artifacts/assets/Release/')" ]; then

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -553,6 +553,7 @@
       <DirsToDeleteWithTrailingSeparator Include="$([MSBuild]::EnsureTrailingSlash('%(DirsToDelete.Identity)'))" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildLogsDir)" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildObjDir)" />
+      <DirsToDeleteWithTrailingSeparator Remove="$(ProjectDirectory)artifacts/sb/" />
     </ItemGroup>
 
     <Message Text="DirSize After Building $(RepositoryName)" Importance="High" Condition="'$(BuildOS)' != 'windows' and '@(DirsToDeleteWithTrailingSeparator)' != ''" />


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/43336

<h1></h1>

Fixes https://github.com/dotnet/source-build/issues/4160

Store the prebuilt files for each repo as pipeline artifacts rather than the overall build's prebuilt report, which will make investigations of prebuilt go more quickly.