### PR TITLE
Allow for older Windows SDK projection packages without profiles to build on .NET 9

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -70,6 +70,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <FrameworkReference Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(TargetPlatformIdentifier)' == 'Windows' and '$(UseUwp)' == 'true' " Include="Microsoft.Windows.SDK.NET.Ref.Xaml" />
   </ItemGroup>
 
+  <!-- If WindowsSdkPackageVersion is specified and it is an older version before profile support was added, 
+       add the non profile framework reference. -->
+  <ItemGroup Condition=" '$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'
+                        and '$(WindowsSdkPackageVersion)' != ''
+                        and '$(UseUwp)' != 'true'
+                        and $([System.Version]::Parse('$(WindowsSdkPackageVersion.Split('-')[0])').Build) &lt;= 26100
+                        and $([System.Version]::Parse('$(WindowsSdkPackageVersion.Split('-')[0])').Revision) &lt;= 34">
+    <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
+  </ItemGroup>
+
   <!-- Default 'CsWinRTUseWindowsUIXamlProjections' to 'false', unless 'UseUwp' is set.
        This is to ensure that using the full Windows SDK projections will work correctly.
        We still allow users to override this, which can help in mixed WinAppSDK scenarios. -->

--- a/test/EndToEnd.Tests/GivenWindowsApp.cs
+++ b/test/EndToEnd.Tests/GivenWindowsApp.cs
@@ -14,7 +14,8 @@ namespace EndToEnd.Tests
         [InlineData("10.0.20348.0")]
         [InlineData("10.0.22000.0")]
         [InlineData("10.0.22621.0")]
-        [InlineData("10.0.26100.0")]
+        // Skipped due to: https://github.com/dotnet/sdk/pull/42090/files#r1680016439
+        //[InlineData("10.0.26100.0")]
         [InlineData("10.0.22621.0", "34")]
         public void ItCanBuildAndRun(string targetPlatformVersion, string packageVersion = "")
         {

--- a/test/EndToEnd.Tests/GivenWindowsApp.cs
+++ b/test/EndToEnd.Tests/GivenWindowsApp.cs
@@ -14,9 +14,9 @@ namespace EndToEnd.Tests
         [InlineData("10.0.20348.0")]
         [InlineData("10.0.22000.0")]
         [InlineData("10.0.22621.0")]
-        // Skipped due to: https://github.com/dotnet/sdk/pull/42090/files#r1680016439
-        //[InlineData("10.0.26100.0")]
-        public void ItCanBuildAndRun(string targetPlatformVersion)
+        [InlineData("10.0.26100.0")]
+        [InlineData("10.0.22621.0", "34")]
+        public void ItCanBuildAndRun(string targetPlatformVersion, string packageVersion = "")
         {
             var testInstance = _testAssetsManager
                 .CopyTestAsset("UseCswinrt", identifier: targetPlatformVersion)
@@ -31,8 +31,20 @@ namespace EndToEnd.Tests
                 .Add(new XElement(ns + "TargetPlatformVersion", targetPlatformVersion));
             project.Root.Element(ns + "PropertyGroup")
                 .Element(ns + "TargetFramework").Value = ToolsetInfo.CurrentTargetFramework;
-            project.Root.Element(ns + "PropertyGroup")
-                .Element(ns + "WindowsSdkPackageVersion").Value = targetPlatformVersion[..^1] + "39"; // Temporary until new projections flow to tests
+
+            if (!string.IsNullOrEmpty(packageVersion))
+            {
+                // Used to test older versions of the package to make sure they can still be referenced.
+                // This currently tests the version before profile support was added to our package.
+                project.Root.Element(ns + "PropertyGroup")
+                    .Element(ns + "WindowsSdkPackageVersion").Value = targetPlatformVersion[..^1] + packageVersion;
+            }
+            else
+            {
+                project.Root.Element(ns + "PropertyGroup")
+                    .Element(ns + "WindowsSdkPackageVersion").Value = targetPlatformVersion[..^1] + "39"; // Temporary until new projections flow to tests
+            }
+
             project.Save(projectPath);
 
             new BuildCommand(testInstance)


### PR DESCRIPTION
**Summary**

.NET 9 added profile support for Windows SDK projection packages.  But we have apps that may set `WindowsSdkPackageVersion` manually to fix the version of the package they want to use.  These apps can be setting them to one of our older versions which doesn't have profile support.  These projects using the new SDK with the profile support changes would fail to build if they use APIs from our package.

This PR addresses that by having a fallback where if an older package version is used and we detect that, then we fallback to including the non profile version of our Windows SDK projection package.

**Customer Impact**

The impact is without this change, projects which have `WindowsSdkPackageVersion` set to an older version that upgrade to .NET 9 may fail to build without them updating `WindowsSdkPackageVersion` to a newer version.
 
**Regression**

Yes, we regressed the capability to use `WindowsSdkPackageVersion` with older package versions.

**Testing**

Tested building with the `WindowsSdkPackageVersion` property set to an older version, to an older preview version, and to a newer version.
 
**Risk**

Low, impacts only Windows OS version TFM when `WindowsSdkPackageVersion` is set.

Fixes #43707 