### PR TITLE
[wasm] Include browser targets if RID is not wasi-wasm

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0">
   <!-- For browser-wasm, we want to import StaticWebAssets SDK which imports SDK. -->
   <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
-  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' != 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />


### PR DESCRIPTION
Because VS publish to container by default set RuntimeIndentifier to linux-x64, we need to treat any non-wasi RID as browser.
This is a SDK part of change, runtime part is in https://github.com/dotnet/runtime/pull/108283.