### PR TITLE
[StaticWebAssets] Avoid generating dependent manifests if original manifest is up to date

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -628,14 +628,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       ManifestType="Build"
       Assets="@(StaticWebAsset)"
       Endpoints="@(StaticWebAssetEndpoint)"
-      ManifestPath="$(StaticWebAssetEndpointsBuildManifestPath)">
+      ManifestPath="$(StaticWebAssetEndpointsBuildManifestPath)"
+      CacheFilePath="$(StaticWebAssetBuildManifestPath)">
     </GenerateStaticWebAssetEndpointsManifest>
 
     <GenerateStaticWebAssetsDevelopmentManifest
       DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"
       Assets="@(StaticWebAsset)"
       Source="$(PackageId)"
-      ManifestPath="$(StaticWebAssetDevelopmentManifestPath)">
+      ManifestPath="$(StaticWebAssetDevelopmentManifestPath)"
+      CacheFilePath="$(StaticWebAssetBuildManifestPath)">
     </GenerateStaticWebAssetsDevelopmentManifest>
 
     <ItemGroup>

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -23,8 +23,17 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
     [Required]
     public string ManifestPath { get; set; }
 
+    [Required]
+    public string CacheFilePath { get; set; }
+
     public override bool Execute()
     {
+        if (File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+        {
+            Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
+            return true;
+        }
+
         try
         {
             // Get the list of the asset that need to be part of the manifest (this is similar to GenerateStaticWebAssetsDevelopmentManifest)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -23,12 +23,11 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
     [Required]
     public string ManifestPath { get; set; }
 
-    [Required]
     public string CacheFilePath { get; set; }
 
     public override bool Execute()
     {
-        if (File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+        if (!string.IsNullOrEmpty(ManifestPath) && File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
         {
             Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
             return true;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -27,7 +27,7 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
 
     public override bool Execute()
     {
-        if (!string.IsNullOrEmpty(ManifestPath) && File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+        if (!string.IsNullOrEmpty(CacheFilePath) && File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
         {
             Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
             return true;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -33,8 +33,17 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
         [Required]
         public string ManifestPath { get; set; }
 
+        [Required]
+        public string CacheFilePath { get; set; }
+
         public override bool Execute()
         {
+            if (File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+            {
+                Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
+                return true;
+            }
+
             try
             {
                 if (Assets.Length == 0 && DiscoveryPatterns.Length == 0)


### PR DESCRIPTION
.5s win

**Before**

![image](https://github.com/user-attachments/assets/9213f8d6-6df4-4566-acb5-787520a8486b)
```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**
![image](https://github.com/user-attachments/assets/81209746-f7e0-4fc2-9ef9-07201167bb65)
```console
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.0s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.9s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.9s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.0s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.9s
```
