### PR TITLE
[Backport] Backports perf fixes to static web assets to RTM

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -222,10 +222,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       CandidateAssets="@(_CompressedStaticWebAssets)"
     >
       <Output TaskParameter="Assets" ItemName="_CompressionBuildStaticWebAsset" />
+      <Output TaskParameter="AssetDetails" ItemName="_ResolveBuildCompressedStaticWebAssetsDetails" />
     </DefineStaticWebAssets>
 
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(_CompressionBuildStaticWebAsset)"
+      AssetFileDetails="@(_ResolveBuildCompressedStaticWebAssetsDetails)"
       ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >
@@ -240,6 +242,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ApplyCompressionNegotiation
       CandidateEndpoints="@(StaticWebAssetEndpoint)"
+      AssetFileDetails="@(_ResolveBuildCompressedStaticWebAssetsDetails)"
       CandidateAssets="@(_CompressionCurrentProjectBuildAssets)"
     >
       <Output TaskParameter="UpdatedEndpoints" ItemName="_UpdatedCompressionBuildEndpoints" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -291,7 +291,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </ResolveCompressedAssets>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IsPackable)' == 'true'">
       <_StaticWebAssetExcludedFromPack Include="@(_CompressedStaticWebAssets)" />
     </ItemGroup>
 

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Pack.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Pack.targets
@@ -75,7 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        targets into their packages are expected to disable the generation of $(PackageId).props files and
        to manually import build\Microsoft.AspNetCore.StaticWebAssets.props in their custom props files.
    -->
-  <Target Name="GenerateStaticWebAssetsPackFiles" AfterTargets="GenerateStaticWebAssetsManifest">
+  <Target Name="GenerateStaticWebAssetsPackFiles" Condition="'$(IsPackable)' == 'true'" AfterTargets="GenerateStaticWebAssetsManifest">
 
     <ItemGroup>
 

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
@@ -61,9 +61,16 @@ Copyright (c) .NET Foundation. All rights reserved.
          for example, assets from packages as a result of a publish (no-build) invocation. Those assets were already taken
          into account when we built the build manifest that we are about to load for resuming the publish process. -->
     <PropertyGroup>
-        <_ShouldLoadBuildManifestAndUpdateAssets>false</_ShouldLoadBuildManifestAndUpdateAssets>
-        <_ShouldLoadBuildManifestAndUpdateAssets
-          Condition="@(_CachedBuildStaticWebAssets) == '' or @(_CachedBuildStaticWebAssetDiscoveryPatterns) == '' or @(_CachedBuildStaticWebAssetReferencedProjectsConfiguration) == ''">true</_ShouldLoadBuildManifestAndUpdateAssets>
+      <_HasStaticWebAssetsProjectReferences Condition="@(ProjectReference) != ''">true</_HasStaticWebAssetsProjectReferences>
+      <_HasCachedBuildStaticWebAssets Condition="@(_CachedBuildStaticWebAssets) == ''">false</_HasCachedBuildStaticWebAssets>
+      <_HasCachedBuildStaticWebAssetEndpoints Condition="@(_CachedBuildStaticWebAssetEndpoints) == ''">false</_HasCachedBuildStaticWebAssetEndpoints>
+      <_HasCachedBuildStaticWebAssetDiscoveryPatterns Condition="@(_CachedBuildStaticWebAssetDiscoveryPatterns) == ''">false</_HasCachedBuildStaticWebAssetDiscoveryPatterns>
+      <_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration Condition="@(_CachedBuildStaticWebAssetReferencedProjectsConfiguration) == ''">false</_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration>
+      <_ShouldLoadBuildManifestAndUpdateAssets>false</_ShouldLoadBuildManifestAndUpdateAssets>
+      <_ShouldLoadBuildManifestAndUpdateAssets Condition="'$(_HasCachedBuildStaticWebAssets)' == 'false' or
+        '$(_HasCachedBuildStaticWebAssetEndpoints)' == 'false' or
+        '$(_HasCachedBuildStaticWebAssetDiscoveryPatterns)' == 'false' or
+        ('$(_HasStaticWebAssetsProjectReferences)' == 'true' and '$(_HasCachedBuildStaticWebAssetReferencedProjectsConfiguration)' == 'false')">true</_ShouldLoadBuildManifestAndUpdateAssets>
     </PropertyGroup>
 
     <ItemGroup>
@@ -131,11 +138,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ReferencedProjectPublishStaticWebAssetsUpdateCandidates
         Include="@(_ReferencedProjectPublishStaticWebAssetsItems)"
-        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAsset'" />        
+        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAsset'" />
 
       <_ReferencedProjectPublishStaticWebAssetEndpointsUpdateCandidates
         Include="@(_ReferencedProjectPublishStaticWebAssetsItems)"
-        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAssetEndpoint'" />        
+        Condition="'%(_ReferencedProjectPublishStaticWebAssetsItems.ResultType)' == 'StaticWebAssetEndpoint'" />
     </ItemGroup>
 
     <UpdateExternallyDefinedStaticWebAssets Condition="$(_HasProjectsWithStaticWebAssetPublishTargets)"

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -641,6 +641,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GenerateStaticWebAssetsDevelopmentManifest>
 
     <ItemGroup>
+      <_CachedBuildStaticWebAssets Condition="'@(_CachedBuildStaticWebAssets)' == ''" Include="@(StaticWebAsset)" />
+      <_CachedBuildStaticWebAssetEndpoints Condition="'@(_CachedBuildStaticWebAssetEndpoints)' == ''" Include="@(StaticWebAssetEndpoint)" />
+      <_CachedBuildStaticWebAssetReferencedProjectsConfiguration Condition="'@(_CachedBuildStaticWebAssetReferencedProjectsConfiguration)' == ''" Include="@(StaticWebAssetProjectConfiguration)" />
+      <_CachedBuildStaticWebAssetDiscoveryPatterns Condition="'@(_CachedBuildStaticWebAssetDiscoveryPatterns)' == ''" Include="@(StaticWebAssetDiscoveryPattern)" />
+    </ItemGroup>
+
+    <ItemGroup>
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(StaticWebAssetEndpointsBuildManifestPath)" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -628,14 +628,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       ManifestType="Build"
       Assets="@(StaticWebAsset)"
       Endpoints="@(StaticWebAssetEndpoint)"
-      ManifestPath="$(StaticWebAssetEndpointsBuildManifestPath)">
+      ManifestPath="$(StaticWebAssetEndpointsBuildManifestPath)"
+      CacheFilePath="$(StaticWebAssetBuildManifestPath)">
     </GenerateStaticWebAssetEndpointsManifest>
 
     <GenerateStaticWebAssetsDevelopmentManifest
       DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"
       Assets="@(StaticWebAsset)"
       Source="$(PackageId)"
-      ManifestPath="$(StaticWebAssetDevelopmentManifestPath)">
+      ManifestPath="$(StaticWebAssetDevelopmentManifestPath)"
+      CacheFilePath="$(StaticWebAssetBuildManifestPath)">
     </GenerateStaticWebAssetsDevelopmentManifest>
 
     <ItemGroup>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -437,6 +437,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Manifest paths -->
       <_StaticWebAssetsManifestBase Condition="'$(_StaticWebAssetsManifestBase)' == ''">$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
       <StaticWebAssetBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.json</StaticWebAssetBuildManifestPath>
+      <StaticWebAssetsBuildManifestCacheFilePath>$(StaticWebAssetBuildManifestPath).cache</StaticWebAssetsBuildManifestCacheFilePath>
       <StaticWebAssetPackManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.pack.json</StaticWebAssetPackManifestPath>
       <StaticWebAssetDevelopmentManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.development.json</StaticWebAssetDevelopmentManifestPath>
       <StaticWebAssetEndpointsBuildManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.build.endpoints.json</StaticWebAssetEndpointsBuildManifestPath>
@@ -620,7 +621,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       DiscoveryPatterns="@(StaticWebAssetDiscoveryPattern)"
       Assets="@(StaticWebAsset)"
       Endpoints="@(StaticWebAssetEndpoint)"
-      ManifestPath="$(StaticWebAssetBuildManifestPath)">
+      ManifestPath="$(StaticWebAssetBuildManifestPath)"
+      ManifestCacheFilePath="$(StaticWebAssetsBuildManifestCacheFilePath)">
     </GenerateStaticWebAssetsManifest>
 
     <GenerateStaticWebAssetEndpointsManifest
@@ -649,6 +651,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <FileWrites Include="$(StaticWebAssetBuildManifestPath)" />
+      <FileWrites Include="$(StaticWebAssetsBuildManifestCacheFilePath)" />
       <FileWrites Include="$(StaticWebAssetDevelopmentManifestPath)" />
       <FileWrites Include="$(StaticWebAssetEndpointsBuildManifestPath)" />
     </ItemGroup>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -672,10 +672,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       BasePath="$(StaticWebAssetBasePath)"
       AssetMergeSource="$(StaticWebAssetMergeTarget)">
         <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+        <Output TaskParameter="AssetDetails" ItemName="_ResolveProjectStaticWebAssetsDetails" />
     </DefineStaticWebAssets>
 
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(StaticWebAsset)"
+      AssetFileDetails="@(_ResolveProjectStaticWebAssetsDetails)"
       ExistingEndpoints="@(StaticWebAssetEndpoint)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
     >

--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
@@ -15,13 +16,27 @@ public class ApplyCompressionNegotiation : Task
     [Required]
     public ITaskItem[] CandidateAssets { get; set; }
 
+    public ITaskItem[] AssetFileDetails { get; set; }
+
     [Output]
     public ITaskItem[] UpdatedEndpoints { get; set; }
 
     public Func<string, long> TestResolveFileLength;
 
+    private Dictionary<string, ITaskItem> _assetFileDetails;
+
     public override bool Execute()
     {
+        if (AssetFileDetails != null)
+        {
+            _assetFileDetails = new(AssetFileDetails.Length, OSPath.PathComparer);
+            for (int i = 0; i < AssetFileDetails.Length; i++)
+            {
+                var item = AssetFileDetails[i];
+                _assetFileDetails[item.ItemSpec] = item;
+            }
+        }
+
         var assetsById = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity);
 
         var endpointsByAsset = CandidateEndpoints.Select(StaticWebAssetEndpoint.FromTaskItem)
@@ -55,10 +70,6 @@ public class ApplyCompressionNegotiation : Task
             }
 
             Log.LogMessage("Processing compressed asset: {0}", compressedAsset.Identity);
-
-            var length = TestResolveFileLength != null
-                ? TestResolveFileLength(compressedAsset.Identity)
-                : new FileInfo(compressedAsset.Identity).Length;
             StaticWebAssetEndpointResponseHeader[] compressionHeaders = [
                 new()
                 {
@@ -72,9 +83,10 @@ public class ApplyCompressionNegotiation : Task
                 }
             ];
 
+            var quality = ResolveQuality(compressedAsset);
             foreach (var compressedEndpoint in compressedEndpoints)
             {
-                if (compressedEndpoint.Selectors.Any(s => string.Equals(s.Name,"Content-Encoding", StringComparison.Ordinal)))
+                if (compressedEndpoint.Selectors.Any(s => string.Equals(s.Name, "Content-Encoding", StringComparison.Ordinal)))
                 {
                     Log.LogMessage(MessageImportance.Low, $"  Skipping endpoint '{compressedEndpoint.Route}' since it already has a Content-Encoding selector");
                     continue;
@@ -102,7 +114,7 @@ public class ApplyCompressionNegotiation : Task
                     {
                         Name = "Content-Encoding",
                         Value = compressedAsset.AssetTraitValue,
-                        Quality = Math.Round(1.0 / (length + 1), 12).ToString("F12")
+                        Quality = quality
                     };
                     Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
                     var endpointCopy = new StaticWebAssetEndpoint
@@ -199,6 +211,25 @@ public class ApplyCompressionNegotiation : Task
         UpdatedEndpoints = updatedEndpoints.Distinct().Select(e => e.ToTaskItem()).ToArray();
 
         return true;
+    }
+
+    private string ResolveQuality(StaticWebAsset compressedAsset)
+    {
+        long length;
+        if(_assetFileDetails != null && _assetFileDetails.TryGetValue(compressedAsset.Identity, out var assetFileDetail))
+        {
+            length = long.Parse(assetFileDetail.GetMetadata("FileLength"));
+        }
+        else if (TestResolveFileLength != null)
+        {
+            length = TestResolveFileLength(compressedAsset.Identity);
+        }
+        else
+        {
+            length = new FileInfo(compressedAsset.Identity).Length;
+        }
+
+        return Math.Round(1.0 / (length + 1), 12).ToString("F12", CultureInfo.InvariantCulture);
     }
 
     private static bool IsCompatible(StaticWebAssetEndpoint compressedEndpoint, StaticWebAssetEndpoint relatedEndpointCandidate)

--- a/src/StaticWebAssetsSdk/Tasks/Data/Serialization/StaticWebAssetsJsonSerializerContext.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/Serialization/StaticWebAssetsJsonSerializerContext.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
+
+namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
+
+[JsonSerializable(typeof(StaticWebAssetsManifest))]
+[JsonSerializable(typeof(GenerateStaticWebAssetsDevelopmentManifest.StaticWebAssetsDevelopmentManifest))]
+[JsonSerializable(typeof(StaticWebAssetEndpointsManifest))]
+public partial class StaticWebAssetsJsonSerializerContext : JsonSerializerContext
+{
+    // Since the manifest is only used at development time, it's ok for it to use the relaxed
+    // json escaping (which is also what MVC uses by default)
+    private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    public static readonly StaticWebAssetsJsonSerializerContext RelaxedEscaping = new(ManifestSerializationOptions);
+}

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         public static StaticWebAssetsManifest FromJsonBytes(byte[] jsonBytes)
         {
-            var manifest = JsonSerializer.Deserialize<StaticWebAssetsManifest>(jsonBytes);
+            var manifest = JsonSerializer.Deserialize(jsonBytes, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsManifest);
             if (manifest.Version != 1)
             {
                 throw new InvalidOperationException($"Invalid manifest version. Expected manifest version '1' and found version '{manifest.Version}'.");

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using Microsoft.Build.Framework;
@@ -232,11 +233,13 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         internal static (string fingerprint, string integrity) ComputeFingerprintAndIntegrity(string identity, string originalItemSpec)
         {
-            using var file = File.Exists(identity) ?
-                File.OpenRead(identity) :
-                (File.Exists(originalItemSpec) ?
-                    File.OpenRead(originalItemSpec) :
-                    throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'."));
+            var fileInfo = ResolveFile(identity, originalItemSpec);
+            return ComputeFingerprintAndIntegrity(fileInfo);
+        }
+
+        internal static (string fingerprint, string integrity) ComputeFingerprintAndIntegrity(FileInfo fileInfo)
+        {
+            using var file = fileInfo.OpenRead();
 
 #if NET6_0_OR_GREATER
             var hash = SHA256.HashData(file);
@@ -249,11 +252,14 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         internal static string ComputeIntegrity(string identity, string originalItemSpec)
         {
-            using var file = File.Exists(identity) ?
-    File.OpenRead(identity) :
-    (File.Exists(originalItemSpec) ?
-        File.OpenRead(originalItemSpec) :
-        throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'."));
+            var fileInfo = ResolveFile(identity, originalItemSpec);
+            return ComputeIntegrity(fileInfo);
+        }
+
+        internal static string ComputeIntegrity(FileInfo fileInfo)
+        {
+            using var file = fileInfo.OpenRead();
+
 #if NET6_0_OR_GREATER
             var hash = SHA256.HashData(file);
 #else
@@ -914,6 +920,24 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             var resolver = StaticWebAssetTokenResolver.Instance;
             pattern.EmbedTokens(this, resolver);
             return pattern.RawPattern;
+        }
+
+        internal FileInfo ResolveFile() => ResolveFile(Identity, OriginalItemSpec);
+
+        internal static FileInfo ResolveFile(string identity, string originalItemSpec)
+        {
+            var fileInfo = new FileInfo(identity);
+            if (fileInfo.Exists)
+            {
+                return fileInfo;
+            }
+            fileInfo = new FileInfo(originalItemSpec);
+            if (fileInfo.Exists)
+            {
+                return fileInfo;
+            }
+
+            throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'.");
         }
 
         [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
@@ -1,22 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointProperty : IComparable<StaticWebAssetEndpointProperty>, IEquatable<StaticWebAssetEndpointProperty>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointProperty[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointPropertyArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
 
     internal static StaticWebAssetEndpointProperty[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointProperty[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     internal static string ToMetadataValue(StaticWebAssetEndpointProperty[] responseHeaders)

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
@@ -1,22 +1,26 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEndpointResponseHeader>, IComparable<StaticWebAssetEndpointResponseHeader>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointResponseHeader[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointResponseHeaderArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
 
     internal static StaticWebAssetEndpointResponseHeader[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointResponseHeader[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     internal static string ToMetadataValue(StaticWebAssetEndpointResponseHeader[] responseHeaders)

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
@@ -4,12 +4,17 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointSelector>, IComparable<StaticWebAssetEndpointSelector>
 {
+    private static readonly JsonTypeInfo<StaticWebAssetEndpointSelector[]> _jsonTypeInfo =
+        StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointSelectorArray;
+
     public string Name { get; set; }
 
     public string Value { get; set; }
@@ -18,7 +23,7 @@ public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointS
 
     public static StaticWebAssetEndpointSelector[] FromMetadataValue(string value)
     {
-        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize<StaticWebAssetEndpointSelector[]>(value);
+        return string.IsNullOrEmpty(value) ? [] : JsonSerializer.Deserialize(value, _jsonTypeInfo);
     }
 
     public static string ToMetadataValue(StaticWebAssetEndpointSelector[] selectors)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -60,7 +60,7 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
                 Endpoints = [.. filteredEndpoints]
             };
 
-            this.PersistFileIfChanged(manifest, ManifestPath);
+            this.PersistFileIfChanged(manifest, ManifestPath, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetEndpointsManifest);
         }
         catch (Exception ex)
         {

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -23,8 +23,16 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
     [Required]
     public string ManifestPath { get; set; }
 
+    public string CacheFilePath { get; set; }
+
     public override bool Execute()
     {
+        if (!string.IsNullOrEmpty(CacheFilePath) && File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+        {
+            Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
+            return true;
+        }
+
         try
         {
             // Get the list of the asset that need to be part of the manifest (this is similar to GenerateStaticWebAssetsDevelopmentManifest)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -13,14 +13,6 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
     // is case insensitive.
     public class GenerateStaticWebAssetsDevelopmentManifest : Task
     {
-        // Since the manifest is only used at development time, it's ok for it to use the relaxed
-        // json escaping (which is also what MVC uses by default) and to produce indented output
-        // since that makes it easier to inspect the manifest when necessary.
-        private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
-        {
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
-
         [Required]
         public string Source { get; set; }
 
@@ -100,7 +92,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private void PersistManifest(StaticWebAssetsDevelopmentManifest manifest)
         {
-            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestSerializationOptions);
+            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsDevelopmentManifest);
             using var sha256 = SHA256.Create();
             var currentHash = sha256.ComputeHash(data);
 

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -25,8 +25,17 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
         [Required]
         public string ManifestPath { get; set; }
 
+        [Required]
+        public string CacheFilePath { get; set; }
+
         public override bool Execute()
         {
+            if (File.Exists(ManifestPath) && File.GetLastWriteTimeUtc(ManifestPath) > File.GetLastWriteTimeUtc(CacheFilePath))
+            {
+                Log.LogMessage(MessageImportance.Low, "Skipping manifest generation because manifest file '{0}' is up to date.", ManifestPath);
+                return true;
+            }
+
             try
             {
                 if (Assets.Length == 0 && DiscoveryPatterns.Length == 0)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
     // is case insensitive.
     public class GenerateStaticWebAssetsDevelopmentManifest : Task
     {
+        private static readonly char[] _separator = ['/'];
+        
         [Required]
         public string Source { get; set; }
 
@@ -62,10 +64,32 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             IEnumerable<StaticWebAssetsDiscoveryPattern> discoveryPatterns)
         {
             var assetsWithPathSegments = ComputeManifestAssets(assets).ToArray();
+            Array.Sort(assetsWithPathSegments);
 
             var discoveryPatternsByBasePath = discoveryPatterns
                 .GroupBy(p => p.HasSourceId(Source) ? "" : p.BasePath,
-                 (key, values) => (key.Split(new[] { '/' }, options: StringSplitOptions.RemoveEmptyEntries), values));
+                 (key, values) =>
+                    (key.Split(_separator, options: StringSplitOptions.RemoveEmptyEntries),
+                    values.OrderBy(id => id.ContentRoot).ThenBy(id => id.Pattern).ToArray())).ToArray();
+
+            Array.Sort(discoveryPatternsByBasePath, (x, y) =>
+            {
+                var lengthResult = x.Item1.Length.CompareTo(y.Item1.Length);
+                if (lengthResult != 0)
+                {
+                    return lengthResult;
+                }
+                for (var i = 0; i < x.Item1.Length; i++)
+                {
+                    var comparison = x.Item1[i].CompareTo(y.Item1[i]);
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+                }
+
+                return 0;
+            });
 
             var manifest = CreateManifest(assetsWithPathSegments, discoveryPatternsByBasePath);
             return manifest;
@@ -133,7 +157,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private StaticWebAssetsDevelopmentManifest CreateManifest(
             SegmentsAssetPair[] assetsWithPathSegments,
-            IEnumerable<(string[], IEnumerable<StaticWebAssetsDiscoveryPattern> values)> discoveryPatternsByBasePath)
+            (string[], StaticWebAssetsDiscoveryPattern[] values)[] discoveryPatternsByBasePath)
         {
             var contentRootIndex = new Dictionary<string, int>();
             var root = new StaticWebAssetNode() { };
@@ -326,17 +350,38 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             public StaticWebAssetPattern[] Patterns { get; set; }
         }
 
-        private struct SegmentsAssetPair
+        private struct SegmentsAssetPair : IComparable<SegmentsAssetPair>
         {
+            private static readonly char[] separator = ['/'];
+
             public SegmentsAssetPair(string path, StaticWebAsset asset)
             {
-                PathSegments = path.Split(new[] { '/' }, options: StringSplitOptions.RemoveEmptyEntries);
+                PathSegments = path.Split(separator, options: StringSplitOptions.RemoveEmptyEntries);
                 Asset = asset;
             }
 
             public string[] PathSegments { get; }
 
             public StaticWebAsset Asset { get; }
+
+            public int CompareTo(SegmentsAssetPair other)
+            {
+                if (PathSegments.Length != other.PathSegments.Length)
+                {
+                    return PathSegments.Length.CompareTo(other.PathSegments.Length);
+                }
+
+                for (var i = 0; i < PathSegments.Length; i++)
+                {
+                    var comparison = PathSegments[i].CompareTo(other.PathSegments[i]);
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+                }
+
+                return 0;
+            }
 
             public void Deconstruct(out string[] segments, out StaticWebAsset asset)
             {

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
@@ -10,15 +9,6 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 {
     public class GenerateStaticWebAssetsManifest : Task
     {
-        // Since the manifest is only used at development time, it's ok for it to use the relaxed
-        // json escaping (which is also what MVC uses by default) and to produce indented output
-        // since that makes it easier to inspect the manifest when necessary.
-        private static readonly JsonSerializerOptions ManifestSerializationOptions = new()
-        {
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            WriteIndented = true
-        };
-
         [Required]
         public string Source { get; set; }
 
@@ -126,7 +116,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
 
         private void PersistManifest(StaticWebAssetsManifest manifest)
         {
-            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestSerializationOptions);
+            var data = JsonSerializer.SerializeToUtf8Bytes(manifest, StaticWebAssetsJsonSerializerContext.RelaxedEscaping.StaticWebAssetsManifest);
             var fileExists = File.Exists(ManifestPath);
             var existingManifestHash = fileExists ? StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(ManifestPath)).Hash : "";
 

--- a/src/StaticWebAssetsSdk/Tasks/Utils/ArtifactWriter.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/ArtifactWriter.cs
@@ -4,21 +4,16 @@
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Utils;
 
 public static class ArtifactWriter
 {
-    public static readonly JsonSerializerOptions ArtifactJsonSerializationOptions = new()
+    public static void PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath, JsonTypeInfo<T> serializer)
     {
-        WriteIndented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
-
-    public static void PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath)
-    {
-        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ArtifactJsonSerializationOptions);
+        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, serializer);
         var newHash = ComputeHash(data);
         var fileExists = File.Exists(artifactPath);
         var existingManifestHash = fileExists ? ComputeHash(artifactPath) : null;

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestTest.cs
@@ -540,8 +540,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 CreateIntermediateNode(
                     ("_other", CreateIntermediateNode(
                         ("_project", CreateIntermediateNode().AddPatterns(
-                            (0, "*.js", 2),
-                            (1, "*.css", 2)))))),
+                            (0, "*.css", 2),
+                            (1, "*.js", 2)))))),
                 Path.GetFullPath("wwwroot"),
                 Path.GetFullPath("styles"));
 

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -692,7 +692,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
 
             // Second build
             var secondBuild = CreateBuildCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
-            secondBuild.Execute("/p:BuildProjectReferences=false").Should().Pass();
+            ExecuteCommand(secondBuild,"/p:BuildProjectReferences=false").Should().Pass();
 
             // GenerateStaticWebAssetsManifest should generate the manifest file.
             new FileInfo(path).Should().Exist();


### PR DESCRIPTION
We improved the build performance to bring back some of the performance we lost in 9.0.

## Description

During 9.0 the inner build perf regressed compared to 8.0 (some of this slowdown was expected as we were doing significantly more work compared to 8.0). 

We received feedback from customers that it is causing slowdowns on larger builds, so we have analyzed the build pipeline for low hanging fruits that we can tackle to bring back some of the lost performance.

## Customer Impact

Build times are slower for warm builds than in 8.0, this PR partially removes the perf gap between 8.0 and 9.0 for warm builds, especially on larger builds.

## Regression?

- [ ] Yes
- [X] No

No in the sense that nothing is broken, but it works slower.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props