### PR TITLE
Show dogfood annotation in prompt

### DIFF
--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -26,6 +26,8 @@ function Print-Usage() {
   Write-Host "if it is set, will be used."
 }
 
+function Global:prompt {"(dogfood) PS $PWD> "} 
+
 if ($help -or (($command -ne $null) -and ($command.Contains("/help") -or $command.Contains("/?")))) {
   Print-Usage
   exit 0

--- a/eng/dogfood.sh
+++ b/eng/dogfood.sh
@@ -25,3 +25,4 @@ export MicrosoftNETBuildExtensionsTargets="$artifacts_dir/bin/$configuration/Sdk
 
 export PATH=$testDotnetRoot:$PATH
 export DOTNET_ROOT=$testDotnetRoot
+export PS1="(dogfood) $PS1"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5fa98521-76ea-43dc-b138-f1ad1d33614c)
It can get confusing to users to know whether they are inside or outside dogfood. An annotation is added to the prompt in Powershell to make this clear to users. 