### PR TITLE
msbuild patch to remove BuildXL feed

### DIFF
--- a/src/SourceBuild/patches/msbuild/0001-Remove-BuildXL-feed.patch
+++ b/src/SourceBuild/patches/msbuild/0001-Remove-BuildXL-feed.patch
@@ -1,0 +1,22 @@
+From 6e9ddc58ab1d805c97e38be2c1978c927ba4bd64 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Tue, 15 Oct 2024 14:24:55 -0500
+Subject: [PATCH] Remove BuildXL feed
+
+Backport: https://github.com/dotnet/msbuild/pull/10765
+---
+ NuGet.config | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/NuGet.config b/NuGet.config
+index bd10a6979c..6cb00e2877 100644
+--- a/NuGet.config
++++ b/NuGet.config
+@@ -18,7 +18,6 @@
+     <add key="dotnet8" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet8/nuget/v3/index.json" />
+     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+     <add key="dotnet9" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9/nuget/v3/index.json" />
+-    <add key="BuildXL" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL/nuget/v3/index.json" />
+   </packageSources>
+   <disabledPackageSources>
+     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/44194