### PR TITLE
[Blazor] Update Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
@@ -285,6 +285,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_JSModulePubishManifestPath>$(IntermediateOutputPath)jsmodules\jsmodules.publish.manifest.json</_JSModulePubishManifestPath>
+      <JSModuleManifestRelativePath Condition="'$(JSModuleManifestRelativePath)' == ''">$(PackageId).modules.json</JSModuleManifestRelativePath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #https://github.com/dotnet/aspnetcore/issues/58321

The relative path was defined on a task that only ran during build, and as a result will not be set if you use `publish --no-build` resulting in the file getting copied to the wrong location.