### PR TITLE
UpdateNuGetConfigPackageSourcesMappings: don't add empty mappings

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
@@ -115,7 +115,11 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 // Skip sources with zero package patterns
                 if (allSourcesPackages[packageSource]?.Count > 0)
                 {
-                    pkgSrcMappingClearElement.AddAfterSelf(GetPackageMappingsElementForSource(packageSource));
+                    var pkgSrc = GetPackageMappingsElementForSource(packageSource);
+                    if (pkgSrc.Elements().Any())
+                    {
+                        pkgSrcMappingClearElement.AddAfterSelf(pkgSrc);
+                    }
                 }
             }
 


### PR DESCRIPTION
I got the error `Package source 'prebuilt' must have at least one package pattern` when building razor in the VMR.

I found that `artifacts/obj/razor/NuGet.config` had an empty package mapping like `<packageSourceMapping>[...]<packageSource key="prebuilt"/>`.

This is the change I'm testing to fix it.  I kept it simple since I'm likely going to apply it downstream in nixpkgs, but it could probably be improved:

- There's already a check "Skip sources with zero package patterns" which doesn't work in all cases.  It seems a little confusing to have two separate checks.
- I'm not sure this covers all the potential `packageSource` elements that could be left empty.

off-topic: Why is this even an error?  If you remove the empty `packageSource` it acts like I'd expect it to with zero patterns.