### PR TITLE
Add SDK support for rooting subsets of inputs in a composite image.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.NET.Build.Tasks
         public ITaskItem[] ImplementationAssemblyReferences { get; set; }
         public ITaskItem[] ReadyToRunCompositeBuildReferences { get; set; }
         public ITaskItem[] ReadyToRunCompositeBuildInput { get; set; }
+        public ITaskItem[] ReadyToRunCompositeUnrootedBuildInput { get; set; }
         public bool ShowCompilerWarnings { get; set; }
         public bool UseCrossgen2 { get; set; }
         public string Crossgen2ExtraCommandLineArgs { get; set; }
@@ -364,6 +365,14 @@ namespace Microsoft.NET.Build.Tasks
                 foreach (var reference in ReadyToRunCompositeBuildInput)
                 {
                     result.AppendLine(reference.ItemSpec);
+                }
+
+                if (ReadyToRunCompositeUnrootedBuildInput != null)
+                {
+                    foreach (var unrooted in ReadyToRunCompositeUnrootedBuildInput)
+                    {
+                        result.AppendLine($"-u:\"{unrooted.ItemSpec}\"");
+                    }
                 }
             }
             else

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -421,7 +421,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)"
                                      ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
                                      Crossgen2Composite="$(PublishReadyToRunComposite)"
-                                     PublishReadyToRunCompositeExclusions="@(PublishReadyToRunCompositeExclusions)">
+                                     PublishReadyToRunCompositeExclusions="@(PublishReadyToRunCompositeExclusions)"
+                                     PublishReadyToRunCompositeRoots="@(PublishReadyToRunCompositeRoots)">
 
       <Output TaskParameter="ReadyToRunCompileList" ItemName="_ReadyToRunCompileList" />
       <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
@@ -430,6 +431,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ReadyToRunAssembliesToReference" ItemName="_ReadyToRunAssembliesToReference" />
       <Output TaskParameter="ReadyToRunCompositeBuildReferences" ItemName="_ReadyToRunCompositeBuildReferences" />
       <Output TaskParameter="ReadyToRunCompositeBuildInput" ItemName="_ReadyToRunCompositeBuildInput" />
+      <Output TaskParameter="ReadyToRunCompositeUnrootedBuildInput" ItemName="_ReadyToRunCompositeUnrootedBuildInput" />
 
     </PrepareForReadyToRunCompilation>
   </Target>
@@ -472,7 +474,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                            CompilationEntry="@(_ReadyToRunCompileList)"
                            ContinueOnError="ErrorAndContinue"
                            ReadyToRunCompositeBuildReferences="@(_ReadyToRunCompositeBuildReferences)"
-                           ReadyToRunCompositeBuildInput="@(_ReadyToRunCompositeBuildInput)">
+                           ReadyToRunCompositeBuildInput="@(_ReadyToRunCompositeBuildInput)"
+                           ReadyToRunCompositeUnrootedBuildInput="@(_ReadyToRunCompositeUnrootedBuildInput)">
       <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
       <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
     </RunReadyToRunCompiler>


### PR DESCRIPTION
This is needed to easily support https://github.com/dotnet/aspnetcore/issues/48013 while maintaining the existing behavior for the composite R2R archive (and resulting docker images)