### PR TITLE
WebSDK: OneDeploy - use 'PLACEHOLDER' value for variable that represent a secret in Unit Tests

### DIFF
--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployStatusServiceTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployStatusServiceTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.OneDeploy.Tests;
 public class OneDeployStatusServiceTests
 {
     private const string Username = "someUser";
-    private const string Password = "123secret";
+    private const string NotShareableValue = "PLACEHOLDER";
     private const string UserAgent = "websdk/8.0"; // as OneDeploy.UserAgentName
     private const string PublishUrl = "https://mysite.scm.azurewebsites.net";
     private const string DeploymentId = "056f49ce-fcd7-497c-929b-d74bc6f8905e";
@@ -57,7 +57,7 @@ public class OneDeployStatusServiceTests
         var oneDeployStatusService = new OneDeployStatusService(taskLoggerMock.Object);
 
         // Act
-        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: poll deployment status runs to completion, resulting in the given expectedDeploymentStatus
         Assert.Equal(expectedDeploymentStatus, deploymentResponse.Status);
@@ -85,7 +85,7 @@ public class OneDeployStatusServiceTests
         var oneDeployStatusService = new OneDeployStatusService(taskLoggerMock.Object);
 
         // Act
-        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: poll deployment status runs to completion, resulting in 'Unknown' status because failed HTTP Response Status code
         Assert.Equal(DeploymentStatus.Unknown, result.Status);
@@ -112,7 +112,7 @@ public class OneDeployStatusServiceTests
         var oneDeployStatusService = new OneDeployStatusService();
 
         // Act
-        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: poll deployment status runs to completion with NULL ITaskLogger
         Assert.Equal(DeploymentStatus.Success, deploymentResponse.Status);
@@ -136,7 +136,7 @@ public class OneDeployStatusServiceTests
 
         // Act
         cancellationTokenSource.Cancel();
-        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, DeploymentUri.AbsoluteUri, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: deployment status won't poll for deployment as 'CancellationToken' is already cancelled
         Assert.Equal(DeploymentStatus.Unknown, result.Status);
@@ -164,7 +164,7 @@ public class OneDeployStatusServiceTests
         var oneDeployStatusService = new OneDeployStatusService(taskLoggerMock.Object);
 
         // Act
-        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, invalidUrl, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(httpClientMock.Object, invalidUrl, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: deployment status won't poll for deployment because given polling URL is invalid
         Assert.Equal(DeploymentStatus.Unknown, result.Status);
@@ -186,7 +186,7 @@ public class OneDeployStatusServiceTests
         var oneDeployStatusService = new OneDeployStatusService(taskLoggerMock.Object);
 
         // Act
-        var result = await oneDeployStatusService.PollDeploymentAsync(null, DeploymentUri.AbsoluteUri, Username, Password, UserAgent, cancellationToken);
+        var result = await oneDeployStatusService.PollDeploymentAsync(null, DeploymentUri.AbsoluteUri, Username, NotShareableValue, UserAgent, cancellationToken);
 
         // Assert: deployment status won't poll for deployment because IHttpClient is NULL
         Assert.Equal(DeploymentStatus.Unknown, result.Status);

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployTests.WebJob.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployTests.WebJob.cs
@@ -61,7 +61,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", WebJobName, webJobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", WebJobName, webJobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: WebJob deployment operation runs to completion with expected result
         Assert.Equal(expectedResult, result);
@@ -93,7 +93,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, invalidUrl, $"{UserAgentName}/8.0", WebJobName, webjobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, invalidUrl, $"{UserAgentName}/8.0", WebJobName, webjobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation fails because 'PublishUrl' is not valid
         Assert.False(result);
@@ -142,7 +142,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName, webjobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName, webjobType, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation fails because since 'WebJobName' and/or 'WebJobType' is invalid, so we calculate the
         // default OneDeploy URI ('<site_scm_ulr>/api/publish'), which target instance does not recognized as valid

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Tasks/OneDeploy/OneDeployTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.OneDeploy.Tests;
 public partial class OneDeployTests
 {
     private const string Username = "someUser";
-    private const string Password = "123secret";
+    private const string NotShareableValue = "PLACEHOLDER";
     private const string PublishUrl = "https://mysite.scm.azurewebsites.net";
     private const string UserAgentName = "websdk"; // as OneDeploy.UserAgentName
     private const string DeploymentUrl = $@"{PublishUrl}/api/deployments/056f49ce-fcd7-497c-929b-d74bc6f8905e";
@@ -87,7 +87,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation runs to completion with expected result
         Assert.Equal(expectedResult, result);
@@ -130,7 +130,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation runs to completion, without polling the deployment because 'Location' header was not found in response
         Assert.True(result);
@@ -161,7 +161,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation fails because HTTP POST request to upload the package returns a failed HTTP Response
         Assert.False(result);
@@ -190,7 +190,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, invalidUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, invalidUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation fails because 'PublishUrl' is not valid
         Assert.False(result);
@@ -219,7 +219,7 @@ public partial class OneDeployTests
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            invalidFileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            invalidFileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation fails because 'FileToPublishPath' is not valid
         Assert.False(result);
@@ -277,12 +277,12 @@ public partial class OneDeployTests
         var oneDeployTask = new OneDeploy(taskLoggerMock.Object);
 
         var msbuildHostObject = new VSMsDeployTaskHostObject();
-        msbuildHostObject.AddCredentialTaskItemIfExists(Username, Password);
+        msbuildHostObject.AddCredentialTaskItemIfExists(Username, NotShareableValue);
         oneDeployTask.HostObject = msbuildHostObject;
 
         // Act
         var result = await oneDeployTask.OneDeployAsync(
-            FileToPublish, Username, Password, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
+            FileToPublish, Username, NotShareableValue, PublishUrl, $"{UserAgentName}/8.0", webjobName: null, webjobType: null, httpClientMock.Object, deploymentStatusServiceMock.Object, CancellationToken.None);
 
         // Assert: deployment operation runs to completion
         // obtaining the credentials from the Task HostObject
@@ -344,7 +344,7 @@ public partial class OneDeployTests
         var statusServiceMock = new Mock<IDeploymentStatusService<DeploymentResponse>>();
 
         statusServiceMock
-            .Setup(s => s.PollDeploymentAsync(httpClient, DeploymentUrl, Username, Password, $"{UserAgentName}/8.0", It.IsAny<CancellationToken>()))
+            .Setup(s => s.PollDeploymentAsync(httpClient, DeploymentUrl, Username, NotShareableValue, $"{UserAgentName}/8.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(deploymentResponse);
 
         return statusServiceMock;


### PR DESCRIPTION
For `WebSDK - OneDeploy` unit tests, use the `"PLACEHOLDER"` value for any variable that represents a secret/pwd. 

This will avoid cred-scan process to incorrectly flag for a loose password value.