### PR TITLE
Fix NetRuntimeBlobVersion

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -11,7 +11,7 @@
     <!-- In unified build, the layout does match, so use the runtime package versions rather than the VS redist versions -->
     <AspNetCoreBlobVersion>$(MicrosoftAspNetCoreAppRefInternalPackageVersion)</AspNetCoreBlobVersion>
 
-    <NetRuntimeBlobVersion>$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)</NetRuntimeBlobVersion>
+    <NetRuntimeBlobVersion>$(MicrosoftNETCorePlatformsPackageVersion)</NetRuntimeBlobVersion>
 
     <WindowsDesktopBlobVersion>$(VSRedistCommonWindowsDesktopSharedFrameworkx6490PackageVersion)</WindowsDesktopBlobVersion>
     <WindowsDesktopBlobVersion Condition=" '$(DotNetBuildOrchestrator)' == 'true' ">$(MicrosoftWindowsDesktopAppRuntimePackageVersion)</WindowsDesktopBlobVersion>

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -12,7 +12,6 @@
     <AspNetCoreBlobVersion>$(MicrosoftAspNetCoreAppRefInternalPackageVersion)</AspNetCoreBlobVersion>
 
     <NetRuntimeBlobVersion>$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)</NetRuntimeBlobVersion>
-    <NetRuntimeBlobVersion Condition=" '$(DotNetBuildOrchestrator)' == 'true' ">$(MicrosoftNETCoreAppRuntimePackageVersion)</NetRuntimeBlobVersion>
 
     <WindowsDesktopBlobVersion>$(VSRedistCommonWindowsDesktopSharedFrameworkx6490PackageVersion)</WindowsDesktopBlobVersion>
     <WindowsDesktopBlobVersion Condition=" '$(DotNetBuildOrchestrator)' == 'true' ">$(MicrosoftWindowsDesktopAppRuntimePackageVersion)</WindowsDesktopBlobVersion>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/online.NuGet.Config
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/online.NuGet.Config
@@ -5,5 +5,6 @@
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-aspnetcore-3cc83de" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-3cc83de3/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-d398172" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-d3981726/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4679

A regression was caused by the merge of https://github.com/dotnet/sdk/pull/44257:

    /vmr/src/sdk/src/Installer/redist-installer/targets/GenerateLayout.targets(410,5): error : Download from all targets failed. List of attempted targets: file:///vmr/artifacts/assets/Release/Runtime/9.0.0/dotnet-runtime-9.0.0-centos.9-x64.tar.gz [/vmr/src/sdk/src/Installer/redist-installer/redist-installer.csproj]
    /vmr/src/sdk/src/Installer/redist-installer/targets/GenerateLayout.targets(410,5): error : Failed to download file using addresses in Uri and/or Uris. [/vmr/src/sdk/src/Installer/redist-installer/redist-installer.csproj]
        0 Warning(s)
        2 Error(s)

This is the same kind of error that occurred for an aspnetcore asset in https://github.com/dotnet/sdk/pull/44196, which was fixed by https://github.com/dotnet/sdk/pull/44196/commits/93f82c24bccdd7689cf7501fdaf930192ee583f7. Following a similar pattern here to fix the issue for the runtime asset.