### PR TITLE
dotnet-format: Support hidden severity for analyzers and code fixes

### DIFF
--- a/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
+++ b/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Tools
         internal const int UnableToLocateMSBuildExitCode = 3;
 
         private static string[] VerbosityLevels => new[] { "q", "quiet", "m", "minimal", "n", "normal", "d", "detailed", "diag", "diagnostic" };
-        private static string[] SeverityLevels => new[] { "info", "warn", "error" };
+        private static string[] SeverityLevels => new[] { "info", "warn", "error", "hidden" };
 
         public static readonly Argument<string> SlnOrProjectArgument = new Argument<string>(Resources.SolutionOrProjectArgumentName)
         {
@@ -290,6 +290,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 FixSeverity.Error => DiagnosticSeverity.Error,
                 FixSeverity.Warn => DiagnosticSeverity.Warning,
                 FixSeverity.Info => DiagnosticSeverity.Info,
+                FixSeverity.Hidden => DiagnosticSeverity.Hidden,
                 _ => throw new ArgumentOutOfRangeException(nameof(severity)),
             };
         }

--- a/src/BuiltInTools/dotnet-format/FixSeverity.cs
+++ b/src/BuiltInTools/dotnet-format/FixSeverity.cs
@@ -7,5 +7,6 @@ namespace Microsoft.CodeAnalysis.Tools
         public const string Error = "error";
         public const string Warn = "warn";
         public const string Info = "info";
+        public const string Hidden = "hidden";
     }
 }


### PR DESCRIPTION
Without this, you can't fix diagnostics such as --diagnostics VSTHRD111 --severity hidden