### PR TITLE
Fix baseline manifest version for RTM branding

### DIFF
--- a/src/Cli/dotnet/CommandFactory/CommandSpec.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandSpec.cs
@@ -6,8 +6,8 @@ namespace Microsoft.DotNet.CommandFactory
     public class CommandSpec
     {
         public CommandSpec(
-            string path,
-            string args,
+            string? path,
+            string? args,
             Dictionary<string, string> environmentVariables = null)
         {
             Path = path;

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsApplyResult.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsApplyResult.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 {
     public class LaunchSettingsApplyResult
     {
-        public LaunchSettingsApplyResult(bool success, string failureReason, ProjectLaunchSettingsModel launchSettings = null)
+        public LaunchSettingsApplyResult(bool success, string? failureReason, ProjectLaunchSettingsModel launchSettings = null)
         {
             Success = success;
             FailureReason = failureReason;

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsModel.cs
@@ -5,17 +5,17 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 {
     public class ProjectLaunchSettingsModel
     {
-        public string LaunchProfileName { get; set; }
+        public string? LaunchProfileName { get; set; }
 
-        public string CommandLineArgs { get; set; }
+        public string? CommandLineArgs { get; set; }
 
         public bool LaunchBrowser { get; set; }
 
-        public string LaunchUrl { get; set; }
+        public string? LaunchUrl { get; set; }
 
-        public string ApplicationUrl { get; set; }
+        public string? ApplicationUrl { get; set; }
 
-        public string DotNetRunMessages { get; set; }
+        public string? DotNetRunMessages { get; set; }
 
         public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
     }

--- a/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     {
                         if (TryGetStringValue(environmentVariable.Value, out var environmentVariableValue))
                         {
-                            config.EnvironmentVariables[environmentVariable.Name] = environmentVariableValue;
+                            config.EnvironmentVariables[environmentVariable.Name] = environmentVariableValue!;
                         }
                     }
                 }

--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadCommandBase.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Workloads.Workload
         public WorkloadCommandBase(
             ParseResult parseResult,
             CliOption<VerbosityOptions> verbosityOptions = null,
-            IReporter reporter = null,
+            IReporter? reporter = null,
             string tempDirPath = null,
             INuGetPackageDownloader nugetPackageDownloader = null) : base(parseResult)
         {

--- a/src/Cli/dotnet/commands/dotnet-workload/clean/WorkloadCleanCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/clean/WorkloadCleanCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Clean
     {
         private readonly bool _cleanAll;
 
-        private string? _dotnetPath;
+        private string _dotnetPath;
         private string _userProfileDir;
 
         private readonly ReleaseVersion _sdkVersion;

--- a/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/config/WorkloadConfigCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Config
         private string? _updateMode;
         private readonly IWorkloadResolverFactory _workloadResolverFactory;
 
-        private string? _dotnetPath;
+        private string _dotnetPath;
         private string _userProfileDir;
         private readonly IWorkloadResolver _workloadResolver;
         private readonly ReleaseVersion _sdkVersion;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public WorkloadSet InstallWorkloadSet(ITransactionContext context, string workloadSetVersion, DirectoryPath? offlineCache = null)
         {
-            string workloadSetPackageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand workloadSetFeatureBand);
+            string workloadSetPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand workloadSetFeatureBand);
             var workloadSetPackageId = GetManifestPackageId(new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId), workloadSetFeatureBand);
 
             var workloadSetPath = Path.Combine(_workloadRootDir, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadSetVersion);
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
 
         public async Task<WorkloadSet> GetWorkloadSetContentsAsync(string workloadSetVersion)
         {
-            string workloadSetPackageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out var workloadSetFeatureBand);
+            string workloadSetPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out var workloadSetFeatureBand);
             var packagePath = await _nugetPackageDownloader.DownloadPackageAsync(GetManifestPackageId(new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId), workloadSetFeatureBand),
                                 new NuGetVersion(workloadSetPackageVersion), _packageSourceLocation);
             var tempExtractionDir = Path.Combine(_tempPackagesDir.Value, $"{WorkloadManifestUpdater.WorkloadSetManifestId}-{workloadSetPackageVersion}-extracted");
@@ -381,7 +381,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             foreach ((string workloadSetVersion, _) in installedWorkloadSets)
             {
                 //  Get the feature band of the workload set
-                WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out var workloadSetFeatureBand);
+                WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out var workloadSetFeatureBand);
 
                 List<SdkFeatureBand> referencingFeatureBands;
                 if (!workloadSetInstallRecords.TryGetValue((workloadSetVersion, workloadSetFeatureBand), out referencingFeatureBands))

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.InstallRecords.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.InstallRecords.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     {
                         using RegistryKey workloadSetPackageVersionKey = workloadSetFeatureBandKey.OpenSubKey(workloadSetPackageVersion);
 
-                        string workloadSetVersion = WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(new SdkFeatureBand(workloadSetFeatureBand), workloadSetPackageVersion);
+                        string workloadSetVersion = WorkloadSetVersion.FromWorkloadSetPackageVersion(new SdkFeatureBand(workloadSetFeatureBand), workloadSetPackageVersion);
 
                         WorkloadSetRecord record = new WorkloadSetRecord()
                         {

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -354,7 +354,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         (MsiPayload msi, string msiPackageId, string installationFolder) GetWorkloadSetPayload(string workloadSetVersion, DirectoryPath? offlineCache)
         {
             SdkFeatureBand workloadSetFeatureBand;
-            string msiPackageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
+            string msiPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out workloadSetFeatureBand);
             string msiPackageId = GetManifestPackageId(new ManifestId("Microsoft.NET.Workloads"), workloadSetFeatureBand).ToString();
 
             Log?.LogMessage($"Resolving Microsoft.NET.Workloads ({workloadSetVersion}) to {msiPackageId} ({msiPackageVersion}).");

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -157,10 +157,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         //  depends on NuGetVersion
         public static string WorkloadSetPackageVersionToWorkloadSetVersion(SdkFeatureBand sdkFeatureBand, string packageVersion)
         {
-            var nugetVersion = new NuGetVersion(packageVersion);
-            var patch = nugetVersion.Patch > 0 ? $".{nugetVersion.Patch}" : string.Empty;
-            var release = string.IsNullOrWhiteSpace(nugetVersion.Release) ? string.Empty : $"-{nugetVersion.Release}";
-            return $"{sdkFeatureBand.Major}.{sdkFeatureBand.Minor}.{nugetVersion.Minor}{patch}{release}";
+            return WorkloadSetVersion.FromWorkloadSetPackageVersion(sdkFeatureBand, packageVersion);
         }
 
         public static void AdvertiseWorkloadUpdates()

--- a/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadManifestUpdater.cs
@@ -153,13 +153,6 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             }
         }
 
-        //  Corresponding method for opposite direction is in WorkloadSet class.  This version is kept here as implementation
-        //  depends on NuGetVersion
-        public static string WorkloadSetPackageVersionToWorkloadSetVersion(SdkFeatureBand sdkFeatureBand, string packageVersion)
-        {
-            return WorkloadSetVersion.FromWorkloadSetPackageVersion(sdkFeatureBand, packageVersion);
-        }
-
         public static void AdvertiseWorkloadUpdates()
         {
             try
@@ -359,7 +352,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         throw new NuGetPackageNotFoundException($"Requested workload version {packageVersion} of {id} but found version {downloadedPackageVersion} instead.");
                     }
 
-                    var workloadSetVersion = WorkloadSetPackageVersionToWorkloadSetVersion(band, downloadedPackageVersion.ToString());
+                    var workloadSetVersion = WorkloadSetVersion.FromWorkloadSetPackageVersion(band, downloadedPackageVersion.ToString());
                     File.WriteAllText(Path.Combine(adManifestPath, Constants.workloadSetVersionFileName), workloadSetVersion);
                 }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
                 {
                     versions = PackageDownloader.GetLatestPackageVersions(packageId, _numberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: !string.IsNullOrWhiteSpace(_sdkVersion.Prerelease))
                         .GetAwaiter().GetResult()
-                        .Select(version => WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(featureBand, version.ToString()))
+                        .Select(version => WorkloadSetVersion.FromWorkloadSetPackageVersion(featureBand, version.ToString()))
                         .ToList();
                 }
                 catch (NuGetPackageNotFoundException)

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -14,6 +14,7 @@
     <UseAppHost>false</UseAppHost>
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="commands\dotnet-new\**" />

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\MSBuildPropertyNames.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common" />
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
     <Compile Remove="commands\dotnet-workload\list\VisualStudioWorkloads.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <Compile Remove="$(RepoRoot)\src\Cli\dotnet\Installer\Windows\Security\*.cs" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <EmbeddedResource Include="commands\dotnet-new\*.zip" />

--- a/src/Common/WorkloadSetVersion.cs
+++ b/src/Common/WorkloadSetVersion.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Workloads.Workload
+{
+    static class WorkloadSetVersion
+    {
+        public static string ToWorkloadSetPackageVersion(string workloadSetVersion, out SdkFeatureBand sdkFeatureBand)
+        {
+            string[] sections = workloadSetVersion.Split(new char[] { '-', '+' }, 2);
+            string versionCore = sections[0];
+            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
+
+            string[] coreComponents = versionCore.Split('.');
+            string major = coreComponents[0];
+            string minor = coreComponents[1];
+            string patch = coreComponents[2];
+
+            string packageVersion = $"{major}.{patch}.";
+            if (coreComponents.Length == 3)
+            {
+                //  No workload set patch version
+                packageVersion += "0";
+
+                //  Use preview specifier (if any) from workload set version as part of SDK feature band
+                sdkFeatureBand = new SdkFeatureBand(workloadSetVersion);
+            }
+            else
+            {
+                //  Workload set version has workload patch version (ie 4 components)
+                packageVersion += coreComponents[3];
+
+                //  Don't include any preview specifiers in SDK feature band
+                sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
+            }
+
+            if (preReleaseOrBuild != null)
+            {
+                //  Figure out if we split on a '-' or '+'
+                char separator = workloadSetVersion[sections[0].Length];
+                packageVersion += separator + preReleaseOrBuild;
+            }
+
+            return packageVersion;
+        }
+
+        public static SdkFeatureBand GetFeatureBand(string workloadSetVersion)
+        {
+            ToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand sdkFeatureBand);
+            return sdkFeatureBand;
+        }
+
+        public static string FromWorkloadSetPackageVersion(SdkFeatureBand sdkFeatureBand, string packageVersion)
+        {
+            var releaseVersion = new ReleaseVersion(packageVersion);
+            var patch = releaseVersion.Patch > 0 ? $".{releaseVersion.Patch}" : string.Empty;
+            var release = string.IsNullOrWhiteSpace(releaseVersion.Prerelease) ? string.Empty : $"-{releaseVersion.Prerelease}";
+            return $"{sdkFeatureBand.Major}.{sdkFeatureBand.Minor}.{releaseVersion.Minor}{patch}{release}";
+        }
+    }
+}

--- a/src/Installer/core-sdk-tasks/GetWorkloadSetFeatureBand.cs
+++ b/src/Installer/core-sdk-tasks/GetWorkloadSetFeatureBand.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Workloads.Workload;
+using WorkloadSetVersionUtil = Microsoft.DotNet.Workloads.Workload.WorkloadSetVersion;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -19,7 +21,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public override bool Execute()
         {
-            WorkloadSetFeatureBand = Microsoft.DotNet.Workloads.Workload.WorkloadSetVersion.GetFeatureBand(WorkloadSetVersion).ToString();
+            WorkloadSetFeatureBand = WorkloadSetVersionUtil.GetFeatureBand(WorkloadSetVersion).ToString();
             return true;
         }
     }

--- a/src/Installer/core-sdk-tasks/GetWorkloadSetFeatureBand.cs
+++ b/src/Installer/core-sdk-tasks/GetWorkloadSetFeatureBand.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GetWorkloadSetFeatureBand : Task
+    {
+        [Required]
+        public string WorkloadSetVersion { get; set; }
+
+        [Output]
+        public string WorkloadSetFeatureBand { get; set; }
+
+        public override bool Execute()
+        {
+            WorkloadSetFeatureBand = Microsoft.DotNet.Workloads.Workload.WorkloadSetVersion.GetFeatureBand(WorkloadSetVersion).ToString();
+            return true;
+        }
+    }
+}

--- a/src/Installer/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/Installer/core-sdk-tasks/core-sdk-tasks.csproj
@@ -7,7 +7,14 @@
     <RootNamespace>Microsoft.DotNet.Cli.Build</RootNamespace>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\SdkFeatureBand.cs" LinkBase="Common"/>
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
+  </ItemGroup>
+  
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
@@ -16,6 +23,7 @@
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="System.Reflection.Metadata" VersionOverride="$(SystemReflectionMetadataLoadContextVersion)" />
+    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Installer/redist-installer/targets/BuildCoreSdkTasks.targets
+++ b/src/Installer/redist-installer/targets/BuildCoreSdkTasks.targets
@@ -37,6 +37,7 @@
   <UsingTask TaskName="GetDependencyInfo" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GetLinuxNativeInstallerDependencyVersions" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GetRuntimePackRids" AssemblyFile="$(CoreSdkTaskDll)" />
+  <UsingTask TaskName="GetWorkloadSetFeatureBand" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="ReplaceFilesWithSymbolicLinks" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="TarGzFileCreateFromDirectory" AssemblyFile="$(CoreSdkTaskDll)" />

--- a/src/Installer/redist-installer/targets/BundledManifests.targets
+++ b/src/Installer/redist-installer/targets/BundledManifests.targets
@@ -106,12 +106,15 @@
     <PropertyGroup>
       <WorkloadSetVersion Condition="'$(DotNetFinalVersionKind)' == 'release'">$(VersionPrefix)-baseline$(_BuildNumberLabels)</WorkloadSetVersion>
       <WorkloadSetVersion Condition="'$(DotNetFinalVersionKind)' != 'release'">$(Version)</WorkloadSetVersion>
-      <WorkloadSetFeatureBand>$(VersionPrefix.Substring(0, $([MSBuild]::Subtract($(VersionPrefix.Length), 2))))00$([System.Text.RegularExpressions.Regex]::Match($(WorkloadSetVersion), `-[A-z]*[\.]*\d*`))</WorkloadSetFeatureBand>
-      <RealFormattedManifestPaths>$(RedistLayoutPath)sdk-manifests\$(WorkloadSetFeatureBand)\workloadsets\$(WorkloadSetVersion)</RealFormattedManifestPaths>
     </PropertyGroup>
 
-    <ItemGroup>
-    </ItemGroup>
+    <GetWorkloadSetFeatureBand WorkloadSetVersion="$(WorkloadSetVersion)">
+      <Output TaskParameter="WorkloadSetFeatureBand" PropertyName="WorkloadSetFeatureBand" />
+    </GetWorkloadSetFeatureBand>
+
+    <PropertyGroup>
+      <RealFormattedManifestPaths>$(RedistLayoutPath)sdk-manifests\$(WorkloadSetFeatureBand)\workloadsets\$(WorkloadSetVersion)</RealFormattedManifestPaths>      
+    </PropertyGroup>
 
     <ItemGroup>
       <FormattedBaselineManifest Include="{" />

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" LinkBase="Microsoft.DotNet.SdkResolver"/>
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common"/>
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Cli\dotnet\commands\dotnet-workload\InstallStateContents.cs" LinkBase="Cli"/>
   </ItemGroup>
 

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -80,6 +80,7 @@
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common"/>
     <Compile Include="$(RepoRoot)src\Common\CliFolderPathCalculatorCore.cs" LinkBase="Common"/>
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common"/>
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/Microsoft.NET.Sdk.WorkloadManifestReader.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\Microsoft.DotNet.MSBuildSdkResolver\FXVersion.cs" />
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common" />
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Cli\dotnet\commands\dotnet-workload\InstallStateContents.cs" LinkBase="Cli"/>
   </ItemGroup>
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -138,7 +138,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 }
 
                 //  Check to see if workload set is from a different feature band
-                WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand workloadSetFeatureBand);
+                var workloadSetFeatureBand = WorkloadSetVersion.GetFeatureBand(workloadSetVersion);
                 if (!workloadSetFeatureBand.Equals(_sdkVersionBand))
                 {
                     var featureBandWorkloadSets = GetAvailableWorkloadSets(workloadSetFeatureBand);
@@ -565,7 +565,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                         var workloadSetVersion = Path.GetFileName(workloadSetDirectory);
                         var workloadSet = WorkloadSet.FromWorkloadSetFolder(workloadSetDirectory, workloadSetVersion, featureBand);
 
-                        if (!WorkloadSet.GetWorkloadSetFeatureBand(workloadSet.Version!).Equals(featureBand))
+                        if (!WorkloadSetVersion.GetFeatureBand(workloadSet.Version!).Equals(featureBand))
                         {
                             //  We have a workload set version where the feature band doesn't match the feature band folder that it's in.
                             //  Skip it, as if we try to actually load it via the workload set version, we'll fail

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.MSBuildSdkResolver;
 using Strings = Microsoft.NET.Sdk.Localization.Strings;
 
 using System.Text.Json;
+using Microsoft.DotNet.Workloads.Workload;
 
 namespace Microsoft.NET.Sdk.WorkloadManifestReader
 {
@@ -130,47 +131,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         //  which we'd like to avoid adding as a dependency here.
         public static string WorkloadSetVersionToWorkloadSetPackageVersion(string setVersion, out SdkFeatureBand sdkFeatureBand)
         {
-            string[] sections = setVersion.Split(new char[] { '-', '+' }, 2);
-            string versionCore = sections[0];
-            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
-
-            string[] coreComponents = versionCore.Split('.');
-            string major = coreComponents[0];
-            string minor = coreComponents[1];
-            string patch = coreComponents[2];
-
-            string packageVersion = $"{major}.{patch}.";
-            if (coreComponents.Length == 3)
-            {
-                //  No workload set patch version
-                packageVersion += "0";
-
-                //  Use preview specifier (if any) from workload set version as part of SDK feature band
-                sdkFeatureBand = new SdkFeatureBand(setVersion);
-            }
-            else
-            {
-                //  Workload set version has workload patch version (ie 4 components)
-                packageVersion += coreComponents[3];
-
-                //  Don't include any preview specifiers in SDK feature band
-                sdkFeatureBand = new SdkFeatureBand($"{major}.{minor}.{patch}");
-            }
-
-            if (preReleaseOrBuild != null)
-            {
-                //  Figure out if we split on a '-' or '+'
-                char separator = setVersion[sections[0].Length];
-                packageVersion += separator + preReleaseOrBuild;
-            }
-
-            return packageVersion;
+            var ret = WorkloadSetVersion.ToWorkloadSetPackageVersion(setVersion, out var band);
+            sdkFeatureBand = band;
+            return ret;
         }
 
         public static SdkFeatureBand GetWorkloadSetFeatureBand(string setVersion)
         {
-            WorkloadSetVersionToWorkloadSetPackageVersion(setVersion, out SdkFeatureBand sdkFeatureBand);
-            return sdkFeatureBand;
+            return WorkloadSetVersion.GetFeatureBand(setVersion);
         }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -126,19 +126,5 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             var json = JsonSerializer.Serialize(ToDictionaryForJson(), new JsonSerializerOptions() { WriteIndented = true });
             return json;
         }
-
-        //  Corresponding method for opposite direction is in WorkloadManifestUpdater, as its implementation depends on NuGetVersion,
-        //  which we'd like to avoid adding as a dependency here.
-        public static string WorkloadSetVersionToWorkloadSetPackageVersion(string setVersion, out SdkFeatureBand sdkFeatureBand)
-        {
-            var ret = WorkloadSetVersion.ToWorkloadSetPackageVersion(setVersion, out var band);
-            sdkFeatureBand = band;
-            return ret;
-        }
-
-        public static SdkFeatureBand GetWorkloadSetFeatureBand(string setVersion)
-        {
-            return WorkloadSetVersion.GetFeatureBand(setVersion);
-        }
     }
 }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -166,5 +166,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             return packageVersion;
         }
+
+        public static SdkFeatureBand GetWorkloadSetFeatureBand(string setVersion)
+        {
+            WorkloadSetVersionToWorkloadSetPackageVersion(setVersion, out SdkFeatureBand sdkFeatureBand);
+            return sdkFeatureBand;
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -95,6 +95,7 @@
     <Compile Include="$(RepoRoot)src\Common\EnvironmentVariableNames.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\CliFolderPathCalculatorCore.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common" />
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Cli\dotnet\commands\dotnet-workload\InstallStateContents.cs" LinkBase="Cli" />
     <Compile Include="$(RepoRoot)src\Cli\dotnet\commands\dotnet-test\IPC\**\*.cs" />
   </ItemGroup>

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.DotNet.MsiInstallerTests.Framework;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
@@ -398,7 +399,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
-            var packageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(WorkloadSetVersion2, out var sdkFeatureBand);
+            var packageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(WorkloadSetVersion2, out var sdkFeatureBand);
 
             //  Rename latest workload set so it won't be installed
             VM.CreateActionGroup($"Disable {WorkloadSetVersion2}",
@@ -454,7 +455,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
 
             //  Get workload set feature band
-            WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(WorkloadSetVersion2, out var workloadSetFeatureBand);
+            var workloadSetFeatureBand = WorkloadSetVersion.GetFeatureBand(WorkloadSetVersion2);
 
             string workloadSet2Path = $@"c:\Program Files\dotnet\sdk-manifests\{workloadSetFeatureBand}\workloadsets\{WorkloadSetVersion2}";
 
@@ -503,8 +504,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         {
             UpdateWithWorkloadSets();
 
-            //  Get workload set feature band
-            WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(WorkloadSetVersion2, out var workloadSetFeatureBand);
+            var workloadSetFeatureBand = WorkloadSetVersion.GetFeatureBand(WorkloadSetVersion2);
 
             string workloadSetPath = $@"c:\Program Files\dotnet\sdk-manifests\{workloadSetFeatureBand}\workloadsets\{WorkloadSetVersion2}";
 

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -1,19 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using Microsoft.DotNet.MsiInstallerTests.Framework;
 using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -16,7 +16,12 @@
   <PropertyGroup>
     <CanRunTestAsTool>false</CanRunTestAsTool>
     <RootNamespace>Microsoft.DotNet.MsiInstallerTests</RootNamespace>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />

--- a/test/dotnet-workload-install.Tests/WorkloadSetVersionMappingTests.cs
+++ b/test/dotnet-workload-install.Tests/WorkloadSetVersionMappingTests.cs
@@ -37,6 +37,10 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                     ["8.0.201.1-preview", "8.0.200", "8.201.1-preview"],
                     ["8.0.201.1-preview.2", "8.0.200", "8.201.1-preview.2"],
 
+                    //  Versions with "rtm" in them are special-cased to not use a preview feature band
+                    ["9.0.100-rtm.23015", "9.0.100", "9.100.0-rtm.23015"],
+                    ["9.0.100-testingrtms.23015", "9.0.100", "9.100.0-testingrtms.23015"],
+
                     //  This apparently works accidentally, since "servicing" contains "ci", which is what the SdkFeatureBand constructor check to see if it should ignore the prerelease specifier
                     ["8.0.201-servicing.23015", "8.0.200", "8.201.0-servicing.23015"],
                     ["9.0.100-preview-servicing.1.23015", "9.0.100", "9.100.0-preview-servicing.1.23015"],

--- a/test/dotnet-workload-install.Tests/WorkloadSetVersionMappingTests.cs
+++ b/test/dotnet-workload-install.Tests/WorkloadSetVersionMappingTests.cs
@@ -12,6 +12,7 @@ using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using System.Text.Json;
 using Microsoft.TemplateEngine.Edge.Constraints;
+using Microsoft.DotNet.Workloads.Workload;
 
 namespace Microsoft.DotNet.Cli.Workload.Install.Tests
 {
@@ -48,7 +49,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         [MemberData(nameof(WorkloadVersionsData))]
         public void TestWorkloadSetVersionParsing(string workloadSetVersion, string expectedFeatureBand, string expectedPackageVersion)
         {
-            string packageVersion = WorkloadSet.WorkloadSetVersionToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand featureBand);
+            string packageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand featureBand);
 
             packageVersion.Should().Be(expectedPackageVersion);
             featureBand.Should().Be(new SdkFeatureBand(expectedFeatureBand));
@@ -58,7 +59,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         [MemberData(nameof(WorkloadVersionsData))]
         public void TestWorkloadSetPackageVersionParsing(string expectedWorkloadSetVersion, string packageFeatureBand, string packageVersion)
         {
-            string workloadSetVersion = WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(new SdkFeatureBand(packageFeatureBand), packageVersion);
+            string workloadSetVersion = WorkloadSetVersion.FromWorkloadSetPackageVersion(new SdkFeatureBand(packageFeatureBand), packageVersion);
 
             workloadSetVersion.Should().Be(expectedWorkloadSetVersion);
         }


### PR DESCRIPTION
In #43483, we hit a test failure where a workload uninstall command was failing.  On investigation, this was because during the SDK build when the baseline workload set was being created, its feature band was being calculated incorrectly.  This led to the workload set being included in a folder such as `sdk-manifests\9.0.100-rtm.24476\workloadsets\9.0.100-rtm.24476.1`, using `9.0.100-rtm.24476` for the feature band instead of `9.0.100` which would have been correct.

When the SDK scanned for workload sets it would find this as workload set `9.0.100-rtm.24476.1`, but when during garbage collection it tried to load the workload set, it would calculate its feature band as `9.0.100` and look for the workload set under the `sdk-manifests\9.0.100` folder, and fail when it couldn't be found.  This meant garbage collection would always fail.  For most workload commands this would be reported as a warning, but for the uninstall command it would cause the whole command to fail.

This PR fixes the issue in two ways:

- Correctly calculate the baseline workload set feature band when creating the baseline workload set
- When scanning for workload sets, ignore any where the feature band folder name isn't a valid feature band, or where there is an inconsistency between the feature band in the folder name and the feature band of the workload set

# Correctly calculate baseline workload set feature band

The `LayoutManifests` target of the build was using a regex to calculate the feature band based on the workload set version.  This PR changes that to use a build task that calls the same code that the product does to do the workload set version mapping.  This involves:

- Consolidating the workload set version mapping logic into a common `WorkloadSetVersion` class
- Allowing nullable annotations in the `dotnet` project, so that the `WorkloadSetVersion` class could use nullability annotations (since it also is consumed by projects that have nullability enabled)
- Switching from `NuGetVersion` to `ReleaseVersion` in the `WorkloadSetVersion.FromWorkloadSetPackageVersion` logic.  Previously, the methods to convert in different directions where in different locations, to avoid adding a dependency on the NuGet APIs where it wasn't necessary.  `ReleaseVersion` appears to be available in all the locations that these methods are used, so it is a better choice.  However, making this change introduces risk that a difference in behavior between `NuGetVersion` and `ReleaseVersion` could cause this to be a change in the SDK behavior.
- Creating a `GetWorkloadSetFeatureBand` task in core-sdk-tasks and using it in the `LayoutManifests` target to calculate the feature band for the baseline workload set

# Ignore workload sets with invalid or mismatched feature bands when scanning for available workload sets

This is a change to `SdkDirectoryWorkloadManifestProvider`.  When scanning for workload sets, it ignores any that it would not be able to find later based on the workload set version due to a mismatched feature band folder.  This will avoid errors if the SDK later tries to load that workload set and can't find it.

However, this does somewhat reduce the diagnosibility of issues, as it will silently ignore any workload sets that are in the wrong feature band folder.  The `SdkDirectoryWorkloadManifestProvider` doesn't currently have any way to write warnings or similar messages to a log.