### PR TITLE
Promote Ubuntu_Offline_MsftSdk SB leg to lite configuration

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -147,6 +147,24 @@ stages:
       #     withPreviousSDK: true              # ✅
       #     sign: false
 
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.ubuntuContainer }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
+          sign: false
+
       ### Additional jobs for full build ###
       - ${{ if in(parameters.scope, 'full') }}:
 
@@ -283,23 +301,6 @@ stages:
             withPreviousSDK: false             # 🚫
             sign: false
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.ubuntuContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
-            sign: false
 
         - template: ../jobs/vmr-build.yml
           parameters:


### PR DESCRIPTION
Given https://github.com/dotnet/source-build/issues/4605 is blocked, we should have an offline leg running in the lite configuration.  It would have surfaced https://github.com/dotnet/source-build/issues/4701 right away.