### PR TITLE
Exclude false positive license ref for fsharp patch

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -172,6 +172,7 @@ src/runtime/src/libraries/System.Text.Json/roadmap/images/higher-level-component
 
 # False positive
 src/sdk/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
+src/sdk/src/SourceBuild/patches/fsharp/0001-Fix17713-Reverting-PR-17649-Make-the-interaction-bet.patch|unknown-license-reference
 
 # Configuration, doesn't apply to source directly
 src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt


### PR DESCRIPTION
The changes from https://github.com/dotnet/sdk/pull/43436 added a patch for fsharp which includes content that is causing license reference to be detected at https://github.com/dotnet/dotnet/blob/dea11f2c2551c2e6a8c5a1b8ca0f946b65b3ed85/src/sdk/src/SourceBuild/patches/fsharp/0001-Fix17713-Reverting-PR-17649-Make-the-interaction-bet.patch#L513. Since this is a false positive, adding it to the exclusions.