### PR TITLE
Continue printing out redirected process output after we detect browser launch URL.

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -112,6 +112,8 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return null;
             }
 
+            bool matchFound = false;
+
             return handler;
 
             void handler(object sender, DataReceivedEventArgs eventArgs)
@@ -119,13 +121,18 @@ namespace Microsoft.DotNet.Watcher.Tools
                 // We've redirected the output, but want to ensure that it continues to appear in the user's console.
                 Console.WriteLine(eventArgs.Data);
 
+                if (matchFound)
+                {
+                    return;
+                }
+
                 var match = s_nowListeningRegex.Match(eventArgs.Data ?? "");
                 if (!match.Success)
                 {
                     return;
                 }
 
-                ((Process)sender).OutputDataReceived -= handler;
+                matchFound = true;
 
                 var projectAddedToAttemptedSet = ImmutableInterlocked.Update(ref _browserLaunchAttempted, static (set, projectNode) => set.Add(projectNode), projectNode);
                 if (projectAddedToAttemptedSet)

--- a/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -22,8 +22,11 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             App.Start(testAsset, [], testFlags: TestFlags.MockBrowser);
 
+            // check that all app output is printed out:
+            await App.AssertOutputLine(line => line.Contains("Content root path:"));
+
             // Verify we launched the browser.
-            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Launching browser: https://localhost:5001/");
+            Assert.Contains(App.Process.Output, line => line.Contains("Launching browser: https://localhost:5001/"));
         }
 
         [Fact]

--- a/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -25,8 +25,11 @@ namespace Microsoft.DotNet.Watcher.Tests
             // check that all app output is printed out:
             await App.AssertOutputLine(line => line.Contains("Content root path:"));
 
+            Assert.Contains(App.Process.Output, line => line.Contains("Application started. Press Ctrl+C to shut down."));
+            Assert.Contains(App.Process.Output, line => line.Contains("Hosting environment: Development"));
+
             // Verify we launched the browser.
-            Assert.Contains(App.Process.Output, line => line.Contains("Launching browser: https://localhost:5001/"));
+            Assert.Contains(App.Process.Output, line => line.Contains("dotnet watch ⌚ Launching browser: https://localhost:5001/"));
         }
 
         [Fact]


### PR DESCRIPTION
The logic that scans for browser launch URL in the process output stopped forwarding the output after the match has been found. This removes information logged by the web app after that point.

Fixes regression from .NET 8.0.