### PR TITLE
Add local package patterns to source-mappings for online feeds

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
@@ -183,6 +183,17 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 if (null != GetElement(pkgSourcesElement, "add", sourceName))
                 {
                     AddSourceMappings(pkgSrcMappingElement, sourceName, packagePatterns);
+
+                    // Add all old source mapping patterns for custom sources.
+                    // Unlike local sources, custom sources cannot be enumerated.
+                    XElement pkgSrcElement = GetElement(pkgSrcMappingElement, "packageSource", sourceName);
+                    if (pkgSrcElement != null)
+                    {
+                        foreach (string pattern in allOldSourceMappingPatterns)
+                        {
+                            pkgSrcElement.Add(new XElement("package", new XAttribute("pattern", pattern)));
+                        }
+                    }
                 }
             }
         }
@@ -381,11 +392,14 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                         !prebuiltPackages.ContainsKey(pattern))
                     {
                         filteredPatterns.Add(pattern);
+                        if (!allOldSourceMappingPatterns.Contains(pattern))
+                        {
+                            allOldSourceMappingPatterns.Add(pattern);
+                        }
                     }
                 }
 
                 oldSourceMappingPatterns.Add(packageSource.Attribute("key").Value, filteredPatterns);
-                allOldSourceMappingPatterns.AddRange(filteredPatterns);
             }
         }
 

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
@@ -62,6 +62,9 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
         private Dictionary<string, List<string>> allSourcesPackages = [];
         private Dictionary<string, List<string>> oldSourceMappingPatterns = [];
 
+        // allOldSourceMappingPatterns is a union of all patterns from oldSourceMappingPatterns
+        List<string> allOldSourceMappingPatterns = [];
+
         // All other dictionaries are: 'package id', 'list of package versions'
         private Dictionary<string, List<string>> currentPackages = [];
         private Dictionary<string, List<string>> referencePackages = [];
@@ -136,14 +139,17 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                     }
                 }
 
-                // Union all package sources to get the distinct list. These will get added to
+                // Union all package sources to get the distinct list. Remove all original patterns
+                // from online feeds that were unique to those feeds.
+                //
+                // These will get added to
                 // all custom sources and all online sources based on the following logic:
                 // If there were existing mappings for online feeds, add cummulative mappings
                 // from all feeds to these two.
                 // If there were no existing mappings, add default mappings for all online feeds.
                 List<string> packagePatterns = pkgSrcMappingElement.Descendants()
                     .Where(e => e.Name == "packageSource")
-                    .SelectMany(e => e.Descendants().Where(e => e.Name == "package"))
+                    .SelectMany(e => e.Descendants().Where(e => e.Name == "package" && !allOldSourceMappingPatterns.Contains(e.Attribute("pattern").Value)))
                     .Select(e => e.Attribute("pattern").Value)
                     .Distinct()
                     .ToList();
@@ -154,11 +160,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 }
 
                 AddMappingsForCustomSources(pkgSrcMappingElement, pkgSourcesElement, packagePatterns);
-
-                if (oldSourceMappingPatterns.Count == 0)
-                {
-                    AddMappingsForOnlineSources(pkgSrcMappingElement, pkgSourcesElement, packagePatterns);
-                }
+                AddMappingsForOnlineSources(pkgSrcMappingElement, pkgSourcesElement, packagePatterns);
             }
 
             using (var writer = XmlWriter.Create(NuGetConfigFile, new XmlWriterSettings { NewLineChars = newLineChars, Indent = true }))
@@ -180,27 +182,29 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
             {
                 if (null != GetElement(pkgSourcesElement, "add", sourceName))
                 {
-                    ReplaceSourceMappings(pkgSrcMappingElement, sourceName, packagePatterns);
+                    AddSourceMappings(pkgSrcMappingElement, sourceName, packagePatterns);
                 }
             }
         }
 
-        private void ReplaceSourceMappings(XElement pkgSrcMappingElement, string sourceName, List<string> packagePatterns)
+        private void AddSourceMappings(XElement pkgSrcMappingElement, string sourceName, List<string> packagePatterns)
         {
-            XElement pkgSrc = new XElement("packageSource", new XAttribute("key", sourceName));
-            foreach (string packagePattern in packagePatterns)
-            {
-                pkgSrc.Add(new XElement("package", new XAttribute("pattern", packagePattern)));
-            }
+            XElement pkgSrc;
 
             XElement existingPkgSrcElement = GetElement(pkgSrcMappingElement, "packageSource", sourceName);
             if (existingPkgSrcElement != null)
             {
-                existingPkgSrcElement.ReplaceWith(pkgSrc);
+                pkgSrc = existingPkgSrcElement;
             }
             else
             {
+                pkgSrc = new XElement("packageSource", new XAttribute("key", sourceName));
                 pkgSrcMappingElement.Add(pkgSrc);
+            }
+
+            foreach (string packagePattern in packagePatterns)
+            {
+                pkgSrc.Add(new XElement("package", new XAttribute("pattern", packagePattern)));
             }
         }
 
@@ -215,7 +219,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 .Select(e => e.Attribute("key").Value)
                 .Distinct())
             {
-                ReplaceSourceMappings(pkgSrcMappingElement, sourceName, packagePatterns);
+                AddSourceMappings(pkgSrcMappingElement, sourceName, packagePatterns);
             }
         }
 
@@ -381,6 +385,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 }
 
                 oldSourceMappingPatterns.Add(packageSource.Attribute("key").Value, filteredPatterns);
+                allOldSourceMappingPatterns.AddRange(filteredPatterns);
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4651

This was a bug in original implementation (https://github.com/dotnet/sdk/commit/ddfd74a598f7dea6c7304b6c5e906953868c883b), that was not noticed in source-build, due to limited number of repos using package source mappings. Code had a correct comment describing the behavior, and now the implementation matches that intent.

In online builds, if a repo has package source-mappings, it could cause issues in unified build due to the way we update NuGet.config to add package source mappings for all feeds. All packages built locally should also be added as package-source mapping patterns to online feeds, so any package with a different version can be resolved from those online feeds.

This code is complex. It was added to original, old, codebase with https://github.com/dotnet/sdk/commit/ddfd74a598f7dea6c7304b6c5e906953868c883b. Due to limited time available for that feature, new code was implemented in a way that followed the original design. This is not easy to maintain and should be refactored - I've created the issue to track that work: https://github.com/dotnet/source-build/issues/4666