### PR TITLE
Enable is shipping package in the installer redist to stabilize branding of the installers

### DIFF
--- a/src/Installer/redist-installer/redist-installer.csproj
+++ b/src/Installer/redist-installer/redist-installer.csproj
@@ -10,6 +10,7 @@
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
     <!-- DotNetBuildOrchestrator is (currently) needed in order to obtain NuGet packages from the runtime build. -->
     <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(SourceBuildUseMonoRuntime)' != 'true' and '$(DotNetBuildOrchestrator)' == 'true'">true</BundleNativeAotCompiler>
+    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Arcade defaults this value to true and the installer repo didn't set it for any of the .csproj files. The SDK repo defaults it to false in the directory.build.props.

Reviewing what files are stable branded versus not in 8 and 9, I think it's the installers that are off. The rest of the csproj files from installer aren't building packages that actually ship so I don't think any of the rest of the projects require this. Doing a test AzDO build to see.