### PR TITLE
Don't fire azdo PR pipelines for simple documentation changes

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -8,6 +8,11 @@ pr:
     - main
     - release/*
     - internal/release/*
+  paths:
+    exclude:
+    - documentation/*
+    - README.md
+    - CODEOWNERS
 
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -19,6 +19,11 @@ pr:
     - release/*.0.2xx
     - release/*.0.3xx
     - release/*.0.4xx
+  paths:
+    exclude:
+    - documentation/*
+    - README.md
+    - CODEOWNERS
 
 parameters:
 - name: vmrBranch


### PR DESCRIPTION
The long pipelines disincentivize docs changes, so lets nip that behavior in the bud.