### PR TITLE
Revert "Clean up error experience when downloading non-tools (#43045)"

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/INuGetPackageDownloader.cs
@@ -16,8 +16,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null,
-            bool isTool = false);
+            PackageSourceMapping packageSourceMapping = null);
 
         Task<string> GetPackageUrl(PackageId packageId,
             NuGetVersion packageVersion = null,

--- a/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
+++ b/src/Cli/dotnet/NugetPackageDownloader/LocalizableStrings.resx
@@ -126,9 +126,6 @@
   <data name="IsNotFoundInNuGetFeeds" xml:space="preserve">
     <value>{0} is not found in NuGet feeds {1}.</value>
   </data>
-  <data name="NotATool" xml:space="preserve">
-    <value>Package {0} is not a .NET tool.</value>
-  </data>
   <data name="DownloadVersionFailed" xml:space="preserve">
     <value>Downloading {0} version {1} failed.</value>
   </data>

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -83,45 +83,19 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null,
-            bool isTool = false)
+            PackageSourceMapping packageSourceMapping = null)
         {
             CancellationToken cancellationToken = CancellationToken.None;
 
             (var source, var resolvedPackageVersion) = await GetPackageSourceAndVersion(packageId, packageVersion,
                 packageSourceLocation, includePreview, includeUnlisted ?? packageVersion is not null, packageSourceMapping).ConfigureAwait(false);
 
+            FindPackageByIdResource resource = null;
             SourceRepository repository = GetSourceRepository(source);
 
-            // TODO: Fix this to use the PackageSearchResourceV3 once https://github.com/NuGet/NuGet.Client/pull/5991 is completed.
-            if (isTool && await repository.GetResourceAsync<ServiceIndexResourceV3>().ConfigureAwait(false) is ServiceIndexResourceV3 serviceIndex)
-            {
-                // See https://learn.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-manifest-nuspec
-                var uri = serviceIndex.GetServiceEntries("PackageBaseAddress/3.0.0")[0].Uri;
-                var queryUri = uri + $"{packageId}/{packageVersion}/{packageId}.nuspec";
-
-                using HttpClient client = new(new HttpClientHandler() { CheckCertificateRevocationList = true });
-                using HttpResponseMessage response = await client.GetAsync(queryUri).ConfigureAwait(false);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    string nuspec = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-                    XDocument doc = XDocument.Parse(nuspec);
-
-                    if (!ToolPackageInstance.IsToolPackage(doc))
-                    {
-                        throw new GracefulException(string.Format(LocalizableStrings.NotATool, packageId));
-                    }
-                }
-                else
-                {
-                    throw new GracefulException(string.Format(LocalizableStrings.NotATool, packageId));
-                }
-            }
-
-            FindPackageByIdResource resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken)
+            resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken)
                 .ConfigureAwait(false);
+
             if (resource == null)
             {
                 throw new NuGetPackageNotFoundException(

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.cs.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Přeskakuje se ověření podpisu balíčku NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.de.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">"{0}" wurde in NuGet-Feeds "{1}" nicht gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Die Überprüfung der NuGet-Paketsignatur wird übersprungen.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.es.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">No se encuentra {0} en las fuentes de NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Omitiendo la comprobación de la firma del paquete NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.fr.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0} est introuvable dans les flux NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">La vérification de la signature du package NuGet est ignorée.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.it.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0} non è stato trovato nei feed NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">La verifica della firma del pacchetto NuGet verrà ignorata.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ja.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0} が NuGet フィード {1} に見つかりません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet パッケージ署名の認証をスキップしています。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ko.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">NuGet 피드 {1} 에서 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet 패키지 서명 확인을 건너뛰는 중입니다.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pl.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">Nie znaleziono pakietu {0} w kanałach informacyjnych NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Pomijanie weryfikacji podpisu pakietu NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0} não foi encontrado no NuGet feeds {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Ignorando a verificação de assinatura do pacote NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.ru.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0} не найдено в веб-каналах NuGet {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">Пропуск проверки подписи пакета NuGet.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.tr.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">{0}, {1} NuGet akışlarında bulunamadı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">NuGet paket imzası doğrulaması atlanıyor.</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">在 NuGet 源 {1} 中找不到 {0}。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">正在跳过 NuGet 包签名验证。</target>

--- a/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/NugetPackageDownloader/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,11 +37,6 @@
         <target state="needs-review-translation">在 NuGet 摘要 {1} 中找不到 {0}"。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotATool">
-        <source>Package {0} is not a .NET tool.</source>
-        <target state="new">Package {0} is not a .NET tool.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NuGetPackageSignatureVerificationSkipped">
         <source>Skipping NuGet package signature verification.</source>
         <target state="translated">正在略過 NuGet 套件簽章驗證。</target>

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -134,21 +134,13 @@ namespace Microsoft.DotNet.Cli.ToolPackage
                     {
                         DownloadAndExtractPackage(packageId, nugetPackageDownloader, toolDownloadDir.Value, packageVersion, packageSourceLocation, includeUnlisted: givenSpecificVersion).GetAwaiter().GetResult();
                     }
-                    else
+                    else if(isGlobalTool)
                     {
-                        if (!ToolPackageInstance.IsToolPackage(package.Nuspec.Xml))
-                        {
-                            throw new GracefulException(string.Format(NuGetPackageDownloader.LocalizableStrings.NotATool, packageId));
-                        }
-
-                        if (isGlobalTool)
-                        {
-                            throw new ToolPackageException(
-                                string.Format(
-                                    CommonLocalizableStrings.ToolPackageConflictPackageId,
-                                    packageId,
-                                    packageVersion.ToNormalizedString()));
-                        }
+                        throw new ToolPackageException(
+                            string.Format(
+                                CommonLocalizableStrings.ToolPackageConflictPackageId,
+                                packageId,
+                                packageVersion.ToNormalizedString()));
                     }
                                        
                     CreateAssetFile(packageId, packageVersion, toolDownloadDir, assetFileDirectory, _runtimeJsonPath, targetFramework);
@@ -292,7 +284,7 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             bool includeUnlisted = false
             )
         {
-            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted, isTool: true).ConfigureAwait(false);
+            var packagePath = await nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation, includeUnlisted: includeUnlisted).ConfigureAwait(false);
 
             // look for package on disk and read the version
             NuGetVersion version;

--- a/src/Cli/dotnet/ToolPackage/ToolPackageInstance.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageInstance.cs
@@ -23,17 +23,6 @@ namespace Microsoft.DotNet.ToolPackage
 
             return new ToolPackageInstance(id, version, packageDirectory, assetsJsonParentDirectory);
         }
-
-        /// <summary>
-        /// Validates that the nuspec XML represents a .NET tool package.
-        /// </summary>
-        /// <param name="nuspec">The nuspec XML to check.</param>
-        /// <returns><see langword="true"/> if the nuspec represents a .NET tool package; otherwise, <see langword="false"/>.</returns>
-        public static bool IsToolPackage(XDocument nuspec) =>
-            nuspec.Root.Descendants().Where(
-                e => e.Name.LocalName == "packageType" &&
-                e.Attributes().Where(a => a.Name.LocalName == "name" && a.Value == "DotnetTool").Any()).Any();
-
         private const string PackagedShimsDirectoryConvention = "shims";
 
         public IEnumerable<string> Warnings => _toolConfiguration.Value.Warnings;

--- a/test/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
+++ b/test/dotnet-workload-install.Tests/FailingNuGetPackageInstaller.cs
@@ -23,8 +23,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null,
-            bool isTool = false)
+            PackageSourceMapping packageSourceMapping = null)
         {
             var mockPackagePath = Path.Combine(MockPackageDir, $"{packageId}.{packageVersion}.nupkg");
             File.WriteAllText(mockPackagePath, string.Empty);

--- a/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
+++ b/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
@@ -38,8 +38,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             bool includePreview = false,
             bool? includeUnlisted = null,
             DirectoryPath? downloadFolder = null,
-            PackageSourceMapping packageSourceMapping = null,
-            bool isTool = false)
+            PackageSourceMapping packageSourceMapping = null)
         {
             DownloadCallParams.Add((packageId, packageVersion, downloadFolder, packageSourceLocation));
 


### PR DESCRIPTION
# Description

We made some changes to detect non-tool packages in RC.2. These changes relied on APIs supported by NuGet, but 3rd party feeds like Artifactory do not necessary support these (https://github.com/dotnet/sdk/issues/43651). We're rolling back the changes for GA and will consider a different approach for 9.0.2xx. We've since identified additional issues that require further investigation and discussions.

# Impact

Users are unable to install tool packages properly when using 3rd party feeds and some global tool operations may fail as well. There is no workaround for this.