### PR TITLE
Project graph restore

### DIFF
--- a/src/BuiltInTools/dotnet-watch/DotNetWatch.targets
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatch.targets
@@ -72,7 +72,7 @@ Returns: @(Watch)
              Condition="'$(UsingMicrosoftNETSdkRazor)'=='true' AND '$(DotNetWatchContentFiles)'!='false' AND '%(Content.Watch)' != 'false' AND $([System.String]::Copy('%(Identity)').Replace('\','/').StartsWith('wwwroot/'))"
              StaticWebAssetPath="$(_DotNetWatchStaticWebAssetBasePath)$([System.String]::Copy('%(Identity)').Replace('\','/').Substring(8))" />
 
-      <_WatchProjects Include="%(ProjectReference.Identity)" Condition="'%(ProjectReference.Watch)' != 'false'" />
+      <_WatchProjects Include="%(ProjectReference.Identity)" Condition="'%(ProjectReference.Watch)' != 'false' and Exists('%(Identity)')" />
     </ItemGroup>
 
     <MSBuild Projects="@(_WatchProjects)"

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Graph;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -12,7 +11,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         public required EnvironmentOptions EnvironmentOptions { get; init; }
         public required IReporter Reporter { get; init; }
 
-        public ProjectGraph? ProjectGraph { get; init; }
         public required ProjectOptions RootProjectOptions { get; init; }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -31,27 +31,27 @@ namespace Microsoft.DotNet.Watcher
             var buildEvaluator = new BuildEvaluator(Context, RootFileSetFactory);
             await using var browserConnector = new BrowserConnector(Context);
 
-            StaticFileHandler? staticFileHandler;
-            ProjectGraphNode? projectRootNode;
-            if (Context.ProjectGraph != null)
-            {
-                projectRootNode = Context.ProjectGraph.GraphRoots.Single();
-                var projectMap = new ProjectNodeMap(Context.ProjectGraph, Context.Reporter);
-                staticFileHandler = new StaticFileHandler(Context.Reporter, projectMap, browserConnector);
-            }
-            else
-            {
-                Context.Reporter.Verbose("Unable to determine if this project is a webapp.");
-                projectRootNode = null;
-                staticFileHandler = null;
-            }
-
             for (var iteration = 0;;iteration++)
             {
                 if (await buildEvaluator.EvaluateAsync(changedFile, cancellationToken) is not { } evaluationResult)
                 {
                     Context.Reporter.Error("Failed to find a list of files to watch");
                     return;
+                }
+
+                StaticFileHandler? staticFileHandler;
+                ProjectGraphNode? projectRootNode;
+                if (evaluationResult.ProjectGraph != null)
+                {
+                    projectRootNode = evaluationResult.ProjectGraph.GraphRoots.Single();
+                    var projectMap = new ProjectNodeMap(evaluationResult.ProjectGraph, Context.Reporter);
+                    staticFileHandler = new StaticFileHandler(Context.Reporter, projectMap, browserConnector);
+                }
+                else
+                {
+                    Context.Reporter.Verbose("Unable to determine if this project is a webapp.");
+                    projectRootNode = null;
+                    staticFileHandler = null;
                 }
 
                 var processSpec = new ProcessSpec

--- a/src/BuiltInTools/dotnet-watch/EvaluationResult.cs
+++ b/src/BuiltInTools/dotnet-watch/EvaluationResult.cs
@@ -1,9 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Build.Graph;
+
 namespace Microsoft.DotNet.Watcher;
 
-internal sealed class EvaluationResult(IReadOnlyDictionary<string, FileItem> files)
+internal sealed class EvaluationResult(IReadOnlyDictionary<string, FileItem> files, ProjectGraph? projectGraph)
 {
     public readonly IReadOnlyDictionary<string, FileItem> Files = files;
+    public readonly ProjectGraph? ProjectGraph = projectGraph;
 }

--- a/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var result = await rootProjectFileSetFactory.TryCreateAsync(cancellationToken);
+                var result = await rootProjectFileSetFactory.TryCreateAsync(requireProjectGraph: true, cancellationToken);
                 if (result != null)
                 {
                     return result;

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -183,6 +183,11 @@ namespace Microsoft.DotNet.Watcher
                 reporter.Verbose("Hot Reload disabled by command line switch.");
                 enableHotReload = false;
             }
+            else if (projectGraph == null)
+            {
+                reporter.Warn($"Hot Reload disabled due to project graph load failure.");
+                enableHotReload = false;
+            }
             else
             {
                 reporter.Report(MessageDescriptor.WatchingWithHotReload);
@@ -221,10 +226,21 @@ namespace Microsoft.DotNet.Watcher
             {
                 return new ProjectGraph(options.ProjectPath, globalOptions);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                reporter.Verbose("Reading the project instance failed.");
-                reporter.Verbose(ex.ToString());
+                reporter.Warn("Failed to load project graph.");
+
+                if (e is AggregateException { InnerExceptions: var innerExceptions })
+                {
+                    foreach (var inner in innerExceptions)
+                    {
+                        reporter.Warn(inner.Message);
+                    }
+                }
+                else
+                {
+                    reporter.Warn(e.Message);
+                }
             }
 
             return null;

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose",
+      "commandLineArgs": "--verbose /bl:DotnetRun.binlog",
       "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -30,7 +30,7 @@ public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTest
             outputSink: null,
             trace: false);
 
-        var projectGraph = factory.TryLoadProjectGraph();
+        var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: false);
         var handler = new CompilationHandler(reporter);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -21,7 +21,16 @@ public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTest
         var reporter = new TestReporter(Logger);
         var options = TestOptions.GetProjectOptions(["--project", hostProject]);
 
-        var projectGraph = Program.TryReadProject(options, reporter);
+        var factory = new MSBuildFileSetFactory(
+            rootProjectFile: options.ProjectPath,
+            targetFramework: null,
+            buildProperties: [],
+            environmentOptions: new EnvironmentOptions(Environment.CurrentDirectory, "dotnet"),
+            reporter,
+            outputSink: null,
+            trace: false);
+
+        var projectGraph = factory.TryLoadProjectGraph();
         var handler = new CompilationHandler(reporter);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);

--- a/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
+++ b/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public class MSBuildEvaluationFilterTest
     {
-        private static readonly EvaluationResult s_emptyEvaluationResult = new(new Dictionary<string, FileItem>());
+        private static readonly EvaluationResult s_emptyEvaluationResult = new(new Dictionary<string, FileItem>(), projectGraph: null);
 
         [Fact]
         public async Task ProcessAsync_EvaluatesFileSetIfProjFileChanges()
@@ -90,11 +90,13 @@ namespace Microsoft.DotNet.Watcher.Tools
             // There's a chance that the watcher does not correctly report edits to msbuild files on
             // concurrent edits. MSBuildEvaluationFilter uses timestamps to additionally track changes to these files.
 
-            var result = new EvaluationResult(new Dictionary<string, FileItem>()
-            {
-                { "Controlller.cs", new FileItem { FilePath = "Controlller.cs" } },
-                { "Proj.csproj", new FileItem { FilePath = "Proj.csproj" } },
-            });
+            var result = new EvaluationResult(
+                new Dictionary<string, FileItem>()
+                {
+                    { "Controlller.cs", new FileItem { FilePath = "Controlller.cs" } },
+                    { "Proj.csproj", new FileItem { FilePath = "Proj.csproj" } },
+                },
+                projectGraph: null);
 
             var fileSetFactory = new MockFileSetFactory() { TryCreateImpl = () => result };
 

--- a/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -330,7 +330,7 @@ $@"<ItemGroup>
 
             var filesetFactory = new MSBuildFileSetFactory(projectA, targetFramework: null, buildProperties: null, options, _reporter, output, trace: true);
 
-            var result = await filesetFactory.TryCreateAsync(CancellationToken.None);
+            var result = await filesetFactory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.NotNull(result);
 
             _reporter.Output(string.Join(
@@ -374,7 +374,7 @@ $@"<ItemGroup>
                 WorkingDirectory: Path.GetDirectoryName(projectPath));
 
             var factory = new MSBuildFileSetFactory(projectPath, targetFramework: null, buildProperties: null, options, _reporter, new OutputSink(), trace: false);
-            var result = await factory.TryCreateAsync(CancellationToken.None);
+            var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.NotNull(result);
             return result;
         }

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -231,7 +231,10 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
 
             var message = new StringBuilder();
-            message.AppendLine($"'{expected}' not found in:");
+            message.AppendLine($"Expected output not found:");
+            message.AppendLine(expected);
+            message.AppendLine();
+            message.AppendLine("Actual output:");
 
             foreach (var item in items)
             {

--- a/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
+++ b/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
@@ -16,6 +16,6 @@ internal class MockFileSetFactory() : MSBuildFileSetFactory(
 {
     public Func<EvaluationResult> TryCreateImpl;
 
-    public override ValueTask<EvaluationResult> TryCreateAsync(CancellationToken cancellationToken)
+    public override ValueTask<EvaluationResult> TryCreateAsync(bool? requireProjectGraph, CancellationToken cancellationToken)
         => ValueTask.FromResult(TryCreateImpl?.Invoke());
 }

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -236,5 +236,31 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLine(line => line.Contains("warning : The value of property is '123'", StringComparison.Ordinal));
         }
+
+        [Fact]
+        public async Task ProjectGraphLoadFailure()
+        {
+            var testAsset = TestAssets
+                .CopyTestAsset("WatchAppWithProjectDeps")
+                .WithSource()
+                .WithProjectChanges((path, proj) =>
+                {
+                    if (Path.GetFileName(path) == "App.WithDeps.csproj")
+                    {
+                        proj.Root.Descendants()
+                            .Single(e => e.Name.LocalName == "ItemGroup")
+                            .Add(XElement.Parse("""
+                            <ProjectReference Include="NonExistentDirectory\X.csproj" />
+                            """));
+                    }
+                });
+
+            App.Start(testAsset, [], "AppWithDeps");
+
+            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Hot Reload disabled due to project graph load failure.");
+
+            App.AssertOutputContains(@"dotnet watch ⌚ Failed to load project graph.");
+            App.AssertOutputContains(@"AppWithDeps\NonExistentDirectory\X.csproj");
+        }
     }
 }

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -257,10 +257,10 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             App.Start(testAsset, [], "AppWithDeps");
 
-            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Hot Reload disabled due to project graph load failure.");
+            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Fix the error to continue or press Ctrl+C to exit.");
 
             App.AssertOutputContains(@"dotnet watch ⌚ Failed to load project graph.");
-            App.AssertOutputContains(@"AppWithDeps\NonExistentDirectory\X.csproj");
+            App.AssertOutputContains($"dotnet watch ❌ The project file could not be loaded. Could not find a part of the path '{Path.Combine(testAsset.Path, "AppWithDeps", "NonExistentDirectory", "X.csproj")}'");
         }
     }
 }


### PR DESCRIPTION
dotnet-watch loaded the msbuild project graph before restoring the project. Capabilities, such as `<ProjectCapability Include="WebAssembly" />` is only added in a props file of `microsoft.net.sdk.webassembly.pack` package. If the project node from the graph loaded before restore is queried for capabilities, it will not have the `WebAssembly` capability.

This causes dotnet-watch to fail to apply changes to WASM.

The change moves project graph loading after project evaluation is performed and includes restore target in the evaluation.

The issue wasn't caught before by existing dotnet-watch WASM test because the test helpers always run `dotnet build` before testing dotnet-watch behavior. The change removes this pre-build step, so that tests validate the correct dotnet-watch behavior on non-restored projects by default.

Fixes https://github.com/dotnet/sdk/issues/44044