### PR TITLE
[release/9.0.1xx] Workloads: Support VS component IDs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/list/VisualStudioWorkloads.cs
@@ -25,22 +25,12 @@ namespace Microsoft.DotNet.Workloads.Workload
         /// Visual Studio product ID filters. We dont' want to query SKUs such as Server, TeamExplorer, TestAgent
         /// TestController and BuildTools.
         /// </summary>
-        private static readonly string[] s_visualStudioProducts = new string[]
+        private static readonly string[] s_visualStudioProducts =
         {
             "Microsoft.VisualStudio.Product.Community",
             "Microsoft.VisualStudio.Product.Professional",
             "Microsoft.VisualStudio.Product.Enterprise",
         };
-
-        /// <summary>
-        /// Default prefix to use for Visual Studio component and component group IDs.
-        /// </summary>
-        private static readonly string s_visualStudioComponentPrefix = "Microsoft.NET.Component";
-
-        /// <summary>
-        /// Well-known prefixes used by some workloads that can be replaced when generating component IDs.
-        /// </summary>
-        private static readonly string[] s_wellKnownWorkloadPrefixes = { "Microsoft.NET.", "Microsoft." };
 
         /// <summary>
         /// The SWIX package ID wrapping the SDK installer in Visual Studio. The ID should contain
@@ -67,22 +57,9 @@ namespace Microsoft.DotNet.Workloads.Workload
             {
                 string workloadId = workload.Id.ToString();
                 // Old style VS components simply replaced '-' with '.' in the workload ID.
-                string componentId = workload.Id.ToString().Replace('-', '.');
-
-                visualStudioComponentWorkloads.Add(componentId, workloadId);
-
+                visualStudioComponentWorkloads.Add(workload.Id.ToSafeId(), workloadId);
                 // Starting in .NET 9.0 and VS 17.12, workload components will follow the VS naming convention.
-                foreach (string wellKnownPrefix in s_wellKnownWorkloadPrefixes)
-                {
-                    if (componentId.StartsWith(wellKnownPrefix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        componentId = componentId.Substring(wellKnownPrefix.Length);
-                        break;
-                    }
-                }
-
-                componentId = s_visualStudioComponentPrefix + "." + componentId;
-                visualStudioComponentWorkloads.Add(componentId, workloadId);
+                visualStudioComponentWorkloads.Add(workload.Id.ToSafeId(includeVisualStudioPrefix: true), workloadId);
             }
 
             return visualStudioComponentWorkloads;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadId.cs
@@ -9,6 +9,10 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// </summary>
     public readonly struct WorkloadId : IComparable<WorkloadId>, IEquatable<WorkloadId>
     {
+        private static readonly string s_visualStudioComponentPrefix = "Microsoft.NET.Component";
+
+        private static readonly string[] s_wellKnownWorkloadPrefixes = { "Microsoft.NET.", "Microsoft." };
+
         private readonly string _id;
 
         public WorkloadId(string id)
@@ -30,6 +34,29 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public override bool Equals(object? obj) => obj is WorkloadId id && Equals(id);
 
         public override string ToString() => _id;
+
+        public string ToSafeId() => ToSafeId(includeVisualStudioPrefix: false);
+
+        public string ToSafeId(bool includeVisualStudioPrefix)
+        {
+            string safeId = _id.Replace('-', '.').Replace(' ', '.').Replace('_', '.');
+
+            if (includeVisualStudioPrefix)
+            {
+                foreach (string wellKnownPrefix in s_wellKnownWorkloadPrefixes)
+                {
+                    if (safeId.StartsWith(wellKnownPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        safeId = safeId.Substring(wellKnownPrefix.Length);
+                        break;
+                    }
+                }
+
+                safeId = s_visualStudioComponentPrefix + "." + safeId;
+            }
+
+            return safeId;
+        }
 
         public static implicit operator string(WorkloadId id) => id._id;
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadId.cs
@@ -35,9 +35,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public override string ToString() => _id;
 
-        public string ToSafeId() => ToSafeId(includeVisualStudioPrefix: false);
-
-        public string ToSafeId(bool includeVisualStudioPrefix)
+        public string ToSafeId(bool includeVisualStudioPrefix = false)
         {
             string safeId = _id.Replace('-', '.').Replace(' ', '.').Replace('_', '.');
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks
             { "android", "android-aot", "ios", "maccatalyst", "macos", "maui", "maui-android",
             "maui-desktop", "maui-ios", "maui-maccatalyst", "maui-mobile", "maui-windows", "tvos" };
         private static readonly HashSet<string> WasmWorkloadIds = new(StringComparer.OrdinalIgnoreCase)
-            { "wasm-tools", "wasm-tools-net6", "wasm-tools-net7" };
+            { "wasm-tools", "wasm-tools-net6", "wasm-tools-net7", "wasm-tools-net8" };
 
         public ITaskItem[] MissingWorkloadPacks { get; set; }
 
@@ -70,7 +70,7 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         var suggestedWorkloadsList = GetSuggestedWorkloadsList(suggestedWorkload);
                         var taskItem = new TaskItem(suggestedWorkload.Id);
-                        taskItem.SetMetadata("VisualStudioComponentId", ToSafeId(suggestedWorkload.Id));
+                        taskItem.SetMetadata("VisualStudioComponentId", suggestedWorkload.Id.ToSafeId(includeVisualStudioPrefix: true));
                         taskItem.SetMetadata("VisualStudioComponentIds", string.Join(";", suggestedWorkloadsList));
                         return taskItem;
                     }).ToArray();
@@ -78,14 +78,10 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        internal static string ToSafeId(string id)
-        {
-            return id.Replace("-", ".").Replace(" ", ".").Replace("_", ".");
-        }
-
         private static IEnumerable<string> GetSuggestedWorkloadsList(WorkloadInfo workloadInfo)
         {
-            yield return ToSafeId(workloadInfo.Id);
+            yield return workloadInfo.Id.ToSafeId();
+            yield return workloadInfo.Id.ToSafeId(includeVisualStudioPrefix: true);
             if (MauiWorkloadIds.Contains(workloadInfo.Id.ToString()))
             {
                 yield return MauiCrossPlatTopLevelVSWorkloads;

--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -63,6 +63,7 @@ namespace Microsoft.NET.Build.Tests
 
             var getValuesCommand = new GetValuesCommand(testAsset, "SuggestedWorkload", GetValuesCommand.ValueType.Item)
             {
+                ShouldEscapeItems = true,
                 DependsOnTargets = "GetSuggestedWorkloads"
             };
             getValuesCommand.MetadataNames.Add("VisualStudioComponentId");
@@ -75,11 +76,11 @@ namespace Microsoft.NET.Build.Tests
 
             getValuesCommand.GetValuesWithMetadata().Select(valueAndMetadata => (valueAndMetadata.value, valueAndMetadata.metadata["VisualStudioComponentId"]))
                 .Should()
-                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload") });
+                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "Microsoft.NET.Component.sdk.missingtestworkload") });
 
             getValuesCommand.GetValuesWithMetadata().Select(valueAndMetadata => (valueAndMetadata.value, valueAndMetadata.metadata["VisualStudioComponentIds"]))
                 .Should()
-                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload") });
+                .BeEquivalentTo(new[] { ("microsoft-net-sdk-missingtestworkload", "microsoft.net.sdk.missingtestworkload;Microsoft.NET.Component.sdk.missingtestworkload") });
         }
 
         [Fact]

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadIdTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadIdTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
+{
+    public class WorkloadIdTests
+    {
+        [Theory]
+        [InlineData("wasm-tools", "wasm.tools")]
+        [InlineData("something_something", "something.something")]
+        public void ItCanCreateSafeIds(string workloadId, string expectedSafeId)
+        {
+            var id = new WorkloadId(workloadId);
+            Assert.Equal(expectedSafeId, id.ToSafeId());
+        }
+
+        [Theory]
+        [InlineData("wasm-tools", "Microsoft.NET.Component.wasm.tools")]
+        [InlineData("microsoft-android-runtime", "Microsoft.NET.Component.android.runtime")]
+        public void ItCanCreateSafeIdsWithVisualStudioStudioPrefix(string workloadId, string expectedSafeId)
+        {
+            var id = new WorkloadId(workloadId);
+            Assert.Equal(expectedSafeId, id.ToSafeId(includeVisualStudioPrefix: true));
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
@@ -16,6 +16,8 @@ namespace Microsoft.NET.TestFramework.Commands
         string _valueName;
         ValueType _valueType;
 
+        public bool ShouldEscapeItems { get; set; } = false;
+
         public bool ShouldCompile { get; set; } = true;
 
         public string DependsOnTargets { get; set; } = "Compile";
@@ -80,6 +82,13 @@ namespace Microsoft.NET.TestFramework.Commands
                 foreach (var metadataName in MetadataNames)
                 {
                     linesAttribute += $"%09%({_valueName}.{metadataName})";
+                }
+
+                if (ShouldEscapeItems)
+                {
+                    // items with semi-colon delimited values need to be escaped to avoid creating separate items
+                    // when the include attribute is evaluated.
+                    linesAttribute = $"$([MSBuild]::Escape({linesAttribute}))";
                 }
             }
 


### PR DESCRIPTION
# Description

Visual Studio publishes a component catalog for extension developers. .NET option workloads do not currently follow the naming convention. 

* Refactored the logic for generating safe IDs into the `WorkloadId` struct to ensure a single source of truth.
* `ShowMissingWorkloads` task will set `VisualStudioComponentId` to use the new component prefix. 'VisualStudioComponentIds` will include the old and new component IDs
*  Added `wasm-tools-net8` to the set of known workload IDs.

# Testing

Additional unit tests to verify the changes to `WorkloadId`. Previous changes for `dotnet workload list` continue to return the expected results. Will likely require additional validation once we have a build with all the workload changes and the CLI with this change inserted into the same VS.

# Risk

Low - if WASM/Maui does not switch to using the new workload IDs it may degrade the IPA experience.