### PR TITLE
License false positive exclusion for zlib cmake file

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -153,6 +153,7 @@ src/runtime/src/mono/mono/mini/mini-windows.c|unknown-license-reference
 src/runtime/src/native/external/libunwind/doc/libunwind-ia64.*|generic-exception
 src/runtime/src/native/external/zlib-ng/cmake/detect-arch.cmake|unknown-license-reference
 src/runtime/src/native/external/zlib-ng/cmake/detect-coverage.cmake|other-permissive,tsl-2020,unknown-license-reference
+src/runtime/src/native/external/zlib-ng/cmake/detect-intrinsics.cmake|unknown-license-reference
 src/runtime/src/native/external/zlib-ng/cmake/detect-sanitizer.cmake|unknown-license-reference
 src/runtime/src/tests/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs|unknown-license-reference
 


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/43588

The changes in https://github.com/dotnet/runtime/pull/105771 included an update to a zlib cmake file that caused an `unknown-license-reference` license detection for the VMR on this line: https://github.com/dotnet/runtime/blob/dcd113e77a19ce1dd2fbc44a6f96cf8c4c4003f7/src/native/external/zlib-ng/cmake/detect-intrinsics.cmake#L2

Adding an exclusion for this since it's a false positive.