### PR TITLE
Bump OmniSharp Version to latest

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 public class OmniSharpTests : SdkTests
 {
     // Update version as new releases become available: https://github.com/OmniSharp/omnisharp-roslyn/releases
-    private const string OmniSharpReleaseVersion = "1.39.11";
+    private const string OmniSharpReleaseVersion = "1.39.12";
 
     private string OmniSharpDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), nameof(OmniSharpTests));
 


### PR DESCRIPTION
Bumping to the latest version. The latest version is already being used in the `main` branch.