### PR TITLE
[StaticWebAssets] Avoid serializing/deserializing manifest for hash

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -437,6 +437,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Manifest paths -->
       <_StaticWebAssetsManifestBase Condition="'$(_StaticWebAssetsManifestBase)' == ''">$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>
+      <StaticWebAssetsBuildManifestCacheFilePath>$(StaticWebAssetBuildManifestPath).cache</StaticWebAssetsBuildManifestCacheFilePath>
       <StaticWebAssetPackManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.pack.json</StaticWebAssetPackManifestPath>
       <StaticWebAssetDevelopmentManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.development.json</StaticWebAssetDevelopmentManifestPath>
       <StaticWebAssetEndpointsBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.endpoints.json</StaticWebAssetEndpointsBuildManifestPath>
@@ -620,7 +621,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"
       Assets="@(StaticWebAsset)"
       Endpoints="@(StaticWebAssetEndpoint)"
-      ManifestPath="$(StaticWebAssetBuildManifestPath)">
+      ManifestPath="$(StaticWebAssetBuildManifestPath)"
+      ManifestCacheFilePath="$(StaticWebAssetsBuildManifestCacheFilePath)">
     </GenerateStaticWebAssetsManifest>
 
     <GenerateStaticWebAssetEndpointsManifest
@@ -649,6 +651,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
+      <FileWrites Include="$(StaticWebAssetsBuildManifestCacheFilePath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(StaticWebAssetEndpointsBuildManifestPath)" />
     </ItemGroup>


### PR DESCRIPTION
The actual win is around ~.5s even if it doesn't show up in this particular run. With so few measurements included (for the sake of conciseness).

**Before**
![image](https://github.com/user-attachments/assets/22c43421-d369-41ec-bfd5-e3cbdfec44e2)

```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**
![image](https://github.com/user-attachments/assets/fda7fb28-541d-4259-ab22-d606ea50502d)
```console
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.3s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.2s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.3s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.3s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.3s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.2s
```
