### PR TITLE
Fix and simplify logic for setting the minimum VS version to display in the installer UI

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,10 +193,13 @@
          from the 'minimumMSBuildVersion' file in non-source-only cases into MicrosoftBuildMinimumVersion,
          then use that in Directory.Packages.props.
 
-         At usage sites, either we use MicrosoftBuildMinimumVersion, or MicrosoftBuildVersion in source-only modes. -->
+         At usage sites, either we use MicrosoftBuildMinimumVersion, or MicrosoftBuildVersion in source-only modes. 
+
+         Additionally, set the MinimumVSVersion for the installer UI that's required for targeting NetCurrent -->
     <MicrosoftBuildVersion>17.12.7</MicrosoftBuildVersion>
     <MicrosoftBuildLocalizationVersion>17.12.7-preview-24522-03</MicrosoftBuildLocalizationVersion>
     <MicrosoftBuildMinimumVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">17.11.4</MicrosoftBuildMinimumVersion>
+    <MinimumVSVersion>17.12</MinimumVSVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,7 +193,7 @@
          from the 'minimumMSBuildVersion' file in non-source-only cases into MicrosoftBuildMinimumVersion,
          then use that in Directory.Packages.props.
 
-         At usage sites, either we use MicrosoftBuildMinimumVersion, or MicrosoftBuildVersion in source-only modes. 
+         At usage sites, either we use MicrosoftBuildMinimumVersion, or MicrosoftBuildVersion in source-only modes.
 
          Additionally, set the MinimumVSVersion for the installer UI that's required for targeting NetCurrent -->
     <MicrosoftBuildVersion>17.12.7</MicrosoftBuildVersion>

--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -285,24 +285,6 @@
                       Overwrite="true" />
   </Target>
 
-  <Target Name="GetMinimumVSVersion"
-          BeforeTargets="GenerateSdkBundle"
-          Condition=" '$(OS)' == 'Windows_NT' "
-          Outputs="$(MinimumVSVersion)">
-    <PropertyGroup>
-      <MinimumMSBuildVersionFile Condition="$([System.Text.RegularExpressions.Regex]::Match(%(SDKInternalFiles.Identity),'.*minimumMSBuildVersion').Success) ">%(SDKInternalFiles.Identity)</MinimumMSBuildVersionFile>
-    </PropertyGroup>
-
-    <ReadLinesFromFile File="$(MinimumMSBuildVersionFile)">
-      <Output TaskParameter="Lines" PropertyName="MinimumVSVersion" />
-    </ReadLinesFromFile>
-
-    <PropertyGroup Condition=" '$(VersionSDKMinor)' == '1' and '$(StabilizePackageVersion)' == 'true' ">
-      <MinimumVSVersion>$(MinimumVSVersion.Substring(0,$(MinimumVSVersion.LastIndexOf('.'))))</MinimumVSVersion>
-      <MinimumVSVersion >$([MSBuild]::Add($(MinimumVSVersion), .1))</MinimumVSVersion>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="GenerateSdkBundle"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;GenerateTemplatesMsis;GenerateWorkloadManifestsWxs"
           Condition=" '$(OS)' == 'Windows_NT' "


### PR DESCRIPTION
Fixes #44360

**Summary**

When SDK and installer were separate repos, we had logic in installer to update the displayed minimum VS version required in the installer Ux. the problem is that we support running on N-1 but require N VS version to actually target the current version (ie we will load in 17.11 but require 17.12 to target net9.0). So logic was added to read that value and increment it but that logic didn't handle a two digit minor VS version.

We noticed previously that this logic of calculating the value on the fly could end up producing a long addition math error (ie we'd get 17.900000000001) as the value when adding .1, let's just hard code this value.

**Customer Impact** 

Currently it says you have to install 17.21 to target net9.

**Regression**

Yes

**Testing**

Build the installer locally

**Risk**

In the future when updating the minimum version, we now have to update it in multiple places but they are all in one repo.