### PR TITLE
Add nowarn for NU1903

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReplaceTextInFile.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReplaceTextInFile.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks
+{
+    public class ReplaceTextInFile : Task
+    {
+        [Required]
+        public string InputFile { get; set; }
+
+        [Required]
+        public string OldText { get; set; }
+
+        [Required]
+        public string NewText { get; set; }
+
+
+        public override bool Execute()
+        {
+            string fileContents = File.ReadAllText(InputFile);
+            string newLineChars = FileUtilities.DetectNewLineChars(fileContents);
+
+            fileContents = fileContents.Replace(OldText, NewText);
+
+            File.WriteAllText(InputFile, FileUtilities.NormalizeNewLineChars(fileContents, newLineChars));
+
+            return true;
+        }
+    }
+}

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -37,7 +37,6 @@
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.ReplaceTextInFile" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="AddNoWarns"
-          BeforeTargets="Build"
           Condition=" EXISTS('$(ProjectDirectory)Directory.Build.props') OR EXISTS('$(ProjectDirectory)src/Directory.Build.props') "
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)AddNoWarns.complete" >
@@ -423,6 +422,7 @@
           Outputs="$(BaseIntermediateOutputPath)Build.complete"
           Condition="'$(BuildCommand)' != ''"
           DependsOnTargets="BuildRepoReferences;
+                            AddNoWarns;
                             UpdateNuGetConfig;
                             UpdateGlobalJsonVersions;
                             UpdateEngCommonFiles;

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -35,6 +35,37 @@
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.ReplaceTextInFile" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="AddNoWarns"
+          BeforeTargets="Build"
+          Condition=" EXISTS('$(ProjectDirectory)Directory.Build.props') OR EXISTS('$(ProjectDirectory)src/Directory.Build.props') "
+          Inputs="$(MSBuildProjectFullPath)"
+          Outputs="$(RepoCompletedSemaphorePath)AddNoWarns.complete" >
+
+    <!-- Don't warn on warnings that can be generated in source-build
+         but not necessarily in repo builds. 
+         NU1603 - See https://github.com/dotnet/source-build/issues/2766.
+         NU5104 - During preview builds, some packages have pre-release versions.
+                  Some repos with stable versions may need to uptake these packages 
+                  with pre-release versions because of PVP when building with 
+                  source-build.  -->
+    <PropertyGroup>
+      <OldText><![CDATA[</Project>]]></OldText>
+      <NewText>
+        <![CDATA[  <PropertyGroup>
+    <NoWarn>%24(NoWarn);NU1903;$(RepoNoWarns)</NoWarn>
+  </PropertyGroup>
+</Project>]]>
+      </NewText>
+
+      <DirectoryBuildPropsFile Condition=" EXISTS('$(ProjectDirectory)Directory.Build.props') ">$(ProjectDirectory)Directory.Build.props</DirectoryBuildPropsFile>
+      <DirectoryBuildPropsFile Condition=" '$(DirectoryBuildPropsFile)' == '' AND EXISTS('$(ProjectDirectory)src/Directory.Build.props') ">$(ProjectDirectory)src/Directory.Build.props</DirectoryBuildPropsFile>
+    </PropertyGroup>
+    <ReplaceTextInFile InputFile="$(DirectoryBuildPropsFile)"
+      OldText="$(OldText)"
+      NewText="$(NewText)" />
+  </Target>
+
   <!-- Returns the repository references of this project and all the projects this project references, recursively -->
   <Target Name="GetTransitiveRepositoryReferences" Returns="@(TransitiveRepositoryReference)">
     <ItemGroup>


### PR DESCRIPTION
Temporary fix for https://github.com/dotnet/source-build/issues/4660 to unblock the builds and the [actual fix](https://github.com/dotnet/sdk/pull/43993) from being checked in.