### PR TITLE
[StaticWebAssets] Avoid running packing logic when project is not packable

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -291,7 +291,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </ResolveCompressedAssets>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IsPackable)' == 'true'">
       <_StaticWebAssetExcludedFromPack Include="@(_CompressedStaticWebAssets)" />
     </ItemGroup>
 

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Pack.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Pack.targets
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        targets into their packages are expected to disable the generation of $(PackageId).props files and
        to manually import build\Microsoft.AspNetCore.StaticWebAssets.props in their custom props files.
    -->
-  <Target Name="GenerateStaticWebAssetsPackFiles" AfterTargets="GenerateStaticWebAssetsManifest">
+  <Target Name="GenerateStaticWebAssetsPackFiles" Condition="'$(IsPackable)' == 'true'" AfterTargets="GenerateStaticWebAssetsManifest">
 
     <ItemGroup>
 


### PR DESCRIPTION
~.9s win

**Before**

![image](https://github.com/user-attachments/assets/bcbb07d7-eb30-4292-984a-816342da1233)

```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**
![image](https://github.com/user-attachments/assets/1ee01cb0-8e6a-490e-a9fd-1e156923dfc2)
```console
Build succeeded in 12.2s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.9s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.9s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.4s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.4s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.7s
```
