### PR TITLE
Add *.props and *.targets to XML section of .editorconfig template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
@@ -5,7 +5,7 @@ root = true
 indent_style = space
 
 # Xml files
-[*.xml]
+[*.{xml,props,targets}]
 indent_size = 2
 
 # C# files

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
@@ -5,7 +5,7 @@
 indent_style = space
 
 # Xml files
-[*.xml]
+[*.{xml,props,targets}]
 indent_size = 2
 
 # C# files


### PR DESCRIPTION
Add `*.props` and `*.targets` to the XML section of the .editorconfig template.