### PR TITLE
When updating workload versions, don't try to update to an older version, or to the same version currently installed

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -221,6 +221,18 @@ namespace Microsoft.DotNet.Workloads.Workload
                 if (updateToLatestWorkloadSet)
                 {
                     resolvedWorkloadSetVersion = _workloadManifestUpdater.GetAdvertisedWorkloadSetVersion();
+                    var currentWorkloadVersionInfo = _workloadResolver.GetWorkloadVersion();
+                    if (resolvedWorkloadSetVersion != null && currentWorkloadVersionInfo.IsInstalled && !currentWorkloadVersionInfo.WorkloadSetsEnabledWithoutWorkloadSet)
+                    {
+                        var currentPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(currentWorkloadVersionInfo.Version, out var currentWorkloadSetSdkFeatureBand);
+                        var advertisedPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(resolvedWorkloadSetVersion, out var advertisedWorkloadSetSdkFeatureBand);
+
+                        if (currentWorkloadSetSdkFeatureBand > advertisedWorkloadSetSdkFeatureBand ||
+                            new NuGetVersion(currentPackageVersion) >= new NuGetVersion(advertisedPackageVersion))
+                        {
+                            resolvedWorkloadSetVersion = null;
+                        }
+                    }
                 }
             }
 

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMAction.cs
@@ -214,6 +214,9 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
         //  Applies to CopyFileToVM, CopyFolderToVM, MoveFolderOnVM, WriteFileToVM, GetRemoteDirectory, GetRemoteFile
         public string TargetPath { get; set; }
 
+        //  Applies to GetRemoteDirectory, GetRemoteFile
+        public bool MustExist { get; set; }
+
         //  Applies to CopyFileToVM, CopyFolderToVM, MoveFolderOnVM
         public string SourcePath { get; set; }
 

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 }
                 else
                 {
-                    var sdkTestingDir = VM.GetRemoteDirectory(@"c:\SdkTesting");
+                    var sdkTestingDir = VM.GetRemoteDirectory(@"c:\SdkTesting", mustExist: true);
 
                     string installerPrefix = "dotnet-sdk-";
                     string installerSuffix = "-win-x64.exe";

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -52,6 +52,8 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             VM.Dispose();
         }
 
+        protected virtual bool NeedsIncludePreviews => false;
+
         Lazy<string> _sdkInstallerVersion;
         private bool _sdkInstalled = false;
 
@@ -130,7 +132,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             string existingVersionToOverwrite = result.StdOut;
 
@@ -185,13 +187,17 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             var command = VM.CreateRunCommand("dotnet", "--version");
             command.IsReadOnly = true;
             var result = command.Execute();
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
             return result.StdOut;
         }
 
         protected CommandResult InstallWorkload(string workloadName, bool skipManifestUpdate)
         {
-            string [] args = { "dotnet", "workload", "install", workloadName, "--include-previews"};
+            string [] args = { "dotnet", "workload", "install", workloadName};
+            if (NeedsIncludePreviews)
+            {
+                args = [.. args, "--include-previews"];
+            }
             if (skipManifestUpdate)
             {
                 args = [.. args, "--skip-manifest-update"];
@@ -201,7 +207,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                     .WithDescription($"Install {workloadName} workload")
                     .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return result;
         }
@@ -213,7 +219,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return ParseRollbackOutput(result.StdOut);
         }
@@ -233,7 +239,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 .WithIsReadOnly(true)
                 .Execute();
 
-            result.Should().Pass();
+            result.Should().PassWithoutWarning();
 
             return result.StdOut;
         }
@@ -244,7 +250,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
                 .WithDescription($"Add {source} to NuGet.config")
                 .Execute()
                 .Should()
-                .Pass();
+                .PassWithoutWarning();
         }
     }
 }

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -203,13 +203,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
-            var packageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(WorkloadSetVersion2, out var sdkFeatureBand);
-
-            VM.CreateActionGroup($"Disable {WorkloadSetVersion2}",
-                    VM.CreateRunCommand("cmd", "/c", "mkdir", @"c:\SdkTesting\DisabledWorkloadSets"),
-                    VM.CreateRunCommand("cmd", "/c", "move", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg", @"c:\SdkTesting\DisabledWorkloadSets"),
-                    VM.CreateRunCommand("cmd", "/c", "move", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg", @"c:\SdkTesting\DisabledWorkloadSets"))
-                .Execute().Should().PassWithoutWarning();
+            RemoveWorkloadSetFromLocalSource(WorkloadSetVersion2);
 
             CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute().Should().PassWithoutWarning();

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -9,29 +9,10 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {
-    public class WorkloadSetTests : VMTestBase
+    public class WorkloadSetTests : WorkloadSetTestsBase
     {
-        readonly string SdkTestingDirectory = @"C:\SdkTesting";
-
-
-        Lazy<Dictionary<string, string>> _testWorkloadSetVersions;
-        string WorkloadSetVersion1 => _testWorkloadSetVersions.Value["version1"];
-        string WorkloadSetVersion2 => _testWorkloadSetVersions.Value["version2"];
-        string WorkloadSetPreviousBandVersion => _testWorkloadSetVersions.Value.GetValueOrDefault("previousbandversion", "8.0.204");
-
         public WorkloadSetTests(ITestOutputHelper log) : base(log)
         {
-            _testWorkloadSetVersions = new Lazy<Dictionary<string, string>>(() =>
-            {
-                string remoteFilePath = @"c:\SdkTesting\workloadsets\testworkloadsetversions.json";
-                var versionsFile = VM.GetRemoteFile(remoteFilePath);
-                if (!versionsFile.Exists)
-                {
-                    throw new FileNotFoundException($"Could not find file {remoteFilePath} on VM");
-                }
-
-                return JsonSerializer.Deserialize<Dictionary<string, string>>(versionsFile.ReadAllText());
-            });
         }
 
         [Fact]
@@ -39,7 +20,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         {
             InstallSdk();
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -48,7 +29,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -57,42 +38,6 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             newRollback.ManifestVersions.Should().BeEquivalentTo(originalRollback.ManifestVersions);
 
-        }
-
-        void UpdateAndSwitchToWorkloadSetMode(out string updatedWorkloadVersion, out WorkloadSet rollbackAfterUpdate)
-        {
-            var featureBand = new SdkFeatureBand(SdkInstallerVersion).ToStringWithoutPrerelease();
-            var originalWorkloadVersion = GetWorkloadVersion();
-            originalWorkloadVersion.Should().StartWith($"{featureBand}-manifests.");
-
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
-                .Execute()
-                .Should()
-                .PassWithoutWarning();
-
-            rollbackAfterUpdate = GetRollback();
-            updatedWorkloadVersion = GetWorkloadVersion();
-            updatedWorkloadVersion.Should().StartWith($"{featureBand}-manifests.");
-            updatedWorkloadVersion.Should().NotBe(originalWorkloadVersion);
-
-            GetUpdateMode().Should().Be("manifests");
-
-            VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode", "workload-set")
-                .WithDescription("Switch mode to workload-set")
-                .Execute()
-                .Should()
-                .PassWithoutWarning();
-
-            GetWorkloadVersion().Should().Be(updatedWorkloadVersion);
-
-            var expectedMessage = "Workloads are configured to install and update using workload versions, but none were found. Run \"dotnet workload restore\" to install a workload version.";
-
-            GetDotnetInfo().Should().Contain(expectedMessage)
-                .And.NotContain("(not installed)");
-            GetDotnetWorkloadInfo().Should().Contain(expectedMessage)
-                .And.NotContain("(not installed)");
-
-            GetUpdateMode().Should().Be("workload-set");
         }
 
         [Fact]
@@ -104,7 +49,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
@@ -121,7 +66,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             UpdateAndSwitchToWorkloadSetMode(out string updatedWorkloadVersion, out WorkloadSet rollbackAfterUpdate);
 
             //  Use a nonexistant source because there may be a valid workload set available on NuGet.org
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews", "--source", @"c:\SdkTesting\EmptySource")
+            CreateInstallingCommand("dotnet", "workload", "update", "--source", @"c:\SdkTesting\EmptySource")
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -154,7 +99,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--version", versionToInstall, "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", versionToInstall)
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -172,7 +117,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             GetWorkloadVersion().Should().Be(versionToInstall);
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -189,7 +134,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var workloadVersionBeforeUpdate = GetWorkloadVersion();
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--version", unavailableWorkloadSetVersion, "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", unavailableWorkloadSetVersion)
                 .Execute()
                 .Should()
                 .Fail()
@@ -215,7 +160,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var workloadVersionBeforeUpdate = GetWorkloadVersion();
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--source", @"c:\SdkTesting\workloadsets", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update", "--source", @"c:\SdkTesting\workloadsets")
                 .Execute()
                 .Should()
                 .Fail();
@@ -236,7 +181,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var workloadVersionBeforeUpdate = GetWorkloadVersion();
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion2, "--source", @"c:\SdkTesting\workloadsets", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion2, "--source", @"c:\SdkTesting\workloadsets")
                 .Execute()
                 .Should()
                 .Fail();
@@ -248,150 +193,6 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
-        }
-
-        void SetupWorkloadSetInGlobalJson(out WorkloadSet originalRollback)
-        {
-            InstallSdk();
-
-            var versionToUpdateTo = WorkloadSetVersion2;
-
-            string originalVersion = GetWorkloadVersion();
-
-            originalRollback = GetRollback(SdkTestingDirectory);
-
-            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{versionToUpdateTo}""}}}}").Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion(SdkTestingDirectory).Should().Be(versionToUpdateTo + " (not installed)");
-            GetDotnetInfo(SdkTestingDirectory).Should().Contain("Workload version:  " + versionToUpdateTo + " (not installed)")
-                .And.Contain($@"Workload version {versionToUpdateTo}, which was specified in C:\SdkTesting\global.json, was not found");
-            GetDotnetWorkloadInfo(SdkTestingDirectory).Should().Contain("Workload version: " + versionToUpdateTo + " (not installed)")
-                .And.Contain($@"Workload version {versionToUpdateTo}, which was specified in C:\SdkTesting\global.json, was not found");
-
-            // The version should have changed but not yet the manifests. Since we expect both, getting the rollback should fail.
-            var result = VM.CreateRunCommand("dotnet", "workload", "update", "--print-rollback")
-               .WithWorkingDirectory(SdkTestingDirectory)
-               .WithIsReadOnly(true)
-               .Execute();
-
-            result.Should().Fail();
-            result.StdErr.Should().Contain("FileNotFoundException");
-            result.StdErr.Should().Contain(versionToUpdateTo);
-
-            AddNuGetSource(@"C:\SdkTesting\workloadsets", SdkTestingDirectory);
-        }
-
-        [Fact]
-        public void RestoreWorkloadSetViaGlobalJson()
-        {
-            InstallSdk();
-
-            var testProjectFolder = Path.Combine(SdkTestingDirectory, "ConsoleApp");
-            VM.CreateRunCommand("dotnet", "new", "console", "-o", "ConsoleApp")
-                .WithWorkingDirectory(SdkTestingDirectory)
-                .Execute().Should().PassWithoutWarning();
-
-            SetupWorkloadSetInGlobalJson(out var originalRollback);
-
-            VM.CreateRunCommand("dotnet", "workload", "restore")
-                .WithWorkingDirectory(testProjectFolder)
-                .Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
-
-            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
-        }
-
-        [Theory]
-        [InlineData("update")]
-        [InlineData("install")]
-        public void UseGlobalJsonToSpecifyWorkloadSet(string command)
-        {
-            SetupWorkloadSetInGlobalJson(out var originalRollback);
-
-            string[] args = command.Equals("install") ? ["dotnet", "workload", "install", "aspire"] : ["dotnet", "workload", command];
-            VM.CreateRunCommand(args).WithWorkingDirectory(SdkTestingDirectory).Execute().Should().PassWithoutWarning();
-            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
-        }
-
-        [Fact]
-        public void DotnetInfoWithGlobalJson()
-        {
-            InstallSdk();
-
-            //  Install a workload before setting up global.json.  Commands like "dotnet workload --info" were previously crashing if global.json specified a workload set that wasn't installed
-            InstallWorkload("aspire", skipManifestUpdate: true);
-
-            SetupWorkloadSetInGlobalJson(out _);
-        }
-
-        [Fact]
-        public void InstallWithGlobalJsonAndSkipManifestUpdate()
-        {
-            SetupWorkloadSetInGlobalJson(out var originalRollback);
-
-            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--skip-manifest-update")
-                .WithWorkingDirectory(SdkTestingDirectory)
-                .Execute().Should().Fail()
-                .And.HaveStdErrContaining("--skip-manifest-update")
-                .And.HaveStdErrContaining(Path.Combine(SdkTestingDirectory, "global.json"));
-        }
-
-        [Fact]
-        public void InstallWithVersionAndSkipManifestUpdate()
-        {
-            InstallSdk();
-
-            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--skip-manifest-update", "--version", WorkloadSetVersion1)
-                .Execute().Should().Fail()
-                .And.HaveStdErrContaining("--skip-manifest-update")
-                .And.HaveStdErrContaining("--sdk-version");
-        }
-
-        [Fact]
-        public void InstallWithVersionWhenPinned()
-        {
-            InstallSdk();
-
-            AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
-
-            string originalVersion = GetWorkloadVersion();
-            originalVersion.Should().NotBe(WorkloadSetVersion1);
-
-            VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1, "--include-previews")
-                .Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
-
-            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--version", WorkloadSetVersion2)
-                .Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
-        }
-
-        [Fact]
-        public void InstallWithGlobalJsonWhenPinned()
-        {
-            SetupWorkloadSetInGlobalJson(out var originalRollback);
-
-            //AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
-
-            string originalVersion = GetWorkloadVersion();
-            originalVersion.Should().NotBe(WorkloadSetVersion1);
-
-            VM.CreateRunCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1, "--include-previews")
-                .Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
-
-            VM.CreateRunCommand("dotnet", "workload", "install", "aspire")
-                .WithWorkingDirectory(SdkTestingDirectory)
-                .Execute().Should().PassWithoutWarning();
-
-            GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
-
-            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
-
         }
 
         [Fact]
@@ -410,7 +211,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                     VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg", $"Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.bak"))
                 .Execute().Should().PassWithoutWarning();
 
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
@@ -452,7 +253,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
 
             //  Update to latest workload set version
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                 .Execute().Should().PassWithoutWarning();
 
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
@@ -475,12 +276,12 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{WorkloadSetVersion1}""}}}}").Execute().Should().PassWithoutWarning();
 
             //  Install pinned version
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                .WithWorkingDirectory(SdkTestingDirectory)
                .Execute().Should().PassWithoutWarning();
 
             //  Update globally installed version to later version
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                .Execute().Should().PassWithoutWarning();
 
             //  Check workload versions in global context and global.json directory
@@ -495,7 +296,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.WriteFile("C:\\SdkTesting\\global.json", "{}").Execute().Should().PassWithoutWarning();
 
             //  Run workload update to do a GC
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews")
+            CreateInstallingCommand("dotnet", "workload", "update")
                .Execute().Should().PassWithoutWarning();
 
             //  Workload set 1 should have been GC'd
@@ -557,7 +358,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             var searchResultWorkloadSet = WorkloadSet.FromDictionaryForJson(JsonSerializer.Deserialize<Dictionary<string, string>>(searchResultJson["manifestVersions"]), new SdkFeatureBand(SdkInstallerVersion));
 
             //  Update to the workload set version we got the search info from so we can check to see if the manifest versions match what we expect
-            VM.CreateRunCommand("dotnet", "workload", "update", "--include-previews", "--version", WorkloadSetVersion2)
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion2)
                 .Execute()
                 .Should()
                 .PassWithoutWarning();
@@ -565,61 +366,5 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetRollback().ManifestVersions.Should().BeEquivalentTo(searchResultWorkloadSet.ManifestVersions);
         }
 
-        string GetWorkloadVersion(string workingDirectory = null)
-        {
-            var result = VM.CreateRunCommand("dotnet", "workload", "--version")
-                .WithWorkingDirectory(workingDirectory)
-                .WithIsReadOnly(true)
-                .Execute();
-
-            result.Should().PassWithoutWarning();
-
-            return result.StdOut;
-        }
-
-        string GetDotnetInfo(string workingDirectory = null)
-        {
-            var result = VM.CreateRunCommand("dotnet", "--info")
-                .WithWorkingDirectory(workingDirectory)
-                .WithIsReadOnly(true)
-                .Execute();
-
-            result.Should().PassWithoutWarning();
-
-            return result.StdOut;
-        }
-
-        string GetDotnetWorkloadInfo(string workingDirectory = null)
-        {
-            var result = VM.CreateRunCommand("dotnet", "workload", "--info")
-                .WithWorkingDirectory(workingDirectory)
-                .WithIsReadOnly(true)
-                .Execute();
-
-            result.Should().PassWithoutWarning();
-
-            return result.StdOut;
-        }
-
-        string GetUpdateMode()
-        {
-            var result = VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode")
-                .WithIsReadOnly(true)
-                .Execute();
-
-            result.Should().PassWithoutWarning();
-
-            return result.StdOut;
-        }
-
-        void AddNuGetSource(string source, string directory = null)
-        {
-            VM.CreateRunCommand("dotnet", "nuget", "add", "source", source)
-                .WithWorkingDirectory(directory)
-                .WithDescription($"Add {source} to NuGet.config")
-                .Execute()
-                .Should()
-                .PassWithoutWarning();
-        }
     }
 }

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -205,10 +205,10 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var packageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(WorkloadSetVersion2, out var sdkFeatureBand);
 
-            //  Rename latest workload set so it won't be installed
             VM.CreateActionGroup($"Disable {WorkloadSetVersion2}",
-                    VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg", $"Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.bak"),
-                    VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg", $"Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.bak"))
+                    VM.CreateRunCommand("cmd", "/c", "mkdir", @"c:\SdkTesting\DisabledWorkloadSets"),
+                    VM.CreateRunCommand("cmd", "/c", "move", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg", @"c:\SdkTesting\DisabledWorkloadSets"),
+                    VM.CreateRunCommand("cmd", "/c", "move", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg", @"c:\SdkTesting\DisabledWorkloadSets"))
                 .Execute().Should().PassWithoutWarning();
 
             CreateInstallingCommand("dotnet", "workload", "update")
@@ -218,8 +218,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             //  Bring latest workload set version back, so installing workload should update to it
             VM.CreateActionGroup($"Enable {WorkloadSetVersion2}",
-                    VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.bak", $"Microsoft.NET.Workloads.{sdkFeatureBand}.{packageVersion}.nupkg"),
-                    VM.CreateRunCommand("cmd", "/c", "ren", @$"c:\SdkTesting\WorkloadSets\Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.bak", $"Microsoft.NET.Workloads.{sdkFeatureBand}.*.{packageVersion}.nupkg"))
+                    VM.CreateRunCommand("cmd", "/c", "move", @"c:\SdkTesting\DisabledWorkloadSets\*.nupkg", @"c:\SdkTesting\WorkloadSets"))
                 .Execute().Should().PassWithoutWarning();
 
             InstallWorkload("aspire", skipManifestUpdate: false);
@@ -227,14 +226,14 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
 
-        [Fact]
+        [Fact(Skip = "Not Implemented")]
         public void WorkloadSetInstallationRecordIsWrittenCorrectly()
         {
             //  Should the workload set version or the package version be used in the registry?
             throw new NotImplementedException();
         }
 
-        [Fact]
+        [Fact(Skip = "Not Implemented")]
         public void TurnOffWorkloadSetUpdateMode()
         {
             //  If you have a workload set installed and then turn off workload set update mode, what should happen?
@@ -319,6 +318,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.GetRemoteDirectory(workloadSetPath).Should().NotExist();
         }
 
+        //  Note: this may fail for rtm-branded non-stabilized SDKs: https://github.com/dotnet/sdk/issues/43890
         [Fact]
         public void WorkloadSearchVersion()
         {

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -56,6 +56,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
             var newRollback = GetRollback();
             newRollback.ManifestVersions.Should().NotBeEquivalentTo(rollbackAfterUpdate.ManifestVersions);
+
+            //  A second workload update command should not try to install any updates
+            CreateInstallingCommand("dotnet", "workload", "update")
+                .Execute().Should().PassWithoutWarning()
+                .And.HaveStdOutContaining("No workload update found")
+                .And.NotHaveStdOutContaining("Installing workload version");
+
         }
 
         [Fact]
@@ -296,6 +303,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.GetRemoteDirectory(workloadSet1Path).Should().NotExist();
         }
 
+        //  Note: this may fail due to https://github.com/dotnet/sdk/issues/43876
         [Fact]
         public void FinalizerUninstallsWorkloadSets()
         {

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
@@ -1,0 +1,165 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.MsiInstallerTests.Framework;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.MsiInstallerTests
+{
+    public class WorkloadSetTests2 : WorkloadSetTestsBase
+    {
+        public WorkloadSetTests2(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        void SetupWorkloadSetInGlobalJson(out WorkloadSet originalRollback)
+        {
+            InstallSdk();
+
+            var versionToUpdateTo = WorkloadSetVersion2;
+
+            string originalVersion = GetWorkloadVersion();
+
+            originalRollback = GetRollback(SdkTestingDirectory);
+
+            VM.WriteFile("C:\\SdkTesting\\global.json", @$"{{""sdk"":{{""workloadVersion"":""{versionToUpdateTo}""}}}}").Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion(SdkTestingDirectory).Should().Be(versionToUpdateTo + " (not installed)");
+            GetDotnetInfo(SdkTestingDirectory).Should().Contain("Workload version:  " + versionToUpdateTo + " (not installed)")
+                .And.Contain($@"Workload version {versionToUpdateTo}, which was specified in C:\SdkTesting\global.json, was not found");
+            GetDotnetWorkloadInfo(SdkTestingDirectory).Should().Contain("Workload version: " + versionToUpdateTo + " (not installed)")
+                .And.Contain($@"Workload version {versionToUpdateTo}, which was specified in C:\SdkTesting\global.json, was not found");
+
+            // The version should have changed but not yet the manifests. Since we expect both, getting the rollback should fail.
+            var result = VM.CreateRunCommand("dotnet", "workload", "update", "--print-rollback")
+               .WithWorkingDirectory(SdkTestingDirectory)
+               .WithIsReadOnly(true)
+               .Execute();
+
+            result.Should().Fail();
+            result.StdErr.Should().Contain("FileNotFoundException");
+            result.StdErr.Should().Contain(versionToUpdateTo);
+
+            AddNuGetSource(@"C:\SdkTesting\workloadsets", SdkTestingDirectory);
+        }
+
+        [Fact]
+        public void RestoreWorkloadSetViaGlobalJson()
+        {
+            InstallSdk();
+
+            var testProjectFolder = Path.Combine(SdkTestingDirectory, "ConsoleApp");
+            VM.CreateRunCommand("dotnet", "new", "console", "-o", "ConsoleApp")
+                .WithWorkingDirectory(SdkTestingDirectory)
+                .Execute().Should().PassWithoutWarning();
+
+            SetupWorkloadSetInGlobalJson(out var originalRollback);
+
+            VM.CreateRunCommand("dotnet", "workload", "restore")
+                .WithWorkingDirectory(testProjectFolder)
+                .Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
+
+            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
+        }
+
+        [Theory]
+        [InlineData("update")]
+        [InlineData("install")]
+        public void UseGlobalJsonToSpecifyWorkloadSet(string command)
+        {
+            SetupWorkloadSetInGlobalJson(out var originalRollback);
+
+            string[] args = command.Equals("install") ? ["dotnet", "workload", "install", "aspire"] : ["dotnet", "workload", command];
+            VM.CreateRunCommand(args).WithWorkingDirectory(SdkTestingDirectory).Execute().Should().PassWithoutWarning();
+            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
+        }
+
+        [Fact]
+        public void InstallWithGlobalJsonAndSkipManifestUpdate()
+        {
+            SetupWorkloadSetInGlobalJson(out var originalRollback);
+
+            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--skip-manifest-update")
+                .WithWorkingDirectory(SdkTestingDirectory)
+                .Execute().Should().Fail()
+                .And.HaveStdErrContaining("--skip-manifest-update")
+                .And.HaveStdErrContaining(Path.Combine(SdkTestingDirectory, "global.json"));
+        }
+
+        [Fact]
+        public void InstallWithVersionAndSkipManifestUpdate()
+        {
+            InstallSdk();
+
+            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--skip-manifest-update", "--version", WorkloadSetVersion1)
+                .Execute().Should().Fail()
+                .And.HaveStdErrContaining("--skip-manifest-update")
+                .And.HaveStdErrContaining("--sdk-version");
+        }
+
+        [Fact]
+        public void InstallWithVersionWhenPinned()
+        {
+            InstallSdk();
+
+            AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
+
+            string originalVersion = GetWorkloadVersion();
+            originalVersion.Should().NotBe(WorkloadSetVersion1);
+
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1)
+                .Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
+
+            VM.CreateRunCommand("dotnet", "workload", "install", "aspire", "--version", WorkloadSetVersion2)
+                .Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
+        }
+
+        [Fact]
+        public void InstallWithGlobalJsonWhenPinned()
+        {
+            SetupWorkloadSetInGlobalJson(out var originalRollback);
+
+            //AddNuGetSource(@"c:\SdkTesting\WorkloadSets");
+
+            string originalVersion = GetWorkloadVersion();
+            originalVersion.Should().NotBe(WorkloadSetVersion1);
+
+            CreateInstallingCommand("dotnet", "workload", "update", "--version", WorkloadSetVersion1)
+                .Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion().Should().Be(WorkloadSetVersion1);
+
+            VM.CreateRunCommand("dotnet", "workload", "install", "aspire")
+                .WithWorkingDirectory(SdkTestingDirectory)
+                .Execute().Should().PassWithoutWarning();
+
+            GetWorkloadVersion(SdkTestingDirectory).Should().Be(WorkloadSetVersion2);
+
+            GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
+
+        }
+
+        [Fact]
+        public void DotnetInfoWithGlobalJson()
+        {
+            InstallSdk();
+
+            //  Install a workload before setting up global.json.  Commands like "dotnet workload --info" were previously crashing if global.json specified a workload set that wasn't installed
+            InstallWorkload("aspire", skipManifestUpdate: true);
+
+            SetupWorkloadSetInGlobalJson(out _);
+        }
+
+    }
+}

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             _testWorkloadSetVersions = new Lazy<Dictionary<string, string>>(() =>
             {
                 string remoteFilePath = @"c:\SdkTesting\workloadsets\testworkloadsetversions.json";
-                var versionsFile = VM.GetRemoteFile(remoteFilePath);
+                var versionsFile = VM.GetRemoteFile(remoteFilePath, mustExist: true);
                 if (!versionsFile.Exists)
                 {
                     throw new FileNotFoundException($"Could not find file {remoteFilePath} on VM");

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.DotNet.MsiInstallerTests.Framework;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.MsiInstallerTests
+{
+    public class WorkloadSetTestsBase : VMTestBase
+    {
+        protected readonly string SdkTestingDirectory = @"C:\SdkTesting";
+
+
+        protected Lazy<Dictionary<string, string>> _testWorkloadSetVersions;
+        protected string WorkloadSetVersion1 => _testWorkloadSetVersions.Value["version1"];
+        protected string WorkloadSetVersion2 => _testWorkloadSetVersions.Value["version2"];
+        protected string WorkloadSetPreviousBandVersion => _testWorkloadSetVersions.Value.GetValueOrDefault("previousbandversion", "8.0.204");
+
+        protected bool NeedsIncludePreviews => bool.Parse(_testWorkloadSetVersions.Value.GetValueOrDefault("needsIncludePreviews", "false"));
+        public WorkloadSetTestsBase(ITestOutputHelper log) : base(log)
+        {
+            _testWorkloadSetVersions = new Lazy<Dictionary<string, string>>(() =>
+            {
+                string remoteFilePath = @"c:\SdkTesting\workloadsets\testworkloadsetversions.json";
+                var versionsFile = VM.GetRemoteFile(remoteFilePath);
+                if (!versionsFile.Exists)
+                {
+                    throw new FileNotFoundException($"Could not find file {remoteFilePath} on VM");
+                }
+
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(versionsFile.ReadAllText());
+            });
+        }
+
+        protected void UpdateAndSwitchToWorkloadSetMode(out string updatedWorkloadVersion, out WorkloadSet rollbackAfterUpdate)
+        {
+            var featureBand = new SdkFeatureBand(SdkInstallerVersion).ToStringWithoutPrerelease();
+            var originalWorkloadVersion = GetWorkloadVersion();
+            originalWorkloadVersion.Should().StartWith($"{featureBand}-manifests.");
+
+            CreateInstallingCommand("dotnet", "workload", "update")
+                .Execute()
+                .Should()
+                .PassWithoutWarning();
+
+            rollbackAfterUpdate = GetRollback();
+            updatedWorkloadVersion = GetWorkloadVersion();
+            updatedWorkloadVersion.Should().StartWith($"{featureBand}-manifests.");
+            updatedWorkloadVersion.Should().NotBe(originalWorkloadVersion);
+
+            GetUpdateMode().Should().Be("manifests");
+
+            VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode", "workload-set")
+                .WithDescription("Switch mode to workload-set")
+                .Execute()
+                .Should()
+                .PassWithoutWarning();
+
+            GetWorkloadVersion().Should().Be(updatedWorkloadVersion);
+
+            var expectedMessage = "Workloads are configured to install and update using workload versions, but none were found. Run \"dotnet workload restore\" to install a workload version.";
+
+            GetDotnetInfo().Should().Contain(expectedMessage)
+                .And.NotContain("(not installed)");
+            GetDotnetWorkloadInfo().Should().Contain(expectedMessage)
+                .And.NotContain("(not installed)");
+
+            GetUpdateMode().Should().Be("workload-set");
+        }
+
+        internal string GetWorkloadVersion(string workingDirectory = null)
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "--version")
+                .WithWorkingDirectory(workingDirectory)
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().PassWithoutWarning();
+
+            return result.StdOut;
+        }
+
+        internal string GetDotnetInfo(string workingDirectory = null)
+        {
+            var result = VM.CreateRunCommand("dotnet", "--info")
+                .WithWorkingDirectory(workingDirectory)
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().PassWithoutWarning();
+
+            return result.StdOut;
+        }
+
+        internal string GetDotnetWorkloadInfo(string workingDirectory = null)
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "--info")
+                .WithWorkingDirectory(workingDirectory)
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().PassWithoutWarning();
+
+            return result.StdOut;
+        }
+
+        internal string GetUpdateMode()
+        {
+            var result = VM.CreateRunCommand("dotnet", "workload", "config", "--update-mode")
+                .WithIsReadOnly(true)
+                .Execute();
+
+            result.Should().PassWithoutWarning();
+
+            return result.StdOut;
+        }
+
+        internal void AddNuGetSource(string source, string directory = null)
+        {
+            VM.CreateRunCommand("dotnet", "nuget", "add", "source", source)
+                .WithWorkingDirectory(directory)
+                .WithDescription($"Add {source} to NuGet.config")
+                .Execute()
+                .Should()
+                .PassWithoutWarning();
+        }
+
+        //  Creates a command and possibly adds "--include-previews" to the argument list
+        internal VMRunAction CreateInstallingCommand(params string[] args)
+        {
+            if (NeedsIncludePreviews)
+            {
+                args = [.. args, "--include-previews"];
+            }
+            return VM.CreateRunCommand(args);
+        }
+    }
+}

--- a/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
+++ b/test/dotnet-workload-search.Tests/MockWorkloadResolver.cs
@@ -38,8 +38,8 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
         public string GetManifestFeatureBand(string manifestId) => throw new NotImplementedException();
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests() => _installedManifests ?? throw new NotImplementedException();
         public IWorkloadResolver CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
-        public string GetSdkFeatureBand() => "12.0.400";
-        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo("12.0.400.2");
+        public string GetSdkFeatureBand() => "8.0.100";
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() => new IWorkloadManifestProvider.WorkloadVersionInfo("8.0.100.2");
         public IEnumerable<WorkloadId> GetUpdatedWorkloads(WorkloadResolver advertisingManifestResolver, IEnumerable<WorkloadId> installedWorkloads) => throw new NotImplementedException();
         WorkloadResolver IWorkloadResolver.CreateOverlayResolver(IWorkloadManifestProvider overlayManifestProvider) => throw new NotImplementedException();
         WorkloadManifest IWorkloadResolver.GetManifestFromWorkload(WorkloadId workloadId) => throw new NotImplementedException();


### PR DESCRIPTION
Previously, when doing a workload update in workload set mode, the SDK would find the latest workload set version available, and then try to install it.  This would happen even if the latest version available was the same version as was currently installed, or if it was lower than the currently installed version.

If it was the same as the currently installed workload set version, then the SDK would display a message that it was installing that version, which could be confusing since that version was already installed.

If the latest version found was lower than the currently installed version, the SDK would download and install that version.  Then it would run garbage collection, which would uninstall the version it just installed, as the newer already-installed version would be the active version.  The SDK would display a message saying it was installing the older version, then a message saying it was uninstalling it.  This situation could most commonly happen by running `dotnet workload install --include-previews` and then `dotnet workload install <workload>`.  The workload install command would by default try to update workloads, but because `--include-previews` wasn't specified, it would find a non-preview workload set which could be an earlier version, and install and then uninstall that version.

This PR adds VM-based tests for these cases, and also includes some other test improvements.