### PR TITLE
Add Windows DevVersions VMR build leg

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -77,5 +77,18 @@
     <Using Include="System.Xml.Linq" />
   </ItemGroup>
 
+  <!-- These aliases need to live outside of Versions.props as VMR / source-build overwrites some of the version properties for live builds. -->
+  <PropertyGroup>
+    <!-- Runtime and Apphost pack versions are the same for all RIDs. We flow the x64 version above and create aliases without the winx64 here for clarity elsewhere. -->
+    <MicrosoftNETCoreAppHostPackageVersion>$(MicrosoftNETCoreAppHostwinx64PackageVersion)</MicrosoftNETCoreAppHostPackageVersion>
+    <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
+    <MicrosoftAspNetCoreAppRuntimePackageVersion>$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)</MicrosoftAspNetCoreAppRuntimePackageVersion>
+    <MicrosoftWindowsDesktopAppRuntimePackageVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</MicrosoftWindowsDesktopAppRuntimePackageVersion>
+
+    <HostFxrVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</HostFxrVersion>
+    <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
+  </PropertyGroup>
+
   <Import Project="build/GenerateResxSource.targets" />
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,6 +166,7 @@
     <!-- These are minimum versions used for netfx-targeted components that run in Visual Studio because in those cases,
          Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
     <MicrosoftBclAsyncInterfacesToolsetPackageVersion>8.0.0</MicrosoftBclAsyncInterfacesToolsetPackageVersion>
+    <MicrosoftDeploymentDotNetReleasesToolsetPackageVersion>2.0.0-preview.1.24427.4</MicrosoftDeploymentDotNetReleasesToolsetPackageVersion>
     <SystemCollectionsImmutableToolsetPackageVersion>8.0.0</SystemCollectionsImmutableToolsetPackageVersion>
     <SystemReflectionMetadataLoadContextToolsetPackageVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetPackageVersion>
     <SystemReflectionMetadataToolsetPackageVersion>8.0.0</SystemReflectionMetadataToolsetPackageVersion>
@@ -278,20 +279,9 @@
     <MicrosoftNETSdkWindowsDesktopPackageVersion>10.0.0-alpha.1.24521.5</MicrosoftNETSdkWindowsDesktopPackageVersion>
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>10.0.0-alpha.1.24521.5</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Label="Runtime and Apphost aliases">
-    <!-- Runtime and Apphost pack versions are the same for all RIDs. We flow the x64 version above and create aliases without the winx64 here for clarity elsewhere. -->
-    <MicrosoftNETCoreAppHostPackageVersion>$(MicrosoftNETCoreAppHostwinx64PackageVersion)</MicrosoftNETCoreAppHostPackageVersion>
-    <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftAspNetCoreAppRuntimePackageVersion>$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)</MicrosoftAspNetCoreAppRuntimePackageVersion>
-    <MicrosoftWindowsDesktopAppRuntimePackageVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</MicrosoftWindowsDesktopAppRuntimePackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="HostFxr and SharedHost versions">
-    <HostFxrVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</HostFxrVersion>
-    <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
-  </PropertyGroup>
   <PropertyGroup Label="Template versions">
     <!-- 10.0 Template versions -->
-    <AspNetCorePackageVersionFor100Templates>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</AspNetCorePackageVersionFor100Templates>
+    <AspNetCorePackageVersionFor100Templates>$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)</AspNetCorePackageVersionFor100Templates>
     <MicrosoftDotnetWinFormsProjectTemplates100PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates100PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates100PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates100PackageVersion>
     <!-- 9.0 Template versions -->

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -398,6 +398,18 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        buildName: Windows_DevVersions
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        vmrBranch: ${{ variables.VmrBranch }}
+        architecture: x64
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x64
+        useDevVersions: true # Use dev versions for CI validation of the experience. If we decide to ship assets from this leg, then we should remove this option.
+        runTests: false # Temporarily do not run tests. The nuget comparison fails for some non-obvious reason and needs further investigation. Mostly, I'm not sure why it ever passed. https://github.com/dotnet/sdk/issues/42920
+
+    - template: ../jobs/vmr-build.yml
+      parameters:
         buildName: Windows
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}

--- a/src/Installer/redist-installer/projects/VSMSBuildExtensions/VSMSBuildExtensions.csproj
+++ b/src/Installer/redist-installer/projects/VSMSBuildExtensions/VSMSBuildExtensions.csproj
@@ -30,7 +30,7 @@
 
   <!-- SdkResolver -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.Deployment.DotNet.Releases" Version="[$(MicrosoftDeploymentDotNetReleasesVersion)]" />
+    <PackageDownload Include="Microsoft.Deployment.DotNet.Releases" Version="[$(MicrosoftDeploymentDotNetReleasesToolsetVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
@@ -65,7 +65,7 @@
                                   DeploymentSubpath="msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/" />
 
       <!-- SdkResolver -->
-      <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.deployment.dotNet.releases\$(MicrosoftDeploymentDotNetReleasesVersion)\lib\netstandard2.0\**\*.*" DeploymentSubpath="MSBuildSdkResolver/" />
+      <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.deployment.dotNet.releases\$(MicrosoftDeploymentDotNetReleasesToolsetVersion)\lib\netstandard2.0\**\*.*" DeploymentSubpath="MSBuildSdkResolver/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x86\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-x86\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/x86/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-x64\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/x64/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-arm64\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-arm64\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/arm64/" />

--- a/src/Installer/redist-installer/projects/VSMSBuildExtensions/VSMSBuildExtensions.csproj
+++ b/src/Installer/redist-installer/projects/VSMSBuildExtensions/VSMSBuildExtensions.csproj
@@ -30,7 +30,7 @@
 
   <!-- SdkResolver -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.Deployment.DotNet.Releases" Version="[$(MicrosoftDeploymentDotNetReleasesToolsetVersion)]" />
+    <PackageDownload Include="Microsoft.Deployment.DotNet.Releases" Version="[$(MicrosoftDeploymentDotNetReleasesToolsetPackageVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
@@ -65,7 +65,7 @@
                                   DeploymentSubpath="msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/" />
 
       <!-- SdkResolver -->
-      <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.deployment.dotNet.releases\$(MicrosoftDeploymentDotNetReleasesToolsetVersion)\lib\netstandard2.0\**\*.*" DeploymentSubpath="MSBuildSdkResolver/" />
+      <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.deployment.dotNet.releases\$(MicrosoftDeploymentDotNetReleasesToolsetPackageVersion)\lib\netstandard2.0\**\*.*" DeploymentSubpath="MSBuildSdkResolver/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x86\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-x86\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/x86/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-x64\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-x64\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/x64/" />
       <VSMSBuildExtensionsContent Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.win-arm64\$(MicrosoftNETCoreAppRuntimePackageVersion)\runtimes\win-arm64\native\hostfxr.dll" DeploymentSubpath="MSBuildSdkResolver/arm64/" />

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -166,7 +166,7 @@
       </BundledLayoutPackage>
 
       <!-- These apphost packages come from different verticals and require a join inside the VMR. Disable for now:
-           https://github.com/dotnet/source-build/issues/4694 -->
+           https://github.com/dotnet/source-build/issues/4114 -->
       <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_Alternate" Condition="'$(AlternateAppHostRid)' != '' and '$(DotNetBuild)' != 'true'">
         <PackageName>Microsoft.NETCore.App.Host.$(AlternateAppHostRid)</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppHostPackageVersion)</PackageVersion>

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -111,8 +111,6 @@
       <NetStandardTargetingPackRootUrl>$(OfficialBaseURL)Runtime/$(NETStandardTargetingPackBlobVersion)</NetStandardTargetingPackRootUrl>
 
       <AspNetCoreSharedFxRootUrl>$(PublicBaseURL)aspnetcore/Runtime/$(AspNetCoreBlobVersion)</AspNetCoreSharedFxRootUrl>
-      <!-- Aspnet is not currently built in the VMR. Remove this line when https://github.com/dotnet/source-build/issues/4022 is complete. -->
-      <AspNetCoreSharedFxRootUrl Condition=" '$(DotNetBuildOrchestrator)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">$(FallbackPublicBaseURL)aspnetcore/Runtime/$(AspNetCoreBlobVersion)</AspNetCoreSharedFxRootUrl>
 
       <WinFormsAndWpfSharedFxRootUrl>$(PublicBaseURL)WindowsDesktop/$(WindowsDesktopBlobVersion)</WinFormsAndWpfSharedFxRootUrl>
 
@@ -167,21 +165,23 @@
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
       </BundledLayoutPackage>
 
-      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_Alternate" Condition="'$(AlternateAppHostRid)' != ''">
+      <!-- These apphost packages come from different verticals and require a join inside the VMR. Disable for now:
+           https://github.com/dotnet/source-build/issues/4694 -->
+      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_Alternate" Condition="'$(AlternateAppHostRid)' != '' and '$(DotNetBuild)' != 'true'">
         <PackageName>Microsoft.NETCore.App.Host.$(AlternateAppHostRid)</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppHostPackageVersion)</PackageVersion>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
       </BundledLayoutPackage>
 
-      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_Arm64" Condition="'$(Arm64AppHostRid)' != ''">
+      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_Arm64" Condition="'$(Arm64AppHostRid)' != '' and '$(DotNetBuild)' != 'true'">
         <PackageName>Microsoft.NETCore.App.Host.$(Arm64AppHostRid)</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppHostPackageVersion)</PackageVersion>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
       </BundledLayoutPackage>
 
-      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_x64" Condition="'$(x64AppHostRid)' != ''">
+      <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg_x64" Condition="'$(x64AppHostRid)' != '' and '$(DotNetBuild)' != 'true'">
         <PackageName>Microsoft.NETCore.App.Host.$(x64AppHostRid)</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppHostPackageVersion)</PackageVersion>
         <TargetFramework>$(TargetFramework)</TargetFramework>
@@ -256,24 +256,19 @@
         <DownloadFileName>$(DownloadedNetCoreAppHostPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
-      <!-- WORKAROUND: Generating the MSIs for x86 and x64 requires the outputs from the other VMR build. Disabled for now. -->
+      <!-- These are apphosts form a different vertical which require a join. Disable for now.
+           https://github.com/dotnet/source-build/issues/4114. -->
       <BundledInstallerComponent Include="DownloadedAlternateNetCoreAppHostPackInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' and '$(InstallerExtension)' == '.msi' and !$(Architecture.StartsWith('arm')) and '$(DotNetBuild)' != 'true'">
         <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
-        <!-- Alternate and arm64 apphosts aren't currently built in the same vertical.
-             This is an issue (see https://github.com/dotnet/source-build/issues/4114). For now, use the
-             dotnetbuilds url in VMR mode to find them. -->
-        <BaseUrl Condition="'$(DotNetBuild)' == 'true'">$(FallbackPublicBaseURL)Runtime/$(NetRuntimeBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedAlternateNetCoreAppHostPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
+      <!-- These are apphosts form a different vertical which require a join. Disable for now.
+           https://github.com/dotnet/source-build/issues/4114. -->
       <BundledInstallerComponent Include="DownloadedArm64NetCoreAppHostPackInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))  and '$(DotNetBuild)' != 'true'">
         <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
-        <!-- Alternate and arm64 apphosts aren't currently built in the same vertical.
-             This is an issue (see https://github.com/dotnet/source-build/issues/4114). For now, use the
-             dotnetbuilds url in VMR mode to find them. -->
-        <BaseUrl Condition="'$(DotNetBuild)' == 'true'">$(FallbackPublicBaseURL)Runtime/$(NetRuntimeBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedArm64NetCoreAppHostPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 

--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -295,7 +295,7 @@
 
   <Target Name="GenerateSdkBundle"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;GenerateTemplatesMsis;GenerateWorkloadManifestsWxs"
-          Condition=" '$(OS)' == 'Windows_NT' "
+          Condition="'$(OS)' == 'Windows_NT' and '$(SkipBuildingSdkBundle)' != 'true'"
           Inputs="$(SdkMSIInstallerFile);
                     $(DownloadedSharedFrameworkInstallerFile);
                     $(DownloadedHostFxrInstallerFile);

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -63,7 +63,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
+    <PackageReference Include="Microsoft.Deployment.DotNet.Releases">
+      <VersionOverride Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">$(MicrosoftDeploymentDotNetReleasesToolsetPackageVersion)</VersionOverride>
+    </PackageReference>
   </ItemGroup>
 
   <!-- To reduce dll load (cause RPS perf regression). Directly compile files from Microsoft.DotNet.NativeWrapper, Microsoft.DotNet.SdkResolver, and the workload resolver -->
@@ -96,9 +98,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="$(SystemCollectionsImmutableToolsetPackageVersion)" />
     <!-- Used by ResolveHostfxrCopyLocalContent below -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" Condition="'$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2'" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" Condition="'$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2'" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" Condition="'$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -106,7 +108,9 @@
     <PackageReference Include="Microsoft.NETCore.Targets" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="ResolveHostfxrCopyLocalContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" BeforeTargets="AssignTargetPaths">
+  <Target Name="ResolveHostfxrCopyLocalContent"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2')"
+          BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="$(NuGetPackageRoot)/microsoft.netcore.app.runtime.win-x86/$(MicrosoftNETCoreAppRuntimePackageVersion)/runtimes/win-x86/native/hostfxr.dll">
         <Link>x86/hostfxr.dll</Link>

--- a/src/Resolvers/Microsoft.DotNet.SdkResolver/Microsoft.DotNet.SdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.SdkResolver/Microsoft.DotNet.SdkResolver.csproj
@@ -26,11 +26,13 @@
     <Reference Include="System.Core" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" ExcludeAssets="Runtime" />
     <!-- Used by ResolveHostfxrCopyLocalContent below -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x86" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" Condition="'$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2'" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.win-x64" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" Condition="'$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2'" />
   </ItemGroup>
 
-  <Target Name="ResolveHostfxrCopyLocalContent" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" BeforeTargets="AssignTargetPaths">
+  <Target Name="ResolveHostfxrCopyLocalContent"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPass)' == '2')"
+          BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="$(NuGetPackageRoot)/microsoft.netcore.app.runtime.win-x86/$(MicrosoftNETCoreAppRuntimePackageVersion)/runtimes/win-x86/native/hostfxr.dll">
         <Link>x86/hostfxr.dll</Link>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -31,6 +31,8 @@
     <BuildArgs Condition="'$(TargetOS)' != 'windows'">$(BuildArgs) /p:NetRuntimeRid=$(TargetRid)</BuildArgs>
     <!-- https://github.com/dotnet/source-build/issues/4138 -->
     <BuildArgs Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'osx'">$(BuildArgs) /p:SkipBuildingInstallers=true</BuildArgs>
+    <!-- https://github.com/dotnet/source-build/issues/4693 -->
+    <BuildArgs Condition="'$(TargetOS)' == 'windows' and '$(UseOfficialBuildVersioning)' != 'true'">$(BuildArgs) /p:SkipBuildingInstallers=true /p:SkipBuildingSdkBundle=true</BuildArgs>
 
     <BuildArgs>$(BuildArgs) /p:PublicBaseURL=file:%2F%2F$(ArtifactsAssetsDir)</BuildArgs>
     <!-- In non-source-only scenarios, currently consume aspnetcore from the normal public base url -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4691
Contributes to https://github.com/dotnet/source-build/issues/3739

- Disable join points in GenerateLayout and GenerateMSIs.targets
- Condition MSBuildSdkResolver & SdkResolver
- Use a toolset version for Microsoft.Deployment.DotNet.Releases for netfx build as VS expects a hardcoded version (follows what STJ does).
- Move aliased version properties out of Versions.props as those have a wrong value when being overridden by the VMR infra.