### PR TITLE
Add extra properties for test results in dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
@@ -1,5 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable
 

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
@@ -5,9 +5,9 @@
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    internal sealed record SuccessfulTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? SessionUid);
+    internal sealed record SuccessfulTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? StandardOutput, string? ErrorOutput, string? SessionUid);
 
-    internal sealed record FailedTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
+    internal sealed record FailedTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? StandardOutput, string? ErrorOutput, string? SessionUid);
 
     internal sealed record TestResultMessages(string? ExecutionId, SuccessfulTestResultMessage[] SuccessfulTestMessages, FailedTestResultMessage[] FailedTestMessages) : IRequest;
 }

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    internal sealed record SuccessfulTestResultMessage(string? Uid, string? DisplayName, byte? State, string? Reason, string? SessionUid);
+    internal sealed record SuccessfulTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? SessionUid);
 
-    internal sealed record FailedTestResultMessage(string? Uid, string? DisplayName, byte? State, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
+    internal sealed record FailedTestResultMessage(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
 
     internal sealed record TestResultMessages(string? ExecutionId, SuccessfulTestResultMessage[] SuccessfulTestMessages, FailedTestResultMessage[] FailedTestMessages) : IRequest;
 }

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/ObjectFieldIds.cs
@@ -71,8 +71,9 @@ namespace Microsoft.DotNet.Tools.Test
         public const ushort Uid = 1;
         public const ushort DisplayName = 2;
         public const ushort State = 3;
-        public const ushort Reason = 4;
-        public const ushort SessionUid = 5;
+        public const ushort Duration = 4;
+        public const ushort Reason = 5;
+        public const ushort SessionUid = 6;
     }
 
     internal static class FailedTestResultMessageFieldsId
@@ -80,10 +81,11 @@ namespace Microsoft.DotNet.Tools.Test
         public const ushort Uid = 1;
         public const ushort DisplayName = 2;
         public const ushort State = 3;
-        public const ushort Reason = 4;
-        public const ushort ErrorMessage = 5;
-        public const ushort ErrorStackTrace = 6;
-        public const ushort SessionUid = 7;
+        public const ushort Duration = 4;
+        public const ushort Reason = 5;
+        public const ushort ErrorMessage = 6;
+        public const ushort ErrorStackTrace = 7;
+        public const ushort SessionUid = 8;
     }
 
     internal static class FileArtifactMessagesFieldsId

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/ObjectFieldIds.cs
@@ -73,7 +73,9 @@ namespace Microsoft.DotNet.Tools.Test
         public const ushort State = 3;
         public const ushort Duration = 4;
         public const ushort Reason = 5;
-        public const ushort SessionUid = 6;
+        public const ushort StandardOutput = 6;
+        public const ushort ErrorOutput = 7;
+        public const ushort SessionUid = 8;
     }
 
     internal static class FailedTestResultMessageFieldsId
@@ -85,7 +87,9 @@ namespace Microsoft.DotNet.Tools.Test
         public const ushort Reason = 5;
         public const ushort ErrorMessage = 6;
         public const ushort ErrorStackTrace = 7;
-        public const ushort SessionUid = 8;
+        public const ushort StandardOutput = 8;
+        public const ushort ErrorOutput = 9;
+        public const ushort SessionUid = 10;
     }
 
     internal static class FileArtifactMessagesFieldsId

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/BaseSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/BaseSerializer.cs
@@ -279,6 +279,18 @@ internal abstract class BaseSerializer
         WriteStringValue(stream, value);
     }
 
+    protected static void WriteField(Stream stream, ushort id, long? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        WriteShort(stream, id);
+        WriteSize<long>(stream);
+        WriteLong(stream, value.Value);
+    }
+
     protected static void WriteField(Stream stream, string? value)
     {
         if (value is null)

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -9,75 +9,84 @@ using System.Diagnostics;
 
 namespace Microsoft.DotNet.Tools.Test
 {
+
     /*
-    |---FieldCount---| 2 bytes
+      |---FieldCount---| 2 bytes
 
-    |---ExecutionId Id---| (2 bytes)
-    |---ExecutionId Size---| (4 bytes)
-    |---ExecutionId Value---| (n bytes)
+      |---ExecutionId Id---| (2 bytes)
+      |---ExecutionId Size---| (4 bytes)
+      |---ExecutionId Value---| (n bytes)
 
-    |---SuccessfulTestMessageList Id---| (2 bytes)
-    |---SuccessfulTestMessageList Size---| (4 bytes)
-    |---SuccessfulTestMessageList Value---| (n bytes)
-        |---SuccessfulTestMessageList Length---| (4 bytes)
+      |---SuccessfulTestMessageList Id---| (2 bytes)
+      |---SuccessfulTestMessageList Size---| (4 bytes)
+      |---SuccessfulTestMessageList Value---| (n bytes)
+          |---SuccessfulTestMessageList Length---| (4 bytes)
 
-        |---SuccessfulTestMessageList[0] FieldCount---| 2 bytes
+          |---SuccessfulTestMessageList[0] FieldCount---| 2 bytes
 
-        |---SuccessfulTestMessageList[0].Uid Id---| (2 bytes)
-        |---SuccessfulTestMessageList[0].Uid Size---| (4 bytes)
-        |---SuccessfulTestMessageList[0].Uid Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].Uid Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].Uid Size---| (4 bytes)
+          |---SuccessfulTestMessageList[0].Uid Value---| (n bytes)
 
-        |---SuccessfulTestMessageList[0].DisplayName Id---| (2 bytes)
-        |---SuccessfulTestMessageList[0].DisplayName Size---| (4 bytes)
-        |---SuccessfulTestMessageList[0].DisplayName Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].DisplayName Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].DisplayName Size---| (4 bytes)
+          |---SuccessfulTestMessageList[0].DisplayName Value---| (n bytes)
 
-        |---SuccessfulTestMessageList[0].State Id---| (2 bytes)
-        |---SuccessfulTestMessageList[0].State Size---| (4 bytes)
-        |---SuccessfulTestMessageList[0].State Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].State Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].State Size---| (1 byte)
+          |---SuccessfulTestMessageList[0].State Value---| (n bytes)
 
-        |---SuccessfulTestMessageList[0].Reason Id---| (2 bytes)
-        |---SuccessfulTestMessageList[0].Reason Size---| (4 bytes)
-        |---SuccessfulTestMessageList[0].Reason Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].Duration Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].Duration Size---| (8 bytes)
+          |---SuccessfulTestMessageList[0].Duration Value---| (n bytes)
 
-        |---SuccessfulTestMessageList[0].SessionUid Id---| (2 bytes)
-        |---SuccessfulTestMessageList[0].SessionUid Size---| (4 bytes)
-        |---SuccessfulTestMessageList[0].SessionUid Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].Reason Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].Reason Size---| (4 bytes)
+          |---SuccessfulTestMessageList[0].Reason Value---| (n bytes)
 
-    |---FailedTestMessageList Id---| (2 bytes)
-    |---FailedTestMessageList Size---| (4 bytes)
-    |---FailedTestMessageList Value---| (n bytes)
-        |---FailedTestMessageList Length---| (4 bytes)
+          |---SuccessfulTestMessageList[0].SessionUid Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].SessionUid Size---| (4 bytes)
+          |---SuccessfulTestMessageList[0].SessionUid Value---| (n bytes)
 
-        |---FailedTestMessageList[0] FieldCount---| 2 bytes
+      |---FailedTestMessageList Id---| (2 bytes)
+      |---FailedTestMessageList Size---| (4 bytes)
+      |---FailedTestMessageList Value---| (n bytes)
+          |---FailedTestMessageList Length---| (4 bytes)
 
-        |---FailedTestMessageList[0].Uid Id---| (2 bytes)
-        |---FailedTestMessageList[0].Uid Size---| (4 bytes)
-        |---FailedTestMessageList[0].Uid Value---| (n bytes)
+          |---FailedTestMessageList[0] FieldCount---| 2 bytes
 
-        |---FailedTestMessageList[0].DisplayName Id---| (2 bytes)
-        |---FailedTestMessageList[0].DisplayName Size---| (4 bytes)
-        |---FailedTestMessageList[0].DisplayName Value---| (n bytes)
+          |---FailedTestMessageList[0].Uid Id---| (2 bytes)
+          |---FailedTestMessageList[0].Uid Size---| (4 bytes)
+          |---FailedTestMessageList[0].Uid Value---| (n bytes)
 
-        |---FailedTestMessageList[0].State Id---| (2 bytes)
-        |---FailedTestMessageList[0].State Size---| (4 bytes)
-        |---FailedTestMessageList[0].State Value---| (n bytes)
+          |---FailedTestMessageList[0].DisplayName Id---| (2 bytes)
+          |---FailedTestMessageList[0].DisplayName Size---| (4 bytes)
+          |---FailedTestMessageList[0].DisplayName Value---| (n bytes)
 
-        |---FailedTestMessageList[0].Reason Id---| (2 bytes)
-        |---FailedTestMessageList[0].Reason Size---| (4 bytes)
-        |---FailedTestMessageList[0].Reason Value---| (n bytes)
+          |---FailedTestMessageList[0].State Id---| (2 bytes)
+          |---FailedTestMessageList[0].State Size---| (1 byte)
+          |---FailedTestMessageList[0].State Value---| (n bytes)
 
-        |---FailedTestMessageList[0].ErrorMessage Id---| (2 bytes)
-        |---FailedTestMessageList[0].ErrorMessage Size---| (4 bytes)
-        |---FailedTestMessageList[0].ErrorMessage Value---| (n bytes)
+          |---SuccessfulTestMessageList[0].Duration Id---| (2 bytes)
+          |---SuccessfulTestMessageList[0].Duration Size---| (8 bytes)
+          |---SuccessfulTestMessageList[0].Duration Value---| (n bytes)
 
-        |---FailedTestMessageList[0].ErrorStackTrace Id---| (2 bytes)
-        |---FailedTestMessageList[0].ErrorStackTrace Size---| (4 bytes)
-        |---FailedTestMessageList[0].ErrorStackTrace Value---| (n bytes)
+          |---FailedTestMessageList[0].Reason Id---| (2 bytes)
+          |---FailedTestMessageList[0].Reason Size---| (4 bytes)
+          |---FailedTestMessageList[0].Reason Value---| (n bytes)
 
-        |---FailedTestMessageList[0].SessionUid Id---| (2 bytes)
-        |---FailedTestMessageList[0].SessionUid Size---| (4 bytes)
-        |---FailedTestMessageList[0].SessionUid Value---| (n bytes)
-    */
+          |---FailedTestMessageList[0].ErrorMessage Id---| (2 bytes)
+          |---FailedTestMessageList[0].ErrorMessage Size---| (4 bytes)
+          |---FailedTestMessageList[0].ErrorMessage Value---| (n bytes)
+
+          |---FailedTestMessageList[0].ErrorStackTrace Id---| (2 bytes)
+          |---FailedTestMessageList[0].ErrorStackTrace Size---| (4 bytes)
+          |---FailedTestMessageList[0].ErrorStackTrace Value---| (n bytes)
+
+          |---FailedTestMessageList[0].SessionUid Id---| (2 bytes)
+          |---FailedTestMessageList[0].SessionUid Size---| (4 bytes)
+          |---FailedTestMessageList[0].SessionUid Value---| (n bytes)
+      */
 
     internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeSerializer
     {
@@ -132,6 +141,7 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 string? uid = null, displayName = null, reason = null, sessionUid = null;
                 byte? state = null;
+                long? duration = null;
 
                 int fieldCount = ReadShort(stream);
 
@@ -154,6 +164,10 @@ namespace Microsoft.DotNet.Tools.Test
                             state = ReadByte(stream);
                             break;
 
+                        case SuccessfulTestResultMessageFieldsId.Duration:
+                            duration = ReadLong(stream);
+                            break;
+
                         case SuccessfulTestResultMessageFieldsId.Reason:
                             reason = ReadStringValue(stream, fieldSize);
                             break;
@@ -168,7 +182,7 @@ namespace Microsoft.DotNet.Tools.Test
                     }
                 }
 
-                successfulTestResultMessages.Add(new SuccessfulTestResultMessage(uid, displayName, state, reason, sessionUid));
+                successfulTestResultMessages.Add(new SuccessfulTestResultMessage(uid, displayName, state, duration, reason, sessionUid));
             }
 
             return successfulTestResultMessages;
@@ -183,6 +197,7 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 string? uid = null, displayName = null, reason = null, sessionUid = null, errorMessage = null, errorStackTrace = null;
                 byte? state = null;
+                long? duration = null;
 
                 int fieldCount = ReadShort(stream);
 
@@ -203,6 +218,10 @@ namespace Microsoft.DotNet.Tools.Test
 
                         case FailedTestResultMessageFieldsId.State:
                             state = ReadByte(stream);
+                            break;
+
+                        case FailedTestResultMessageFieldsId.Duration:
+                            duration = ReadLong(stream);
                             break;
 
                         case FailedTestResultMessageFieldsId.Reason:
@@ -227,7 +246,7 @@ namespace Microsoft.DotNet.Tools.Test
                     }
                 }
 
-                failedTestResultMessages.Add(new FailedTestResultMessage(uid, displayName, state, reason, errorMessage, errorStackTrace, sessionUid));
+                failedTestResultMessages.Add(new FailedTestResultMessage(uid, displayName, state, duration, reason, errorMessage, errorStackTrace, sessionUid));
             }
 
             return failedTestResultMessages;
@@ -268,6 +287,7 @@ namespace Microsoft.DotNet.Tools.Test
                 WriteField(stream, SuccessfulTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
                 WriteField(stream, SuccessfulTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
                 WriteField(stream, SuccessfulTestResultMessageFieldsId.State, successfulTestResultMessage.State);
+                WriteField(stream, SuccessfulTestResultMessageFieldsId.Duration, successfulTestResultMessage.Duration);
                 WriteField(stream, SuccessfulTestResultMessageFieldsId.Reason, successfulTestResultMessage.Reason);
                 WriteField(stream, SuccessfulTestResultMessageFieldsId.SessionUid, successfulTestResultMessage.SessionUid);
             }
@@ -299,6 +319,7 @@ namespace Microsoft.DotNet.Tools.Test
                 WriteField(stream, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
                 WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
                 WriteField(stream, FailedTestResultMessageFieldsId.State, failedTestResultMessage.State);
+                WriteField(stream, FailedTestResultMessageFieldsId.Duration, failedTestResultMessage.Duration);
                 WriteField(stream, FailedTestResultMessageFieldsId.Reason, failedTestResultMessage.Reason);
                 WriteField(stream, FailedTestResultMessageFieldsId.ErrorMessage, failedTestResultMessage.ErrorMessage);
                 WriteField(stream, FailedTestResultMessageFieldsId.ErrorStackTrace, failedTestResultMessage.ErrorStackTrace);
@@ -319,6 +340,7 @@ namespace Microsoft.DotNet.Tools.Test
             (ushort)((successfulTestResultMessage.Uid is null ? 0 : 1) +
             (successfulTestResultMessage.DisplayName is null ? 0 : 1) +
             (successfulTestResultMessage.State is null ? 0 : 1) +
+            (successfulTestResultMessage.Duration is null ? 0 : 1) +
             (successfulTestResultMessage.Reason is null ? 0 : 1) +
             (successfulTestResultMessage.SessionUid is null ? 0 : 1));
 
@@ -326,9 +348,11 @@ namespace Microsoft.DotNet.Tools.Test
             (ushort)((failedTestResultMessage.Uid is null ? 0 : 1) +
             (failedTestResultMessage.DisplayName is null ? 0 : 1) +
             (failedTestResultMessage.State is null ? 0 : 1) +
+            (failedTestResultMessage.Duration is null ? 0 : 1) +
             (failedTestResultMessage.Reason is null ? 0 : 1) +
             (failedTestResultMessage.ErrorMessage is null ? 0 : 1) +
             (failedTestResultMessage.ErrorStackTrace is null ? 0 : 1) +
             (failedTestResultMessage.SessionUid is null ? 0 : 1));
     }
+
 }

--- a/src/Cli/dotnet/commands/dotnet-test/Models.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Models.cs
@@ -13,9 +13,9 @@ namespace Microsoft.DotNet.Cli
 
     internal sealed record DiscoveredTest(string? Uid, string? DisplayName);
 
-    internal sealed record SuccessfulTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? SessionUid);
+    internal sealed record SuccessfulTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? StandardOutput, string? ErrorOutput, string? SessionUid);
 
-    internal sealed record FailedTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
+    internal sealed record FailedTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? StandardOutput, string? ErrorOutput, string? SessionUid);
 
     internal sealed record FileArtifact(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid);
 

--- a/src/Cli/dotnet/commands/dotnet-test/Models.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Models.cs
@@ -13,9 +13,9 @@ namespace Microsoft.DotNet.Cli
 
     internal sealed record DiscoveredTest(string? Uid, string? DisplayName);
 
-    internal sealed record SuccessfulTestResult(string? Uid, string? DisplayName, byte? State, string? Reason, string? SessionUid);
+    internal sealed record SuccessfulTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? SessionUid);
 
-    internal sealed record FailedTestResult(string? Uid, string? DisplayName, byte? State, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
+    internal sealed record FailedTestResult(string? Uid, string? DisplayName, byte? State, long? Duration, string? Reason, string? ErrorMessage, string? ErrorStackTrace, string? SessionUid);
 
     internal sealed record FileArtifact(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid);
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli
 
         public async Task<int> RunAsync(bool isFilterMode, bool enableHelp, BuiltInOptions builtInOptions)
         {
-            DebuggerUtility.AttachCurrentProcessToVSProcessPID(37568);
+            DebuggerUtility.AttachCurrentProcessToVSProcessPID(29016);
             Run?.Invoke(this, EventArgs.Empty);
 
             if (isFilterMode && !ModulePathExists())
@@ -337,8 +337,8 @@ namespace Microsoft.DotNet.Cli
             TestResultsReceived?.Invoke(this, new TestResultEventArgs
             {
                 ExecutionId = testResultMessage.ExecutionId,
-                SuccessfulTestResults = testResultMessage.SuccessfulTestMessages.Select(message => new SuccessfulTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.SessionUid)).ToArray(),
-                FailedTestResults = testResultMessage.FailedTestMessages.Select(message => new FailedTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.ErrorMessage, message.ErrorStackTrace, message.SessionUid)).ToArray()
+                SuccessfulTestResults = testResultMessage.SuccessfulTestMessages.Select(message => new SuccessfulTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.StandardOutput, message.ErrorOutput, message.SessionUid)).ToArray(),
+                FailedTestResults = testResultMessage.FailedTestMessages.Select(message => new FailedTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.ErrorMessage, message.ErrorStackTrace, message.StandardOutput, message.ErrorOutput, message.SessionUid)).ToArray()
             });
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipes;
 using Microsoft.DotNet.Tools.Test;
-using Microsoft.Testing.TestInfrastructure;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -49,7 +48,6 @@ namespace Microsoft.DotNet.Cli
 
         public async Task<int> RunAsync(bool isFilterMode, bool enableHelp, BuiltInOptions builtInOptions)
         {
-            DebuggerUtility.AttachCurrentProcessToVSProcessPID(29016);
             Run?.Invoke(this, EventArgs.Empty);
 
             if (isFilterMode && !ModulePathExists())

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipes;
 using Microsoft.DotNet.Tools.Test;
+using Microsoft.Testing.TestInfrastructure;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -48,6 +49,7 @@ namespace Microsoft.DotNet.Cli
 
         public async Task<int> RunAsync(bool isFilterMode, bool enableHelp, BuiltInOptions builtInOptions)
         {
+            DebuggerUtility.AttachCurrentProcessToVSProcessPID(37568);
             Run?.Invoke(this, EventArgs.Empty);
 
             if (isFilterMode && !ModulePathExists())
@@ -335,8 +337,8 @@ namespace Microsoft.DotNet.Cli
             TestResultsReceived?.Invoke(this, new TestResultEventArgs
             {
                 ExecutionId = testResultMessage.ExecutionId,
-                SuccessfulTestResults = testResultMessage.SuccessfulTestMessages.Select(message => new SuccessfulTestResult(message.Uid, message.DisplayName, message.State, message.Reason, message.SessionUid)).ToArray(),
-                FailedTestResults = testResultMessage.FailedTestMessages.Select(message => new FailedTestResult(message.Uid, message.DisplayName, message.State, message.Reason, message.ErrorMessage, message.ErrorStackTrace, message.SessionUid)).ToArray()
+                SuccessfulTestResults = testResultMessage.SuccessfulTestMessages.Select(message => new SuccessfulTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.SessionUid)).ToArray(),
+                FailedTestResults = testResultMessage.FailedTestMessages.Select(message => new FailedTestResult(message.Uid, message.DisplayName, message.State, message.Duration, message.Reason, message.ErrorMessage, message.ErrorStackTrace, message.SessionUid)).ToArray()
             });
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -163,14 +163,15 @@ namespace Microsoft.DotNet.Cli
             foreach (SuccessfulTestResult successfulTestResult in args.SuccessfulTestResults)
             {
                 VSTestTrace.SafeWriteTrace(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
-                $"{successfulTestResult.State}, {successfulTestResult.Duration}, {successfulTestResult.Reason}, {successfulTestResult.SessionUid}");
+                $"{successfulTestResult.State}, {successfulTestResult.Duration}, {successfulTestResult.Reason}, {successfulTestResult.StandardOutput}," +
+                $"{successfulTestResult.ErrorOutput}, {successfulTestResult.SessionUid}");
             }
 
             foreach (FailedTestResult failedTestResult in args.FailedTestResults)
             {
                 VSTestTrace.SafeWriteTrace(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
                 $"{failedTestResult.State}, {failedTestResult.Duration}, {failedTestResult.Reason}, {failedTestResult.ErrorMessage}," +
-                $" {failedTestResult.ErrorStackTrace}, {failedTestResult.SessionUid}");
+                $"{failedTestResult.ErrorStackTrace}, {failedTestResult.StandardOutput}, {failedTestResult.ErrorOutput}, {failedTestResult.SessionUid}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -163,13 +163,13 @@ namespace Microsoft.DotNet.Cli
             foreach (SuccessfulTestResult successfulTestResult in args.SuccessfulTestResults)
             {
                 VSTestTrace.SafeWriteTrace(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
-                $"{successfulTestResult.State}, {successfulTestResult.Reason}, {successfulTestResult.SessionUid}");
+                $"{successfulTestResult.State}, {successfulTestResult.Duration}, {successfulTestResult.Reason}, {successfulTestResult.SessionUid}");
             }
 
             foreach (FailedTestResult failedTestResult in args.FailedTestResults)
             {
                 VSTestTrace.SafeWriteTrace(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
-                $"{failedTestResult.State}, {failedTestResult.Reason}, {failedTestResult.ErrorMessage}," +
+                $"{failedTestResult.State}, {failedTestResult.Duration}, {failedTestResult.Reason}, {failedTestResult.ErrorMessage}," +
                 $" {failedTestResult.ErrorStackTrace}, {failedTestResult.SessionUid}");
             }
         }
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Cli
 
             foreach (FileArtifact fileArtifactMessage in args.FileArtifacts)
             {
-                VSTestTrace.SafeWriteTrace(() => $"FileArtifacr: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
+                VSTestTrace.SafeWriteTrace(() => $"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
                 $"{fileArtifactMessage.Description}, {fileArtifactMessage.TestUid}, {fileArtifactMessage.TestDisplayName}, " +
                 $"{fileArtifactMessage.SessionUid}");
             }


### PR DESCRIPTION
This pull request introduces several enhancements to the test result messaging system, primarily focusing on adding new fields to test result messages and updating related serializers and handlers. The most important changes include extending the `SuccessfulTestResultMessage` and `FailedTestResultMessage` records, updating field IDs, and modifying the serializers to handle the new fields.

### Enhancements to Test Result Messages:

* [`src/Cli/dotnet/commands/dotnet-test/IPC/Models/TestResultMessages.cs`](diffhunk://#diff-80a8ee64c5a93a579172e4a8029381e412d207bbf076e5d23971d98d142c7ccbL1-R10): Added `Duration`, `StandardOutput`, and `ErrorOutput` fields to `SuccessfulTestResultMessage` and `FailedTestResultMessage` records.

### Updates to Field IDs:

* [`src/Cli/dotnet/commands/dotnet-test/IPC/ObjectFieldIds.cs`](diffhunk://#diff-ea80e935394c39a82e357278fbe17f67c9fe440373662e5d1a940265d7888d86L74-R92): Updated field IDs to include `Duration`, `StandardOutput`, and `ErrorOutput` for both `SuccessfulTestResultMessage` and `FailedTestResultMessage`.

### Serializer Modifications:

* [`src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/BaseSerializer.cs`](diffhunk://#diff-b6eb529440a6cd2a0939dc396f83f71dce504bd821a0aae7e4ac1638f5537ee4R282-R293): Added a new method to write `long?` values to the stream.
* [`src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/TestResultMessagesSerializer.cs`](diffhunk://#diff-4c5b4b6340b221fcf0c944ee4bff0dfd8ca585ccdce014c33cf79cbbb26f7343L35-R53): Updated the serializer to handle the new fields (`Duration`, `StandardOutput`, `ErrorOutput`) for both successful and failed test messages.

### Additional Changes:

* [`src/Cli/dotnet/commands/dotnet-test/Models.cs`](diffhunk://#diff-3ee56fe6c4fb8020f4ca49c84e9d3b4e858f3d62d307244d53669d94db84013fL16-R18): Added new fields to the `SuccessfulTestResult` and `FailedTestResult` records to match the changes in `TestResultMessages`.
* [`src/Cli/dotnet/commands/dotnet-test/TestApplication.cs`](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL338-R341): Updated the `OnTestResultMessages` method to handle the new fields in the test result messages.