### PR TITLE
[FIX] tool-install: Support --ignore-failed-sources flag correctly

### DIFF
--- a/src/Cli/dotnet/ToolPackage/IToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/IToolPackageDownloader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.ToolPackage;
 using NuGet.Versioning;
 
@@ -13,7 +14,8 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             VerbosityOptions verbosity,
             VersionRange versionRange = null,
             string targetFramework = null,
-            bool isGlobalTool = false
+            bool isGlobalTool = false,
+            RestoreActionConfig restoreActionConfig = null
         );
     }
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -72,7 +72,8 @@ namespace Microsoft.DotNet.Cli.ToolPackage
             VerbosityOptions verbosity = VerbosityOptions.normal,
             VersionRange versionRange = null,
             string targetFramework = null,
-            bool isGlobalTool = false
+            bool isGlobalTool = false,
+            RestoreActionConfig restoreActionConfig = null
             )
         {
             var packageRootDirectory = _toolPackageStore.GetRootPackageDirectory(packageId);
@@ -95,7 +96,11 @@ namespace Microsoft.DotNet.Cli.ToolPackage
 
                     var toolDownloadDir = isGlobalTool ? _globalToolStageDir : _localToolDownloadDir;
                     var assetFileDirectory = isGlobalTool ? _globalToolStageDir : _localToolAssetDir;
-                    var nugetPackageDownloader = new NuGetPackageDownloader.NuGetPackageDownloader(toolDownloadDir, verboseLogger: nugetLogger, isNuGetTool: true);
+                    var nugetPackageDownloader = new NuGetPackageDownloader.NuGetPackageDownloader(
+                        toolDownloadDir,
+                        verboseLogger: nugetLogger,
+                        isNuGetTool: true,
+                        restoreActionConfig: restoreActionConfig);
 
                     var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, null, packageLocation.AdditionalFeeds);
 

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -44,6 +44,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private readonly string _architectureOption;
         private IEnumerable<string> _forwardRestoreArguments;
 
+        internal readonly RestoreActionConfig _restoreActionConfig;
+
         public ToolInstallGlobalOrToolPathCommand(
             ParseResult parseResult,
             CreateToolPackageStoresAndDownloader createToolPackageStoreAndDownloader = null,
@@ -74,11 +76,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             var configOption = parseResult.GetValue(ToolInstallCommandParser.ConfigOption);
             var sourceOption = parseResult.GetValue(ToolInstallCommandParser.AddSourceOption);
             var packageSourceLocation = new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), additionalSourceFeeds: sourceOption);
-            var restoreAction = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+            _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
                 NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption),
                 IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
                 Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
-            nugetPackageDownloader ??= new NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: restoreAction);
+            nugetPackageDownloader ??= new NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: _restoreActionConfig);
             _shellShimTemplateFinder = new ShellShimTemplateFinder(nugetPackageDownloader, tempDir, packageSourceLocation);
 
             _reporter = (reporter ?? Reporter.Output);
@@ -132,7 +134,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         versionRange: versionRange,
                         targetFramework: _framework,
                         verbosity: _verbosity,
-                        isGlobalTool: true
+                        isGlobalTool: true,
+                        restoreActionConfig: _restoreActionConfig
                     );
 
                     NuGetFramework framework;

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
@@ -22,6 +23,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
         private readonly string _explicitManifestFile;
         private readonly bool _createManifestIfNeeded;
+
+        internal readonly RestoreActionConfig _restoreActionConfig;
 
         public ToolInstallLocalCommand(
             ParseResult parseResult,
@@ -43,7 +46,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                                   new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
             _toolManifestEditor = toolManifestEditor ?? new ToolManifestEditor();
             _localToolsResolverCache = localToolsResolverCache ?? new LocalToolsResolverCache();
-            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader);
+            _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+                NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption),
+                IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
+                Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
+            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader, _restoreActionConfig);
         }
 
         public override int Execute()

--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallLocalInstaller.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.IO;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolPackage;
@@ -24,10 +25,12 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private readonly string _configFilePath;
         private readonly string[] _sources;
         private readonly VerbosityOptions _verbosity;
+        private readonly RestoreActionConfig _restoreActionConfig;
 
         public ToolInstallLocalInstaller(
             ParseResult parseResult,
-            IToolPackageDownloader toolPackageDownloader = null)
+            IToolPackageDownloader toolPackageDownloader = null,
+            RestoreActionConfig restoreActionConfig = null)
         {
             _parseResult = parseResult;
             _packageId = new PackageId(parseResult.GetValue(ToolInstallCommandParser.PackageIdArgument));
@@ -43,7 +46,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         additionalRestoreArguments: parseResult.OptionValuesToBeForwarded(ToolInstallCommandParser.GetCommand()));
             _toolPackageStore = toolPackageStoresAndDownloader.store;
             _toolPackageDownloader = toolPackageDownloader?? toolPackageStoresAndDownloader.downloader;
-            
+            _restoreActionConfig = restoreActionConfig;
             
             TargetFrameworkToInstall = BundledTargetFramework.GetTargetFrameworkMoniker();
         }
@@ -76,7 +79,8 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         _packageId,
                         verbosity: _verbosity,
                         versionRange,
-                        TargetFrameworkToInstall
+                        TargetFrameworkToInstall,
+                        restoreActionConfig: _restoreActionConfig
                         );
 
                 return toolDownloadedPackage;

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateGlobalOrToolPathCommand.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.Tools.Tool.Uninstall;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Versioning;
 using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 
 namespace Microsoft.DotNet.Tools.Tool.Update
 {
@@ -38,6 +39,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
         private readonly IEnumerable<string> _forwardRestoreArguments;
         private readonly string _packageVersion;
 
+        internal readonly RestoreActionConfig _restoreActionConfig;
+
         public ToolUpdateGlobalOrToolPathCommand(ParseResult parseResult,
             CreateToolPackageStoresAndDownloaderAndUninstaller createToolPackageStoreDownloaderUninstaller = null,
             CreateShellShimRepository createShellShimRepository = null,
@@ -59,6 +62,11 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
             _createShellShimRepository =
                 createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
+
+            _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+                NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption),
+                IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
+                Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
 
             _reporter = (reporter ?? Reporter.Output);
             _errorReporter = (reporter ?? Reporter.Error);
@@ -111,7 +119,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
                         versionRange: versionRange,
                         targetFramework: _framework,
                         verbosity: _verbosity,
-                        isGlobalTool: true
+                        isGlobalTool: true,
+                        restoreActionConfig: _restoreActionConfig
                     );
 
                     EnsureVersionIsHigher(oldPackageNullable, newInstalledPackage);

--- a/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateLocalCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/update/ToolUpdateLocalCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
@@ -25,6 +26,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
         private readonly PackageId _packageId;
         private readonly string _explicitManifestFile;
+
+        internal readonly RestoreActionConfig _restoreActionConfig;
 
         public ToolUpdateLocalCommand(
             ParseResult parseResult,
@@ -59,7 +62,12 @@ namespace Microsoft.DotNet.Tools.Tool.Update
             _toolManifestEditor = toolManifestEditor ?? new ToolManifestEditor();
             _localToolsResolverCache = localToolsResolverCache ?? new LocalToolsResolverCache();
 
-            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader);
+            _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+                NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption),
+                IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
+                Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
+
+            _toolLocalPackageInstaller = new ToolInstallLocalInstaller(parseResult, toolPackageDownloader, _restoreActionConfig);
             _toolInstallLocalCommand = new Lazy<ToolInstallLocalCommand>(
                 () => new ToolInstallLocalCommand(
                     parseResult,

--- a/src/Tests/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
+++ b/src/Tests/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolPackage;
@@ -96,7 +97,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             VerbosityOptions verbosity,
             VersionRange versionRange = null,
             string targetFramework = null,
-            bool isGlobalTool = false
+            bool isGlobalTool = false,
+            RestoreActionConfig restoreActionConfig = null
             )
         {
             string rollbackDirectory = null;

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -64,6 +64,30 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void WhenPassingRestoreActionConfigOptions()
+        {
+            var parseResult = Parser.Instance.Parse($"dotnet tool install -g {PackageId} --ignore-failed-sources");
+            var toolInstallCommand = new ToolInstallGlobalOrToolPathCommand(parseResult);
+            toolInstallCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenPassingIgnoreFailedSourcesItShouldNotThrow()
+        {
+            _fileSystem.File.WriteAllText(Path.Combine(_temporaryDirectory, "nuget.config"), _nugetConfigWithInvalidSources);
+
+            var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
+                _parseResult,
+                _createToolPackageStoresAndDownloader,
+                _createShellShimRepository,
+                _environmentPathInstructionMock,
+                _reporter);
+
+            toolInstallGlobalOrToolPathCommand.Execute().Should().Be(0);
+            _fileSystem.File.Delete(Path.Combine(_temporaryDirectory, "nuget.config"));
+        }
+
+        [Fact]
         public void WhenRunWithPackageIdItShouldCreateValidShim()
         {
             var toolInstallGlobalOrToolPathCommand = new ToolInstallGlobalOrToolPathCommand(
@@ -630,6 +654,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             {
             }
         }
+
+        private string _nugetConfigWithInvalidSources = @"{
+<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""invalid_source"" value=""https://api.nuget.org/v3/invalid.json"" />
+  </packageSources>
+</configuration>
+}";
     }
 }
 

--- a/src/Tests/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
@@ -97,6 +97,32 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void WhenPassingRestoreActionConfigOptions()
+        {
+            var parseResult = Parser.Instance.Parse($"dotnet tool install {_packageIdA.ToString()} --ignore-failed-sources");
+            var command = new ToolInstallLocalCommand(parseResult);
+            command._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenPassingIgnoreFailedSourcesItShouldNotThrow()
+        {
+            _fileSystem.File.WriteAllText(Path.Combine(_temporaryDirectory, "nuget.config"), _nugetConfigWithInvalidSources);
+            var parseResult = Parser.Instance.Parse($"dotnet tool install {_packageIdA.ToString()} --ignore-failed-sources");
+            var installLocalCommand = new ToolInstallLocalCommand(
+                parseResult,
+                _toolPackageDownloaderMock,
+                _toolManifestFinder,
+                _toolManifestEditor,
+                _localToolsResolverCache,
+                _reporter);
+
+            installLocalCommand.Execute().Should().Be(0);
+
+            _fileSystem.File.Delete(Path.Combine(_temporaryDirectory, "nuget.config"));
+        }
+
+        [Fact]
         public void WhenRunWithPackageIdItShouldSaveToCacheAndAddToManifestFile()
         {
             var toolInstallLocalCommand = GetDefaultTestToolInstallLocalCommand();
@@ -440,6 +466,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
    ""isRoot"":true,
    ""tools"":{
    }
+}";
+
+        private string _nugetConfigWithInvalidSources = @"{
+<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""invalid_source"" value=""https://api.nuget.org/v3/invalid.json"" />
+  </packageSources>
+</configuration>
 }";
     }
 }

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -12,6 +12,8 @@ using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Update.LocalizableStrings
 using Microsoft.DotNet.ShellShim;
 using System.CommandLine;
 using Parser = Microsoft.DotNet.Cli.Parser;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.Tools.Tool.Uninstall;
 
 namespace Microsoft.DotNet.Tests.Commands.Tool
 {
@@ -28,14 +30,15 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         private const string HigherPreviewPackageVersion = "1.0.5-preview3";
         private readonly string _shimsDirectory;
         private readonly string _toolsDirectory;
+        private readonly string _tempDirectory;
 
         public ToolUpdateGlobalOrToolPathCommandTests()
         {
             _reporter = new BufferedReporter();
             _fileSystem = new FileSystemMockBuilder().UseCurrentSystemTemporaryDirectory().Build();
-            var tempDirectory = _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
-            _shimsDirectory = Path.Combine(tempDirectory, "shims");
-            _toolsDirectory = Path.Combine(tempDirectory, "tools");
+            _tempDirectory = _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
+            _shimsDirectory = Path.Combine(_tempDirectory, "shims");
+            _toolsDirectory = Path.Combine(_tempDirectory, "tools");
             _environmentPathInstructionMock = new EnvironmentPathInstructionMock(_reporter, _shimsDirectory);
             _store = new ToolPackageStoreMock(new DirectoryPath(_toolsDirectory), _fileSystem);
             _mockFeeds = new List<MockFeed>
@@ -66,6 +69,25 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     }
                 }
             };
+        }
+
+        [Fact]
+        public void WhenPassingRestoreActionConfigOptions()
+        {
+            var parseResult = Parser.Instance.Parse($"dotnet tool update -g {_packageId} --ignore-failed-sources");
+            var toolUpdateCommand = new ToolUpdateGlobalOrToolPathCommand(parseResult);
+            toolUpdateCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenPassingIgnoreFailedSourcesItShouldNotThrow()
+        {
+            _fileSystem.File.WriteAllText(Path.Combine(_tempDirectory, "nuget.config"), _nugetConfigWithInvalidSources);
+
+            var command = CreateUpdateCommand($"-g {_packageId} --ignore-failed-sources");
+
+            command.Execute().Should().Be(0);
+            _fileSystem.File.Delete(Path.Combine(_tempDirectory, "nuget.config"));
         }
 
         [Fact]
@@ -373,6 +395,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     appHostShellShimMaker: new AppHostShellShimMakerMock(_fileSystem),
                     filePermissionSetter: new ToolInstallGlobalOrToolPathCommandTests.NoOpFilePermissionSetter());
         }
+
+        private string _nugetConfigWithInvalidSources = @"{
+<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""invalid_source"" value=""https://api.nuget.org/v3/invalid.json"" />
+  </packageSources>
+</configuration>
+}";
     }
 }
 

--- a/src/Tests/dotnet.Tests/CommandTests/ToolUpdateLocalCommandTests.cs
+++ b/src/Tests/dotnet.Tests/CommandTests/ToolUpdateLocalCommandTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tests.ComponentMocks;
+using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tool.Restore;
 using Microsoft.DotNet.Tools.Tool.Update;
 using Microsoft.Extensions.DependencyModel.Tests;
@@ -110,6 +111,32 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                 _toolManifestEditor,
                 _localToolsResolverCache,
                 _reporter);
+        }
+
+        [Fact]
+        public void WhenPassingRestoreActionConfigOptions()
+        {
+            var parseResult = Parser.Instance.Parse($"dotnet tool update {_packageIdA.ToString()} --ignore-failed-sources");
+            var command = new ToolUpdateLocalCommand(parseResult);
+            command._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenPassingIgnoreFailedSourcesItShouldNotThrow()
+        {
+            _fileSystem.File.WriteAllText(Path.Combine(_temporaryDirectory, "nuget.config"), _nugetConfigWithInvalidSources);
+            var parseResult = Parser.Instance.Parse($"dotnet tool update {_packageIdA.ToString()} --ignore-failed-sources");
+            var updateLocalCommand = new ToolUpdateLocalCommand(
+                parseResult,
+                _toolPackageDownloaderMock,
+                _toolManifestFinder,
+                _toolManifestEditor,
+                _localToolsResolverCache,
+                _reporter);
+
+            updateLocalCommand.Execute().Should().Be(0);
+
+            _fileSystem.File.Delete(Path.Combine(_temporaryDirectory, "nuget.config"));
         }
 
         [Fact]
@@ -349,6 +376,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
   ""version"": 1,
   ""isRoot"": false,
   ""tools"": {}
+}";
+
+        private string _nugetConfigWithInvalidSources = @"{
+<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""invalid_source"" value=""https://api.nuget.org/v3/invalid.json"" />
+  </packageSources>
+</configuration>
 }";
     }
 }


### PR DESCRIPTION
Description
dotnet tool install or update did not respect the --ignore-failed-sources flag. A fix for this was contributed on main but an automatic backport could not be made.

Testing
Additional unit tests to verify the changes were made, making sure the flag is being parsed accurately and that command execution matches desired results. Manual testing was also made.

Risk
Low - implements missing logic for flag. 

Regression
No

Customer Impact
Allows customers to install or update tools even if one or more of their NuGet feeds is invalid. 

Backport of #44309 to release/8.0.1xx