### PR TITLE
Create a dotnet-new template for .gitattributes

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.gitattrbutes
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.gitattrbutes
@@ -1,0 +1,107 @@
+## Set Git attributes for paths including line ending
+## normalization, diff behavior, etc.
+##
+## Get latest from `dotnet new gitattributes`
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+*.cs     text diff=csharp
+*.cshtml text diff=html
+*.csx    text diff=csharp
+*.sln    text eol=crlf
+
+# Content below from: https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+# Per RFC 4180, .csv should be CRLF
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+# Force Unix scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# Likewise, force cmd and batch scripts to always use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+# Exclude files from exporting
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/dotnetcli.host.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host"
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "soubor gitattributes pro dotnet",
+  "description": "Vytvoří soubor gitattributes pro projekt dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "„dotNet gitattributes“-Datei",
+  "description": "Erstellt eine „gitattributes“-Datei für ein „dotnet“-Projekt."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "dotnet gitattributes file",
+  "description": "Creates a gitattributes file for a dotnet project."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "archivo gitattributes de dotnet",
+  "description": "Crea un archivo gitattributes para un proyecto dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "fichier gitattributes dotnet",
+  "description": "Crée un fichier gitattributes pour un projet dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "file gitattributes dotnet",
+  "description": "Crea un file gitattributes per un progetto dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "dotnet gitattributes ファイル",
+  "description": "dotnet プロジェクト用の gitattributes ファイルを作成します。"
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "dotnet gitattributes 파일",
+  "description": "dotnet 프로젝트에 대한 gitattributes 파일을 만듭니다."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "plik dotnet gitattributes",
+  "description": "Tworzy plik gitattributes dla projektu dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "arquivo de dotnet gitattributes",
+  "description": "Cria um arquivo gitattributes em um projeto dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Майкрософт",
+  "name": "файл gitattributes dotnet",
+  "description": "Создает файл gitattributes для проекта dotnet."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "DotNet gitattributes dosyası",
+  "description": "DotNet projesi için bir gitattributes dosyası oluşturur."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "dotnet gitattributes 文件",
+  "description": "为 dotnet 项目创建 gitattributes 文件。"
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+﻿{
+  "author": "Microsoft",
+  "name": "dotnet gitattributes 檔案",
+  "description": "為 dotnet 專案建立 gitattributes 檔案。"
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [
+    "Config"
+  ],
+  "name": "dotnet gitattributes file",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "Creates a gitattributes file for a dotnet project.",
+  "tags": {
+    "type": "item"
+  },
+  "groupIdentity": "GitattributesFile",
+  "precedence": "100",
+  "identity": "Microsoft.Standard.QuickStarts.GitattributesFile",
+  "shortName": [ "gitattributes", ".gitattributes" ],
+  "primaryOutputs": [
+    {
+      "path": ".gitattributes"
+    }
+  ]
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Create_GetAllSuggestions.verified.txt
@@ -35,6 +35,13 @@
     Documentation: Creates an .editorconfig file for configuring code style preferences.
   },
   {
+    Label: gitattributes,
+    Kind: Value,
+    SortText: gitattributes,
+    InsertText: gitattributes,
+    Documentation: Creates a gitattributes file for a dotnet project.
+  },
+  {
     Label: gitignore,
     Kind: Value,
     SortText: gitignore,

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.RootCommand_GetAllSuggestions.verified.txt
@@ -35,6 +35,13 @@
     Documentation: Creates an .editorconfig file for configuring code style preferences.
   },
   {
+    Label: gitattributes,
+    Kind: Value,
+    SortText: gitattributes,
+    InsertText: gitattributes,
+    Documentation: Creates a gitattributes file for a dotnet project.
+  },
+  {
     Label: gitignore,
     Kind: Value,
     SortText: gitignore,

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitattributes-file#-n#item.verified/dotnet-gitattributes-file/.gitattributes
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitattributes-file#-n#item.verified/dotnet-gitattributes-file/.gitattributes
@@ -1,0 +1,107 @@
+﻿## Set Git attributes for paths including line ending
+## normalization, diff behavior, etc.
+##
+## Get latest from `dotnet new gitattributes`
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+*.cs     text diff=csharp
+*.cshtml text diff=html
+*.csx    text diff=csharp
+*.sln    text eol=crlf
+
+# Content below from: https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+# Per RFC 4180, .csv should be CRLF
+*.csv      text eol=crlf
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+*.epub     diff=astextplain
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+# Force Unix scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.ksh      text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# Likewise, force cmd and batch scripts to always use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.bz       binary
+*.bz2      binary
+*.bzip2    binary
+*.gz       binary
+*.lz       binary
+*.lzma     binary
+*.rar      binary
+*.tar      binary
+*.taz      binary
+*.tbz      binary
+*.tbz2     binary
+*.tgz      binary
+*.tlz      binary
+*.txz      binary
+*.xz       binary
+*.Z        binary
+*.zip      binary
+*.zst      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+# Exclude files from exporting
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitattributes-file#-n#item.verified/std-streams/stdout.txt
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitattributes-file#-n#item.verified/std-streams/stdout.txt
@@ -1,0 +1,1 @@
+﻿The template "%TEMPLATE_NAME%" was created successfully.

--- a/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
@@ -6,6 +6,7 @@ buildtargets
 classlib
 console
 editorconfig
+gitattributes
 gitignore
 globaljson
 grpc

--- a/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
@@ -6,6 +6,7 @@ buildtargets
 classlib
 console
 editorconfig
+gitattributes
 gitignore
 globaljson
 grpc

--- a/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
@@ -6,6 +6,7 @@ buildtargets
 classlib
 console
 editorconfig
+gitattributes
 gitignore
 globaljson
 grpc

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
@@ -4,43 +4,44 @@ For more information, run:
 
 These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
@@ -4,43 +4,44 @@ For more information, run:
 
 These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
@@ -4,50 +4,51 @@ For more information, run:
 
 These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Windows Forms App                             winforms                    [C#],VB     Common/WinForms               
-Windows Forms Class Library                   winformslib                 [C#],VB     Common/WinForms               
-Windows Forms Control Library                 winformscontrollib          [C#],VB     Common/WinForms               
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-WPF Application                               wpf                         [C#],VB     Common/WPF                    
-WPF Class Library                             wpflib                      [C#],VB     Common/WPF                    
-WPF Custom Control Library                    wpfcustomcontrollib         [C#],VB     Common/WPF                    
-WPF User Control Library                      wpfusercontrollib           [C#],VB     Common/WPF                    
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Windows Forms App                             winforms                      [C#],VB     Common/WinForms               
+Windows Forms Class Library                   winformslib                   [C#],VB     Common/WinForms               
+Windows Forms Control Library                 winformscontrollib            [C#],VB     Common/WinForms               
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+WPF Application                               wpf                           [C#],VB     Common/WPF                    
+WPF Class Library                             wpflib                        [C#],VB     Common/WPF                    
+WPF Custom Control Library                    wpfcustomcontrollib           [C#],VB     Common/WPF                    
+WPF User Control Library                      wpfusercontrollib             [C#],VB     Common/WPF                    
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
@@ -1,42 +1,43 @@
 ﻿These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
@@ -1,42 +1,43 @@
 ﻿These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
@@ -1,49 +1,50 @@
 ﻿These templates matched your input: 
 
-Template Name                                 Short Name                  Language    Tags                          
---------------------------------------------  --------------------------  ----------  ------------------------------
-API Controller                                apicontroller               [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                         [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                        [C#]        Web/gRPC/API/Service          
-ASP.NET Core Web API                          webapi                      [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                   [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                         [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                [C#]        Web/Blazor                    
-Blazor Web App                                blazor                      [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                  [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                    [C#],F#,VB  Common/Library                
-Console App                                   console                     [C#],F#,VB  Common/Console                
-dotnet gitignore file                         gitignore,.gitignore                    Config                        
-Dotnet local tool manifest file               tool-manifest                           Config                        
-EditorConfig file                             editorconfig,.editorconfig              Config                        
-global.json file                              globaljson,global.json                  Config                        
-MSBuild Directory.Build.props file            buildprops                              MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                            MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                           MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright           [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                      [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller               [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                 [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                   [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                Config                        
-NUnit 3 Test Item                             nunit-test                  [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                       [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright            [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                   Web/gRPC                      
-Razor Class Library                           razorclasslib               [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent              [C#]        Web/ASP.NET                   
-Razor Page                                    page                        [C#]        Web/ASP.NET                   
-Razor View                                    view                        [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                            Solution                      
-Web Config                                    webconfig                               Config                        
-Windows Forms App                             winforms                    [C#],VB     Common/WinForms               
-Windows Forms Class Library                   winformslib                 [C#],VB     Common/WinForms               
-Windows Forms Control Library                 winformscontrollib          [C#],VB     Common/WinForms               
-Worker Service                                worker                      [C#],F#     Common/Worker/Web             
-WPF Application                               wpf                         [C#],VB     Common/WPF                    
-WPF Class Library                             wpflib                      [C#],VB     Common/WPF                    
-WPF Custom Control Library                    wpfcustomcontrollib         [C#],VB     Common/WPF                    
-WPF User Control Library                      wpfusercontrollib           [C#],VB     Common/WPF                    
-xUnit Test Project                            xunit                       [C#],F#,VB  Test/xUnit                    
+Template Name                                 Short Name                    Language    Tags                          
+--------------------------------------------  ----------------------------  ----------  ------------------------------
+API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class Library                                 classlib                      [C#],F#,VB  Common/Library                
+Console App                                   console                       [C#],F#,VB  Common/Console                
+dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
+dotnet gitignore file                         gitignore,.gitignore                      Config                        
+Dotnet local tool manifest file               tool-manifest                             Config                        
+EditorConfig file                             editorconfig,.editorconfig                Config                        
+global.json file                              globaljson,global.json                    Config                        
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
+NuGet Config                                  nugetconfig,nuget.config                  Config                        
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
+Protocol Buffer File                          proto                                     Web/gRPC                      
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
+Razor Page                                    page                          [C#]        Web/ASP.NET                   
+Razor View                                    view                          [C#]        Web/ASP.NET                   
+Solution File                                 sln,solution                              Solution                      
+Web Config                                    webconfig                                 Config                        
+Windows Forms App                             winforms                      [C#],VB     Common/WinForms               
+Windows Forms Class Library                   winformslib                   [C#],VB     Common/WinForms               
+Windows Forms Control Library                 winformscontrollib            [C#],VB     Common/WinForms               
+Worker Service                                worker                        [C#],F#     Common/Worker/Web             
+WPF Application                               wpf                           [C#],VB     Common/WPF                    
+WPF Class Library                             wpflib                        [C#],VB     Common/WPF                    
+WPF Custom Control Library                    wpfcustomcontrollib           [C#],VB     Common/WPF                    
+WPF User Control Library                      wpfusercontrollib             [C#],VB     Common/WPF                    
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    


### PR DESCRIPTION
Create a `dotnet new` template for `.gitattributes`, similar to what we already have for `.gitignore` and `.editorconfig`. Like those files, this template provides a set of best practices and basis for customization to both get a new repo up-and-running quickly and to standardize behavior for existing repos.

I started with the common template @ https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes (attribution given inline) like we do for .gitignore, then made a few changes:

## 1. C#-specific changes

```
*.cs     text diff=csharp
*.cshtml text diff=html
*.csx    text diff=csharp
```

This tells Git how to do diff hunk headers where there's a built-in pattern.

## 2. Handle .sln files

```
*.sln    text eol=crlf
```

This follows best practice used by most repos in GitHub under the dotnet organization that specify to use `CRLF` on checkout for VS Solution files.

## 3. Add a comment for CSV

```
# Per RFC 4180, .csv should be CRLF
*.csv      text eol=crlf
```

Common.gitattributes specifies to use CRLF for CSV files but doesn't specify why. I added a comment from the commit message to clarify that it's for RFC 4180 conformance.

## 4. Update Scripts section comment

```
# Force Unix scripts to always use lf line endings so that if a repo is accessed
# in Unix via a file share from Windows, the scripts will work
...
# Likewise, force cmd and batch scripts to always use crlf
```

The handling of line endings for shell scripts matches between Common.gitattributes and dotnet/runtime, but I used dotnet/runtime's comments because they clarify _why_ certain line endings are needed.