### PR TITLE
[VMR] Install dependencies on macOS

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -298,6 +298,10 @@ jobs:
         timeoutInMinutes: ${{ variables.runTestsTimeout }}
 
   - ${{ else }}:
+    - ${{ if eq(variables['Agent.Os'], 'Darwin') }}:
+      - script: |
+          $(sourcesPath)/src/runtime/eng/install-native-dependencies.sh osx
+        displayName: Install dependencies
     - ${{ if eq(parameters.buildSourceOnly, 'true') }}:
       - script: |
           set -ex


### PR DESCRIPTION
Looks like ICU got removed from the internal macOS image, breaking the VMR build. Install the deps from the runtime requirements to fix that.