### PR TITLE
make the Details command faster to create and drag in fewer DLLs

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/details/DetailsCommand.cs
@@ -10,8 +10,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 {
     internal class DetailsCommand : BaseCommand<DetailsCommandArgs>
     {
-        private static NugetApiManager _nugetApiManager = new();
-
         internal DetailsCommand(
             Func<ParseResult, ITemplateEngineHost> hostBuilder)
             : base(hostBuilder, "details", SymbolStrings.Command_Details_Description)
@@ -52,7 +50,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 args.VersionCriteria,
                 args.Interactive,
                 args.AdditionalSources,
-                _nugetApiManager,
+                new NugetApiManager(),
                 cancellationToken).ConfigureAwait(false);
 
             await CheckTemplatesWithSubCommandName(args, templatePackageManager, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
We should minimize the cost (performance and DLL-loading) of creating the CLI graph to prevent errors like Rainer saw when doing MSBuild bootstrapping today.