### PR TITLE
[StaticWebAssets] Remove multiple file accesses per asset

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -222,10 +222,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       CandidateAssets="@(_CompressedStaticWebAssets)"
     >
       <Output TaskParameter="Assets" ItemName="_CompressionBuildStaticWebAsset" />
+      <Output TaskParameter="AssetDetails" ItemName="_ResolveBuildCompressedStaticWebAssetsDetails" />
     </DefineStaticWebAssets>
 
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(_CompressionBuildStaticWebAsset)"
+      AssetFileDetails="@(_ResolveBuildCompressedStaticWebAssetsDetails)"
       ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >
@@ -240,6 +242,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ApplyCompressionNegotiation
       CandidateEndpoints="@(StaticWebAssetEndpoint)"
+      AssetFileDetails="@(_ResolveBuildCompressedStaticWebAssetsDetails)"
       CandidateAssets="@(_CompressionCurrentProjectBuildAssets)"
     >
       <Output TaskParameter="UpdatedEndpoints" ItemName="_UpdatedCompressionBuildEndpoints" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -670,10 +670,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       BasePath="$(StaticWebAssetBasePath)"
       AssetMergeSource="$(StaticWebAssetMergeTarget)">
         <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+        <Output TaskParameter="AssetDetails" ItemName="_ResolveProjectStaticWebAssetsDetails" />
     </DefineStaticWebAssets>
 
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(StaticWebAsset)"
+      AssetFileDetails="@(_ResolveProjectStaticWebAssetsDetails)"
       ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >

--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
@@ -15,13 +16,27 @@ public class ApplyCompressionNegotiation : Task
     [Required]
     public ITaskItem[] CandidateAssets { get; set; }
 
+    public ITaskItem[] AssetFileDetails { get; set; }
+
     [Output]
     public ITaskItem[] UpdatedEndpoints { get; set; }
 
     public Func<string, long> TestResolveFileLength;
 
+    private Dictionary<string, ITaskItem> _assetFileDetails;
+
     public override bool Execute()
     {
+        if (AssetFileDetails != null)
+        {
+            _assetFileDetails = new(AssetFileDetails.Length, OSPath.PathComparer);
+            for (int i = 0; i < AssetFileDetails.Length; i++)
+            {
+                var item = AssetFileDetails[i];
+                _assetFileDetails[item.ItemSpec] = item;
+            }
+        }
+
         var assetsById = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity);
 
         var endpointsByAsset = CandidateEndpoints.Select(StaticWebAssetEndpoint.FromTaskItem)
@@ -55,10 +70,6 @@ public class ApplyCompressionNegotiation : Task
             }
 
             Log.LogMessage("Processing compressed asset: {0}", compressedAsset.Identity);
-
-            var length = TestResolveFileLength != null
-                ? TestResolveFileLength(compressedAsset.Identity)
-                : new FileInfo(compressedAsset.Identity).Length;
             StaticWebAssetEndpointResponseHeader[] compressionHeaders = [
                 new()
                 {
@@ -72,9 +83,10 @@ public class ApplyCompressionNegotiation : Task
                 }
             ];
 
+            var quality = ResolveQuality(compressedAsset);
             foreach (var compressedEndpoint in compressedEndpoints)
             {
-                if (compressedEndpoint.Selectors.Any(s => string.Equals(s.Name,"Content-Encoding", StringComparison.Ordinal)))
+                if (compressedEndpoint.Selectors.Any(s => string.Equals(s.Name, "Content-Encoding", StringComparison.Ordinal)))
                 {
                     Log.LogMessage(MessageImportance.Low, $"  Skipping endpoint '{compressedEndpoint.Route}' since it already has a Content-Encoding selector");
                     continue;
@@ -102,7 +114,7 @@ public class ApplyCompressionNegotiation : Task
                     {
                         Name = "Content-Encoding",
                         Value = compressedAsset.AssetTraitValue,
-                        Quality = Math.Round(1.0 / (length + 1), 12).ToString("F12")
+                        Quality = quality
                     };
                     Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
                     var endpointCopy = new StaticWebAssetEndpoint
@@ -199,6 +211,25 @@ public class ApplyCompressionNegotiation : Task
         UpdatedEndpoints = updatedEndpoints.Distinct().Select(e => e.ToTaskItem()).ToArray();
 
         return true;
+    }
+
+    private string ResolveQuality(StaticWebAsset compressedAsset)
+    {
+        long length;
+        if(_assetFileDetails != null && _assetFileDetails.TryGetValue(compressedAsset.Identity, out var assetFileDetail))
+        {
+            length = long.Parse(assetFileDetail.GetMetadata("FileLength"));
+        }
+        else if (TestResolveFileLength != null)
+        {
+            length = TestResolveFileLength(compressedAsset.Identity);
+        }
+        else
+        {
+            length = new FileInfo(compressedAsset.Identity).Length;
+        }
+
+        return Math.Round(1.0 / (length + 1), 12).ToString("F12", CultureInfo.InvariantCulture);
     }
 
     private static bool IsCompatible(StaticWebAssetEndpoint compressedEndpoint, StaticWebAssetEndpoint relatedEndpointCandidate)

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using Microsoft.Build.Framework;
@@ -232,11 +233,13 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         internal static (string fingerprint, string integrity) ComputeFingerprintAndIntegrity(string identity, string originalItemSpec)
         {
-            using var file = File.Exists(identity) ?
-                File.OpenRead(identity) :
-                (File.Exists(originalItemSpec) ?
-                    File.OpenRead(originalItemSpec) :
-                    throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'."));
+            var fileInfo = ResolveFile(identity, originalItemSpec);
+            return ComputeFingerprintAndIntegrity(fileInfo);
+        }
+
+        internal static (string fingerprint, string integrity) ComputeFingerprintAndIntegrity(FileInfo fileInfo)
+        {
+            using var file = fileInfo.OpenRead();
 
 #if NET6_0_OR_GREATER
             var hash = SHA256.HashData(file);
@@ -249,11 +252,14 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         internal static string ComputeIntegrity(string identity, string originalItemSpec)
         {
-            using var file = File.Exists(identity) ?
-    File.OpenRead(identity) :
-    (File.Exists(originalItemSpec) ?
-        File.OpenRead(originalItemSpec) :
-        throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'."));
+            var fileInfo = ResolveFile(identity, originalItemSpec);
+            return ComputeIntegrity(fileInfo);
+        }
+
+        internal static string ComputeIntegrity(FileInfo fileInfo)
+        {
+            using var file = fileInfo.OpenRead();
+
 #if NET6_0_OR_GREATER
             var hash = SHA256.HashData(file);
 #else
@@ -914,6 +920,24 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             var resolver = StaticWebAssetTokenResolver.Instance;
             pattern.EmbedTokens(this, resolver);
             return pattern.RawPattern;
+        }
+
+        internal FileInfo ResolveFile() => ResolveFile(Identity, OriginalItemSpec);
+
+        internal static FileInfo ResolveFile(string identity, string originalItemSpec)
+        {
+            var fileInfo = new FileInfo(identity);
+            if (fileInfo.Exists)
+            {
+                return fileInfo;
+            }
+            fileInfo = new FileInfo(originalItemSpec);
+            if (fileInfo.Exists)
+            {
+                return fileInfo;
+            }
+
+            throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'.");
         }
 
         [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq.Expressions;
 using System.Net.Http.Headers;
@@ -79,12 +80,16 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
         [Output]
         public ITaskItem[] CopyCandidates { get; set; }
 
+        [Output]
+        public ITaskItem[] AssetDetails { get; set; }
+
         public override bool Execute()
         {
             try
             {
                 var results = new List<ITaskItem>();
                 var copyCandidates = new List<ITaskItem>();
+                var assetDetails = new List<ITaskItem>();
 
                 var matcher = !string.IsNullOrEmpty(RelativePathPattern) ? new Matcher().AddInclude(RelativePathPattern) : null;
                 var filter = !string.IsNullOrEmpty(RelativePathFilter) ? new Matcher().AddInclude(RelativePathFilter) : null;
@@ -176,11 +181,12 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                     // the asset.
                     var fingerprint = ComputePropertyValue(candidate, nameof(StaticWebAsset.Fingerprint), null, false);
                     var integrity = ComputePropertyValue(candidate, nameof(StaticWebAsset.Integrity), null, false);
+                    var file = StaticWebAsset.ResolveFile(candidate.ItemSpec, originalItemSpec);
                     switch ((fingerprint, integrity))
                     {
                         case (null, null):
                             Log.LogMessage(MessageImportance.Low, "Computing fingerprint and integrity for asset '{0}'", candidate.ItemSpec);
-                            (fingerprint, integrity) = (StaticWebAsset.ComputeFingerprintAndIntegrity(candidate.ItemSpec, originalItemSpec));
+                            (fingerprint, integrity) = (StaticWebAsset.ComputeFingerprintAndIntegrity(file));
                             break;
                         case (null, not null):
                             Log.LogMessage(MessageImportance.Low, "Computing fingerprint for asset '{0}'", candidate.ItemSpec);
@@ -188,9 +194,17 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                             break;
                         case (not null, null):
                             Log.LogMessage(MessageImportance.Low, "Computing integrity for asset '{0}'", candidate.ItemSpec);
-                            integrity = StaticWebAsset.ComputeIntegrity(candidate.ItemSpec, originalItemSpec);
+                            integrity = StaticWebAsset.ComputeIntegrity(file);
                             break;
                     }
+
+                    // Record the FileLength and LastWriteTimeUtc for the asset so that we don't have to read it again on other tasks
+                    // we'll flow this information to them
+                    assetDetails.Add(new TaskItem(file.FullName, new Dictionary<string, string>
+                    {
+                        ["FileLength"] = file.Length.ToString(CultureInfo.InvariantCulture),
+                        ["LastWriteTimeUtc"] = file.LastWriteTimeUtc.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture),
+                    }));
 
                     // If we are not able to compute the value based on an existing value or a default, we produce an error and stop.
                     if (Log.HasLoggedErrors)
@@ -251,6 +265,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
                 Assets = [.. results];
                 CopyCandidates = [.. copyCandidates];
+                AssetDetails = [.. assetDetails];
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Up to .5s speed up. 

More importantly, this makes other tasks CPU bound, which enables further optimizations in other areas.

**Before**

```console
Build succeeded in 12.8s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.8s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.7s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.7s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.6s
```

**After**

```console
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.4s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.3s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.6s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.5s
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  mvc-dotnet-9 succeeded (11.2s) → bin\Debug\net9.0\mvc-dotnet-9.dll

Build succeeded in 12.1s
```