### PR TITLE
Fix NETSDK1197 translated command

### DIFF
--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -1093,8 +1093,8 @@ Vous devrez peut-être générer le projet sur un autre système d’exploitatio
       <trans-unit id="WorkloadNotInstalled">
         <source>NETSDK1147: To build this project, the following workloads must be installed: {0}
 To install these workloads, run the following command: dotnet workload restore</source>
-        <target state="needs-review-translation">NETSDK1147: pour générer ce projet, les charges de travail suivantes doivent être installées : {0}
-Pour installer ces charges de travail, exécutez la commande suivante : restauration de la charge de travail de dotnet.</target>
+        <target state="translated">NETSDK1147: pour générer ce projet, les charges de travail suivantes doivent être installées : {0}
+Pour installer ces charges de travail, exécutez la commande suivante : dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
The french localization file contained translated commands. This was highlighted in a previous pull request (#43263) and a locked statement was added to prevent translating the command.

This change fixes the french translation for the command and marks the unit as translated.