### PR TITLE
[release/9.0.1xx] Publish prebuilt reports for each repo

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -464,6 +464,10 @@ jobs:
         CopyWithRelativeFolders "src/"                       $targetFolder "*.binlog"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.log"
 
+        if (Test-Path "src/**/artifacts/prebuilt-report/") {
+            CopyWithRelativeFolders "src/**/artifacts/prebuilt-report/" $targetFolder "*"
+        }
+
         if (Test-Path "artifacts/scenario-tests/") {
             CopyWithRelativeFolders "artifacts/scenario-tests/" $targetFolder "*.binlog"
             echo "##vso[task.setvariable variable=hasScenarioTestResults]true"
@@ -517,6 +521,10 @@ jobs:
 
         find src/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
         find src/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;
+
+        if [ $(find src/**/artifacts/prebuilt-report/ -type d | wc -l) -gt 0 ]; then
+          find src/**/artifacts/prebuilt-report/ -type f -exec rsync -R {} -t ${targetFolder} \;
+        fi
 
         # check if we have assets to publish
         if [ -n "$(ls -A 'artifacts/assets/Release/')" ]; then

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -464,10 +464,6 @@ jobs:
         CopyWithRelativeFolders "src/"                       $targetFolder "*.binlog"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.log"
 
-        if (Test-Path "src/**/artifacts/prebuilt-report/") {
-            CopyWithRelativeFolders "src/**/artifacts/prebuilt-report/" $targetFolder "*"
-        }
-
         if (Test-Path "artifacts/scenario-tests/") {
             CopyWithRelativeFolders "artifacts/scenario-tests/" $targetFolder "*.binlog"
             echo "##vso[task.setvariable variable=hasScenarioTestResults]true"
@@ -521,10 +517,6 @@ jobs:
 
         find src/ -type f -name "*.binlog" -exec rsync -R {} -t ${targetFolder} \;
         find src/ -type f -name "*.log" -exec rsync -R {} -t ${targetFolder} \;
-
-        if [ $(find src/**/artifacts/prebuilt-report/ -type d | wc -l) -gt 0 ]; then
-          find src/**/artifacts/prebuilt-report/ -type f -exec rsync -R {} -t ${targetFolder} \;
-        fi
 
         # check if we have assets to publish
         if [ -n "$(ls -A 'artifacts/assets/Release/')" ]; then

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -171,7 +171,8 @@
 
     <PackageReportDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'prebuilt-report'))</PackageReportDir>
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
-
+    <DotNetBuildPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', '$(MSBuildProjectName)'))</DotNetBuildPrebuiltReportDir>
+    
     <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -511,6 +511,19 @@
           Condition="'@(_InnerPackageCacheFiles)' != ''" />
   </Target>
 
+  <Target Name="MoveDotNetBuildLogs"
+        Condition="'$(IsUtilityProject)' != 'true' and
+                    Exists('$(ProjectDirectory)artifacts')">
+    <ItemGroup>
+      <PrebuiltReportsToMove Include="$(ProjectDirectory)artifacts/sb/prebuilt-report/*" />
+    </ItemGroup>
+
+    <!-- Move the prebuilt reports -->
+    <Move SourceFiles="@(PrebuiltReportsToMove)"
+          DestinationFolder="$(DotNetBuildPrebuiltReportDir)"
+          Condition="'@(PrebuiltReportsToMove)' != ''" />
+  </Target>
+
   <Target Name="CleanupRepo"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)CleanupRepo.complete"
@@ -531,14 +544,12 @@
     <PropertyGroup>
       <BuildLogsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'buildLogs'))</BuildLogsDir>
       <BuildObjDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'buildObj'))</BuildObjDir>
-      <PrebuiltReportsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'prebuilt-report'))</PrebuiltReportsDir>
     </PropertyGroup>
 
     <ItemGroup>
       <LogFilesToCopy Include="$(ProjectDirectory)artifacts/**/*.log" />
       <LogFilesToCopy Include="$(ProjectDirectory)artifacts/**/*.binlog" />
       <ObjFilesToCopy Include="$(ProjectDirectory)artifacts/**/project.assets.json" />
-      <PrebuiltReportsToMove Include="$(ProjectDirectory)artifacts/sb/prebuilt-report/*" />
     </ItemGroup>
 
     <!-- Make a copy of the build logs & project.assets.json files -->
@@ -548,11 +559,6 @@
     <Copy SourceFiles="@(ObjFilesToCopy)"
           DestinationFolder="$(BuildObjDir)%(RecursiveDir)"
           Condition="'@(ObjFilesToCopy)' != ''" />
-
-    <!-- Move the prebuilt reports -->
-    <Move SourceFiles="@(PrebuiltReportsToMove)"
-          DestinationFolder="$(PrebuiltReportsDir)"
-          Condition="'@(PrebuiltReportsToMove)' != ''" />
 
     <ItemGroup>
       <DirsToDelete Include="$([System.IO.Directory]::GetDirectories('$(ProjectDirectory)artifacts'))" />
@@ -634,6 +640,7 @@
     LogRepoArtifacts;
     CopyInnerBuildRestoredPackages;
     ExtractToolPackage;
+    MoveDotNetBuildLogs;
     CleanupRepo" />
 
   <Target Name="Test">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -566,7 +566,6 @@
       <DirsToDeleteWithTrailingSeparator Include="$([MSBuild]::EnsureTrailingSlash('%(DirsToDelete.Identity)'))" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildLogsDir)" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildObjDir)" />
-      <DirsToDeleteWithTrailingSeparator Remove="$(PrebuiltReportsDir)" />
     </ItemGroup>
 
     <Message Text="DirSize After Building $(RepositoryName)" Importance="High" Condition="'$(BuildOS)' != 'windows' and '@(DirsToDeleteWithTrailingSeparator)' != ''" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -531,12 +531,14 @@
     <PropertyGroup>
       <BuildLogsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'buildLogs'))</BuildLogsDir>
       <BuildObjDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'buildObj'))</BuildObjDir>
+      <PrebuiltReportsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'prebuilt-report'))</PrebuiltReportsDir>
     </PropertyGroup>
 
     <ItemGroup>
       <LogFilesToCopy Include="$(ProjectDirectory)artifacts/**/*.log" />
       <LogFilesToCopy Include="$(ProjectDirectory)artifacts/**/*.binlog" />
       <ObjFilesToCopy Include="$(ProjectDirectory)artifacts/**/project.assets.json" />
+      <PrebuiltReportsToMove Include="$(ProjectDirectory)artifacts/sb/prebuilt-report/*" />
     </ItemGroup>
 
     <!-- Make a copy of the build logs & project.assets.json files -->
@@ -547,12 +549,18 @@
           DestinationFolder="$(BuildObjDir)%(RecursiveDir)"
           Condition="'@(ObjFilesToCopy)' != ''" />
 
+    <!-- Move the prebuilt reports -->
+    <Move SourceFiles="@(PrebuiltReportsToMove)"
+          DestinationFolder="$(PrebuiltReportsDir)"
+          Condition="'@(PrebuiltReportsToMove)' != ''" />
+
     <ItemGroup>
       <DirsToDelete Include="$([System.IO.Directory]::GetDirectories('$(ProjectDirectory)artifacts'))" />
 
       <DirsToDeleteWithTrailingSeparator Include="$([MSBuild]::EnsureTrailingSlash('%(DirsToDelete.Identity)'))" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildLogsDir)" />
       <DirsToDeleteWithTrailingSeparator Remove="$(BuildObjDir)" />
+      <DirsToDeleteWithTrailingSeparator Remove="$(PrebuiltReportsDir)" />
     </ItemGroup>
 
     <Message Text="DirSize After Building $(RepositoryName)" Importance="High" Condition="'$(BuildOS)' != 'windows' and '@(DirsToDeleteWithTrailingSeparator)' != ''" />


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/43336

<h1></h1>

Fixes https://github.com/dotnet/source-build/issues/4160

Store the prebuilt files for each repo as pipeline artifacts rather than the overall build's prebuilt report, which will make investigations of prebuilt go more quickly.

I introduced a new property `DotNetBuildPrebuiltReportDir` which point to `artifacts\prebuilt-report\<reponame>\`, all repo's prebuilt reports will respect this property and move to that folder.