### PR TITLE
Bump version of Microsoft.IO.Redist to preview from maintenance-packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
          compiler API targeted by analyzer assemblies. This is mostly an issue on source-build as
          in that build mode analyzer assemblies always target the live compiler API. -->
     <UsingToolMicrosoftNetCompilers Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</UsingToolMicrosoftNetCompilers>
-    <MicrosoftIORedistPackageVersion>6.0.1</MicrosoftIORedistPackageVersion>
+    <MicrosoftIORedistPackageVersion>6.1.0-preview.1.24511.1</MicrosoftIORedistPackageVersion>
     <FlagNetStandard1XDependencies Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</FlagNetStandard1XDependencies>
   </PropertyGroup>
   <PropertyGroup Label="Servicing version information">


### PR DESCRIPTION
We have published out of the dotnet/maintenance-packages repo new preview versions of various OOB packages: https://github.com/dotnet/maintenance-packages/tree/main/src

These packages do not have any source code changes. They only have a new version number because they have a new repo of origin that uses modern arcade infrastructure (they were all residing in out-of-support branches).

Of those packages, the only one actively consumed by the dotnet/sdk repo is Microsoft.IO.Redist via the dotnet-libraries feed: https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-libraries/NuGet/Microsoft.IO.Redist/overview/6.1.0-preview.1.24511.1

We don't yet have subscriptions. We first want to test the packages via manual dependency updates.

This is a similar PR to the one we have for dotnet/runtime: https://github.com/dotnet/runtime/pull/108806