### PR TITLE
[StaticWebAssets] Process endpoint definitions in parallel

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -228,7 +228,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(_CompressionBuildStaticWebAsset)"
       AssetFileDetails="@(_ResolveBuildCompressedStaticWebAssetsDetails)"
-      ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >
       <Output TaskParameter="Endpoints" ItemName="_CompressionBuildStaticWebAssetEndpoint" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -688,7 +688,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(StaticWebAsset)"
       AssetFileDetails="@(_ResolveProjectStaticWebAssetsDetails)"
-      ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >
       <Output TaskParameter="Endpoints" ItemName="StaticWebAssetEndpoint" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -682,11 +682,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       BasePath="$(StaticWebAssetBasePath)"
       AssetMergeSource="$(StaticWebAssetMergeTarget)">
         <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+        <Output TaskParameter="Assets" ItemName="_CurrentProjectStaticWebAsset" />
         <Output TaskParameter="AssetDetails" ItemName="_ResolveProjectStaticWebAssetsDetails" />
     </DefineStaticWebAssets>
 
     <DefineStaticWebAssetEndpoints
-      CandidateAssets="@(StaticWebAsset)"
+      CandidateAssets="@(_CurrentProjectStaticWebAsset)"
       AssetFileDetails="@(_ResolveProjectStaticWebAssetsDetails)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using Microsoft.Build.Framework;

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -230,6 +231,23 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         }
 
         return 0;
+    }
+
+    internal static ITaskItem[] ToTaskItems(ConcurrentBag<StaticWebAssetEndpoint> endpoints)
+    {
+        if (endpoints == null || endpoints.IsEmpty)
+        {
+            return [];
+        }
+
+        var endpointItems = new ITaskItem[endpoints.Count];
+        var i = 0;
+        foreach (var endpoint in endpoints)
+        {
+            endpointItems[i++] = endpoint.ToTaskItem();
+        }
+
+        return endpointItems;
     }
 
     private class RouteAndAssetEqualityComparer : IEqualityComparer<StaticWebAssetEndpoint>

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.Build.Framework;
+using System.Collections.Concurrent;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
-using System.Collections.Concurrent;
-using System.Globalization;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 {
@@ -89,8 +88,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             if (ExistingEndpoints != null && ExistingEndpoints.Length > 0)
             {
                 Dictionary<string, HashSet<string>> existingEndpointsByAssetFile = new(OSPath.PathComparer);
-                existingEndpointsByAssetFile = new(OSPath.PathComparer);
-                var assets = new HashSet<string>();
+                var assets = new HashSet<string>(CandidateAssets.Length, OSPath.PathComparer);
                 foreach (var asset in CandidateAssets)
                 {
                     assets.Add(asset.ItemSpec);
@@ -108,7 +106,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
                     if (!existingEndpointsByAssetFile.TryGetValue(assetFile, out var set))
                     {
-                        set = new HashSet<string>();
+                        set = new HashSet<string>(OSPath.PathComparer);
                         existingEndpointsByAssetFile[assetFile] = set;
                     }
 

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
+using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
@@ -12,7 +13,6 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
         [Required]
         public ITaskItem[] CandidateAssets { get; set; }
 
-        [Required]
         public ITaskItem[] ExistingEndpoints { get; set; }
 
         [Required]
@@ -40,69 +40,90 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                 }
             }
 
-            var staticWebAssets = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity);
-            var existingEndpoints = StaticWebAssetEndpoint.FromItemGroup(ExistingEndpoints);
-            var existingEndpointsByAssetFile = existingEndpoints
-                .GroupBy(e => e.AssetFile, OSPath.PathComparer)
-                .ToDictionary(g => g.Key, g => new HashSet<StaticWebAssetEndpoint>(g, StaticWebAssetEndpoint.RouteAndAssetComparer));
-
-            var assetsToRemove = new List<string>();
-            foreach (var kvp in existingEndpointsByAssetFile)
-            {
-                var asset = kvp.Key;
-                var set = kvp.Value;
-                if (!staticWebAssets.ContainsKey(asset))
-                {
-                    assetsToRemove.Remove(asset);
-                }
-            }
-            foreach (var asset in assetsToRemove)
-            {
-                Log.LogMessage(MessageImportance.Low, $"Removing endpoints for asset '{asset}' because it no longer exists.");
-                existingEndpointsByAssetFile.Remove(asset);
-            }
-
+            var existingEndpointsByAssetFile = CreateEndpointsByAssetFile();
             var contentTypeMappings = ContentTypeMappings.Select(ContentTypeMapping.FromTaskItem).OrderByDescending(m => m.Priority).ToArray();
             var contentTypeProvider = new ContentTypeProvider(contentTypeMappings);
-            var endpoints = new List<StaticWebAssetEndpoint>();
+            var endpoints = new ConcurrentBag<StaticWebAssetEndpoint>();
 
-            foreach (var kvp in staticWebAssets)
+            Parallel.For(0, CandidateAssets.Length, i =>
             {
-                var asset = kvp.Value;
+                var asset = StaticWebAsset.FromTaskItem(CandidateAssets[i]);
+                var routes = asset.ComputeRoutes().ToList();
 
-                // StaticWebAssets has this behavior where the base path for an asset only gets applied if the asset comes from a
-                // package or a referenced project and ignored if it comes from the current project.
-                // When we define the endpoint, we apply the path to the asset as if it was coming from the current project.
-                // If the endpoint is then passed to a referencing project or packaged into a nuget package, the path will be
-                // adjusted at that time.
-                var assetEndpoints = CreateEndpoints(asset, contentTypeProvider);
-
-                foreach (var endpoint in assetEndpoints)
+                if (existingEndpointsByAssetFile != null && existingEndpointsByAssetFile.TryGetValue(asset.Identity, out var set))
                 {
-                    // Check if the endpoint we are about to define already exists. This can happen during publish as assets defined
-                    // during the build will have already defined endpoints and we only want to add new ones.
-                    if (existingEndpointsByAssetFile.TryGetValue(asset.Identity, out var set) &&
-                        set.TryGetValue(endpoint, out var existingEndpoint))
+                    for (var j = routes.Count; j >= 0; j--)
                     {
-                        Log.LogMessage(MessageImportance.Low, $"Skipping asset {asset.Identity} because an endpoint for it already exists at {existingEndpoint.Route}.");
-                        continue;
-                    }
+                        var (label, route, values) = routes[j];
+                        // StaticWebAssets has this behavior where the base path for an asset only gets applied if the asset comes from a
+                        // package or a referenced project and ignored if it comes from the current project.
+                        // When we define the endpoint, we apply the path to the asset as if it was coming from the current project.
+                        // If the endpoint is then passed to a referencing project or packaged into a nuget package, the path will be
+                        // adjusted at that time.
+                        var finalRoute = asset.IsProject() || asset.IsPackage() ? StaticWebAsset.Normalize(Path.Combine(asset.BasePath, route)) : route;
 
+                        // Check if the endpoint we are about to define already exists. This can happen during publish as assets defined
+                        // during the build will have already defined endpoints and we only want to add new ones.
+                        if (set.Contains(finalRoute))
+                        {
+                            Log.LogMessage(MessageImportance.Low, $"Skipping asset {asset.Identity} because an endpoint for it already exists at {route}.");
+                            routes.RemoveAt(j);
+                        }
+                    }
+                }
+
+                foreach (var endpoint in CreateEndpoints(routes, asset, contentTypeProvider))
+                {
                     Log.LogMessage(MessageImportance.Low, $"Adding endpoint {endpoint.Route} for asset {asset.Identity}.");
                     endpoints.Add(endpoint);
                 }
-            }
+            });
 
             Endpoints = StaticWebAssetEndpoint.ToTaskItems(endpoints);
 
             return !Log.HasLoggedErrors;
         }
 
-        private List<StaticWebAssetEndpoint> CreateEndpoints(StaticWebAsset asset, ContentTypeProvider contentTypeMappings)
+        private Dictionary<string, HashSet<string>> CreateEndpointsByAssetFile()
         {
-            var routes = asset.ComputeRoutes();
+            if (ExistingEndpoints != null && ExistingEndpoints.Length > 0)
+            {
+                Dictionary<string, HashSet<string>> existingEndpointsByAssetFile = new(OSPath.PathComparer);
+                existingEndpointsByAssetFile = new(OSPath.PathComparer);
+                var assets = new HashSet<string>();
+                foreach (var asset in CandidateAssets)
+                {
+                    assets.Add(asset.ItemSpec);
+                }
+
+                for (int i = 0; i < ExistingEndpoints.Length; i++)
+                {
+                    var endpointCandidate = ExistingEndpoints[i];
+                    var assetFile = endpointCandidate.GetMetadata(nameof(StaticWebAssetEndpoint.AssetFile));
+                    if (!assets.Contains(assetFile))
+                    {
+                        Log.LogMessage(MessageImportance.Low, $"Removing endpoints for asset '{assetFile}' because it no longer exists.");
+                        continue;
+                    }
+
+                    if (!existingEndpointsByAssetFile.TryGetValue(assetFile, out var set))
+                    {
+                        set = [];
+                        existingEndpointsByAssetFile[assetFile] = set;
+                    }
+
+                    // Add the route
+                    set.Add(endpointCandidate.ItemSpec);
+                }
+            }
+
+            return null;
+        }
+
+        private List<StaticWebAssetEndpoint> CreateEndpoints(List<StaticWebAsset.StaticWebAssetResolvedRoute> routes, StaticWebAsset asset, ContentTypeProvider contentTypeMappings)
+        {
             var (length, lastModified) = ResolveDetails(asset);
-            var result = new List<StaticWebAssetEndpoint>(); 
+            var result = new List<StaticWebAssetEndpoint>();
             foreach (var (label, route, values) in routes)
             {
                 var (mimeType, cacheSetting) = ResolveContentType(asset, contentTypeMappings);

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
                 if (existingEndpointsByAssetFile != null && existingEndpointsByAssetFile.TryGetValue(asset.Identity, out var set))
                 {
-                    for (var j = routes.Count; j >= 0; j--)
+                    for (var j = routes.Count -1; j >= 0; j--)
                     {
                         var (label, route, values) = routes[j];
                         // StaticWebAssets has this behavior where the base path for an asset only gets applied if the asset comes from a
@@ -108,13 +108,15 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
                     if (!existingEndpointsByAssetFile.TryGetValue(assetFile, out var set))
                     {
-                        set = [];
+                        set = new HashSet<string>();
                         existingEndpointsByAssetFile[assetFile] = set;
                     }
 
                     // Add the route
                     set.Add(endpointCandidate.ItemSpec);
                 }
+
+                return existingEndpointsByAssetFile;
             }
 
             return null;


### PR DESCRIPTION
* Do not pass ExistingEndpoints to the `DefineStaticWebAssetEndpoints` calls for build assets (they aren't needed).
* Avoid deserializing the full endpoint (only the asset file and the route are used to avoid adding duplicate endpoints).
* Process endpoints in parallel

Around ~1s saving

**Before**
```console
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.29

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.26

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.08

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.22

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.23

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.29

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.20

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.21

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.22

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:08.24
```

**After**
```console
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.13

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.26

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.19

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.12

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.16

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.26

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.11

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.15

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.27

Build succeeded.
    0 Warning(s)
    0 Error(s)
```