### PR TITLE
Remove Maestro feed automation from NuGet.config in main

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,29 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from dotnet-aspire -->
-    <add key="darc-pub-dotnet-aspire-2c38f6c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-2c38f6c8/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-aspire-2c38f6c-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-2c38f6c8-1/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-aspire -->
-    <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <!--  End: Package sources from dotnet-aspnetcore -->
-    <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
-    <!--  End: Package sources from DotNet-msbuild-Trusted -->
-    <!--  Begin: Package sources from dotnet-roslyn-analyzers -->
-    <!--  End: Package sources from dotnet-roslyn-analyzers -->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e77011b" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e77011b3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e77011b-5" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e77011b3-5/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e77011b-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e77011b3-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e77011b-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e77011b3-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e77011b-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e77011b3-1/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-runtime -->
-    <!--  Begin: Package sources from dotnet-templating -->
-    <!--  End: Package sources from dotnet-templating -->
-    <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <!--  End: Package sources from dotnet-windowsdesktop -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
@@ -47,20 +24,6 @@
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from dotnet-templating -->
-    <!--  End: Package sources from dotnet-templating -->
-    <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <!--  End: Package sources from dotnet-aspnetcore -->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e77011b-1" value="true" />
-    <add key="darc-int-dotnet-runtime-e77011b-2" value="true" />
-    <add key="darc-int-dotnet-runtime-e77011b-3" value="true" />
-    <add key="darc-int-dotnet-runtime-e77011b-5" value="true" />
-    <add key="darc-int-dotnet-runtime-e77011b" value="true" />
-    <!--  End: Package sources from dotnet-runtime -->
-    <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <!--  End: Package sources from dotnet-windowsdesktop -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <clear />
   </disabledPackageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,12 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-aspire -->
+    <add key="darc-pub-dotnet-aspire-2c38f6c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-2c38f6c8/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-aspire-2c38f6c-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-2c38f6c8-1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-aspire -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />


### PR DESCRIPTION
All these release/servicing only feeds should never get added to the main branch. This is causing VMR builds to fail when building locally.