### PR TITLE
Improve logging from agent

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/AgentReporter.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/AgentReporter.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.HotReload;
+
+internal sealed class AgentReporter
+{
+    private readonly List<(string message, AgentMessageSeverity severity)> _log = [];
+
+    public void Report(string message, AgentMessageSeverity severity)
+    {
+        _log.Add((message, severity));
+    }
+
+    public IReadOnlyCollection<(string message, AgentMessageSeverity severity)> GetAndClearLogEntries(ResponseLoggingLevel level)
+    {
+        lock (_log)
+        {
+            var filteredLog = (level != ResponseLoggingLevel.Verbose)
+                ? _log.Where(static entry => entry.severity != AgentMessageSeverity.Verbose)
+                : _log;
+
+            var log = filteredLog.ToArray();
+            _log.Clear();
+            return log;
+        }
+    }
+}

--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -3,54 +3,107 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Reflection;
 
 namespace Microsoft.Extensions.HotReload
 {
     internal sealed class HotReloadAgent : IDisposable
     {
+        private const string MetadataUpdaterTypeName = "System.Reflection.Metadata.MetadataUpdater";
+        private const string ApplyUpdateMethodName = "ApplyUpdate";
+        private const string GetCapabilitiesMethodName = "GetCapabilities";
+
         private delegate void ApplyUpdateDelegate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta);
 
-        private readonly Action<string> _log;
+        private readonly AgentReporter _reporter = new();
+        private readonly NamedPipeClientStream _pipeClient;
+        private readonly Action<string> _stdOutLog;
         private readonly AssemblyLoadEventHandler _assemblyLoad;
         private readonly ConcurrentDictionary<Guid, List<UpdateDelta>> _deltas = new();
         private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
         private readonly ApplyUpdateDelegate? _applyUpdate;
         private readonly string? _capabilities;
-        private volatile UpdateHandlerActions? _handlerActions;
+        private readonly MetadataUpdateHandlerInvoker _metadataUpdateHandlerInvoker;
 
-        public HotReloadAgent(Action<string> log)
+        public HotReloadAgent(NamedPipeClientStream pipeClient, Action<string> stdOutLog)
         {
-            var metadataUpdater = Type.GetType("System.Reflection.Metadata.MetadataUpdater, System.Runtime.Loader", throwOnError: false);
+            _assemblyLoad = OnAssemblyLoad;
+            _pipeClient = pipeClient;
+            _stdOutLog = stdOutLog;
+            _metadataUpdateHandlerInvoker = new(_reporter);
 
-            if (metadataUpdater != null)
+            GetUpdaterMethods(out _applyUpdate, out _capabilities);
+            AppDomain.CurrentDomain.AssemblyLoad += _assemblyLoad;
+        }
+
+        private void GetUpdaterMethods(out ApplyUpdateDelegate? applyUpdate, out string? capabilities)
+        {
+            applyUpdate = null;
+            capabilities = null;
+
+            var metadataUpdater = Type.GetType(MetadataUpdaterTypeName + ", System.Runtime.Loader", throwOnError: false);
+            if (metadataUpdater == null)
             {
-                _applyUpdate = (ApplyUpdateDelegate?)metadataUpdater.GetMethod("ApplyUpdate", BindingFlags.Public | BindingFlags.Static, binder: null,
-                    new[] { typeof(Assembly), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>) }, modifiers: null)?.CreateDelegate(typeof(ApplyUpdateDelegate));
-
-                if (_applyUpdate != null)
-                {
-                    try
-                    {
-                        _capabilities = metadataUpdater.GetMethod("GetCapabilities", BindingFlags.NonPublic | BindingFlags.Static, binder: null, Type.EmptyTypes, modifiers: null)?.
-                            Invoke(obj: null, parameters: null) as string;
-                    }
-                    catch
-                    {
-                    }
-                }
+                _reporter.Report($"Type not found: {MetadataUpdaterTypeName}", AgentMessageSeverity.Error);
+                return;
             }
 
-            _log = log;
-            _assemblyLoad = OnAssemblyLoad;
-            AppDomain.CurrentDomain.AssemblyLoad += _assemblyLoad;
+            var applyUpdateMethod = metadataUpdater.GetMethod(ApplyUpdateMethodName, BindingFlags.Public | BindingFlags.Static, binder: null, [typeof(Assembly), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>)], modifiers: null);
+            if (applyUpdateMethod == null)
+            {
+                _reporter.Report($"{MetadataUpdaterTypeName}.{ApplyUpdateMethodName} not found.", AgentMessageSeverity.Error);
+                return;
+            }
+
+            applyUpdate = (ApplyUpdateDelegate)applyUpdateMethod.CreateDelegate(typeof(ApplyUpdateDelegate));
+
+            var getCapabilities = metadataUpdater.GetMethod(GetCapabilitiesMethodName, BindingFlags.NonPublic | BindingFlags.Static, binder: null, Type.EmptyTypes, modifiers: null);
+            if (getCapabilities == null)
+            {
+                _reporter.Report($"{MetadataUpdaterTypeName}.{GetCapabilitiesMethodName} not found.", AgentMessageSeverity.Error);
+                return;
+            }
+
+            try
+            {
+                capabilities = getCapabilities.Invoke(obj: null, parameters: null) as string;
+            }
+            catch (Exception e)
+            {
+                _reporter.Report($"Error retrieving capabilities: {e.Message}", AgentMessageSeverity.Error);
+            }
+        }
+
+        public async Task ReceiveDeltasAsync()
+        {
+            _reporter.Report("Writing capabilities: " + Capabilities, AgentMessageSeverity.Verbose);
+
+            var initPayload = new ClientInitializationPayload(Capabilities);
+            initPayload.Write(_pipeClient);
+
+            while (_pipeClient.IsConnected)
+            {
+                var update = await UpdatePayload.ReadAsync(_pipeClient, CancellationToken.None);
+
+                _stdOutLog($"ResponseLoggingLevel = {update.ResponseLoggingLevel}");
+
+                _reporter.Report("Attempting to apply deltas.", AgentMessageSeverity.Verbose);
+
+                ApplyDeltas(update.Deltas);
+
+                _pipeClient.WriteByte(UpdatePayload.ApplySuccessValue);
+
+                UpdatePayload.WriteLog(_pipeClient, _reporter.GetAndClearLogEntries(update.ResponseLoggingLevel));
+            }
         }
 
         public string Capabilities => _capabilities ?? string.Empty;
 
         private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
         {
-            _handlerActions = null;
+            _metadataUpdateHandlerInvoker.Clear();
+
             var loadedAssembly = eventArgs.LoadedAssembly;
             var moduleId = TryGetModuleId(loadedAssembly);
             if (moduleId is null)
@@ -65,159 +118,6 @@ namespace Microsoft.Extensions.HotReload
             }
         }
 
-        internal sealed class UpdateHandlerActions
-        {
-            public List<Action<Type[]?>> ClearCache { get; } = new();
-            public List<Action<Type[]?>> UpdateApplication { get; } = new();
-        }
-
-        private UpdateHandlerActions GetMetadataUpdateHandlerActions()
-        {
-            // We need to execute MetadataUpdateHandlers in a well-defined order. For v1, the strategy that is used is to topologically
-            // sort assemblies so that handlers in a dependency are executed before the dependent (e.g. the reflection cache action
-            // in System.Private.CoreLib is executed before System.Text.Json clears its own cache.)
-            // This would ensure that caches and updates more lower in the application stack are up to date
-            // before ones higher in the stack are recomputed.
-            var sortedAssemblies = TopologicalSort(AppDomain.CurrentDomain.GetAssemblies());
-            var handlerActions = new UpdateHandlerActions();
-            foreach (var assembly in sortedAssemblies)
-            {
-                foreach (var attr in TryGetCustomAttributesData(assembly))
-                {
-                    // Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
-                    // define their own copy without having to cross-compile.
-                    if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
-                    {
-                        continue;
-                    }
-
-                    IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
-                    if (ctorArgs.Count != 1 ||
-                        ctorArgs[0].Value is not Type handlerType)
-                    {
-                        _log($"'{attr}' found with invalid arguments.");
-                        continue;
-                    }
-
-                    GetHandlerActions(handlerActions, handlerType);
-                }
-            }
-
-            return handlerActions;
-        }
-
-        private IList<CustomAttributeData> TryGetCustomAttributesData(Assembly assembly)
-        {
-            try
-            {
-                return assembly.GetCustomAttributesData();
-            }
-            catch (Exception e)
-            {
-                // In cross-platform scenarios, such as debugging in VS through WSL, Roslyn
-                // runs on Windows, and the agent runs on Linux. Assemblies accessible to Windows
-                // may not be available or loaded on linux (such as WPF's assemblies).
-                // In such case, we can ignore the assemblies and continue enumerating handlers for
-                // the rest of the assemblies of current domain.
-                _log($"'{assembly.FullName}' is not loaded ({e.Message})");
-
-                return new List<CustomAttributeData>();
-            }
-        }
-
-        internal void GetHandlerActions(UpdateHandlerActions handlerActions, Type handlerType)
-        {
-            bool methodFound = false;
-
-            if (GetUpdateMethod(handlerType, "ClearCache") is MethodInfo clearCache)
-            {
-                handlerActions.ClearCache.Add(CreateAction(clearCache));
-                methodFound = true;
-            }
-
-            if (GetUpdateMethod(handlerType, "UpdateApplication") is MethodInfo updateApplication)
-            {
-                handlerActions.UpdateApplication.Add(CreateAction(updateApplication));
-                methodFound = true;
-            }
-
-            if (!methodFound)
-            {
-                _log($"No invokable methods found on metadata handler type '{handlerType}'. " +
-                    $"Allowed methods are ClearCache, UpdateApplication");
-            }
-
-            Action<Type[]?> CreateAction(MethodInfo update)
-            {
-                var action = (Action<Type[]?>)update.CreateDelegate(typeof(Action<Type[]?>));
-                return types =>
-                {
-                    try
-                    {
-                        action(types);
-                    }
-                    catch (Exception ex)
-                    {
-                        _log($"Exception from '{action}': {ex}");
-                    }
-                };
-            }
-
-            MethodInfo? GetUpdateMethod(Type handlerType, string name)
-            {
-                if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, binder: null, new[] { typeof(Type[]) }, modifiers: null) is MethodInfo updateMethod &&
-                    updateMethod.ReturnType == typeof(void))
-                {
-                    return updateMethod;
-                }
-
-                foreach (MethodInfo method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-                {
-                    if (method.Name == name)
-                    {
-                        _log($"Type '{handlerType}' has method '{method}' that does not match the required signature.");
-                        break;
-                    }
-                }
-
-                return null;
-            }
-        }
-
-        internal static List<Assembly> TopologicalSort(Assembly[] assemblies)
-        {
-            var sortedAssemblies = new List<Assembly>(assemblies.Length);
-
-            var visited = new HashSet<string>(StringComparer.Ordinal);
-
-            foreach (var assembly in assemblies)
-            {
-                Visit(assemblies, assembly, sortedAssemblies, visited);
-            }
-
-            static void Visit(Assembly[] assemblies, Assembly assembly, List<Assembly> sortedAssemblies, HashSet<string> visited)
-            {
-                var assemblyIdentifier = assembly.GetName().Name!;
-                if (!visited.Add(assemblyIdentifier))
-                {
-                    return;
-                }
-
-                foreach (var dependencyName in assembly.GetReferencedAssemblies())
-                {
-                    var dependency = Array.Find(assemblies, a => a.GetName().Name == dependencyName.Name);
-                    if (dependency is not null)
-                    {
-                        Visit(assemblies, dependency, sortedAssemblies, visited);
-                    }
-                }
-
-                sortedAssemblies.Add(assembly);
-            }
-
-            return sortedAssemblies;
-        }
-
         public void ApplyDeltas(IReadOnlyList<UpdateDelta> deltas)
         {
             Debug.Assert(Capabilities.Length > 0);
@@ -230,7 +130,7 @@ namespace Microsoft.Extensions.HotReload
                 {
                     if (TryGetModuleId(assembly) is Guid moduleId && moduleId == item.ModuleId)
                     {
-                        _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                        _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, pdbDelta: []);
                     }
                 }
 
@@ -239,24 +139,7 @@ namespace Microsoft.Extensions.HotReload
                 cachedDeltas.Add(item);
             }
 
-            try
-            {
-                // Defer discovering metadata updata handlers until after hot reload deltas have been applied.
-                // This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
-                _handlerActions ??= GetMetadataUpdateHandlerActions();
-                var handlerActions = _handlerActions;
-
-                Type[]? updatedTypes = GetMetadataUpdateTypes(deltas);
-
-                handlerActions.ClearCache.ForEach(a => a(updatedTypes));
-                handlerActions.UpdateApplication.ForEach(a => a(updatedTypes));
-
-                _log("Deltas applied.");
-            }
-            catch (Exception ex)
-            {
-                _log(ex.ToString());
-            }
+            _metadataUpdateHandlerInvoker.Invoke(GetMetadataUpdateTypes(deltas));
         }
 
         private Type[] GetMetadataUpdateTypes(IReadOnlyList<UpdateDelta> deltas)
@@ -285,7 +168,7 @@ namespace Microsoft.Extensions.HotReload
                     }
                     catch (Exception e)
                     {
-                        _log($"Failed to load type 0x{updatedType:X8}: {e.Message}");
+                        _reporter.Report($"Failed to load type 0x{updatedType:X8}: {e.Message}", AgentMessageSeverity.Warning);
                     }
                 }
             }
@@ -304,11 +187,11 @@ namespace Microsoft.Extensions.HotReload
                     _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
                 }
 
-                _log("Deltas applied.");
+                _reporter.Report("Deltas applied.", AgentMessageSeverity.Verbose);
             }
             catch (Exception ex)
             {
-                _log(ex.ToString());
+                _reporter.Report(ex.ToString(), AgentMessageSeverity.Warning);
             }
         }
 

--- a/src/BuiltInTools/DotNetDeltaApplier/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/MetadataUpdateHandlerInvoker.cs
@@ -1,0 +1,239 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace Microsoft.Extensions.HotReload;
+
+/// <summary>
+/// Finds and invokes metadata update handlers.
+/// </summary>
+internal sealed class MetadataUpdateHandlerInvoker(AgentReporter reporter)
+{
+    internal sealed class RegisteredActions(IReadOnlyList<Action<Type[]?>> clearCache, IReadOnlyList<Action<Type[]?>> updateApplication)
+    {
+        public void Invoke(Type[] updatedTypes)
+        {
+            foreach (var action in clearCache)
+            {
+                action(updatedTypes);
+            }
+
+            foreach (var action in updateApplication)
+            {
+                action(updatedTypes);
+            }
+        }
+
+        /// <summary>
+        /// For testing.
+        /// </summary>
+        internal IEnumerable<Action<Type[]?>> ClearCache => clearCache;
+
+        /// <summary>
+        /// For testing.
+        /// </summary>
+        internal IEnumerable<Action<Type[]?>> UpdateApplication => updateApplication;
+    }
+
+    private const string ClearCacheHandlerName = "ClearCache";
+    private const string UpdateApplicationHandlerName = "UpdateApplication";
+
+    private RegisteredActions? _actions;
+
+    /// <summary>
+    /// Call when a new assembly is loaded.
+    /// </summary>
+    internal void Clear()
+        => Interlocked.Exchange(ref _actions, null);
+
+    /// <summary>
+    /// Invokes all registerd handlers.
+    /// </summary>
+    internal void Invoke(Type[] updatedTypes)
+    {
+        try
+        {
+            // Defer discovering metadata updata handlers until after hot reload deltas have been applied.
+            // This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
+            var actions = _actions;
+            if (actions == null)
+            {
+                Interlocked.CompareExchange(ref _actions, GetMetadataUpdateHandlerActions(), null);
+                actions = _actions;
+            }
+
+            reporter.Report("Invoking metadata update handlers.", AgentMessageSeverity.Verbose);
+
+            actions.Invoke(updatedTypes);
+
+            reporter.Report("Deltas applied.", AgentMessageSeverity.Verbose);
+        }
+        catch (Exception e)
+        {
+            reporter.Report(e.ToString(), AgentMessageSeverity.Warning);
+        }
+    }
+
+    private IEnumerable<Type> GetHandlerTypes()
+    {
+        // We need to execute MetadataUpdateHandlers in a well-defined order. For v1, the strategy that is used is to topologically
+        // sort assemblies so that handlers in a dependency are executed before the dependent (e.g. the reflection cache action
+        // in System.Private.CoreLib is executed before System.Text.Json clears its own cache.)
+        // This would ensure that caches and updates more lower in the application stack are up to date
+        // before ones higher in the stack are recomputed.
+        var sortedAssemblies = TopologicalSort(AppDomain.CurrentDomain.GetAssemblies());
+
+        foreach (var assembly in sortedAssemblies)
+        {
+            foreach (var attr in TryGetCustomAttributesData(assembly))
+            {
+                // Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
+                // define their own copy without having to cross-compile.
+                if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+                {
+                    continue;
+                }
+
+                IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
+                if (ctorArgs.Count != 1 ||
+                    ctorArgs[0].Value is not Type handlerType)
+                {
+                    reporter.Report($"'{attr}' found with invalid arguments.", AgentMessageSeverity.Warning);
+                    continue;
+                }
+
+                yield return handlerType;
+            }
+        }
+    }
+
+    public RegisteredActions GetMetadataUpdateHandlerActions()
+        => GetMetadataUpdateHandlerActions(GetHandlerTypes());
+
+    /// <summary>
+    /// Internal for testing.
+    /// </summary>
+    internal RegisteredActions GetMetadataUpdateHandlerActions(IEnumerable<Type> handlerTypes)
+    {
+        var clearCacheActions = new List<Action<Type[]?>>();
+        var updateApplicationActions = new List<Action<Type[]?>>();
+
+        foreach (var handlerType in handlerTypes)
+        {
+            bool methodFound = false;
+
+            if (GetUpdateMethod(handlerType, ClearCacheHandlerName) is MethodInfo clearCache)
+            {
+                clearCacheActions.Add(CreateAction(clearCache));
+                methodFound = true;
+            }
+
+            if (GetUpdateMethod(handlerType, UpdateApplicationHandlerName) is MethodInfo updateApplication)
+            {
+                updateApplicationActions.Add(CreateAction(updateApplication));
+                methodFound = true;
+            }
+
+            if (!methodFound)
+            {
+                reporter.Report(
+                    $"Expected to find a static method '{ClearCacheHandlerName}' or '{UpdateApplicationHandlerName}' on type '{handlerType.AssemblyQualifiedName}' but neither exists.",
+                    AgentMessageSeverity.Warning);
+            }
+        }
+
+        return new RegisteredActions(clearCacheActions, updateApplicationActions);
+
+        Action<Type[]?> CreateAction(MethodInfo update)
+        {
+            var action = (Action<Type[]?>)update.CreateDelegate(typeof(Action<Type[]?>));
+            return types =>
+            {
+                try
+                {
+                    action(types);
+                }
+                catch (Exception ex)
+                {
+                    reporter.Report($"Exception from '{action}': {ex}", AgentMessageSeverity.Warning);
+                }
+            };
+        }
+
+        MethodInfo? GetUpdateMethod(Type handlerType, string name)
+        {
+            if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, binder: null, new[] { typeof(Type[]) }, modifiers: null) is MethodInfo updateMethod &&
+                updateMethod.ReturnType == typeof(void))
+            {
+                return updateMethod;
+            }
+
+            foreach (MethodInfo method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            {
+                if (method.Name == name)
+                {
+                    reporter.Report($"Type '{handlerType}' has method '{method}' that does not match the required signature.", AgentMessageSeverity.Warning);
+                    break;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private IList<CustomAttributeData> TryGetCustomAttributesData(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetCustomAttributesData();
+        }
+        catch (Exception e)
+        {
+            // In cross-platform scenarios, such as debugging in VS through WSL, Roslyn
+            // runs on Windows, and the agent runs on Linux. Assemblies accessible to Windows
+            // may not be available or loaded on linux (such as WPF's assemblies).
+            // In such case, we can ignore the assemblies and continue enumerating handlers for
+            // the rest of the assemblies of current domain.
+            reporter.Report($"'{assembly.FullName}' is not loaded ({e.Message})", AgentMessageSeverity.Verbose);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Internal for testing.
+    /// </summary>
+    internal static List<Assembly> TopologicalSort(Assembly[] assemblies)
+    {
+        var sortedAssemblies = new List<Assembly>(assemblies.Length);
+
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var assembly in assemblies)
+        {
+            Visit(assemblies, assembly, sortedAssemblies, visited);
+        }
+
+        static void Visit(Assembly[] assemblies, Assembly assembly, List<Assembly> sortedAssemblies, HashSet<string> visited)
+        {
+            var assemblyIdentifier = assembly.GetName().Name!;
+            if (!visited.Add(assemblyIdentifier))
+            {
+                return;
+            }
+
+            foreach (var dependencyName in assembly.GetReferencedAssemblies())
+            {
+                var dependency = Array.Find(assemblies, a => a.GetName().Name == dependencyName.Name);
+                if (dependency is not null)
+                {
+                    Visit(assemblies, dependency, sortedAssemblies, visited);
+                }
+            }
+
+            sortedAssemblies.Add(assembly);
+        }
+
+        return sortedAssemblies;
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher
 {
@@ -11,6 +12,11 @@ namespace Microsoft.DotNet.Watcher
         None = 0,
         RunningAsTest = 1 << 0,
         MockBrowser = 1 << 1,
+
+        /// <summary>
+        /// Elevates the severity of <see cref="MessageDescriptor.WaitingForChanges"/> from <see cref="MessageSeverity.Output"/>.
+        /// </summary>
+        ElevateWaitingForChangesMessageSeverity = 1 << 2,
     }
 
     internal sealed record EnvironmentOptions(

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -83,11 +83,13 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return ApplyStatus.NoChangesApplied;
             }
 
-            var payload = new UpdatePayload(applicableUpdates.Select(update => new UpdateDelta(
-                update.ModuleId,
-                metadataDelta: update.MetadataDelta.ToArray(),
-                ilDelta: update.ILDelta.ToArray(),
-                update.UpdatedTypes.ToArray())).ToArray());
+            var payload = new UpdatePayload(
+                deltas: applicableUpdates.Select(update => new UpdateDelta(
+                    update.ModuleId,
+                    metadataDelta: update.MetadataDelta.ToArray(),
+                    ilDelta: update.ILDelta.ToArray(),
+                    update.UpdatedTypes.ToArray())).ToArray(),
+                responseLoggingLevel: Reporter.IsVerbose ? ResponseLoggingLevel.Verbose : ResponseLoggingLevel.WarningsAndErrors);
 
             var success = false;
             var canceled = false;
@@ -131,21 +133,43 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             Debug.Assert(_pipe != null);
 
-            var bytes = ArrayPool<byte>.Shared.Rent(1);
+            var status = ArrayPool<byte>.Shared.Rent(1);
             try
             {
-                var numBytes = await _pipe.ReadAsync(bytes, cancellationToken);
-                if (numBytes != 1 || bytes[0] != UpdatePayload.ApplySuccessValue)
+                var statusBytesRead = await _pipe.ReadAsync(status, cancellationToken);
+                if (statusBytesRead != 1 || status[0] != UpdatePayload.ApplySuccessValue)
                 {
-                    Reporter.Error($"Change failed to apply (error code: '{BitConverter.ToString(bytes, 0, numBytes)}'). Further changes won't be applied to this process.");
+                    Reporter.Error($"Change failed to apply (error code: '{BitConverter.ToString(status, 0, statusBytesRead)}'). Further changes won't be applied to this process.");
                     return false;
+                }
+
+                foreach (var (message, severity) in UpdatePayload.ReadLog(_pipe))
+                {
+                    switch (severity)
+                    {
+                        case AgentMessageSeverity.Verbose:
+                            Reporter.Verbose(message, emoji: "🕵️");
+                            break;
+
+                        case AgentMessageSeverity.Error:
+                            Reporter.Error(message);
+                            break;
+
+                        case AgentMessageSeverity.Warning:
+                            Reporter.Warn(message, emoji: "⚠");
+                            break;
+
+                        default:
+                            Reporter.Error($"Unexpected message severity: {severity}");
+                            return false;
+                    }
                 }
 
                 return true;
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(bytes);
+                ArrayPool<byte>.Shared.Return(status);
             }
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Watcher
                         return;
                     }
 
-                    fileSetWatcher = new HotReloadFileSetWatcher(evaluationResult.Files, buildCompletionTime, Context.Reporter);
+                    fileSetWatcher = new HotReloadFileSetWatcher(evaluationResult.Files, buildCompletionTime, Context.Reporter, Context.EnvironmentOptions.TestFlags);
 
                     // Hot Reload loop - exits when the root process needs to be restarted.
                     while (true)
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.Watcher
 
                             ReportFileChanges(changedFiles);
 
-                            fileSetWatcher = new HotReloadFileSetWatcher(evaluationResult.Files, buildCompletionTime, Context.Reporter);
+                            fileSetWatcher = new HotReloadFileSetWatcher(evaluationResult.Files, buildCompletionTime, Context.Reporter, Context.EnvironmentOptions.TestFlags);
                         }
                         else
                         {
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.Watcher
                             !shutdownCancellationToken.IsCancellationRequested &&
                             !forceRestartCancellationSource.IsCancellationRequested)
                         {
-                            fileSetWatcher ??= new HotReloadFileSetWatcher(evaluationResult.Files, DateTime.MinValue, Context.Reporter);
+                            fileSetWatcher ??= new HotReloadFileSetWatcher(evaluationResult.Files, DateTime.MinValue, Context.Reporter, Context.EnvironmentOptions.TestFlags);
                             Context.Reporter.Report(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
 
                             using var shutdownOrForcedRestartSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellationToken, forceRestartCancellationSource.Token);

--- a/src/BuiltInTools/dotnet-watch/Internal/MessagePrefixingReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MessagePrefixingReporter.cs
@@ -7,6 +7,9 @@ namespace Microsoft.DotNet.Watcher;
 
 internal sealed class MessagePrefixingReporter(string additionalPrefix, IReporter underlyingReporter) : IReporter
 {
+    public bool IsVerbose
+        => underlyingReporter.IsVerbose;
+
     public bool ReportProcessOutput
         => underlyingReporter.ReportProcessOutput;
 

--- a/test/TestAssets/TestProjects/WatchHotReloadApp/Program.cs
+++ b/test/TestAssets/TestProjects/WatchHotReloadApp/Program.cs
@@ -7,6 +7,9 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Versioning;
 using System.Threading;
+using System.Threading.Tasks;
+
+// <metadata update handler placeholder>
 
 var assembly = typeof(C).Assembly;
 
@@ -21,15 +24,10 @@ Console.WriteLine($"Version = {assembly.GetCustomAttributes<AssemblyVersionAttri
 Console.WriteLine($"TFM = {assembly.GetCustomAttributes<TargetFrameworkAttribute>().FirstOrDefault()?.FrameworkName ?? "<unspecified>"}");
 Console.WriteLine($"Configuration = {assembly.GetCustomAttributes<AssemblyConfigurationAttribute>().FirstOrDefault()?.Configuration ?? "<unspecified>"}");
 
-Loop();
-
-static void Loop()
+while (true)
 {
-    while (true)
-    {
-        Console.WriteLine(".");
-        Thread.Sleep(1000);
-    }
+    Console.WriteLine(".");
+    await Task.Delay(1000);
 }
 
 class C { }

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -124,9 +124,11 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             UpdateSourceFile(sourcePath, source.Replace("Console.WriteLine(\".\");", "Console.WriteLine(\"Updated\");"));
 
-            await App.AssertOutputLineStartsWith("dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' but neither exists.");
-
             await App.AssertOutputLineStartsWith("Updated");
+
+            Assert.Contains(
+                "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
+                App.Process.Output);
         }
 
         [Theory]
@@ -163,22 +165,21 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             UpdateSourceFile(sourcePath, source.Replace("Console.WriteLine(\".\");", "Console.WriteLine(\"Updated\");"));
 
+            await App.AssertOutputLineStartsWith("Updated");
 
-            await App.AssertOutputLineStartsWith("dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!");
+            Assert.Contains(
+                "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!",
+                App.Process.Output);
 
             if (verbose)
             {
-                await App.AssertOutputLineStartsWith("dotnet watch 🕵️ [WatchHotReloadApp (net9.0)] Deltas applied.");
+                Assert.Contains("dotnet watch 🕵️ [WatchHotReloadApp (net9.0)] Deltas applied.", App.Process.Output);
             }
             else
             {
                 // shouldn't see any agent messages:
-                await App.AssertOutputLineStartsWith(MessageDescriptor.HotReloadSucceeded, failure: line => line.Contains("🕵️"));
+                Assert.DoesNotContain("🕵️", App.Process.Output);
             }
-
-            await App.AssertOutputLineStartsWith("   at AppUpdateHandler.ClearCache(Type[] types)");
-
-            await App.AssertOutputLineStartsWith("Updated");
         }
 
         [Fact]

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tests
@@ -126,7 +127,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            Assert.Contains(
+            AssertEx.Contains(
                 "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
                 App.Process.Output);
         }
@@ -167,18 +168,18 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            Assert.Contains(
+            AssertEx.Contains(
                 "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!",
                 App.Process.Output);
 
             if (verbose)
             {
-                Assert.Contains("dotnet watch 🕵️ [WatchHotReloadApp (net9.0)] Deltas applied.", App.Process.Output);
+                AssertEx.Contains("dotnet watch 🕵️ [WatchHotReloadApp (net9.0)] Deltas applied.", App.Process.Output);
             }
             else
             {
                 // shouldn't see any agent messages:
-                Assert.DoesNotContain("🕵️", App.Process.Output);
+                AssertEx.DoesNotContain("🕵️", App.Process.Output);
             }
         }
 

--- a/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
@@ -23,7 +23,8 @@ namespace Microsoft.DotNet.Watcher.Tests
                         ilDelta: new byte[] { 1, 0, 0 },
                         metadataDelta: new byte[] { 1, 0, 1 },
                         updatedTypes: Array.Empty<int>())
-                });
+                },
+                responseLoggingLevel: ResponseLoggingLevel.Verbose);
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);
@@ -50,7 +51,8 @@ namespace Microsoft.DotNet.Watcher.Tests
                         ilDelta: new byte[] { 1, 0, 0 },
                         metadataDelta: new byte[] { 1, 0, 1 },
                         updatedTypes: new int[] { -18 })
-                });
+                },
+                responseLoggingLevel: ResponseLoggingLevel.WarningsAndErrors);
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);
@@ -72,7 +74,8 @@ namespace Microsoft.DotNet.Watcher.Tests
                         ilDelta: Enumerable.Range(0, 68200).Select(c => (byte)(c%2)).ToArray(),
                         metadataDelta: new byte[] { 0, 1, 1 },
                         updatedTypes: Array.Empty<int>())
-                });
+                },
+                responseLoggingLevel: ResponseLoggingLevel.Verbose);
 
             using var stream = new MemoryStream();
             await initial.WriteAsync(stream, default);
@@ -104,6 +107,8 @@ namespace Microsoft.DotNet.Watcher.Tests
                     Assert.Equal(e.UpdatedTypes, a.UpdatedTypes);
                 }
             }
+
+            Assert.Equal(initial.ResponseLoggingLevel, read.ResponseLoggingLevel);
         }
     }
 }

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -222,5 +222,26 @@ namespace Microsoft.DotNet.Watcher.Tools
                     banner: "File sets should be equal");
             }
         }
+
+        public static void Contains(string expected, IEnumerable<string> items)
+        {
+            if (items.Any(item => item == expected))
+            {
+                return;
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine($"'{expected}' not found in:");
+
+            foreach (var item in items)
+            {
+                message.AppendLine($"'{item}'");
+            }
+
+            Fail(message.ToString());
+        }
+
+        public static void DoesNotContain(string expected, IEnumerable<string> items)
+            => Assert.DoesNotContain(expected, items);
     }
 }

--- a/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -37,8 +37,8 @@ namespace Microsoft.DotNet.Watcher.Tests
         public static string GetLinePrefix(MessageDescriptor descriptor)
             => $"dotnet watch {descriptor.Emoji} {descriptor.Format}";
 
-        public Task<string> AssertOutputLineStartsWith(MessageDescriptor descriptor)
-            => AssertOutputLineStartsWith(GetLinePrefix(descriptor));
+        public Task<string> AssertOutputLineStartsWith(MessageDescriptor descriptor, Predicate<string> failure = null)
+            => AssertOutputLineStartsWith(GetLinePrefix(descriptor), failure);
 
         /// <summary>
         /// Asserts that the watched process outputs a line starting with <paramref name="expectedPrefix"/> and returns the remainder of that line.
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             var encLogPath = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT") is { } ciOutputRoot
                 ? Path.Combine(ciOutputRoot, ".hotreload", asset.Name)
-                : Path.Combine(asset.Path, ".hotreload");
+                : asset.Path + ".hotreload";
 
             commandSpec.WithEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", encLogPath);
 


### PR DESCRIPTION
Currently the agent only logs to std out, which is redirected by apps (e.g. asp.net). It also doesn't consider output verbosity of dotnet-watch.
Instead of logging via stdout we now send log messages back to the dotnet-watch pipe, so that dotnet-watch can report them in the same way it does other messages.

Also refactors and cleans up the agent implementation.

Implements https://github.com/dotnet/sdk/issues/43323.