### PR TITLE
Gather test diag logging to track down nuget issue

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -23,6 +23,7 @@ mkdir %TestExecutionDirectory%
 REM https://stackoverflow.com/a/7487697/294804
 robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutionDirectory% /s /nfl /ndl /njh /njs /np
 
+set Verbosity=diagnostic
 set DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%
 set DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\r
 set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -23,7 +23,6 @@ mkdir %TestExecutionDirectory%
 REM https://stackoverflow.com/a/7487697/294804
 robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutionDirectory% /s /nfl /ndl /njh /njs /np
 
-set Verbosity=diagnostic
 set DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%
 set DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\r
 set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -133,9 +133,17 @@ namespace Microsoft.NET.TestFramework.Commands
                 args = new[] { "/restore" }.Concat(args);
             }
 
-            args = args.Concat(new[] { "-v:diag" });
+            var command = base.Execute(args);
 
-            return base.Execute(args);
+            var error = command.StdErr.ToString();
+            var output = command.StdOut.ToString();
+            if ((!String.IsNullOrEmpty(error) && error.Contains("NU3003")) || (!String.IsNullOrEmpty(output) && output.Contains("NU3003")))
+            {
+                args = args.Concat(new[] { "-v:diag" });
+                command = base.Execute(args);
+            }
+
+            return command;
         }
 
         public CommandResult ExecuteWithoutRestore(IEnumerable<string> args)

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -133,6 +133,8 @@ namespace Microsoft.NET.TestFramework.Commands
                 args = new[] { "/restore" }.Concat(args);
             }
 
+            args = args.Concat(new[] { "-v:diag" });
+
             return base.Execute(args);
         }
 


### PR DESCRIPTION
We're seeing NU3003 for packages that when downloaded manually, don't show an issue. Per NuGet team, this means an exception is thrown and collecting verbosity information should help.

I believe I've mostly seen this on windows so let's enable for windows and just keep rerunning until we hit it.