### PR TITLE
[release/9.0.1xx] BinSkim: Enable CFG

### DIFF
--- a/src/Installer/finalizer/CMakeLists.txt
+++ b/src/Installer/finalizer/CMakeLists.txt
@@ -42,11 +42,14 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4703>) # Potentially uninitia
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4789>) # destination of memory copy is too small
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4995>) # 'function': name was marked as #pragma deprecated
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4996>) # 'function': was declared deprecated also 'std::'
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/guard:cf>) # Enable control flow guard
 
 add_executable(Finalizer 
   finalizer.cpp
   native.rc
 )
+
+add_link_options(/guard:cf)
 
 # These are normally part of a .vcxproj in Visual Studio, but appears to be missing when CMAKE generates a .vcxproj for arm64.
 target_link_libraries(Finalizer shell32.lib)


### PR DESCRIPTION
# Description

.NET SDK contains a native binary (finalizer.exe) that's used to clean up optional workloads when the SDK is uninstalled. The binary was flagged by BinSkim because control flow guard was not enabled.

# Risk

Low

# Testing

Built locally and verified that the necessary sections and tables are present as described [here](https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard)

![image](https://github.com/user-attachments/assets/4193a33e-a434-4829-806a-2a731653be40)

Also tested the installer to ensure there aren't any regressions when running this when the SDK is being removed.

