### PR TITLE
Use non-stable SDK version for SB artifacts

### DIFF
--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -30,16 +30,46 @@
                           OutputPath="$(ArtifactsLogDir)" />
   </Target>
 
+  <UsingTask TaskName="IndexItemGroup" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <Items Required="true" ParameterType="Microsoft.Build.Framework.ITaskItem[]"/>
+      <Index Required="true" ParameterType="System.Int32"/>
+      <Item Output="true" ParameterType="Microsoft.Build.Framework.ITaskItem"/>
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[Item = Items[ Index ];]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="DetermineSourceBuiltSdkNonStableVersion"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion">
+    <ItemGroup>
+      <SdkVersionFileItem Include="$(DotNetSdkExtractDir)/sdk/**/.version" />
+    </ItemGroup>
+
+    <ReadLinesFromFile File="%(SdkVersionFileItem.Identity)">
+      <Output
+          TaskParameter="Lines"
+          ItemName="VersionFileLines"/>
+    </ReadLinesFromFile>
+
+    <IndexItemGroup Items="@(VersionFileLines)" Index="3">
+      <Output PropertyName="SourceBuiltSdkNonStableVersion" TaskParameter="Item"/>
+    </IndexItemGroup>
+  </Target>
+
   <!--
     Determine symbols tarball names and discover all intermediate symbols,
     to be used as inputs and outputs of symbols repackaging targets.
   -->
   <Target Name="DetermineSymbolsTargetsInputsAndOutputs"
           AfterTargets="Build"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion">
+          DependsOnTargets="DetermineSourceBuiltSdkNonStableVersion">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-all-$(SourceBuiltSdkVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
-      <SdkSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-sdk-$(SourceBuiltSdkVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
+      <UnifiedSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-all-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
+      <SdkSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-sdk-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
     </PropertyGroup>
     <ItemGroup>
       <IntermediateSymbol Include="$(IntermediateSymbolsRootDir)**/*" />
@@ -162,10 +192,10 @@
   </Target>
 
   <Target Name="CreatePrebuiltsTarballIfPrebuiltsExist"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion"
+          DependsOnTargets="DetermineSourceBuiltSdkNonStableVersion"
           Condition="'@(PrebuiltFile)' != ''">
     <PropertyGroup>
-      <PrebuiltsTarball>$(ArtifactsAssetsDir)$(SourceBuiltPrebuiltsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</PrebuiltsTarball>
+      <PrebuiltsTarball>$(ArtifactsAssetsDir)$(SourceBuiltPrebuiltsTarballName).$(SourceBuiltSdkNonStableVersion).$(TargetRid)$(ArchiveExtension)</PrebuiltsTarball>
       <PrebuiltsTarballWorkingDir>$(ResultingPrebuiltPackagesDir)</PrebuiltsTarballWorkingDir>
     </PropertyGroup>
 
@@ -182,7 +212,7 @@
 
 
   <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion;ResolveProjectReferences">
+          DependsOnTargets="DetermineSourceBuiltSdkNonStableVersion;ResolveProjectReferences">
     <!-- Inputs: Packages to include in the tarball -->
     <ItemGroup>
       <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
@@ -198,7 +228,7 @@
       <SourceBuiltLayoutDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'artifacts-layout'))</SourceBuiltLayoutDir>
 
       <!-- Outputs -->
-      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
+      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkNonStableVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
       <SourceBuiltVersionName>$(SourceBuiltLayoutDir).version</SourceBuiltVersionName>
       <AllPackageVersionsPropsName>$(SourceBuiltLayoutDir)PackageVersions.props</AllPackageVersionsPropsName>
       <SourceBuiltMergedAssetManifestName>$(SourceBuiltLayoutDir)%(MergedAssetManifest.Filename)%(MergedAssetManifest.Extension)</SourceBuiltMergedAssetManifestName>
@@ -231,7 +261,7 @@
 
     <!-- Content of the .version file to include in the tarball -->
     <ItemGroup>
-      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
+      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkNonStableVersion)" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(SourceBuiltVersionName)"

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -30,34 +30,15 @@
                           OutputPath="$(ArtifactsLogDir)" />
   </Target>
 
-  <UsingTask TaskName="IndexItemGroup" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-    <ParameterGroup>
-      <Items Required="true" ParameterType="Microsoft.Build.Framework.ITaskItem[]"/>
-      <Index Required="true" ParameterType="System.Int32"/>
-      <Item Output="true" ParameterType="Microsoft.Build.Framework.ITaskItem"/>
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[Item = Items[ Index ];]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
   <Target Name="DetermineSourceBuiltSdkNonStableVersion"
           DependsOnTargets="DetermineSourceBuiltSdkVersion">
     <ItemGroup>
       <SdkVersionFileItem Include="$(DotNetSdkExtractDir)/sdk/**/.version" />
     </ItemGroup>
 
-    <ReadLinesFromFile File="%(SdkVersionFileItem.Identity)">
-      <Output
-          TaskParameter="Lines"
-          ItemName="VersionFileLines"/>
-    </ReadLinesFromFile>
-
-    <IndexItemGroup Items="@(VersionFileLines)" Index="3">
-      <Output PropertyName="SourceBuiltSdkNonStableVersion" TaskParameter="Item"/>
-    </IndexItemGroup>
+    <PropertyGroup>
+      <SourceBuiltSdkNonStableVersion>$([System.Text.RegularExpressions.Regex]::Split('$([System.IO.File]::ReadAllText('%(SdkVersionFileItem.Identity)'))', '\r\n|\r|\n')[3])</SourceBuiltSdkNonStableVersion>
+    </PropertyGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4682

Due to several changes made early in 9.0, particularly https://github.com/dotnet/installer/pull/18153, we're versioning GA and Servicing source-build packages with SDK's stable version. This was a result of a switch to not use the version from the intermediate package, which was always of non-stable kind. We're now using the version in sdk tarballs filename, which is always stable for GA and during servicing.

The fix is to obtain the non-stable version from SDK's `.version` file.

Currently, in failing 9.0 VMR build:
```
dotnet-sdk-9.0.100-fedora.40-x64.tar.gz
dotnet-symbols-all-9.0.100-fedora.40-x64.tar.gz
dotnet-symbols-sdk-9.0.100-fedora.40-x64.tar.gz
Private.SourceBuilt.Artifacts.9.0.100.fedora.40-x64.tar.gz
```
With this fix:
```
dotnet-sdk-9.0.100-fedora.40-x64.tar.gz
dotnet-symbols-all-9.0.100-rtm.24521.1-fedora.40-x64.tar.gz
dotnet-symbols-sdk-9.0.100-rtm.24521.1-fedora.40-x64.tar.gz
Private.SourceBuilt.Artifacts.9.0.100-rtm.24521.1.fedora.40-x64.tar.gz
```

This also updates the content of the `.version` file in `Private.SourceBuilt.Artifacts.*` package, to use the non-stable version. This matches the expected experience from previous releases, i.e. 8.0 GA.

8.0 RTM and GA packages, for comparison, can be obtained from links in following PRs: https://github.com/dotnet/installer/pull/17784, https://github.com/dotnet/installer/pull/20172