### PR TITLE
Execute GetTestsProject msbuild task if IsTestApplication property is true

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
@@ -19,7 +19,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition="Exists('$(VSTestTargets)')" Project="$(VSTestTargets)" />
   <!-- Register TestingPlatform task -->
   <UsingTask TaskName="GetTestsProject" AssemblyFile="$(MicrosoftNETBuildTasksDirectory)Microsoft.NET.Build.Tasks.dll" />
-  <Target Name="_GetTestsProject" Condition=" $(IsTestProject) == 'true' OR '$(IsTestingPlatformApplication)' == 'true' " >
+  <Target Name="_GetTestsProject" Condition=" $(IsTestProject) == 'true' OR '$(IsTestingPlatformApplication)' == 'true' OR '$(IsTestApplication)' == 'true' " >
     <GetTestsProject TargetPath="$(TargetPath)" GetTestsProjectPipeName="$(GetTestsProjectPipeName)" ProjectFullPath="$(MSBuildProjectFullPath)" TargetFramework="$(TargetFramework)" RunSettingsFilePath="$(RunSettingsFilePath)" />
   </Target>
 </Project>


### PR DESCRIPTION
This pull request includes a small but important change to the `src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets` file. The change modifies the condition for the `_GetTestsProject` target to include an additional check for `IsTestApplication`.

Most important change:

* [`src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets`](diffhunk://#diff-3f7b2597025eca7c8bdaa8632fab1a3a6894415a704c2b08c2b0760ac708ba39L22-R22): Modified the condition for the `_GetTestsProject` target to include `$(IsTestApplication) == 'true'` to ensure that test applications are correctly recognized and processed.


There was a bug that required us to build in CLI (dotnet build) before running dotnet test in case the project wasn't built before.