### PR TITLE
Support additional VS component IDs for workloads

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
@@ -4,7 +4,6 @@
 using System.Runtime.Versioning;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -34,18 +33,60 @@ namespace Microsoft.DotNet.Workloads.Workload
         };
 
         /// <summary>
+        /// Default prefix to use for Visual Studio component and component group IDs.
+        /// </summary>
+        private static readonly string s_visualStudioComponentPrefix = "Microsoft.NET.Component";
+
+        /// <summary>
+        /// Well-known prefixes used by some workloads that can be replaced when generating component IDs.
+        /// </summary>
+        private static readonly string[] s_wellKnownWorkloadPrefixes = { "Microsoft.NET.", "Microsoft." };
+
+        /// <summary>
         /// The SWIX package ID wrapping the SDK installer in Visual Studio. The ID should contain
         /// the SDK version as a suffix, e.g., "Microsoft.NetCore.Toolset.5.0.403".
         /// </summary>
         private static readonly string s_visualStudioSdkPackageIdPrefix = "Microsoft.NetCore.Toolset.";
 
         /// <summary>
-        /// Gets a set of workload components based on the available set of workloads for the current SDK.
+        /// Gets a dictionary of mapping possible Visual Studio component IDs to .NET workload IDs in the current SDK.
         /// </summary>
         /// <param name="workloadResolver">The workload resolver used to obtain available workloads.</param>
-        /// <returns>A collection of Visual Studio component IDs corresponding to workload IDs.</returns>
-        internal static IEnumerable<string> GetAvailableVisualStudioWorkloads(IWorkloadResolver workloadResolver) =>
-            workloadResolver.GetAvailableWorkloads().Select(w => w.Id.ToString().Replace('-', '.'));
+        /// <returns>A dictionary of Visual Studio component IDs corresponding to workload IDs.</returns>
+        internal static Dictionary<string, string> GetAvailableVisualStudioWorkloads(IWorkloadResolver workloadResolver)
+        {
+            Dictionary<string, string> visualStudioComponentWorkloads = new(StringComparer.OrdinalIgnoreCase);
+
+            // Iterate through all the available workload IDs and generate potential Visual Studio
+            // component IDs that map back to the original workload ID. This ensures that we
+            // can do reverse lookups for special cases where a workload ID contains a prefix
+            // corresponding with the full VS component ID prefix. For example,
+            // Microsoft.NET.Component.runtime.android would be a valid component ID for both
+            // microsoft-net-runtime-android and runtime-android.
+            foreach (var workload in workloadResolver.GetAvailableWorkloads())
+            {
+                string workloadId = workload.Id.ToString();
+                // Old style VS components simply replaced '-' with '.' in the workload ID.
+                string componentId = workload.Id.ToString().Replace('-', '.');
+
+                visualStudioComponentWorkloads.Add(componentId, workloadId);
+
+                // Starting in .NET 9.0 and VS 17.12, workload components will follow the VS naming convention.
+                foreach (string wellKnownPrefix in s_wellKnownWorkloadPrefixes)
+                {
+                    if (componentId.StartsWith(wellKnownPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        componentId = componentId.Substring(wellKnownPrefix.Length);
+                        break;
+                    }
+                }
+
+                componentId = s_visualStudioComponentPrefix + "." + componentId;
+                visualStudioComponentWorkloads.Add(componentId, workloadId);
+            }
+
+            return visualStudioComponentWorkloads;
+        }
 
         /// <summary>
         /// Finds all workloads installed by all Visual Studio instances given that the
@@ -59,7 +100,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         internal static void GetInstalledWorkloads(IWorkloadResolver workloadResolver,
             InstalledWorkloadsCollection installedWorkloads, SdkFeatureBand? sdkFeatureBand = null)
         {
-            IEnumerable<string> visualStudioWorkloadIds = GetAvailableVisualStudioWorkloads(workloadResolver);
+            Dictionary<string, string> visualStudioWorkloadIds = GetAvailableVisualStudioWorkloads(workloadResolver);
             HashSet<string> installedWorkloadComponents = new();
 
             // Visual Studio instances contain a large set of packages and we have to perform a linear
@@ -105,10 +146,9 @@ namespace Microsoft.DotNet.Workloads.Workload
                         continue;
                     }
 
-                    if (visualStudioWorkloadIds.Contains(packageId, StringComparer.OrdinalIgnoreCase))
+                    if (visualStudioWorkloadIds.TryGetValue(packageId, out string workloadId))
                     {
-                        // Normalize back to an SDK style workload ID.
-                        installedWorkloadComponents.Add(packageId.Replace('.', '-'));
+                        installedWorkloadComponents.Add(workloadId);
                     }
                 }
 

--- a/test/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
+++ b/test/dotnet-workload-list.Tests/GivenDotnetWorkloadList.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using ManifestReaderTests;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.DotNet.Workloads.Workload.List;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using ListStrings = Microsoft.DotNet.Workloads.Workload.List.LocalizableStrings;
@@ -35,6 +36,18 @@ namespace Microsoft.DotNet.Cli.Workload.List.Tests
 
             // Expected number of lines for table headers
             _reporter.Lines.Count.Should().Be(6);
+        }
+
+        [WindowsOnlyFact]
+        public void GivenAvailableWorkloadsItCanComputeVisualStudioIds()
+        {
+            var workloadResolver = WorkloadResolver.CreateForTests(new MockManifestProvider(("SampleManifest", _manifestPath, "5.0.0", "6.0.100")), Directory.GetCurrentDirectory());
+
+#pragma warning disable CA1416 // Validate platform compatibility
+            var availableWorkloads = VisualStudioWorkloads.GetAvailableVisualStudioWorkloads(workloadResolver);
+            availableWorkloads.Should().Contain("mock.workload.1", "mock-workload-1");
+            availableWorkloads.Should().Contain("Microsoft.NET.Component.mock.workload.1", "mock-workload-1");
+#pragma warning restore CA1416 // Validate platform compatibility
         }
 
         [Fact]


### PR DESCRIPTION
# Description

Visual Studio [publishes](https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2022) all the component and component group IDs from their catalog to support extension developers. The norm is to follow their naming convention and include a prefix like `Microsoft.VisualStudio.Component` in the ID. .NET optional workloads (including abstract workloads) generate components and component groups that matches the .NET workload ID. This enables features like IPA to easily locate components when SDK resolvers report missing optional workloads.

Visual Studio asked that we follow their guidelines so starting in .NET 9, we will prefix our components with 'Microsoft.NET.Component'. Repos will be able to opt-in and generate new IDs (related Arcade change: https://github.com/dotnet/arcade/pull/15103)

This PR enables the SDK to search for both the old and new component IDs.

# Risk

Low - if we decide not to leverage this, the SDK will add a few more IDs that won't be used.

# Testing

Additional unit tests added to verify the mapping logic.