### PR TITLE
Remove additional TL characters from the dotnet run output special casing for tests

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -812,8 +812,6 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("netcoreapp3.1", ".NET Core 3.1")]
-        [InlineData("netcoreapp2.1", ".NET Core 2.1")]
-        [InlineData("netstandard2.1", ".NET Standard 2.1")]
         [InlineData(ToolsetInfo.CurrentTargetFramework, $".NET {ToolsetInfo.CurrentTargetFrameworkVersion}")]
         public void CheckTargetFrameworkDisplayName(string targetFrameworkVersion, string expectedFrameworkDisplayName)
         {

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -812,6 +812,8 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("netcoreapp3.1", ".NET Core 3.1")]
+        [InlineData("netcoreapp2.1", ".NET Core 2.1")]
+        [InlineData("netstandard2.1", ".NET Standard 2.1")]
         [InlineData(ToolsetInfo.CurrentTargetFramework, $".NET {ToolsetInfo.CurrentTargetFrameworkVersion}")]
         public void CheckTargetFrameworkDisplayName(string targetFrameworkVersion, string expectedFrameworkDisplayName)
         {

--- a/test/Microsoft.NET.TestFramework/Utilities/TerminalLoggerStringExtensions.cs
+++ b/test/Microsoft.NET.TestFramework/Utilities/TerminalLoggerStringExtensions.cs
@@ -12,6 +12,8 @@ public static class TerminalLoggerExtensions
     {
         return stdout
             .Replace("\x1b]9;4;3;\x1b\\", "") // indeterminate progress start
-            .Replace("\x1b]9;4;0;\x1b\\", ""); // indeterminate progress end
+            .Replace("\x1b]9;4;0;\x1b\\", "") // indeterminate progress end
+            .Replace("\x1b[?25l", "") // make cursor invisble
+            .Replace("\x1b[?25h", ""); // make cursor visible
     }
 }


### PR DESCRIPTION
I've seen this test fail a couple of times in the past week or so and it always seems to pass on rerun. Since I only noticed it failing when targeting 2.1, it didn't seem worth keeping these specific versions of the test around and taking time to investigate. Let me know if you think it's worth investigating.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=852383&view=ms.vss-test-web.build-test-results-tab&runId=22136852&resultId=103685&paneView=debug

Expected string to be equivalent to ".NET Core 2.1" with a length of 13, but "[?25l[1F
[?25h.NET Core 2.1" has a length of 31, differs near "[?" (index 0).