### PR TITLE
Fix installing dependencies in vmr-build.yml

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -298,7 +298,7 @@ jobs:
         timeoutInMinutes: ${{ variables.runTestsTimeout }}
 
   - ${{ else }}:
-    - ${{ if eq(variables['Agent.Os'], 'Darwin') }}:
+    - ${{ if eq(parameters.targetOS, 'osx') }}:
       - script: |
           $(sourcesPath)/src/runtime/eng/install-native-dependencies.sh osx
         displayName: Install dependencies


### PR DESCRIPTION
I didn't notice that agent variables aren't available in template expressions. Use our own parameter instead.