### PR TITLE
Fix assembly version diff test for missing file

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -169,7 +169,7 @@ public class SdkContentTests : SdkTests
             }
         }
 
-        Assert.Fail($"Unable to find matching file for '{representativeFile}' in '{rootDir}'.");
+        OutputHelper.WriteLine($"Unable to find matching file for '{representativeFile}' in '{rootDir}'.");
         return string.Empty;
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4668

The source build assembly version diff test doesn't handle cases where the source built SDK contains files that do not exist in the Microsoft-built SDK. Some recent changes came in where this file diff was baselined (https://github.com/dotnet/sdk/pull/43964). Two of the example files in this case are `./sdk/x.y.z/Microsoft.Bcl.AsyncInterfaces.dll` and `./sdk/x.y.z/Microsoft.Bcl.Cryptography.dll`.

The logic in the test will see that these files exist in the source built SDK and then try to find the matching file in the Microsoft SDK. When it can't find it, it causes an error. The `Assert` that is causing the error should be replaced with just a message that the file was not found. The rest of the logic gracefully handles it when no matching file exists.