### PR TITLE
sln-list: Support for slnx

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -183,4 +183,10 @@
   <data name="SlnxGenerated" xml:space="preserve">
     <value>.slnx file {0} generated.</value>
   </data>
+  <data name="CannotMigrateSlnx" xml:space="preserve">
+    <value>Cannot migrate .slnx file.</value>
+  </data>
+  <data name="SerializerNotFound" xml:space="preserve">
+    <value>Could not find serializer for file {0}.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -184,9 +184,9 @@
     <value>.slnx file {0} generated.</value>
   </data>
   <data name="CannotMigrateSlnx" xml:space="preserve">
-    <value>Cannot migrate .slnx file.</value>
+    <value>Only .sln files can be migrated to .slnx format.</value>
   </data>
   <data name="SerializerNotFound" xml:space="preserve">
-    <value>Could not find serializer for file {0}.</value>
+    <value>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli
         {
             if (File.Exists(slnFileOrDirectory))
             {
-                return slnFileOrDirectory;
+                return Path.GetFullPath(slnFileOrDirectory);
             }
             if (Directory.Exists(slnFileOrDirectory))
             {
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli
                 {
                     throw new GracefulException(CommonLocalizableStrings.MoreThanOneSolutionInDirectory, slnFileOrDirectory);
                 }
-                return files.Single().ToString();
+                return Path.GetFullPath(files.Single().ToString());
             }
             throw new GracefulException(CommonLocalizableStrings.CouldNotFindSolutionOrDirectory, slnFileOrDirectory);
         }

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli
             ISolutionSerializer? serializer = SolutionSerializers.GetSerializerByMoniker(solutionFilePath);
             if (serializer is null)
             {
-                throw new GracefulException(CommonLocalizableStrings.SerializerNotFound, solutionFilePath);
+                throw new GracefulException(LocalizableStrings.SerializerNotFound, solutionFilePath);
             }
             return serializer;
         }

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -4,6 +4,8 @@
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
+using Microsoft.VisualStudio.SolutionPersistence;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using NuGet.Packaging;
 using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
 
@@ -68,6 +70,16 @@ namespace Microsoft.DotNet.Cli
                 return Path.GetFullPath(files.Single().ToString());
             }
             throw new GracefulException(CommonLocalizableStrings.CouldNotFindSolutionOrDirectory, slnFileOrDirectory);
+        }
+
+        internal static ISolutionSerializer GetSolutionSerializer(string solutionFilePath)
+        {
+            ISolutionSerializer? serializer = SolutionSerializers.GetSerializerByMoniker(solutionFilePath);
+            if (serializer is null)
+            {
+                throw new GracefulException(CommonLocalizableStrings.SerializerNotFound, solutionFilePath);
+            }
+            return serializer;
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -54,7 +54,9 @@ namespace Microsoft.DotNet.Cli
             }
             if (Directory.Exists(slnFileOrDirectory))
             {
-                var files = Directory.GetFiles(slnFileOrDirectory, "*.sln", SearchOption.TopDirectoryOnly);
+                string[] files = [
+                    ..Directory.GetFiles(slnFileOrDirectory, "*.sln", SearchOption.TopDirectoryOnly),
+                    ..Directory.GetFiles(slnFileOrDirectory, "*.slnx", SearchOption.TopDirectoryOnly)];
                 if (files.Length == 0)
                 {
                     throw new GracefulException(CommonLocalizableStrings.CouldNotFindSolutionIn, slnFileOrDirectory);

--- a/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnCommandParser.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli
                 {
                     throw new GracefulException(CommonLocalizableStrings.MoreThanOneSolutionInDirectory, slnFileOrDirectory);
                 }
-                return Path.GetFullPath(files.Single().ToString());
+                return Path.GetFullPath(files.Single());
             }
             throw new GracefulException(CommonLocalizableStrings.CouldNotFindSolutionOrDirectory, slnFileOrDirectory);
         }

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -31,22 +31,17 @@ namespace Microsoft.DotNet.Tools.Sln.List
             try
             {
                 ListAllProjectsAsync(solutionFileFullPath, CancellationToken.None).Wait();
+                return 0;
             }
             catch (Exception ex)
             {
                 throw new GracefulException(ex.Message, ex);
             }
-            return 0;
         }
 
         private async Task ListAllProjectsAsync(string solutionFileFullPath, CancellationToken cancellationToken)
         {
-            ISolutionSerializer? serializer = SolutionSerializers.GetSerializerByMoniker(solutionFileFullPath);
-            if (serializer == null)
-            {
-                throw new GracefulException("Could not find serializer for file {0}", solutionFileFullPath);
-            }
-
+            ISolutionSerializer serializer = SlnCommandParser.GetSolutionSerializer(solutionFileFullPath);
             SolutionModel solution = await serializer.OpenAsync(solutionFileFullPath, cancellationToken);
             string[] paths = solution.SolutionProjects
                 .Where(solution => _displaySolutionFolders ? (solution.Type == ProjectTypeGuids.SolutionFolderGuid) : (solution.Type != ProjectTypeGuids.SolutionFolderGuid))

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -39,7 +39,6 @@ namespace Microsoft.DotNet.Tools.Sln.List
 
         private async Task ListAllProjectsAsync(string solutionFileFullPath, CancellationToken cancellationToken)
         {
-            Guid solutionFolderGuid = new Guid(ProjectTypeGuids.SolutionFolderGuid);
             ISolutionSerializer serializer = SlnCommandParser.GetSolutionSerializer(solutionFileFullPath);
             SolutionModel solution = await serializer.OpenAsync(solutionFileFullPath, cancellationToken);
             string[] paths;

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.Cli.Sln.Internal;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.VisualStudio.SolutionPersistence;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
+using CommandLocalizableStrings = Microsoft.DotNet.Tools.CommonLocalizableStrings;
 
 namespace Microsoft.DotNet.Tools.Sln.List
 {
@@ -32,7 +33,7 @@ namespace Microsoft.DotNet.Tools.Sln.List
             }
             catch (Exception ex)
             {
-                throw new GracefulException(ex.Message, ex);
+                throw new GracefulException(CommandLocalizableStrings.InvalidSolutionFormatString, solutionFileFullPath, ex.Message);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -46,7 +46,8 @@ namespace Microsoft.DotNet.Tools.Sln.List
             if (_displaySolutionFolders)
             {
                 paths = solution.SolutionFolders
-                    .Select(folder => folder.Path.Substring(1))
+                    // VS-SolutionPersistence does not return a path object, so there might be issues with forward/backward slashes on different platforms
+                    .Select(folder => Path.GetDirectoryName(folder.Path.TrimStart("/")))
                     .ToArray();
             }
             else

--- a/src/Cli/dotnet/commands/dotnet-sln/migrate/SlnMigrateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/migrate/SlnMigrateCommand.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.SolutionPersistence;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
 using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
+using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -26,13 +27,17 @@ namespace Microsoft.DotNet.Cli
             IReporter reporter = null)
             : base(parseResult)
         {
-            _slnFileOrDirectory = Path.GetFullPath(parseResult.GetValue(SlnCommandParser.SlnArgument));
+            _slnFileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
             _reporter = reporter ?? Reporter.Output;
         }
 
         public override int Execute()
         {
             string slnFileFullPath = SlnCommandParser.GetSlnFileFullPath(_slnFileOrDirectory);
+            if (slnFileFullPath.HasExtension(".slnx"))
+            {
+                throw new GracefulException("Cannot migrate a .slnx file");
+            }
             string slnxFileFullPath = Path.ChangeExtension(slnFileFullPath, "slnx");
             try
             {

--- a/src/Cli/dotnet/commands/dotnet-sln/migrate/SlnMigrateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/migrate/SlnMigrateCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli
             string slnFileFullPath = SlnCommandParser.GetSlnFileFullPath(_slnFileOrDirectory);
             if (slnFileFullPath.HasExtension(".slnx"))
             {
-                throw new GracefulException("Cannot migrate a .slnx file");
+                throw new GracefulException(LocalizableStrings.CannotMigrateSlnx);
             }
             string slnxFileFullPath = Path.ChangeExtension(slnFileFullPath, "slnx");
             try
@@ -50,12 +50,7 @@ namespace Microsoft.DotNet.Cli
 
         private async Task ConvertToSlnxAsync(string filePath, string slnxFilePath, CancellationToken cancellationToken)
         {
-            // See if the file is a known solution file.
-            ISolutionSerializer? serializer = SolutionSerializers.GetSerializerByMoniker(filePath);
-            if (serializer is null)
-            {
-                throw new GracefulException("Could not find serializer for file {0}", filePath);
-            }
+            ISolutionSerializer serializer = SlnCommandParser.GetSolutionSerializer(filePath);
             SolutionModel solution = await serializer.OpenAsync(filePath, cancellationToken);
             await SolutionSerializers.SlnXml.SaveAsync(slnxFilePath, solution, cancellationToken);
             _reporter.WriteLine(LocalizableStrings.SlnxGenerated, slnxFilePath);

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Přidá do souboru řešení jeden nebo více projektů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umístěte projekt do kořene řešení, není potřeba vytvářet složku řešení.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Vypíše seznam všech projektů v řešení.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Fügt einer Projektmappendatei ein oder mehrere Projekte hinzu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Platzieren Sie das Projekt im Stamm der Projektmappe, statt einen Projektmappenordner zu erstellen.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Listet alle Projekte in der Projektmappe auf.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Agrega uno o varios proyectos a un archivo de solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque el proyecto en la raíz de la solución, en lugar de crear una carpeta de soluciones.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Enumere todos los proyectos de la solución.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Ajoutez un ou plusieurs projets à un fichier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Place le projet à la racine de la solution, au lieu de créer un dossier solution.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Répertoriez tous les projets de la solution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Consente di aggiungere uno o più progetti a un file di soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Inserisce il progetto nella radice della soluzione invece di creare una cartella soluzione.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Elenca tutti i progetti presenti nella soluzione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">1 つ以上のプロジェクトをソリューション ファイルに追加します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">ソリューション フォルダーを作成するのではなく、プロジェクトをソリューションのルートに配置します。</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">ソリューション内のすべてのプロジェクトを一覧表示します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">솔루션 파일에 하나 이상의 프로젝트를 추가합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">솔루션 폴더를 만드는 대신, 솔루션의 루트에 프로젝트를 배치하세요.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">솔루션의 프로젝트를 모두 나열합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Dodaj co najmniej jeden projekt do pliku rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Umieść projekt w katalogu głównym rozwiązania zamiast tworzyć folder rozwiązania.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Wyświetl listę wszystkich projektów w rozwiązaniu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Adicionar um ou mais projetos em um arquivo de solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Coloque o projeto na raiz da solução, em vez de criar uma pasta da solução.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Listar todos os projetos na solução.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Добавление проектов в файл решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Поместите проект в корень решения вместо создания папки решения.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Перечисляет все проекты в решении.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Bir çözüm dosyasına bir veya daha fazla proje ekler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">Bir çözüm klasörü oluşturmak yerine projeyi çözümün köküne yerleştirin.</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">Çözümdeki tüm projeleri listeleyin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">将一个或多个项目添加到解决方案文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">将项目放在解决方案的根目录下，而不是创建解决方案文件夹。</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">列出解决方案中的所有项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotMigrateSlnx">
-        <source>Cannot migrate .slnx file.</source>
-        <target state="new">Cannot migrate .slnx file.</target>
+        <source>Only .sln files can be migrated to .slnx format.</source>
+        <target state="new">Only .sln files can be migrated to .slnx format.</target>
         <note />
       </trans-unit>
       <trans-unit id="InRoot">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SerializerNotFound">
-        <source>Could not find serializer for file {0}.</source>
-        <target state="new">Could not find serializer for file {0}.</target>
+        <source>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</source>
+        <target state="new">Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">為解決方案檔新增一或多個專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotMigrateSlnx">
+        <source>Cannot migrate .slnx file.</source>
+        <target state="new">Cannot migrate .slnx file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InRoot">
         <source>Place project in root of the solution, rather than creating a solution folder.</source>
         <target state="translated">請將專案放置在解決方案的根目錄中，而非放置於建立解決方案的資料夾中。</target>
@@ -60,6 +65,11 @@
       <trans-unit id="ListSubcommandHelpText">
         <source>List all projects in the solution.</source>
         <target state="translated">列出解決方案中的所有專案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SerializerNotFound">
+        <source>Could not find serializer for file {0}.</source>
+        <target state="new">Could not find serializer for file {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="SlnxGenerated">

--- a/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
@@ -100,7 +100,8 @@ Options:
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(solutionCommand, "InvalidSolution.sln", "list");
             cmd.Should().Fail();
-            cmd.StdErr.Should().Be(string.Format(CommonLocalizableStrings.InvalidSolutionFormatString, "InvalidSolution.sln", LocalizableStrings.FileHeaderMissingError));
+            cmd.StdErr.Should().Contain(
+                String.Format(CommonLocalizableStrings.InvalidSolutionFormatString, Path.Combine(projectDirectory, "InvalidSolution.sln"), "").TrimEnd("."));
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
         }
 
@@ -119,7 +120,8 @@ Options:
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(solutionCommand, "list");
             cmd.Should().Fail();
-            cmd.StdErr.Should().Be(string.Format(CommonLocalizableStrings.InvalidSolutionFormatString, solutionFullPath, LocalizableStrings.FileHeaderMissingError));
+            cmd.StdErr.Should().Contain(
+                String.Format(CommonLocalizableStrings.InvalidSolutionFormatString, solutionFullPath, "").TrimEnd("."));
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
         }
 

--- a/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
@@ -101,7 +101,7 @@ Options:
                 .Execute(solutionCommand, "InvalidSolution.sln", "list");
             cmd.Should().Fail();
             cmd.StdErr.Should().Contain(
-                String.Format(CommonLocalizableStrings.InvalidSolutionFormatString, Path.Combine(projectDirectory, "InvalidSolution.sln"), "").TrimEnd("."));
+                string.Format(CommonLocalizableStrings.InvalidSolutionFormatString, Path.Combine(projectDirectory, "InvalidSolution.sln"), "").TrimEnd("."));
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
         }
 
@@ -121,7 +121,7 @@ Options:
                 .Execute(solutionCommand, "list");
             cmd.Should().Fail();
             cmd.StdErr.Should().Contain(
-                String.Format(CommonLocalizableStrings.InvalidSolutionFormatString, solutionFullPath, "").TrimEnd("."));
+                string.Format(CommonLocalizableStrings.InvalidSolutionFormatString, solutionFullPath, "").TrimEnd("."));
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
         }
 


### PR DESCRIPTION
Contributes to #40913 
> The dotnet CLI should support the new slnx format for building and in the existing solution management commands. It should also help interested users migrate to the new format.

This adds `dotnet sln list` support for .slnx files

![image](https://github.com/user-attachments/assets/1ac24c1e-c79e-4ed4-a02d-1e686cb0ec30)

-----

This also adds reusable logic to `SlnCommandParser` to be reused by other sln commands moving forward.
