### PR TITLE
[DO NOT MERGE] Restore ability for users to consume the containers package easily

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -48,8 +48,14 @@ internal static class KnownStrings
 
     public static class ErrorCodes
     {
+        // current version doesn't support containerization
         public static readonly string CONTAINER002 = nameof(CONTAINER002);
+        // containerimagename rename
         public static readonly string CONTAINER003 = nameof(CONTAINER003);
+        // generic http error
+        public static readonly string CONTAINER004 = nameof(CONTAINER004);
+        // don't use the containers package
+        public static readonly string CONTAINER005 = nameof(CONTAINER005);
         public static readonly string CONTAINER1011 = nameof(CONTAINER1011);
         public static readonly string CONTAINER1012 = nameof(CONTAINER1012);
         public static readonly string CONTAINER1013 = nameof(CONTAINER1013);

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -222,6 +222,7 @@
           ($(_SdkCanPublishWorker) and $(_IsWorkerProject)) or
           ($(_SdkCanPublishConsole) and '$(EnableSdkContainerSupport)' == 'true')
         )"
+      Code="CONTAINER005"
       Text="The $(_ContainersPackageIdentity) NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to $(_ContainersPackageIdentity) because it is no longer needed." />
 
     <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -55,14 +55,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import targets from Microdoft.NET.Build.Container.targets -->
   <PropertyGroup>
-    <_IsNotDefinedContainersTargetsDir>false</_IsNotDefinedContainersTargetsDir>
-    <_IsNotDefinedContainersTargetsDir Condition=" '$(_ContainersTargetsDir)'=='' ">true</_IsNotDefinedContainersTargetsDir>
-    <_ContainersTargetsDir Condition="$(_IsNotDefinedContainersTargetsDir)">$(MSBuildThisFileDirectory)..\..\..\Containers\build\</_ContainersTargetsDir>
+    <_IsNotSetContainersTargetsDir>false</_IsNotSetContainersTargetsDir>
+    <_IsNotSetContainersTargetsDir Condition=" '$(_ContainersTargetsDir)'=='' ">true</_IsNotSetContainersTargetsDir>
+    <_ContainersTargetsDir Condition="$(_IsNotSetContainersTargetsDir)">$(MSBuildThisFileDirectory)..\..\..\Containers\build\</_ContainersTargetsDir>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props"
           Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
 
   <Import Project="$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets"
-    Condition="$(_IsNotDefinedContainersTargetsDir) AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets') AND '$(TargetFramework)' != ''" />
+    Condition="$(_IsNotSetContainersTargetsDir) AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets') AND '$(TargetFramework)' != ''" />
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -55,12 +55,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import targets from Microdoft.NET.Build.Container.targets -->
   <PropertyGroup>
-    <_ContainersTargetsDir Condition=" '$(_ContainersTargetsDir)'=='' ">$(MSBuildThisFileDirectory)..\..\..\Containers\build\</_ContainersTargetsDir>
+    <_IsNotDefinedContainersTargetsDir>false</_IsNotDefinedContainersTargetsDir>
+    <_IsNotDefinedContainersTargetsDir Condition=" '$(_ContainersTargetsDir)'=='' ">true</_IsNotDefinedContainersTargetsDir>
+    <_ContainersTargetsDir Condition="$(_IsNotDefinedContainersTargetsDir)">$(MSBuildThisFileDirectory)..\..\..\Containers\build\</_ContainersTargetsDir>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props"
           Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
 
   <Import Project="$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets"
-    Condition="Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets') AND '$(TargetFramework)' != ''" />
+    Condition="$(_IsNotDefinedContainersTargetsDir) AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets') AND '$(TargetFramework)' != ''" />
 </Project>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -369,7 +369,7 @@ public class EndToEndTests : IDisposable
 
         if (addPackageReference)
         {
-            commandResult.Should().HaveStdOutContaining("warning : The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers because it is no longer needed.");
+            commandResult.Should().HaveStdOutContaining("warning CONTAINER005: The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers because it is no longer needed.");
         }
         else
         {


### PR DESCRIPTION
## Description

Users that try to use the NuGet package for containers with an SDK that already ships Containers support hit two main blockers that are difficult to work around for users that are not extremely skilled in MSBuild. We should enable users on 8.0 SDKs to use updated 8.0 packages for containerization to satisfy cases where users cannot update SDKs to the latest features.

This PR fixes two things:

1. When the user references the `Microsoft.NET.Build.Containers` package and sets `_ContainersTargetsDir ` ([or it is set inside the package](https://github.com/dotnet/sdk/pull/43085/commits/014e0c4eeb740cab8234aeb5c6a068151f26fb4b)), a warning appears when running `dotnet publish -t:PublishContainer` that says: 
``` 
warning MSB4011: "{path}\.nuget\packages\microsoft.net.build.containers\8.0.403\build\Microsoft.NET.Build.Containers.targets" 
cannot be imported again. It was already imported at 
"{path to the project that we try to publish}.csproj.nuget.g.targets (4,5)". This is most likely a build authoring error. 
This subsequent import will be ignored.
```

2. Silencing the warning 
```
The Microsoft.NET.Build.Containers NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to Microsoft.NET.Build.Containers because it is no longer needed.
```

Solution:

1. Importing .targets from internal build only when `_ContainersTargetsDir` was not set.
2. Adding code to the warning (Chet's commit + test fix)

## Customer Impact

Without this, users cannot easily switch to using the Containers package - they get impossible to suppress warnings (which are errors if WarningsAsErrors is enabled) and some of the SDK logic will be pinned in a way that the Containers package cannot overwrite due to MSBuild semantics, so the experience of the user will be mixed.

## Regression

Yes, we regressed the 'pluggability' aspect of the user experience in 8.0.200.

## Risk

**Low** - we have excellent test coverage here and have added to it to check the semantics here.