### PR TITLE
[FIX] tool-update: Compare tool versions correctly

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/install/ToolInstallGlobalOrToolPathCommand.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
         private static bool ToolVersionAlreadyInstalled(IToolPackage oldPackageNullable, NuGetVersion nuGetVersion)
         {
-            return oldPackageNullable != null && (oldPackageNullable.Version.Version == nuGetVersion.Version);
+            return oldPackageNullable != null && (oldPackageNullable.Version == nuGetVersion);
         }
 
         private static void EnsureVersionIsHigher(IToolPackage oldPackageNullable, IToolPackage newInstalledPackage, bool allowDowngrade)

--- a/test/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -201,6 +201,20 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         }
 
         [Fact]
+        public void GivenAnExistedPreviewVersionInstallationWhenUpdateToHigherVersionItSucceeds()
+        {
+            CreateInstallCommand($"-g {_packageId} --version {HigherPreviewPackageVersion} --verbosity minimal");
+            _reporter.Lines.Clear();
+
+            var command = CreateUpdateCommand($"-g {_packageId} --version {HigherPackageVersion} --verbosity minimal");
+            command.Execute().Should().Be(0);
+
+            _reporter.Lines.First().Should().NotContain(string.Format(
+                Microsoft.DotNet.Tools.Tool.Install.LocalizableStrings.ToolAlreadyInstalled,
+                _packageId, HigherPackageVersion));
+        }
+
+        [Fact]
         public void GivenAnExistedHigherversionInstallationWhenUpdateToLowerVersionItErrors()
         {
             CreateInstallCommand($"-g {_packageId} --version {HigherPackageVersion}").Execute();

--- a/test/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -203,15 +203,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         [Fact]
         public void GivenAnExistedPreviewVersionInstallationWhenUpdateToHigherVersionItSucceeds()
         {
-            CreateInstallCommand($"-g {_packageId} --version {HigherPreviewPackageVersion} --verbosity minimal");
+            var installCommand = CreateInstallCommand($"-g {_packageId} --version {HigherPreviewPackageVersion} --verbosity minimal");
+            installCommand.Execute();
             _reporter.Lines.Clear();
 
             var command = CreateUpdateCommand($"-g {_packageId} --version {HigherPackageVersion} --verbosity minimal");
             command.Execute().Should().Be(0);
 
-            _reporter.Lines.First().Should().NotContain(string.Format(
-                Microsoft.DotNet.Tools.Tool.Install.LocalizableStrings.ToolAlreadyInstalled,
-                _packageId, HigherPackageVersion));
+            _reporter.Lines.First().Should().Contain(string.Format(
+                LocalizableStrings.UpdateSucceeded,
+                _packageId, HigherPreviewPackageVersion, HigherPackageVersion));
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #43089 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2288480

When attempting to update a package to a new version, a check is made to ensure the same version is not installed twice. However, this check currently ignores the version suffix, which means users cannot update between versions with different release tags. 