### PR TITLE
[StaticWebAssets] Make sure the quality is serialized as culture invariant

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.NET.Sdk.StaticWebAssets.Tasks;
 
@@ -102,7 +103,7 @@ public class ApplyCompressionNegotiation : Task
                     {
                         Name = "Content-Encoding",
                         Value = compressedAsset.AssetTraitValue,
-                        Quality = Math.Round(1.0 / (length + 1), 12).ToString("F12")
+                        Quality = Math.Round(1.0 / (length + 1), 12).ToString("F12", CultureInfo.InvariantCulture)
                     };
                     Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
                     var endpointCopy = new StaticWebAssetEndpoint


### PR DESCRIPTION
## Description

* During the build we compute a quality parameter for each endpoint that is used for content encoding negotiation.
* This value is persisted into a manifest that is generated at build time.
* The generated manifest is read at runtime while defining the endpoints.

* The code that reads the manifest at runtime, correctly uses the invariant culture to parse the value.

* The issue is that the code that writes the manifest at build time, uses the current culture to serialize the value, which causes an
  error to happen at runtime when the manifest is read on environments that don't use a culture that uses a dot as the decimal separator.

https://github.com/dotnet/aspnetcore/issues/58422

## Customer Impact

Customers that use a culture that doesn't use a dot as the decimal separator will experience an error when they try to run the application.

## Regression?

- [X] Yes
- [ ] No

8.0

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix involves invoking the overload that takes the culture as a parameter to serialize the value and passing the invariant culture.

## Verification

- [ ] Manual (required)
- [X] Automated

We have enabled an analyzer that will warn of future incorrect usages of methods that don't explicitly receive a formatter https://github.com/dotnet/sdk/pull/44237

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props