### PR TITLE
[StaticWebAssets] Avoid reading the manifest as part of the Build

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
@@ -61,9 +61,16 @@ Copyright (c) .NET Foundation. All rights reserved.
          for example, assets from packages as a result of a publish (no-build) invocation. Those assets were already taken
          into account when we built the build manifest that we are about to load for resuming the publish process. -->
     <PropertyGroup>
-        <_ShouldLoadBuildManifestAndUpdateAssets>false</_ShouldLoadBuildManifestAndUpdateAssets>
-        <_ShouldLoadBuildManifestAndUpdateAssets
-          Condition="@(_CachedBuildStaticWebAssets) == '' or @(_CachedBuildStaticWebAssetDiscoveryPatterns) == '' or @(_CachedBuildStaticWebAssetReferencedProjectsConfiguration) == ''">true</_ShouldLoadBuildManifestAndUpdateAssets>
+      <_HasStaticWebAssetsProjectReferences Condition="@(ProjectReference) != ''">true</_HasStaticWebAssetsProjectReferences>
+      <_HasCachedBuildStaticWebAssets Condition="@(_CachedBuildStaticWebAssets) == ''">false</_HasCachedBuildStaticWebAssets>
+      <_HasCachedBuildStaticWebAssetEndpoints Condition="@(_CachedBuildStaticWebAssetEndpoints) == ''">false</_HasCachedBuildStaticWebAssetEndpoints>
+      <_HasCachedBuildStaticWebAssetDiscoveryPatterns Condition="@(_CachedBuildStaticWebAssetDiscoveryPatterns) == ''">false</_HasCachedBuildStaticWebAssetDiscoveryPatterns>
+      <_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration Condition="@(_CachedBuildStaticWebAssetReferencedProjectsConfiguration) == ''">false</_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration>
+      <_ShouldLoadBuildManifestAndUpdateAssets>false</_ShouldLoadBuildManifestAndUpdateAssets>
+      <_ShouldLoadBuildManifestAndUpdateAssets Condition="'$(_HasCachedBuildStaticWebAssets)' == 'false' or
+        '$(_HasCachedBuildStaticWebAssetEndpoints)' == 'false' or
+        '$(_HasCachedBuildStaticWebAssetDiscoveryPatterns)' == 'false' or
+        ('$(_HasStaticWebAssetsProjectReferences)' == 'true' and '$(_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration)' == 'false')">true</_ShouldLoadBuildManifestAndUpdateAssets>
     </PropertyGroup>
 
     <ItemGroup>
@@ -131,11 +138,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ReferencedProjectPublishStaticWebAssetsUpdateCandidates
         Include="@(_ReferencedProjectPublishStaticWebAssetsItems)"
-        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAsset'" />        
+        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAsset'" />
 
       <_ReferencedProjectPublishStaticWebAssetEndpointsUpdateCandidates
         Include="@(_ReferencedProjectPublishStaticWebAssetsItems)"
-        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAssetEndpoint'" />        
+        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAssetEndpoint'" />
     </ItemGroup>
 
     <UpdateExternallyDefinedStaticWebAssets Condition="$(_HasProjectsWithStaticWebAssetPublishTargets)"

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -639,6 +639,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GenerateStaticWebAssetsDevelopmentManifest>
 
     <ItemGroup>
+      <_CachedBuildStaticWebAssets Condition="'@(_CachedBuildStaticWebAssets)' == ''" Include="@(StaticWebAsset)" />
+      <_CachedBuildStaticWebAssetEndpoints Condition="'@(_CachedBuildStaticWebAssetEndpoints)' == ''" Include="@(StaticWebAssetEndpoint)" />
+      <_CachedBuildStaticWebAssetReferencedProjectsConfiguration Condition="'@(_CachedBuildStaticWebAssetReferencedProjectsConfiguration)' == ''" Include="@(StaticWebAssetProjectConfiguration)" />
+      <_CachedBuildStaticWebAssetDiscoveryPatterns Condition="'@(_CachedBuildStaticWebAssetDiscoveryPatterns)' == ''" Include="@(StaticWebAssetDiscoveryPattern)" />
+    </ItemGroup>
+
+    <ItemGroup>
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(StaticWebAssetEndpointsBuildManifestPath)" />

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -33,6 +33,8 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
         [Required]
         public string ManifestPath { get; set; }
 
+        private static readonly char[] _separator = ['/'];
+
         public override bool Execute()
         {
             try
@@ -61,10 +63,32 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             IEnumerable<StaticWebAssetsDiscoveryPattern> discoveryPatterns)
         {
             var assetsWithPathSegments = ComputeManifestAssets(assets).ToArray();
+            Array.Sort(assetsWithPathSegments);
 
             var discoveryPatternsByBasePath = discoveryPatterns
                 .GroupBy(p => p.HasSourceId(Source) ? "" : p.BasePath,
-                 (key, values) => (key.Split(new[] { '/' }, options: StringSplitOptions.RemoveEmptyEntries), values));
+                 (key, values) =>
+                    (key.Split(_separator, options: StringSplitOptions.RemoveEmptyEntries),
+                    values.OrderBy(id => id.ContentRoot).ThenBy(id => id.Pattern).ToArray())).ToArray();
+
+            Array.Sort(discoveryPatternsByBasePath, (x, y) =>
+            {
+                var lengthResult = x.Item1.Length.CompareTo(y.Item1.Length);
+                if (lengthResult != 0)
+                {
+                    return lengthResult;
+                }
+                for (var i = 0; i < x.Item1.Length; i++)
+                {
+                    var comparison = x.Item1[i].CompareTo(y.Item1[i]);
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+                }
+
+                return 0;
+            });
 
             var manifest = CreateManifest(assetsWithPathSegments, discoveryPatternsByBasePath);
             return manifest;
@@ -132,7 +156,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private StaticWebAssetsDevelopmentManifest CreateManifest(
             SegmentsAssetPair[] assetsWithPathSegments,
-            IEnumerable<(string[], IEnumerable<StaticWebAssetsDiscoveryPattern> values)> discoveryPatternsByBasePath)
+            (string[], StaticWebAssetsDiscoveryPattern[] values)[] discoveryPatternsByBasePath)
         {
             var contentRootIndex = new Dictionary<string, int>();
             var root = new StaticWebAssetNode() { };
@@ -325,17 +349,38 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             public StaticWebAssetPattern[] Patterns { get; set; }
         }
 
-        private struct SegmentsAssetPair
+        private struct SegmentsAssetPair : IComparable<SegmentsAssetPair>
         {
+            private static readonly char[] separator = ['/'];
+
             public SegmentsAssetPair(string path, StaticWebAsset asset)
             {
-                PathSegments = path.Split(new[] { '/' }, options: StringSplitOptions.RemoveEmptyEntries);
+                PathSegments = path.Split(separator, options: StringSplitOptions.RemoveEmptyEntries);
                 Asset = asset;
             }
 
             public string[] PathSegments { get; }
 
             public StaticWebAsset Asset { get; }
+
+            public int CompareTo(SegmentsAssetPair other)
+            {
+                if (PathSegments.Length != other.PathSegments.Length)
+                {
+                    return PathSegments.Length.CompareTo(other.PathSegments.Length);
+                }
+
+                for (var i = 0; i < PathSegments.Length; i++)
+                {
+                    var comparison = PathSegments[i].CompareTo(other.PathSegments[i]);
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+                }
+
+                return 0;
+            }
 
             public void Deconstruct(out string[] segments, out StaticWebAsset asset)
             {

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestTest.cs
@@ -540,8 +540,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 CreateIntermediateNode(
                     ("_other", CreateIntermediateNode(
                         ("_project", CreateIntermediateNode().AddPatterns(
-                            (0, "*.js", 2),
-                            (1, "*.css", 2)))))),
+                            (0, "*.css", 2),
+                            (1, "*.js", 2)))))),
                 Path.GetFullPath("wwwroot"),
                 Path.GetFullPath("styles"));
 

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -692,7 +692,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
             // Second build
             var secondBuild = CreateBuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
-            secondBuild.Execute("/p:BuildProjectReferences=false").Should().Pass();
+            ExecuteCommand(secondBuild,"/p:BuildProjectReferences=false").Should().Pass();
 
             // GenerateStaticWebAssetsManifest should generate the manifest file.
             new FileInfo(path).Should().Exist();


### PR DESCRIPTION
~.8s win

**Before**

![image](https://github.com/user-attachments/assets/9407e927-5fba-446a-8d87-e2a83694a924)

```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**
![image](https://github.com/user-attachments/assets/878b9eb6-705c-4805-8dd4-e019d67e42c5)
```console
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.0s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.9s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (10.9s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 11.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.3s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.2s
```
