### PR TITLE
[StaticWebAssets] Enable analyzers

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -210,9 +210,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishProfiles", "PublishP
 		src\WebSdk\Publish\Targets\PublishProfiles\Default.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\Default.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeploy.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeployPackage.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultMSDeployPackage.pubxml
-		src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultOneDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultOneDeploy.pubxml
 		src\WebSdk\Publish\Targets\PublishProfiles\DefaultWebJobOneDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultWebJobOneDeploy.pubxml
+		src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml = src\WebSdk\Publish\Targets\PublishProfiles\DefaultZipDeploy.pubxml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishTargets", "PublishTargets", "{40E6E4B1-286B-4542-B814-2A3DA29510D1}"
@@ -222,8 +222,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishTargets", "PublishTa
 		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.Kudu.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.Kudu.targets
 		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.MSDeploy.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.MSDeploy.targets
 		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.MSDeployPackage.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.MSDeployPackage.targets
-		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.ZipDeploy.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.ZipDeploy.targets
 		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.OneDeploy.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.OneDeploy.targets
+		src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.ZipDeploy.targets = src\WebSdk\Publish\Targets\PublishTargets\Microsoft.NET.Sdk.Publish.ZipDeploy.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TransformTargets", "TransformTargets", "{DFA91CC3-D6E4-45B7-AF6F-4385288886E4}"
@@ -415,6 +415,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.Sdk.Web.Tests", "test\Microsoft.NET.Sdk.Web.Tests\Microsoft.NET.Sdk.Web.Tests.csproj", "{B8A61A5C-A9A4-45C5-97E3-CB368358682F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StaticWebAssetsSdk", "StaticWebAssetsSdk", "{9E9F3BB2-6FED-47BC-869C-BFAF6E7C85FC}"
+	ProjectSection(SolutionItems) = preProject
+		src\StaticWebAssetsSdk\.editorconfig = src\StaticWebAssetsSdk\.editorconfig
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sdk", "Sdk", "{CA976F33-7BFA-4F56-8F86-AE132B3B4CBE}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/StaticWebAssetsSdk/.editorconfig
+++ b/src/StaticWebAssetsSdk/.editorconfig
@@ -7,3 +7,143 @@
 csharp_style_var_elsewhere = true
 csharp_style_var_for_built_in_types = true
 csharp_style_var_when_type_is_apparent = true
+
+[*.cs]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.static_field_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_field_should_be_pascal_case.symbols = static_field
+dotnet_naming_rule.static_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_field_should_be_begins_with__.severity = error
+dotnet_naming_rule.private_field_should_be_begins_with__.symbols = private_field
+dotnet_naming_rule.private_field_should_be_begins_with__.style = begins_with__
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.static_field.applicable_kinds = field
+dotnet_naming_symbols.static_field.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.static_field.required_modifiers = static
+
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with__.required_prefix = _
+dotnet_naming_style.begins_with__.required_suffix = 
+dotnet_naming_style.begins_with__.word_separator = 
+dotnet_naming_style.begins_with__.capitalization = camel_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:suggestion
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:warning
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+
+[*.vb]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be_begins_with__.severity = suggestion
+dotnet_naming_rule.private_or_internal_field_should_be_begins_with__.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_begins_with__.style = begins_with__
+
+# Symbol specifications
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, friend, private, protected, protected_friend, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = friend, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with__.required_prefix = _
+dotnet_naming_style.begins_with__.required_suffix = 
+dotnet_naming_style.begins_with__.word_separator = 
+dotnet_naming_style.begins_with__.capitalization = camel_case
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_diagnostic.CA1304.severity = warning
+dotnet_diagnostic.CA1305.severity = warning

--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -218,7 +218,7 @@ public class ApplyCompressionNegotiation : Task
         long length;
         if(_assetFileDetails != null && _assetFileDetails.TryGetValue(compressedAsset.Identity, out var assetFileDetail))
         {
-            length = long.Parse(assetFileDetail.GetMetadata("FileLength"));
+            length = long.Parse(assetFileDetail.GetMetadata("FileLength"), CultureInfo.InvariantCulture);
         }
         else if (TestResolveFileLength != null)
         {

--- a/src/StaticWebAssetsSdk/Tasks/ComputeReferenceStaticWebAssetItems.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeReferenceStaticWebAssetItems.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
@@ -114,6 +115,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             if (!StaticWebAssetsManifest.ManifestModes.ShouldIncludeAssetAsReference(candidate, ProjectMode))
             {
                 reason = string.Format(
+                    CultureInfo.InvariantCulture,
                     "Skipping candidate asset '{0}' because project mode is '{1}' and asset mode is '{2}'",
                     candidate.Identity,
                     ProjectMode,
@@ -122,6 +124,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             }
 
             reason = string.Format(
+                CultureInfo.InvariantCulture,
                 "Accepted candidate asset '{0}' because project mode is '{1}' and asset mode is '{2}'",
                 candidate.Identity,
                 ProjectMode,

--- a/src/StaticWebAssetsSdk/Tasks/Data/ContentTypeMapping.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/ContentTypeMapping.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.FileSystemGlobbing;
 
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                 contentTypeMappings.ItemSpec,
                 contentTypeMappings.GetMetadata(nameof(Cache)),
                 contentTypeMappings.GetMetadata(nameof(Pattern)),
-                int.Parse(contentTypeMappings.GetMetadata(nameof(Priority))));
+                int.Parse(contentTypeMappings.GetMetadata(nameof(Priority)), CultureInfo.InvariantCulture));
 
         internal bool Matches(string identity)
         {

--- a/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 
@@ -60,7 +61,11 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                 {
                     var importPath = NormalizePath(Path.Combine(prefix, ProjectBundles[i].ItemSpec));
 
+#if !NET9_0_OR_GREATER
                     builder.AppendLine($"@import '{importPath}';");
+#else
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"@import '{importPath}';");
+#endif
                 }
 
                 builder.AppendLine();
@@ -69,7 +74,11 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             for (var i = 0; i < ScopedCssFiles.Length; i++)
             {
                 var current = ScopedCssFiles[i];
+#if !NET9_0_OR_GREATER
                 builder.AppendLine($"/* {NormalizePath(current.GetMetadata("BasePath"))}/{NormalizePath(current.GetMetadata("RelativePath"))} */");
+#else
+                builder.AppendLine(CultureInfo.InvariantCulture, $"/* {NormalizePath(current.GetMetadata("BasePath"))}/{NormalizePath(current.GetMetadata("RelativePath"))} */");
+#endif
                 foreach (var line in File.ReadLines(current.GetMetadata("FullPath")))
                 {
                     builder.AppendLine(line);

--- a/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles50.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles50.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 
@@ -63,7 +64,11 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                     var relativePath = NormalizePath(bundle.GetMetadata("RelativePath"));
                     var importPath = NormalizePath(Path.Combine(prefix, bundleBasePath, relativePath));
 
+#if !NET9_0_OR_GREATER
                     builder.AppendLine($"@import '{importPath}';");
+#else
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"@import '{importPath}';");
+#endif
                 }
 
                 builder.AppendLine();
@@ -72,7 +77,11 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
             for (var i = 0; i < ScopedCssFiles.Length; i++)
             {
                 var current = ScopedCssFiles[i];
+#if !NET9_0_OR_GREATER
                 builder.AppendLine($"/* {NormalizePath(current.GetMetadata("BasePath"))}/{NormalizePath(current.GetMetadata("RelativePath"))} */");
+#else
+                builder.AppendLine(CultureInfo.InvariantCulture, $"/* {NormalizePath(current.GetMetadata("BasePath"))}/{NormalizePath(current.GetMetadata("RelativePath"))} */");
+#endif
                 foreach (var line in File.ReadLines(current.GetMetadata("FullPath")))
                 {
                     builder.AppendLine(line);

--- a/src/StaticWebAssetsSdk/Tasks/ScopedCss/RewriteCss.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ScopedCss/RewriteCss.cs
@@ -469,7 +469,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks
                 MessageArgs = messageArgs;
             }
 
-            public override string ToString() => string.Format(Message, MessageArgs);
+            public override string ToString() => string.Format(CultureInfo.InvariantCulture, Message, MessageArgs);
         }
     }
 }


### PR DESCRIPTION
* Analyzers weren't working for this part of the repo. This PR makes sure they are on.
* Enables some Globalization analyzers and fixes issues.

Further work to ensure that all rules are enabled and in sync with asp.net core rules tracked by https://github.com/dotnet/aspnetcore/issues/58463