### PR TITLE
Fix source-build legs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -80,7 +80,6 @@ stages:
     - template: ../variables/vmr-build.yml
       parameters:
         vmrBranch: ${{ parameters.vmrBranch }}
-        sign: false
 
     jobs:
 
@@ -101,6 +100,7 @@ stages:
         runOnline: true                    # ✅
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
+        sign: false
 
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
@@ -124,6 +124,7 @@ stages:
       #     withPreviousSDK: false             # 🚫
       #     reuseBuildArtifactsFrom:
       #     - ${{ format('{0}_Online_MsftSdk_x64', variables.centOSStreamName) }}
+      #     sign: false
 
       # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
       # - template: ../jobs/vmr-build.yml
@@ -144,6 +145,7 @@ stages:
       #     runOnline: false                   # 🚫
       #     useMonoRuntime: false              # 🚫
       #     withPreviousSDK: true              # ✅
+      #     sign: false
 
       ### Additional jobs for full build ###
       - ${{ if in(parameters.scope, 'full') }}:
@@ -166,6 +168,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -184,6 +187,7 @@ stages:
             runOnline: true                    # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -201,6 +205,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
@@ -220,6 +225,7 @@ stages:
         #     runOnline: true                    # ✅
         #     useMonoRuntime: false              # 🚫
         #     withPreviousSDK: true              # ✅
+        #     sign: false
 
         # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
@@ -239,6 +245,7 @@ stages:
         #     runOnline: false                   # 🚫
         #     useMonoRuntime: false              # 🚫
         #     withPreviousSDK: true              # ✅
+        #     sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -256,6 +263,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: true               # ✅
             withPreviousSDK: false             # 🚫
+            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -273,6 +281,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -290,6 +299,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -307,6 +317,7 @@ stages:
             runOnline: false                   # 🚫
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
+            sign: false
 
         # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
@@ -327,6 +338,7 @@ stages:
         #     withPreviousSDK: false             # 🚫
         #     reuseBuildArtifactsFrom:
         #     - ${{ format('{0}_Offline_MsftSdk_x64', variables.fedoraName) }}
+        #     sign: false
 
         # Disabled until net9.0 -> net10.0 transition is complete - see https://github.com/dotnet/source-build/issues/4605
         # - template: ../jobs/vmr-build.yml
@@ -347,6 +359,7 @@ stages:
         #     withPreviousSDK: false             # 🚫
         #     reuseBuildArtifactsFrom:
         #     - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
+        #     sign: false
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:


### PR DESCRIPTION
Regressed when enabling signing by default. Hardcode sign:false for now to unblock builds.

https://github.com/dotnet/sdk/pull/44306