### PR TITLE
Fix .NET Framework test helix submission

### DIFF
--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/CompatibleFrameworkInPackageValidatorIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/CompatibleFrameworkInPackageValidatorIntegrationTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             return (log, validator);
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
         public void CompatibleFrameworksInPackage()
         {
             string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
@@ -67,7 +67,7 @@ namespace PackageValidationTests
             Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
         public void MultipleCompatibleFrameworksInPackage()
         {
             string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             return (log, validator);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void InvalidPackage()
         {
             var testAsset = _testAssetsManager
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeAPINotIn6_0()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net6.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = _testAssetsManager
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
         {
             var testAsset = _testAssetsManager
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
         {
             var testAsset = _testAssetsManager
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
         public void ValidatePackageWithReferences()
         {
             string testDependencySource = @"namespace PackageValidationTests { public class ItermediateBaseClass
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains($"CP0008 Type 'PackageValidationTests.First' does not implement interface 'PackageValidationTests.IBaseInterface' on lib/{ToolsetInfo.CurrentTargetFramework}/{asset.TestProject.Name}.dll but it does on lib/netstandard2.0/{asset.TestProject.Name}.dll", log.errors);
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0")]
+        [RequiresMSBuildVersionTheory("17.12")]
         [InlineData(false, true, false)]
         [InlineData(false, false, false)]
         [InlineData(true, false, false)]
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 Assert.DoesNotContain($"CP1002 Could not find matching assembly: '{testDummyDependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0")]
+        [RequiresMSBuildVersionTheory("17.12")]
         [InlineData(false, true, false, false)]
         [InlineData(true, false, false, false)]
         [InlineData(true, true, true, true)]
@@ -270,7 +270,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains($"CP1002 Could not find matching assembly: '{dependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
         public void EnsureOnlyOneAssemblyLoadErrorIsLoggedPerMissingAssembly()
         {
             string dependencySourceCode = @"namespace PackageValidationTests { public interface ISomeInterface { }
@@ -310,7 +310,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Single(log.errors, e => e.Contains("CP1002"));
         }
 
-        [RequiresMSBuildVersionTheory("16.8.0")]
+        [RequiresMSBuildVersionTheory("17.12")]
         [InlineData(true)]
         [InlineData(false)]
         public void ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences(bool useReferences)
@@ -336,7 +336,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");
@@ -358,7 +358,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersionInStrictMode()
         {
             var testAsset = _testAssetsManager
@@ -379,7 +379,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetSucceedsWithBaselineVersionNotInStrictMode()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             return (log, validator);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void InvalidPackage()
         {
             var testAsset = _testAssetsManager
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeAPINotIn6_0()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net6.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = _testAssetsManager
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
         {
             var testAsset = _testAssetsManager
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
         {
             var testAsset = _testAssetsManager
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageWithReferences()
         {
             string testDependencySource = @"namespace PackageValidationTests { public class ItermediateBaseClass
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains($"CP0008 Type 'PackageValidationTests.First' does not implement interface 'PackageValidationTests.IBaseInterface' on lib/{ToolsetInfo.CurrentTargetFramework}/{asset.TestProject.Name}.dll but it does on lib/netstandard2.0/{asset.TestProject.Name}.dll", log.errors);
         }
 
-        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData(false, true, false)]
         [InlineData(false, false, false)]
         [InlineData(true, false, false)]
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 Assert.DoesNotContain($"CP1002 Could not find matching assembly: '{testDummyDependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData(false, true, false, false)]
         [InlineData(true, false, false, false)]
         [InlineData(true, true, true, true)]
@@ -270,7 +270,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains($"CP1002 Could not find matching assembly: '{dependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [RequiresMSBuildVersionFact("16.8.0")]
         public void EnsureOnlyOneAssemblyLoadErrorIsLoggedPerMissingAssembly()
         {
             string dependencySourceCode = @"namespace PackageValidationTests { public interface ISomeInterface { }
@@ -310,7 +310,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Single(log.errors, e => e.Contains("CP1002"));
         }
 
-        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [RequiresMSBuildVersionTheory("16.8.0")]
         [InlineData(true)]
         [InlineData(false)]
         public void ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences(bool useReferences)
@@ -336,7 +336,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");
@@ -358,7 +358,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersionInStrictMode()
         {
             var testAsset = _testAssetsManager
@@ -379,7 +379,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        [RequiresMSBuildVersionFact("16.8.0", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetSucceedsWithBaselineVersionNotInStrictMode()
         {
             var testAsset = _testAssetsManager

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             return (log, validator);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void InvalidPackage()
         {
             var testAsset = _testAssetsManager
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeAPINotIn6_0()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net6.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = _testAssetsManager
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
         {
             var testAsset = _testAssetsManager
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersion()
         {
             var testAsset = _testAssetsManager
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
         {
             var testAsset = _testAssetsManager
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Equal(0, result.ExitCode);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void ValidatePackageWithReferences()
         {
             string testDependencySource = @"namespace PackageValidationTests { public class ItermediateBaseClass
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             Assert.Contains($"CP0008 Type 'PackageValidationTests.First' does not implement interface 'PackageValidationTests.IBaseInterface' on lib/{ToolsetInfo.CurrentTargetFramework}/{asset.TestProject.Name}.dll but it does on lib/netstandard2.0/{asset.TestProject.Name}.dll", log.errors);
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(false, true, false)]
         [InlineData(false, false, false)]
         [InlineData(true, false, false)]
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 Assert.DoesNotContain($"CP1002 Could not find matching assembly: '{testDummyDependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(false, true, false, false)]
         [InlineData(true, false, false, false)]
         [InlineData(true, true, true, true)]
@@ -270,7 +270,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains($"CP1002 Could not find matching assembly: '{dependency.Name}.dll' in any of the search directories.", log.errors);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901")]
         public void EnsureOnlyOneAssemblyLoadErrorIsLoggedPerMissingAssembly()
         {
             string dependencySourceCode = @"namespace PackageValidationTests { public interface ISomeInterface { }
@@ -310,7 +310,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Single(log.errors, e => e.Contains("CP1002"));
         }
 
-        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        // [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData(true)]
         [InlineData(false)]
         public void ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences(bool useReferences)
@@ -336,7 +336,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");
@@ -358,7 +358,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains(log.warnings, e => e.Contains("CP1003"));
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetFailsWithBaselineVersionInStrictMode()
         {
             var testAsset = _testAssetsManager
@@ -379,7 +379,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             Assert.Contains("error CP0002: Member 'PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
+        // [RequiresMSBuildVersionFact("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/23533")]
         public void ValidatePackageTargetSucceedsWithBaselineVersionNotInStrictMode()
         {
             var testAsset = _testAssetsManager

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.DotNet.Helix.Sdk">
+﻿﻿<Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <PropertyGroup>
     <HelixType>test/product/</HelixType>
@@ -11,43 +11,43 @@
     <XUnitWorkItemTimeout>00:45:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 
-  <ItemGroup>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="**\*.Tests.csproj" Exclude="**\*.AoT.Tests.csproj;TestAssets\**\*.Tests.csproj" />
+  <ItemGroup Condition="'$(TestFullMSBuild)' != 'true'">
+    <SDKCustomXUnitProject Include="**\*.Tests.csproj" Exclude="**\*.AoT.Tests.csproj;TestAssets\**\*.Tests.csproj" />
+
     <!--containers tests end with UnitTests and IntegrationTests, therefore included manually -->
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="containerize.UnitTests\containerize.UnitTests.csproj" />
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' != 'true'" Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj" />
-    <!-- on Windows_NT_FullFramework leg, net472 tests should be run -->
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'"  Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj">
-      <TargetFramework>net472</TargetFramework>
-      <RuntimeTargetFramework>net472</RuntimeTargetFramework>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj" />
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="..\src\Tasks\Microsoft.NET.Build.Extensions.Tasks.UnitTests\Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj">
-      <ExcludeAdditionalParameters>true</ExcludeAdditionalParameters>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="..\src\Tasks\Microsoft.NET.Build.Tasks.UnitTests\Microsoft.NET.Build.Tasks.UnitTests.csproj">
-      <ExcludeAdditionalParameters>true</ExcludeAdditionalParameters>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' == 'true'" Include="**\*.AoT.Tests.csproj" />
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj">
-      <TargetFramework>net472</TargetFramework>
-      <RuntimeTargetFramework>net472</RuntimeTargetFramework>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj">
-      <TargetFramework>net472</TargetFramework>
-      <RuntimeTargetFramework>net472</RuntimeTargetFramework>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj">
-      <TargetFramework>net472</TargetFramework>
-      <RuntimeTargetFramework>net472</RuntimeTargetFramework>
-    </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.NET.Sdk.Publish.Tasks.Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj">
-      <TargetFramework>net472</TargetFramework>
-      <RuntimeTargetFramework>net472</RuntimeTargetFramework>
-    </SDKCustomXUnitProject>
+    <SDKCustomXUnitProject Include="containerize.UnitTests\containerize.UnitTests.csproj" />
+    <SDKCustomXUnitProject Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj" />
+
+    <SDKCustomXUnitProject Include="Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj" />
+    <SDKCustomXUnitProject Include="..\src\Tasks\Microsoft.NET.Build.Extensions.Tasks.UnitTests\Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj" ExcludeAdditionalParameters="true" />
+    <SDKCustomXUnitProject Include="..\src\Tasks\Microsoft.NET.Build.Tasks.UnitTests\Microsoft.NET.Build.Tasks.UnitTests.csproj" ExcludeAdditionalParameters="true" />
 
     <!-- Don't run MSI installation tests in Helix / CI -->
     <SdkCustomXUnitProject Remove="dotnet-MsiInstallation.Tests\**\*" />
+  </ItemGroup>
+
+  <!-- On Windows_NT_FullFramework leg, only the net472 tests should be run -->
+  <ItemGroup Condition="'$(TestFullMSBuild)' == 'true'">
+    <SDKCustomXUnitProject Include="
+      core-sdk-tasks.Tests\core-sdk-tasks.Tests.csproj;
+      Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
+      Microsoft.DotNet.ApiCompat.Tests\Microsoft.DotNet.ApiCompat.Tests.csproj;
+      Microsoft.DotNet.ApiCompatibility.Tests\Microsoft.DotNet.ApiCompatibility.Tests.csproj;
+      Microsoft.DotNet.ApiSymbolExtensions.Tests\Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj;
+      Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj;
+      Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj;
+      Microsoft.DotNet.TemplateLocator.Tests\Microsoft.DotNet.TemplateLocator.Tests.csproj;
+      Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj;
+      Microsoft.NET.Sdk.Publish.Tasks.Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj;
+      Microsoft.NET.Sdk.WorkloadManifestReader.Tests\Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj;
+      Microsoft.Win32.Msi.Tests\Microsoft.Win32.Msi.Tests.csproj"
+                           TargetFramework="net472"
+                           RuntimeTargetFramework="net472" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RunAoTTests)' == 'true'">
+    <SDKCustomXUnitProject Remove="@(SDKCustomXUnitProject)" />
+    <SDKCustomXUnitProject Include="**\*.AoT.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(CustomHelixTargetQueue)' != '' ">

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -11,7 +11,7 @@
     <XUnitWorkItemTimeout>00:45:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TestFullMSBuild)' != 'true'">
+  <ItemGroup>
     <SDKCustomXUnitProject Include="**\*.Tests.csproj" Exclude="**\*.AoT.Tests.csproj;TestAssets\**\*.Tests.csproj" />
 
     <!--containers tests end with UnitTests and IntegrationTests, therefore included manually -->
@@ -26,7 +26,8 @@
     <SdkCustomXUnitProject Remove="dotnet-MsiInstallation.Tests\**\*" />
   </ItemGroup>
 
-  <!-- On Windows_NT_FullFramework leg, only the net472 tests should be run -->
+  <!-- When TestFullMSBuild=true, include the .NET Framework tests. .NETCoreApp tests are also executed
+       as that validates running tests with desktop msbuild. -->
   <ItemGroup Condition="'$(TestFullMSBuild)' == 'true'">
     <SDKCustomXUnitProject Include="
       core-sdk-tasks.Tests\core-sdk-tasks.Tests.csproj;

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -30,7 +30,7 @@
   <ItemGroup Condition="'$(TestFullMSBuild)' == 'true'">
     <SDKCustomXUnitProject Include="
       core-sdk-tasks.Tests\core-sdk-tasks.Tests.csproj;
-      Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
+      Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj;
       Microsoft.DotNet.ApiCompat.Tests\Microsoft.DotNet.ApiCompat.Tests.csproj;
       Microsoft.DotNet.ApiCompatibility.Tests\Microsoft.DotNet.ApiCompatibility.Tests.csproj;
       Microsoft.DotNet.ApiSymbolExtensions.Tests\Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj;

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -15,9 +15,9 @@
     <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="**\*.Tests.csproj" Exclude="**\*.AoT.Tests.csproj;TestAssets\**\*.Tests.csproj" />
     <!--containers tests end with UnitTests and IntegrationTests, therefore included manually -->
     <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true'" Include="containerize.UnitTests\containerize.UnitTests.csproj" />
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) != 'Windows_NT_FullFramework'" Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj" />
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' != 'true'" Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj" />
     <!-- on Windows_NT_FullFramework leg, net472 tests should be run -->
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) == 'Windows_NT_FullFramework'"  Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj">
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'"  Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>
@@ -29,19 +29,19 @@
       <ExcludeAdditionalParameters>true</ExcludeAdditionalParameters>
     </SDKCustomXUnitProject>
     <SDKCustomXUnitProject Condition="'$(RunAoTTests)' == 'true'" Include="**\*.AoT.Tests.csproj" />
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) == 'Windows_NT_FullFramework'" Include="Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj">
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) == 'Windows_NT_FullFramework'" Include="Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj">
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) == 'Windows_NT_FullFramework'" Include="Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj">
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>
-    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And $(_AGENTOSNAME) == 'Windows_NT_FullFramework'" Include="Microsoft.NET.Sdk.Publish.Tasks.Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj">
+    <SDKCustomXUnitProject Condition="'$(RunAoTTests)' != 'true' And '$(TestFullMSBuild)' == 'true'" Include="Microsoft.NET.Sdk.Publish.Tasks.Tests\Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.DotNet.Helix.Sdk">
+<Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <PropertyGroup>
     <HelixType>test/product/</HelixType>


### PR DESCRIPTION
According to AzDO and a binlog from the NETFULLFRAMEWORK leg, .NET Framework tests don't run.

The `_AGENTOSNAME` property / env var doesn't exist anymore. This regressed between 9.0 P4 and P5: https://github.com/dotnet/sdk/blame/eaecfdeddb3e4c87f34a075e7b6892d0eab2a343/eng/build.yml#L47-L48

### Changes
1. Replace the `_AGENTOSNAME` property with the `TestFullMSBuild` property.
2. Add seven missing test projects that target .NET Framework to the hardcoded list of projects to submit to helix for .NET Framework testing.
3. ~~Don't run .NETCoreApp tests in the NETFULLFRAMEWORK leg.~~ I realized that they intentionally run as they are exercised with desktop msbuild which provides some usefulness.
4. Restructure code to make things more explicit and easier to add.