### PR TITLE
[release/9.0.1xx] Fix writing dotnet test results when terminal logger is off

### DIFF
--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "dotnet": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "test S:\\c\\openapi-extensions\\tests\\OpenApi.Extensions.Tests\\MartinCostello.OpenApi.Extensions.Tests.csproj --configuration Release --tl:off -bl"
     }
   }
 }

--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "dotnet": {
-      "commandName": "Project",
-      "commandLineArgs": "test S:\\c\\openapi-extensions\\tests\\OpenApi.Extensions.Tests\\MartinCostello.OpenApi.Extensions.Tests.csproj --configuration Release --tl:off -bl"
+      "commandName": "Project"
     }
   }
 }


### PR DESCRIPTION
When terminal logger is turned off we need to know it before calling msbuild to force it into mode that forwards standard output from child nodes, and disabling node reuse to stay compatible with the previous behavior.

To achieve this we need the same logic as terminal logger to detect the option, environment variables and console capability

Copying code from MSBuild here, to hopefully replace this in the future with MSBuild provided solution.

Fix https://github.com/microsoft/vstest/issues/10358