### PR TITLE
Fix SB assembly version test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -98,7 +98,11 @@ public class SdkContentTests : SdkTests
         {
             string assemblyPath = sbSdkFileArray[i];
             Version? sbVersion = sbSdkAssemblyVersions[assemblyPath];
-            Version? msftVersion = msftSdkAssemblyVersions[assemblyPath];
+            if (!msftSdkAssemblyVersions.TryGetValue(assemblyPath, out Version? msftVersion))
+            {
+                sbSdkAssemblyVersions.Remove(assemblyPath);
+                continue;
+            }
 
             if (sbVersion is not null &&
                 msftVersion is not null &&


### PR DESCRIPTION
Follow up to https://github.com/dotnet/sdk/pull/44156. When running the `CompareMsftToSbAssemblyVersions` test, the following exception occurs: 

```
System.Collections.Generic.KeyNotFoundException : The given key 'sdk/x.y.z/Containers/tasks/netx.y/Microsoft.Bcl.AsyncInterfaces.dll' was not present in the dictionary.
at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
[at Microsoft.DotNet.SourceBuild.SmokeTests.SdkContentTests.RemoveExcludedAssemblyVersionPaths(Dictionary`2 sbSdkAssemblyVersions, Dictionary`2 msftSdkAssemblyVersions) in /mnt/vss/_work/1/s/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs:line 101](https://dev.azure.com/dnceng/internal/_git/ddda0dd6-918f-48ba-ba8f-730d9d8c9320?path=%2Fmnt%2Fvss%2F_work%2F1%2Fs%2Ftest%2FMicrosoft.DotNet.SourceBuild.SmokeTests%2FSdkContentTests.cs&version=GBmain&_a=contents&line=101&lineEnd=102&lineStartColumn=1&lineEndColumn=1&lineStyle=plain)
[at Microsoft.DotNet.SourceBuild.SmokeTests.SdkContentTests.CompareMsftToSbAssemblyVersions() in /mnt/vss/_work/1/s/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs:line 72](https://dev.azure.com/dnceng/internal/_git/ddda0dd6-918f-48ba-ba8f-730d9d8c9320?path=%2Fmnt%2Fvss%2F_work%2F1%2Fs%2Ftest%2FMicrosoft.DotNet.SourceBuild.SmokeTests%2FSdkContentTests.cs&version=GBmain&_a=contents&line=72&lineEnd=73&lineStartColumn=1&lineEndColumn=1&lineStyle=plain)
at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

This occurs because the logic expects the path to exist in the dictionary for a file that exists in the source build SDK but not the Microsoft SDK. In this case, it should skip over that file.