### PR TITLE
[StaticWebAssets] Switch to source generated System.Text.Json

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Data/Serialization/StaticWebAssetsJsonSerializerContext.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/Serialization/StaticWebAssetsJsonSerializerContext.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
+
+namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
+
+[JsonSerializable(typeof(StaticWebAssetsManifest))]
+[JsonSerializable(typeof(GenerateStaticWebAssetsDevelopmentManifest.StaticWebAssetsDevelopmentManifest))]
+[JsonSerializable(typeof(StaticWebAssetEndpointsManifest))]
+public partial class StaticWebAssetsJsonSerializerContext : JsonSerializerContext
+{
+    // Since the manifest is only used at development time, it's ok for it to use the relaxed
+    // json escaping (which is also what MVC uses by default)
+    private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    public static readonly StaticWebAssetsJsonSerializerContext RelaxedEscaping = new(ManifestSerializationOptions);
+}

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         public static StaticWebAssetsManifest FromJsonBytes(byte[] jsonBytes)
         {
-            var manifest = JsonSerializer.Deserialize<StaticWebAssetsManifest>(jsonBytes);
+            var manifest = JsonSerializer.Deserialize(jsonBytes, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsManifest);
             if (manifest.Version != 1)
             {
                 throw new InvalidOperationException($"Invalid manifest version. Expected manifest version '1' and found version '{manifest.Version}'.");

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
@@ -1,22 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointProperty : IComparable<StaticWebAssetEndpointProperty>, IEquatable<StaticWebAssetEndpointProperty>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointProperty[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointPropertyArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
 
     internal static StaticWebAssetEndpointProperty[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointProperty[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     internal static string ToMetadataValue(StaticWebAssetEndpointProperty[] responseHeaders)

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
@@ -1,22 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEndpointResponseHeader>, IComparable<StaticWebAssetEndpointResponseHeader>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointResponseHeader[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointResponseHeaderArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
 
     internal static StaticWebAssetEndpointResponseHeader[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointResponseHeader[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     internal static string ToMetadataValue(StaticWebAssetEndpointResponseHeader[] responseHeaders)

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
@@ -4,12 +4,17 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointSelector>, IComparable<StaticWebAssetEndpointSelector>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointSelector[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointSelectorArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
@@ -18,7 +23,7 @@ public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointS
 
     public static StaticWebAssetEndpointSelector[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointSelector[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     public static string ToMetadataValue(StaticWebAssetEndpointSelector[] selectors)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -60,7 +60,7 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
                 Endpoints = [.. filteredEndpoints]
             };
 
-            this.PersistFileIfChanged(manifest, ManifestPath);
+            this.PersistFileIfChanged(manifest, ManifestPath, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetEndpointsManifest);
         }
         catch (Exception ex)
         {

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -13,14 +13,6 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
     // is case insensitive.
     public class GenerateStaticWebAssetsDevelopmentManifest : Task
     {
-        // Since the manifest is only used at development time, it's ok for it to use the relaxed
-        // json escaping (which is also what MVC uses by default) and to produce indented output
-        // since that makes it easier to inspect the manifest when necessary.
-        private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
-        {
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
-
         [Required]
         public string Source { get; set; }
 
@@ -100,7 +92,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private void PersistManifest(StaticWebAssetsDevelopmentManifest manifest)
         {
-            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestSerializationOptions);
+            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsDevelopmentManifest);
             using var sha256 = SHA256.Create();
             var currentHash = sha256.ComputeHash(data);
 

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
@@ -10,15 +9,6 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 {
     public class GenerateStaticWebAssetsManifest : Task
     {
-        // Since the manifest is only used at development time, it's ok for it to use the relaxed
-        // json escaping (which is also what MVC uses by default) and to produce indented output
-        // since that makes it easier to inspect the manifest when necessary.
-        private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
-        {
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            WriteIndented = true
-        };
-
         [Required]
         public string Source { get; set; }
 
@@ -126,7 +116,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private void PersistManifest(StaticWebAssetsManifest manifest)
         {
-            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestSerializationOptions);
+            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsManifest);
             var fileExists = File.Exists(ManifestPath);
             var existingManifestHash = fileExists ? StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(ManifestPath)).Hash : "";
 

--- a/src/StaticWebAssetsSdk/Tasks/Utils/ArtifactWriter.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/ArtifactWriter.cs
@@ -4,21 +4,16 @@
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Utils;
 
 public static class ArtifactWriter
 {
-    public static readonly JsonSerializerOptions ArtifactJsonSerializationOptions = new()
+    public static void PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath, JsonTypeInfo<T> serializer)
     {
-        WriteIndented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
-
-    public static void PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath)
-    {
-        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ArtifactJsonSerializationOptions);
+        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, serializer);
         var newHash = ComputeHash(data);
         var fileExists = File.Exists(artifactPath);
         var existingManifestHash = fileExists ? ComputeHash(artifactPath) : null;


### PR DESCRIPTION
~1s win total.
**Before**
```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**
```console
Build succeeded in 12.2s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.9s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.9s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.4s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.4s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.7s
```
