### PR TITLE
Set mediaType from http response if manifest mediaType is not present

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -34,6 +34,11 @@ internal readonly struct BuiltImage
     internal required ManifestV2 Manifest { get; init; }
 
     /// <summary>
+    /// Gets manifest mediaType.
+    /// </summary>
+    internal required string ManifestMediaType { get; init; }
+
+    /// <summary>
     /// Gets layers descriptors.
     /// </summary>
     internal IEnumerable<Descriptor> LayerDescriptors

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -19,6 +19,7 @@ internal sealed class ImageBuilder
 
     // the mutable internal manifest that we're building by modifying the base and applying customizations
     private readonly ManifestV2 _manifest;
+    private readonly string _manifestMediaType;
     private readonly ImageConfig _baseImageConfig;
     private readonly ILogger _logger;
 
@@ -33,12 +34,13 @@ internal sealed class ImageBuilder
     /// <summary>
     /// MediaType of the output manifest.
     /// </summary>
-    public string ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
+    public string ManifestMediaType => _manifestMediaType; // output the same media type as the base image manifest.
 
-    internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig, ILogger logger)
+    internal ImageBuilder(ManifestV2 manifest, string manifestMediaType, ImageConfig baseImageConfig, ILogger logger)
     {
         _baseImageManifest = manifest;
         _manifest = new ManifestV2() { SchemaVersion = manifest.SchemaVersion, Config = manifest.Config, Layers = new(manifest.Layers), MediaType = manifest.MediaType };
+        _manifestMediaType = manifestMediaType;
         _baseImageConfig = baseImageConfig;
         _logger = logger;
     }
@@ -83,6 +85,7 @@ internal sealed class ImageBuilder
             ImageSha = imageSha,
             ImageSize = imageSize,
             Manifest = newManifest,
+            ManifestMediaType = ManifestMediaType
         };
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -33,7 +33,7 @@ internal sealed class ImageBuilder
     /// <summary>
     /// MediaType of the output manifest.
     /// </summary>
-    public string ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
+    public string ManifestMediaType => _manifest.MediaType!; // output the same media type as the base image manifest.
 
     internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig, ILogger logger)
     {

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -33,7 +33,7 @@ internal sealed class ImageBuilder
     /// <summary>
     /// MediaType of the output manifest.
     /// </summary>
-    public string ManifestMediaType => _manifest.MediaType!; // output the same media type as the base image manifest.
+    public string ManifestMediaType => _manifest.MediaType; // output the same media type as the base image manifest.
 
     internal ImageBuilder(ManifestV2 manifest, ImageConfig baseImageConfig, ILogger logger)
     {

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
@@ -30,7 +30,7 @@ public class ManifestV2
     /// When used, this field MUST contain the media type application/vnd.oci.image.manifest.v1+json. This field usage differs from the descriptor use of mediaType.
     /// </summary>
     [JsonPropertyName("mediaType")]
-    public required string MediaType { get; init; }
+    public string? MediaType { get; init; }
 
     /// <summary>
     /// This REQUIRED property references a configuration object for a container, by digest.

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
@@ -30,7 +30,7 @@ public class ManifestV2
     /// When used, this field MUST contain the media type application/vnd.oci.image.manifest.v1+json. This field usage differs from the descriptor use of mediaType.
     /// </summary>
     [JsonPropertyName("mediaType")]
-    public required string MediaType { get; init; }
+    public string? MediaType { get; set; }
 
     /// <summary>
     /// This REQUIRED property references a configuration object for a container, by digest.

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
@@ -30,7 +30,7 @@ public class ManifestV2
     /// When used, this field MUST contain the media type application/vnd.oci.image.manifest.v1+json. This field usage differs from the descriptor use of mediaType.
     /// </summary>
     [JsonPropertyName("mediaType")]
-    public string? MediaType { get; set; }
+    public required string MediaType { get; init; }
 
     /// <summary>
     /// This REQUIRED property references a configuration object for a container, by digest.

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -90,7 +90,7 @@ Microsoft.NET.Build.Containers.ManifestV2.KnownDigest.set -> void
 Microsoft.NET.Build.Containers.ManifestV2.Layers.get -> System.Collections.Generic.List<Microsoft.NET.Build.Containers.ManifestLayer>!
 Microsoft.NET.Build.Containers.ManifestV2.Layers.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.ManifestV2() -> void
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string!
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string?
 Microsoft.NET.Build.Containers.ManifestV2.MediaType.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.get -> int
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.init -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -90,9 +90,8 @@ Microsoft.NET.Build.Containers.ManifestV2.KnownDigest.set -> void
 Microsoft.NET.Build.Containers.ManifestV2.Layers.get -> System.Collections.Generic.List<Microsoft.NET.Build.Containers.ManifestLayer>!
 Microsoft.NET.Build.Containers.ManifestV2.Layers.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.ManifestV2() -> void
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string?
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.set -> void
-
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string!
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.get -> int
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.init -> void
 Microsoft.NET.Build.Containers.PlatformInformation

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -90,8 +90,9 @@ Microsoft.NET.Build.Containers.ManifestV2.KnownDigest.set -> void
 Microsoft.NET.Build.Containers.ManifestV2.Layers.get -> System.Collections.Generic.List<Microsoft.NET.Build.Containers.ManifestLayer>!
 Microsoft.NET.Build.Containers.ManifestV2.Layers.init -> void
 Microsoft.NET.Build.Containers.ManifestV2.ManifestV2() -> void
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string!
-Microsoft.NET.Build.Containers.ManifestV2.MediaType.init -> void
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.get -> string?
+Microsoft.NET.Build.Containers.ManifestV2.MediaType.set -> void
+
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.get -> int
 Microsoft.NET.Build.Containers.ManifestV2.SchemaVersion.init -> void
 Microsoft.NET.Build.Containers.PlatformInformation

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -38,11 +38,11 @@ internal class DefaultManifestOperations : IManifestOperations
         };
     }
 
-    public async Task PutAsync(string repositoryName, string reference, ManifestV2 manifest, CancellationToken cancellationToken)
+    public async Task PutAsync(string repositoryName, string reference, ManifestV2 manifest, string mediaType, CancellationToken cancellationToken)
     {
         string jsonString = JsonSerializer.SerializeToNode(manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
-        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType);
+        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
         HttpResponseMessage putResponse = await _client.PutAsync(new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}"), manifestUploadContent, cancellationToken).ConfigureAwait(false);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -42,7 +42,7 @@ internal class DefaultManifestOperations : IManifestOperations
     {
         string jsonString = JsonSerializer.SerializeToNode(manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
-        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType);
+        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType!);
 
         HttpResponseMessage putResponse = await _client.PutAsync(new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}"), manifestUploadContent, cancellationToken).ConfigureAwait(false);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -42,7 +42,7 @@ internal class DefaultManifestOperations : IManifestOperations
     {
         string jsonString = JsonSerializer.SerializeToNode(manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
-        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType!);
+        manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(manifest.MediaType);
 
         HttpResponseMessage putResponse = await _client.PutAsync(new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}"), manifestUploadContent, cancellationToken).ConfigureAwait(false);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
@@ -14,5 +14,5 @@ internal interface IManifestOperations
 {
     public Task<HttpResponseMessage> GetAsync(string repositoryName, string reference, CancellationToken cancellationToken);
 
-    public Task PutAsync(string repositoryName, string reference, ManifestV2 manifest, CancellationToken cancellationToken);
+    public Task PutAsync(string repositoryName, string reference, ManifestV2 manifest, string mediaType, CancellationToken cancellationToken);
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -215,6 +215,7 @@ internal sealed class Registry
             {
                 manifest.KnownDigest = knownDigestValue;
             }
+            manifest.MediaType ??= initialManifestResponse.Content.Headers.ContentType!.MediaType;
             return manifest;
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -183,6 +183,7 @@ internal sealed class Registry
             SchemaTypes.DockerManifestV2 or SchemaTypes.OciManifestV1 => await ReadSingleImageAsync(
                 repositoryName,
                 await ReadManifest().ConfigureAwait(false),
+                initialManifestResponse.Content.Headers.ContentType.MediaType,
                 cancellationToken).ConfigureAwait(false),
             SchemaTypes.DockerManifestListV2 => await PickBestImageFromManifestListAsync(
                 repositoryName,
@@ -231,7 +232,7 @@ internal sealed class Registry
         };
     }
 
-    private async Task<ImageBuilder> ReadSingleImageAsync(string repositoryName, ManifestV2 manifest, CancellationToken cancellationToken)
+    private async Task<ImageBuilder> ReadSingleImageAsync(string repositoryName, ManifestV2 manifest, string manifestMediaType, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ManifestConfig config = manifest.Config;
@@ -240,7 +241,8 @@ internal sealed class Registry
         JsonNode configDoc = await _registryAPI.Blob.GetJsonAsync(repositoryName, configSha, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        return new ImageBuilder(manifest, new ImageConfig(configDoc), _logger);
+        // ManifestV2.MediaType can be null, so we also provide manifest mediaType from http response
+        return new ImageBuilder(manifest, manifest.MediaType ?? manifestMediaType, new ImageConfig(configDoc), _logger);
     }
 
 
@@ -348,6 +350,7 @@ internal sealed class Registry
             return await ReadSingleImageAsync(
                 repositoryName,
                 manifest,
+                matchingManifest.mediaType,
                 cancellationToken).ConfigureAwait(false);
         }
         else
@@ -560,7 +563,7 @@ internal sealed class Registry
             foreach (string tag in destination.Tags)
             {
                 _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
-                await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
+                await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
                 _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
             }
         }
@@ -568,7 +571,7 @@ internal sealed class Registry
         {
             string manifestDigest = builtImage.Manifest.GetDigest();
             _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, manifestDigest);
-            await _registryAPI.Manifest.PutAsync(destination.Repository, manifestDigest, builtImage.Manifest, cancellationToken).ConfigureAwait(false);
+            await _registryAPI.Manifest.PutAsync(destination.Repository, manifestDigest, builtImage.Manifest, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation(Strings.Registry_ManifestUploaded, RegistryName);
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -215,7 +215,6 @@ internal sealed class Registry
             {
                 manifest.KnownDigest = knownDigestValue;
             }
-            manifest.MediaType ??= initialManifestResponse.Content.Headers.ContentType!.MediaType;
             return manifest;
         }
     }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -702,6 +702,6 @@ public class ImageBuilderTests
             Layers = new List<ManifestLayer>(),
             KnownDigest = StaticKnownDigestValue
         };
-        return new ImageBuilder(manifest, new ImageConfig(baseImageConfig), _loggerFactory.CreateLogger(testName));
+        return new ImageBuilder(manifest, manifest.MediaType, new ImageConfig(baseImageConfig), _loggerFactory.CreateLogger(testName));
     }
 }


### PR DESCRIPTION
### Context

Fixes https://github.com/dotnet/sdk-container-builds/issues/567.

### Customer impact

Some (rare) images do not have a media type, which instructs container tooling how to interpret the data in the container image. Our tooling incorrectly interpreted the spec and required the mediaType to be present, instead of probing and defaulting to a fallback mediaType if one is present. Without this change, users using custom base images may be blocked from using the SDK tooling.

### Details
Manifest MediaType field is optional in the docs.  

I found this when I was trying to set base image as an oci image. For that i used `skopeo` to convert aspnet 8 to oci image. 
```
skopeo copy docker://mcr.microsoft.com/dotnet/aspnet:8.0 oci:/path/to/aspnet_oci:latest
skopeo oci:/path/to/aspnet_oci:latest docker://docker.io/{user}/my-aspnet:8.0
```
that image manifest didn't have mediaType. I got "error MSB4018: The "CreateNewImage" task failed unexpectedly." that failed here :
https://github.com/dotnet/sdk/blob/1ed097ec1a8e88f9427b540ac3f83ac132b3f767/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs#L213

### Changes
Made ManifestV2.MediaType optional
Set mediaType from http response content for image building in case when manifest mediaType is not present.

Related https://github.com/dotnet/sdk/pull/40776

### Risk

*Low* - These images are rare in the wild, though some fairly-widely-used tooling does seem to trigger this corner case.