### PR TITLE
Browser refresh and WASM delta applier refactoring

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/.editorconfig
+++ b/src/BuiltInTools/BrowserRefresh/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 2

--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,3 +1,6 @@
+// Use by older versions of Microsoft.AspNetCore.Components.WebAssembly.
+// For back compat only. 
+
 export function receiveHotReload() {
   return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));
 }

--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,5 +1,5 @@
 // Used by older versions of Microsoft.AspNetCore.Components.WebAssembly.
-// For back compat only until updated ASP.NET is inserted into the SDK.
+// For back compat only to support WASM packages older than the SDK.
 
 export function receiveHotReload() {
   return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));

--- a/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
+++ b/src/BuiltInTools/BrowserRefresh/BlazorHotReload.js
@@ -1,5 +1,5 @@
-// Use by older versions of Microsoft.AspNetCore.Components.WebAssembly.
-// For back compat only. 
+// Used by older versions of Microsoft.AspNetCore.Components.WebAssembly.
+// For back compat only until updated ASP.NET is inserted into the SDK.
 
 export function receiveHotReload() {
   return BINDING.js_to_mono_obj(new Promise((resolve) => receiveHotReloadAsync().then(resolve(0))));
@@ -8,10 +8,12 @@ export function receiveHotReload() {
 export async function receiveHotReloadAsync() {
   const response = await fetch('/_framework/blazor-hotreload');
   if (response.status === 200) {
-    const deltas = await response.json();
-    if (deltas) {
+    const updates = await response.json();
+    if (updates) {
       try {
-        deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta, d.updatedTypes));
+        updates.forEach(u => {
+          u.deltas.forEach(d => window.Blazor._internal.applyHotReload(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta, d.updatedTypes));
+        })
       } catch (error) {
         console.warn(error);
         return;

--- a/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
     /// A middleware that manages receiving and sending deltas from a BlazorWebAssembly app.
     /// This assembly is shared between Visual Studio and dotnet-watch. By putting some of the complexity
     /// in here, we can avoid duplicating work in watch and VS.
+    ///
+    /// Mapped to <see cref="ApplicationPaths.BlazorHotReloadMiddleware"/>.
     /// </summary>
     internal sealed class BlazorWasmHotReloadMiddleware
     {

--- a/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
@@ -15,9 +13,22 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
     /// </summary>
     internal sealed class BlazorWasmHotReloadMiddleware
     {
-        private readonly object @lock = new();
-        private readonly string EtagDiscriminator = Guid.NewGuid().ToString();
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        internal sealed class Update
+        {
+            public int Id { get; set; }
+            public Delta[] Deltas { get; set; } = default!;
+        }
+
+        internal sealed class Delta
+        {
+            public string ModuleId { get; set; } = default!;
+            public string MetadataDelta { get; set; } = default!;
+            public string ILDelta { get; set; } = default!;
+            public string PdbDelta { get; set; } = default!;
+            public int[] UpdatedTypes { get; set; } = default!;
+        }
+
+        private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
@@ -26,13 +37,13 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         {
         }
 
-        internal List<UpdateDelta> Deltas { get; } = new();
+        internal List<Update> Updates { get; } = [];
 
         public Task InvokeAsync(HttpContext context)
         {
             // Multiple instances of the BlazorWebAssembly app could be running (multiple tabs or multiple browsers).
             // We want to avoid serialize reads and writes between then
-            lock (@lock)
+            lock (Updates)
             {
                 if (HttpMethods.IsGet(context.Request.Method))
                 {
@@ -54,85 +65,31 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
         private async Task OnGet(HttpContext context)
         {
-            if (Deltas.Count == 0)
+            if (Updates.Count == 0)
             {
                 context.Response.StatusCode = StatusCodes.Status204NoContent;
                 return;
             }
 
-            if (EtagMatches(context))
-            {
-                context.Response.StatusCode = StatusCodes.Status304NotModified;
-                return;
-            }
-
-            WriteETag(context);
-            await JsonSerializer.SerializeAsync(context.Response.Body, Deltas, _jsonSerializerOptions);
-        }
-
-        private bool EtagMatches(HttpContext context)
-        {
-            if (context.Request.Headers[HeaderNames.IfNoneMatch] is not { Count: 1 } ifNoneMatch)
-            {
-                return false;
-            }
-
-            var expected = GetETag();
-            return string.Equals(expected, ifNoneMatch[0], StringComparison.Ordinal);
+            await JsonSerializer.SerializeAsync(context.Response.Body, Updates, s_jsonSerializerOptions);
         }
 
         private async Task OnPost(HttpContext context)
         {
-            var updateDeltas = await JsonSerializer.DeserializeAsync<UpdateDelta[]>(context.Request.Body, _jsonSerializerOptions);
-            AppendDeltas(updateDeltas);
-
-            WriteETag(context);
-        }
-
-        private void WriteETag(HttpContext context)
-        {
-            var etag = GetETag();
-            if (etag is not null)
+            var update = await JsonSerializer.DeserializeAsync<Update>(context.Request.Body, s_jsonSerializerOptions);
+            if (update == null)
             {
-                context.Response.Headers[HeaderNames.ETag] = etag;
-            }
-        }
-
-        private string? GetETag()
-        {
-            if (Deltas.Count == 0)
-            {
-                return null;
-            }
-
-            return string.Format(CultureInfo.InvariantCulture, "W/\"{0}{1}\"", EtagDiscriminator, Deltas[^1].SequenceId);
-        }
-
-        private void AppendDeltas(UpdateDelta[]? updateDeltas)
-        {
-            if (updateDeltas == null || updateDeltas.Length == 0)
-            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 return;
             }
 
             // It's possible that multiple instances of the BlazorWasm are simultaneously executing and could be posting the same deltas
             // We'll use the sequence id to ensure that we're not recording duplicate entries. Replaying duplicated values would cause
             // ApplyDelta to fail.
-            // It's currently not possible to receive different ranges of sequences from different clients (for e.g client 1 sends deltas 1 - 3,
-            // and client 2 sends deltas 2 - 4, client 3 sends 1 - 5 etc), so we only need to verify that the first item in the sequence has not already been seen.
-            if (Deltas.Count == 0 || Deltas[^1].SequenceId < updateDeltas[0].SequenceId)
+            if (Updates is [] || Updates[^1].Id < update.Id)
             {
-                Deltas.AddRange(updateDeltas);
+                Updates.Add(update);
             }
-        }
-
-        internal class UpdateDelta
-        {
-            public int SequenceId { get; set; }
-            public string ModuleId { get; set; } = default!;
-            public string MetadataDelta { get; set; } = default!;
-            public string ILDelta { get; set; } = default!;
-            public int[]? UpdatedTypes { get; set; } = default!;
         }
     }
 }

--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -11,10 +11,10 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
     public class BrowserRefreshMiddleware
     {
-        private static readonly MediaTypeHeaderValue _textHtmlMediaType = new("text/html");
-        private static readonly MediaTypeHeaderValue _applicationJsonMediaType = new("application/json");
-        private readonly string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
-        private readonly string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
+        private static readonly MediaTypeHeaderValue s_textHtmlMediaType = new("text/html");
+        private static readonly MediaTypeHeaderValue s_applicationJsonMediaType = new("application/json");
+        private static readonly string? s_dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
+        private static readonly string? s_aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
 
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
@@ -76,9 +76,9 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             {
                 if (!context.Response.Headers.ContainsKey("DOTNET-MODIFIABLE-ASSEMBLIES"))
                 {
-                    if(_dotnetModifiableAssemblies != null)
+                    if(s_dotnetModifiableAssemblies != null)
                     {
-                        context.Response.Headers.Add("DOTNET-MODIFIABLE-ASSEMBLIES", _dotnetModifiableAssemblies);
+                        context.Response.Headers.Add("DOTNET-MODIFIABLE-ASSEMBLIES", s_dotnetModifiableAssemblies);
                     }
                     else
                     {
@@ -92,9 +92,9 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
                 if (!context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"))
                 {
-                    if (_aspnetcoreBrowserTools != null)
+                    if (s_aspnetcoreBrowserTools != null)
                     {
-                        context.Response.Headers.Add("ASPNETCORE-BROWSER-TOOLS", _aspnetcoreBrowserTools);
+                        context.Response.Headers.Add("ASPNETCORE-BROWSER-TOOLS", s_aspnetcoreBrowserTools);
                     }
                     else
                     {
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             for (var i = 0; i < acceptHeaders.Count; i++)
             {
-                if (acceptHeaders[i].MatchesAllTypes || acceptHeaders[i].IsSubsetOf(_applicationJsonMediaType))
+                if (acceptHeaders[i].MatchesAllTypes || acceptHeaders[i].IsSubsetOf(s_applicationJsonMediaType))
                 {
                     return true;
                 }
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             for (var i = 0; i < acceptHeaders.Count; i++)
             {
-                if (acceptHeaders[i].IsSubsetOf(_textHtmlMediaType))
+                if (acceptHeaders[i].IsSubsetOf(s_textHtmlMediaType))
                 {
                     return true;
                 }

--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -9,39 +9,33 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
-    public class BrowserRefreshMiddleware
+    public sealed class BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger)
     {
         private static readonly MediaTypeHeaderValue s_textHtmlMediaType = new("text/html");
         private static readonly MediaTypeHeaderValue s_applicationJsonMediaType = new("application/json");
-        private static readonly string? s_dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
-        private static readonly string? s_aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
-
-        private readonly RequestDelegate _next;
-        private readonly ILogger _logger;
+        private string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
+        private string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
 
         private static string? GetNonEmptyEnvironmentVariableValue(string name)
             => Environment.GetEnvironmentVariable(name) is { Length: > 0 } value ? value : null;
-
-        public BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger) =>
-            (_next, _logger) = (next, logger);
 
         public async Task InvokeAsync(HttpContext context)
         {
             if (IsWebAssemblyBootRequest(context))
             {
                 AttachWebAssemblyHeaders(context);
-                await _next(context);
+                await next(context);
             }
             else if (IsBrowserDocumentRequest(context))
             {
                 // Use a custom StreamWrapper to rewrite output on Write/WriteAsync
-                using var responseStreamWrapper = new ResponseStreamWrapper(context, _logger);
+                using var responseStreamWrapper = new ResponseStreamWrapper(context, logger);
                 var originalBodyFeature = context.Features.Get<IHttpResponseBodyFeature>();
                 context.Features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(responseStreamWrapper));
 
                 try
                 {
-                    await _next(context);
+                    await next(context);
                 }
                 finally
                 {
@@ -52,21 +46,21 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 {
                     if (responseStreamWrapper.ScriptInjectionPerformed)
                     {
-                        Log.BrowserConfiguredForRefreshes(_logger);
+                        Log.BrowserConfiguredForRefreshes(logger);
                     }
                     else if (context.Response.Headers.TryGetValue(HeaderNames.ContentEncoding, out var contentEncodings))
                     {
-                        Log.ResponseCompressionDetected(_logger, contentEncodings);
+                        Log.ResponseCompressionDetected(logger, contentEncodings);
                     }
                     else
                     {
-                        Log.FailedToConfiguredForRefreshes(_logger);
+                        Log.FailedToConfiguredForRefreshes(logger);
                     }
                 }
             }
             else
             {
-                await _next(context);
+                await next(context);
             }
         }
 
@@ -76,34 +70,34 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             {
                 if (!context.Response.Headers.ContainsKey("DOTNET-MODIFIABLE-ASSEMBLIES"))
                 {
-                    if(s_dotnetModifiableAssemblies != null)
+                    if (_dotnetModifiableAssemblies != null)
                     {
-                        context.Response.Headers.Add("DOTNET-MODIFIABLE-ASSEMBLIES", s_dotnetModifiableAssemblies);
+                        context.Response.Headers.Add("DOTNET-MODIFIABLE-ASSEMBLIES", _dotnetModifiableAssemblies);
                     }
                     else
                     {
-                        _logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES environment variable is not set, likely because hot reload is not enabled. The browser refresh feature may not work as expected.");
+                        logger.LogDebug("DOTNET_MODIFIABLE_ASSEMBLIES environment variable is not set, likely because hot reload is not enabled. The browser refresh feature may not work as expected.");
                     }
                 }
                 else
                 {
-                    _logger.LogDebug("DOTNET-MODIFIABLE-ASSEMBLIES header is already set.");
+                    logger.LogDebug("DOTNET-MODIFIABLE-ASSEMBLIES header is already set.");
                 }
 
                 if (!context.Response.Headers.ContainsKey("ASPNETCORE-BROWSER-TOOLS"))
                 {
-                    if (s_aspnetcoreBrowserTools != null)
+                    if (_aspnetcoreBrowserTools != null)
                     {
-                        context.Response.Headers.Add("ASPNETCORE-BROWSER-TOOLS", s_aspnetcoreBrowserTools);
+                        context.Response.Headers.Add("ASPNETCORE-BROWSER-TOOLS", _aspnetcoreBrowserTools);
                     }
                     else
                     {
-                        _logger.LogDebug("__ASPNETCORE_BROWSER_TOOLS environment variable is not set. The browser refresh feature may not work as expected.");
+                        logger.LogDebug("__ASPNETCORE_BROWSER_TOOLS environment variable is not set. The browser refresh feature may not work as expected.");
                     }
                 }
                 else
                 {
-                    _logger.LogDebug("ASPNETCORE-BROWSER-TOOLS header is already set.");
+                    logger.LogDebug("ASPNETCORE-BROWSER-TOOLS header is already set.");
                 }
 
                 return Task.CompletedTask;
@@ -182,6 +176,12 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             }
 
             return false;
+        }
+
+        internal void Test_SetEnvironment(string dotnetModifiableAssemblies, string aspnetcoreBrowserTools)
+        {
+            _dotnetModifiableAssemblies = dotnetModifiableAssemblies;
+            _aspnetcoreBrowserTools = aspnetcoreBrowserTools;
         }
 
         internal static class Log

--- a/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserScriptMiddleware.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             await context.Response.Body.WriteAsync(_scriptBytes.AsMemory(), context.RequestAborted);
         }
 
+        // for backwards compat only
         internal static byte[] GetBlazorHotReloadJS()
         {
             var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorHotReload.js";

--- a/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
@@ -45,9 +45,6 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
                         app.Map(ApplicationPaths.BrowserRefreshJS,
                             static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBrowserRefreshJS()));
-
-                        app.Map(ApplicationPaths.BlazorHotReloadJS,
-                            static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBlazorHotReloadJS()));
                     });
 
                 app.UseMiddleware<BrowserRefreshMiddleware>();

--- a/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
@@ -45,6 +45,10 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
                         app.Map(ApplicationPaths.BrowserRefreshJS,
                             static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBrowserRefreshJS()));
+
+                        // backwards compat only:
+                        app.Map(ApplicationPaths.BlazorHotReloadJS,
+                            static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBlazorHotReloadJS()));
                     });
 
                 app.UseMiddleware<BrowserRefreshMiddleware>();

--- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
@@ -11,17 +11,19 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <EmbeddedResource Include="WebSocketScriptInjection.js" />
+
+    <!-- Back compat only -->
     <EmbeddedResource Include="BlazorHotReload.js" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <!-- Reference 6.0.2 targeting packs in Source Build - this was the earliest version after the API surface stabilized -->
-    <FrameworkReference
-      Update="Microsoft.AspNetCore.App"
-      TargetingPackVersion="6.0.2" />
-    <FrameworkReference
-      Update="Microsoft.NETCore.App"
-      TargetingPackVersion="6.0.2" />
+    <FrameworkReference Update="Microsoft.AspNetCore.App" TargetingPackVersion="6.0.2" />
+    <FrameworkReference Update="Microsoft.NETCore.App" TargetingPackVersion="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Watch.BrowserRefresh.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -44,8 +44,9 @@ setTimeout(async function () {
       const payload = JSON.parse(message.data);
       const action = {
         'UpdateStaticFile': () => updateStaticFile(payload.path),
-        'BlazorHotReloadDeltav1': () => applyBlazorDeltas(payload.sharedSecret, payload.deltas, false),
-        'BlazorHotReloadDeltav2': () => applyBlazorDeltas(payload.sharedSecret, payload.deltas, true),
+        'BlazorHotReloadDeltav1': () => applyBlazorDeltas_legacy(payload.sharedSecret, payload.deltas, false),
+        'BlazorHotReloadDeltav2': () => applyBlazorDeltas_legacy(payload.sharedSecret, payload.deltas, true),
+        'BlazorHotReloadDeltav3': () => applyBlazorDeltas(payload.sharedSecret, payload.updateId, payload.deltas, payload.responseLoggingLevel),
         'HotReloadDiagnosticsv1': () => displayDiagnostics(payload.diagnostics),
         'BlazorRequestApplyUpdateCapabilities': () => getBlazorWasmApplyUpdateCapabilities(false),
         'BlazorRequestApplyUpdateCapabilities2': () => getBlazorWasmApplyUpdateCapabilities(true),
@@ -95,19 +96,22 @@ setTimeout(async function () {
       .forEach(e => updateCssElement(e));
   }
 
+  function getMessageAndStack(error) {
+    const message = error.message || '<unknown error>'
+    let messageAndStack = error.stack || message
+    if (!messageAndStack.includes(message)) {
+      messageAndStack = message + "\n" + messageAndStack;
+    }
+
+    return messageAndStack
+  }
+
   function getBlazorWasmApplyUpdateCapabilities(sendErrorToClient) {
     let applyUpdateCapabilities;
     try {
       applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
     } catch (error) {
-      const message = error.message || '<unknown error>'
-      let messageAndStack = error.stack || message
-      if (!messageAndStack.includes(message))
-      {
-         messageAndStack = message + "\n" + messageAndStack;
-      }
-
-      applyUpdateCapabilities = sendErrorToClient ? "!" + messageAndStack : '';
+      applyUpdateCapabilities = sendErrorToClient ? "!" + getMessageAndStack(error) : '';
     }
     connection.send(applyUpdateCapabilities);
   }
@@ -133,7 +137,7 @@ setTimeout(async function () {
     styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
   }
 
-  async function applyBlazorDeltas(serverSecret, deltas, sendErrorToClient) {
+  async function applyBlazorDeltas_legacy(serverSecret, deltas, sendErrorToClient) {
     if (sharedSecret && (serverSecret != sharedSecret.encodedSharedSecret)) {
       // Validate the shared secret if it was specified. It might be unspecified in older versions of VS
       // that do not support this feature as yet.
@@ -166,6 +170,63 @@ setTimeout(async function () {
       sendDeltaNotApplied(sendErrorToClient ? applyError : undefined);
     } else {
       sendDeltaApplied();
+      notifyHotReloadApplied();
+    }
+  }
+
+  async function applyBlazorDeltas(serverSecret, updateId, deltas, responseLoggingLevel) {
+    if (sharedSecret && (serverSecret != sharedSecret.encodedSharedSecret)) {
+      // Validate the shared secret if it was specified. It might be unspecified in older versions of VS
+      // that do not support this feature as yet.
+      throw 'Unable to validate the server. Rejecting apply-update payload.';
+    }
+
+    const AgentMessageSeverity_Error = 2
+
+    let applyError = undefined;
+    let log = [];
+    if (window.Blazor?._internal?.applyHotReloadDeltas) {
+      // Only apply hot reload deltas if Blazor has been initialized.
+      // It's possible for Blazor to start after the initial page load, so we don't consider skipping this step
+      // to be a failure. These deltas will get applied later, when Blazor completes initialization.
+      try {
+        let wasmDeltas = deltas.map(delta => {
+          return {
+            "moduleId": delta.moduleId,
+            "metadataDelta": delta.metadataDelta,
+            "ilDelta": delta.ilDelta,
+            "pdbDelta": delta.pdbDelta,
+            "updatedTypes": delta.updatedTypes,
+          };
+        });
+
+        log = window.Blazor._internal.applyHotReloadDeltas(wasmDeltas, responseLoggingLevel);
+      } catch (error) {
+        console.warn(error);
+        applyError = error;
+        log.push({ "message": getMessageAndStack(error), "severity": AgentMessageSeverity_Error });
+      }
+    }
+
+    try {
+      let body = JSON.stringify({
+        "id": updateId,
+        "deltas": deltas
+      });
+
+      await fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: body });
+    } catch (error) {
+      console.warn(error);
+      applyError = error;
+      log.push({ "message": getMessageAndStack(error), "severity": AgentMessageSeverity_Error });
+    }
+
+    connection.send(JSON.stringify({
+      "success": !applyError,
+      "log": log
+    }));
+
+    if (!applyError) {
       notifyHotReloadApplied();
     }
   }
@@ -219,19 +280,6 @@ setTimeout(async function () {
       }
     } else {
       location.reload();
-    }
-  }
-
-  function sendDeltaApplied() {
-    connection.send(new Uint8Array([1]).buffer);
-  }
-
-  function sendDeltaNotApplied(error) {
-    if (error) {
-      let encoder = new TextEncoder()
-      connection.send(encoder.encode("\0" + error.message + "\0" + error.stack));
-    } else {
-      connection.send(new Uint8Array([0]).buffer);
     }
   }
 

--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -5,189 +5,191 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 
-namespace Microsoft.Extensions.HotReload
+namespace Microsoft.Extensions.HotReload;
+
+#if NET
+[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Hot reload is only expected to work when trimming is disabled.")]
+#endif
+internal sealed class HotReloadAgent : IDisposable
 {
-    internal sealed class HotReloadAgent : IDisposable
+    private const string MetadataUpdaterTypeName = "System.Reflection.Metadata.MetadataUpdater";
+    private const string ApplyUpdateMethodName = "ApplyUpdate";
+    private const string GetCapabilitiesMethodName = "GetCapabilities";
+
+    private delegate void ApplyUpdateDelegate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta);
+
+    public AgentReporter Reporter { get; } = new();
+
+    private readonly ConcurrentDictionary<Guid, List<UpdateDelta>> _deltas = new();
+    private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
+    private readonly ApplyUpdateDelegate? _applyUpdate;
+    private readonly string? _capabilities;
+    private readonly MetadataUpdateHandlerInvoker _metadataUpdateHandlerInvoker;
+
+    public HotReloadAgent()
     {
-        private const string MetadataUpdaterTypeName = "System.Reflection.Metadata.MetadataUpdater";
-        private const string ApplyUpdateMethodName = "ApplyUpdate";
-        private const string GetCapabilitiesMethodName = "GetCapabilities";
+        _metadataUpdateHandlerInvoker = new(Reporter);
 
-        private delegate void ApplyUpdateDelegate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta);
+        GetUpdaterMethodsAndCapabilities(out _applyUpdate, out _capabilities);
 
-        public readonly AgentReporter Reporter = new();
+        AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+    }
 
-        private readonly ConcurrentDictionary<Guid, List<UpdateDelta>> _deltas = new();
-        private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
-        private readonly ApplyUpdateDelegate? _applyUpdate;
-        private readonly string? _capabilities;
-        private readonly MetadataUpdateHandlerInvoker _metadataUpdateHandlerInvoker;
+    public void Dispose()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
+    }
 
-        public HotReloadAgent()
+    private void GetUpdaterMethodsAndCapabilities(out ApplyUpdateDelegate? applyUpdate, out string? capabilities)
+    {
+        applyUpdate = null;
+        capabilities = null;
+
+        var metadataUpdater = Type.GetType(MetadataUpdaterTypeName + ", System.Runtime.Loader", throwOnError: false);
+        if (metadataUpdater == null)
         {
-            _metadataUpdateHandlerInvoker = new(Reporter);
-
-            GetUpdaterMethodsAndCapabilities(out _applyUpdate, out _capabilities);
-
-            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+            Reporter.Report($"Type not found: {MetadataUpdaterTypeName}", AgentMessageSeverity.Error);
+            return;
         }
 
-        public void Dispose()
+        var applyUpdateMethod = metadataUpdater.GetMethod(ApplyUpdateMethodName, BindingFlags.Public | BindingFlags.Static, binder: null, [typeof(Assembly), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>)], modifiers: null);
+        if (applyUpdateMethod == null)
         {
-            AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
+            Reporter.Report($"{MetadataUpdaterTypeName}.{ApplyUpdateMethodName} not found.", AgentMessageSeverity.Error);
+            return;
         }
 
-        private void GetUpdaterMethodsAndCapabilities(out ApplyUpdateDelegate? applyUpdate, out string? capabilities)
+        applyUpdate = (ApplyUpdateDelegate)applyUpdateMethod.CreateDelegate(typeof(ApplyUpdateDelegate));
+
+        var getCapabilities = metadataUpdater.GetMethod(GetCapabilitiesMethodName, BindingFlags.NonPublic | BindingFlags.Static, binder: null, Type.EmptyTypes, modifiers: null);
+        if (getCapabilities == null)
         {
-            applyUpdate = null;
-            capabilities = null;
-
-            var metadataUpdater = Type.GetType(MetadataUpdaterTypeName + ", System.Runtime.Loader", throwOnError: false);
-            if (metadataUpdater == null)
-            {
-                Reporter.Report($"Type not found: {MetadataUpdaterTypeName}", AgentMessageSeverity.Error);
-                return;
-            }
-
-            var applyUpdateMethod = metadataUpdater.GetMethod(ApplyUpdateMethodName, BindingFlags.Public | BindingFlags.Static, binder: null, [typeof(Assembly), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>), typeof(ReadOnlySpan<byte>)], modifiers: null);
-            if (applyUpdateMethod == null)
-            {
-                Reporter.Report($"{MetadataUpdaterTypeName}.{ApplyUpdateMethodName} not found.", AgentMessageSeverity.Error);
-                return;
-            }
-
-            applyUpdate = (ApplyUpdateDelegate)applyUpdateMethod.CreateDelegate(typeof(ApplyUpdateDelegate));
-
-            var getCapabilities = metadataUpdater.GetMethod(GetCapabilitiesMethodName, BindingFlags.NonPublic | BindingFlags.Static, binder: null, Type.EmptyTypes, modifiers: null);
-            if (getCapabilities == null)
-            {
-                Reporter.Report($"{MetadataUpdaterTypeName}.{GetCapabilitiesMethodName} not found.", AgentMessageSeverity.Error);
-                return;
-            }
-
-            try
-            {
-                capabilities = getCapabilities.Invoke(obj: null, parameters: null) as string;
-            }
-            catch (Exception e)
-            {
-                Reporter.Report($"Error retrieving capabilities: {e.Message}", AgentMessageSeverity.Error);
-            }
+            Reporter.Report($"{MetadataUpdaterTypeName}.{GetCapabilitiesMethodName} not found.", AgentMessageSeverity.Error);
+            return;
         }
 
-        public string Capabilities => _capabilities ?? string.Empty;
-
-        private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
+        try
         {
-            _metadataUpdateHandlerInvoker.Clear();
+            capabilities = getCapabilities.Invoke(obj: null, parameters: null) as string;
+        }
+        catch (Exception e)
+        {
+            Reporter.Report($"Error retrieving capabilities: {e.Message}", AgentMessageSeverity.Error);
+        }
+    }
 
-            var loadedAssembly = eventArgs.LoadedAssembly;
-            var moduleId = TryGetModuleId(loadedAssembly);
-            if (moduleId is null)
-            {
-                return;
-            }
+    public string Capabilities => _capabilities ?? string.Empty;
 
-            if (_deltas.TryGetValue(moduleId.Value, out var updateDeltas) && _appliedAssemblies.TryAdd(loadedAssembly, loadedAssembly))
-            {
-                // A delta for this specific Module exists and we haven't called ApplyUpdate on this instance of Assembly as yet.
-                ApplyDeltas(loadedAssembly, updateDeltas);
-            }
+    private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
+    {
+        _metadataUpdateHandlerInvoker.Clear();
+
+        var loadedAssembly = eventArgs.LoadedAssembly;
+        var moduleId = TryGetModuleId(loadedAssembly);
+        if (moduleId is null)
+        {
+            return;
         }
 
-        public IReadOnlyCollection<(string message, AgentMessageSeverity severity)> ApplyDeltas(IReadOnlyList<UpdateDelta> deltas, ResponseLoggingLevel loggingLevel)
+        if (_deltas.TryGetValue(moduleId.Value, out var updateDeltas) && _appliedAssemblies.TryAdd(loadedAssembly, loadedAssembly))
         {
-            Reporter.Report("Attempting to apply deltas.", AgentMessageSeverity.Verbose);
+            // A delta for this specific Module exists and we haven't called ApplyUpdate on this instance of Assembly as yet.
+            ApplyDeltas(loadedAssembly, updateDeltas);
+        }
+    }
 
-            Debug.Assert(Capabilities.Length > 0);
-            Debug.Assert(_applyUpdate != null);
+    public IReadOnlyCollection<(string message, AgentMessageSeverity severity)> GetAndClearLogEntries(ResponseLoggingLevel loggingLevel)
+        => Reporter.GetAndClearLogEntries(loggingLevel);
 
-            for (var i = 0; i < deltas.Count; i++)
+    public void ApplyDeltas(IEnumerable<UpdateDelta> deltas)
+    {
+        Debug.Assert(Capabilities.Length > 0);
+        Debug.Assert(_applyUpdate != null);
+
+        foreach (var delta in deltas)
+        {
+            Reporter.Report($"Applying delta to module {delta.ModuleId}.", AgentMessageSeverity.Verbose);
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var item = deltas[i];
-                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                if (TryGetModuleId(assembly) is Guid moduleId && moduleId == delta.ModuleId)
                 {
-                    if (TryGetModuleId(assembly) is Guid moduleId && moduleId == item.ModuleId)
-                    {
-                        _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, pdbDelta: []);
-                    }
-                }
-
-                // Additionally stash the deltas away so it may be applied to assemblies loaded later.
-                var cachedDeltas = _deltas.GetOrAdd(item.ModuleId, static _ => new());
-                cachedDeltas.Add(item);
-            }
-
-            _metadataUpdateHandlerInvoker.Invoke(GetMetadataUpdateTypes(deltas));
-
-            return Reporter.GetAndClearLogEntries(loggingLevel);
-        }
-
-        private Type[] GetMetadataUpdateTypes(IReadOnlyList<UpdateDelta> deltas)
-        {
-            List<Type>? types = null;
-
-            foreach (var delta in deltas)
-            {
-                var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly => TryGetModuleId(assembly) is Guid moduleId && moduleId == delta.ModuleId);
-                if (assembly is null)
-                {
-                    continue;
-                }
-
-                foreach (var updatedType in delta.UpdatedTypes)
-                {
-                    // Must be a TypeDef.
-                    Debug.Assert(updatedType >> 24 == 0x02);
-
-                    // The type has to be in the manifest module since Hot Reload does not support multi-module assemblies:
-                    try
-                    {
-                        var type = assembly.ManifestModule.ResolveType(updatedType);
-                        types ??= new();
-                        types.Add(type);
-                    }
-                    catch (Exception e)
-                    {
-                        Reporter.Report($"Failed to load type 0x{updatedType:X8}: {e.Message}", AgentMessageSeverity.Warning);
-                    }
+                    _applyUpdate(assembly, delta.MetadataDelta, delta.ILDelta, delta.PdbDelta);
                 }
             }
 
-            return types?.ToArray() ?? Type.EmptyTypes;
+            // Additionally stash the deltas away so it may be applied to assemblies loaded later.
+            var cachedDeltas = _deltas.GetOrAdd(delta.ModuleId, static _ => new());
+            cachedDeltas.Add(delta);
         }
 
-        public void ApplyDeltas(Assembly assembly, IReadOnlyList<UpdateDelta> deltas)
-        {
-            Debug.Assert(_applyUpdate != null);
+        _metadataUpdateHandlerInvoker.Invoke(GetMetadataUpdateTypes(deltas));
+    }
 
-            try
+    private Type[] GetMetadataUpdateTypes(IEnumerable<UpdateDelta> deltas)
+    {
+        List<Type>? types = null;
+
+        foreach (var delta in deltas)
+        {
+            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly => TryGetModuleId(assembly) is Guid moduleId && moduleId == delta.ModuleId);
+            if (assembly is null)
             {
-                foreach (var item in deltas)
+                continue;
+            }
+
+            foreach (var updatedType in delta.UpdatedTypes)
+            {
+                // Must be a TypeDef.
+                Debug.Assert(updatedType >> 24 == 0x02);
+
+                // The type has to be in the manifest module since Hot Reload does not support multi-module assemblies:
+                try
                 {
-                    _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                    var type = assembly.ManifestModule.ResolveType(updatedType);
+                    types ??= new();
+                    types.Add(type);
                 }
-
-                Reporter.Report("Deltas applied.", AgentMessageSeverity.Verbose);
-            }
-            catch (Exception ex)
-            {
-                Reporter.Report(ex.ToString(), AgentMessageSeverity.Warning);
+                catch (Exception e)
+                {
+                    Reporter.Report($"Failed to load type 0x{updatedType:X8}: {e.Message}", AgentMessageSeverity.Warning);
+                }
             }
         }
 
-        private static Guid? TryGetModuleId(Assembly loadedAssembly)
+        return types?.ToArray() ?? Type.EmptyTypes;
+    }
+
+    private void ApplyDeltas(Assembly assembly, IReadOnlyList<UpdateDelta> deltas)
+    {
+        Debug.Assert(_applyUpdate != null);
+
+        try
         {
-            try
+            foreach (var item in deltas)
             {
-                return loadedAssembly.Modules.FirstOrDefault()?.ModuleVersionId;
-            }
-            catch
-            {
-                // Assembly.Modules might throw. See https://github.com/dotnet/aspnetcore/issues/33152
+                _applyUpdate(assembly, item.MetadataDelta, item.ILDelta, item.PdbDelta);
             }
 
-            return default;
+            Reporter.Report("Deltas applied.", AgentMessageSeverity.Verbose);
         }
+        catch (Exception ex)
+        {
+            Reporter.Report(ex.ToString(), AgentMessageSeverity.Warning);
+        }
+    }
+
+    private static Guid? TryGetModuleId(Assembly loadedAssembly)
+    {
+        try
+        {
+            return loadedAssembly.Modules.FirstOrDefault()?.ModuleVersionId;
+        }
+        catch
+        {
+            // Assembly.Modules might throw. See https://github.com/dotnet/aspnetcore/issues/33152
+        }
+
+        return default;
     }
 }

--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <Compile Include="..\dotnet-watch\EnvironmentVariables_StartupHook.cs" Link="EnvironmentVariables_StartupHook.cs" />
     <Compile Include="..\dotnet-watch\HotReload\NamedPipeContract.cs" />
+    <Compile Include="..\dotnet-watch\HotReload\AgentMessageSeverity.cs" />
+    <Compile Include="..\dotnet-watch\HotReload\ResponseLoggingLevel.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\dotnet-watch\HotReload\NamedPipeContract.cs" />
     <Compile Include="..\dotnet-watch\HotReload\AgentMessageSeverity.cs" />
     <Compile Include="..\dotnet-watch\HotReload\ResponseLoggingLevel.cs" />
+    <Compile Include="..\dotnet-watch\HotReload\UpdateDelta.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -65,8 +65,10 @@ internal sealed class StartupHook
 
                     Log($"ResponseLoggingLevel = {update.ResponseLoggingLevel}");
 
-                    var logEntries = agent.ApplyDeltas(update.Deltas, update.ResponseLoggingLevel);
+                    agent.ApplyDeltas(update.Deltas);
+                    var logEntries = agent.GetAndClearLogEntries(update.ResponseLoggingLevel);
 
+                    // response:
                     pipeClient.WriteByte(UpdatePayload.ApplySuccessValue);
                     UpdatePayload.WriteLog(pipeClient, logEntries);
                 }

--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -51,10 +51,25 @@ internal sealed class StartupHook
                 return;
             }
 
-            using var agent = new HotReloadAgent(pipeClient, Log);
+            using var agent = new HotReloadAgent();
             try
             {
-                await agent.ReceiveDeltasAsync();
+                agent.Reporter.Report("Writing capabilities: " + agent.Capabilities, AgentMessageSeverity.Verbose);
+
+                var initPayload = new ClientInitializationPayload(agent.Capabilities);
+                initPayload.Write(pipeClient);
+
+                while (pipeClient.IsConnected)
+                {
+                    var update = await UpdatePayload.ReadAsync(pipeClient, CancellationToken.None);
+
+                    Log($"ResponseLoggingLevel = {update.ResponseLoggingLevel}");
+
+                    var logEntries = agent.ApplyDeltas(update.Deltas, update.ResponseLoggingLevel);
+
+                    pipeClient.WriteByte(UpdatePayload.ApplySuccessValue);
+                    UpdatePayload.WriteLog(pipeClient, logEntries);
+                }
             }
             catch (Exception ex)
             {

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System.Buffers;
+using System.Net.WebSockets;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher.Tools;
+
+internal readonly struct BrowserConnection : IAsyncDisposable
+{
+    private static int s_lastId;
+
+    public WebSocket ClientSocket { get; }
+    public string? SharedSecret { get; }
+    public int Id { get; }
+    public IReporter Reporter { get; }
+
+    public BrowserConnection(WebSocket clientSocket, string? sharedSecret, IReporter reporter)
+    {
+        ClientSocket = clientSocket;
+        SharedSecret = sharedSecret;
+        Id = Interlocked.Increment(ref s_lastId);
+        Reporter = new MessagePrefixingReporter($"[Browser #{Id}] ", reporter);
+
+        Reporter.Verbose($"Connected to referesh server.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await ClientSocket.CloseOutputAsync(WebSocketCloseStatus.Empty, null, default);
+        ClientSocket.Dispose();
+
+        Reporter.Verbose($"Disconnected.");
+    }
+
+    internal async ValueTask<bool> TrySendMessageAsync(ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ClientSocket.SendAsync(messageBytes, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            Reporter.Verbose($"Failed to send message: {e.Message}");
+            return false;
+        }
+
+        return true;
+    }
+
+    internal async ValueTask<bool> TryReceiveMessageAsync(Action<ReadOnlySpan<byte>, IReporter> receiver, CancellationToken cancellationToken)
+    {
+        var writer = new ArrayBufferWriter<byte>(initialCapacity: 10);
+
+        while (true)
+        {
+            ValueWebSocketReceiveResult result;
+            try
+            {
+                result = await ClientSocket.ReceiveAsync(writer.GetMemory(), cancellationToken);
+            }
+            catch (Exception e) when (e is not OperationCanceledException)
+            {
+                Reporter.Verbose($"Failed to receive response: {e.Message}");
+                return false;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return false;
+            }
+
+            writer.Advance(result.Count);
+            if (result.EndOfMessage)
+            {
+                break;
+            }
+        }
+
+        receiver(writer.WrittenSpan, Reporter);
+        return true;
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
@@ -22,7 +22,7 @@ internal readonly struct BrowserConnection : IAsyncDisposable
         ClientSocket = clientSocket;
         SharedSecret = sharedSecret;
         Id = Interlocked.Increment(ref s_lastId);
-        Reporter = new MessagePrefixingReporter($"[Browser #{Id}] ", reporter);
+        Reporter = new BrowserSpecificReporter(Id, reporter);
 
         Reporter.Verbose($"Connected to referesh server.");
     }
@@ -52,7 +52,7 @@ internal readonly struct BrowserConnection : IAsyncDisposable
 
     internal async ValueTask<bool> TryReceiveMessageAsync(Action<ReadOnlySpan<byte>, IReporter> receiver, CancellationToken cancellationToken)
     {
-        var writer = new ArrayBufferWriter<byte>(initialCapacity: 10);
+        var writer = new ArrayBufferWriter<byte>(initialCapacity: 1024);
 
         while (true)
         {

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             else
             {
                 // Notify the browser of a project rebuild (delta applier notifies of updates):
-                await server.SendWaitMessageAsync(cancellationToken);
+                await server.SendWaitMessage(cancellationToken);
             }
 
             return server;
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     // Subsequent iterations (project has been rebuilt and relaunched).
                     // Use refresh server to reload the browser, if available.
                     context.Reporter.Verbose("Reloading browser.");
-                    _ = server.ReloadAsync(cancellationToken);
+                    _ = server.Reload(cancellationToken);
                 }
             }
         }

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             else
             {
                 // Notify the browser of a project rebuild (delta applier notifies of updates):
-                await server.SendWaitMessage(cancellationToken);
+                await server.SendWaitMessageAsync(cancellationToken);
             }
 
             return server;
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     // Subsequent iterations (project has been rebuilt and relaunched).
                     // Use refresh server to reload the browser, if available.
                     context.Reporter.Verbose("Reloading browser.");
-                    _ = server.Reload(cancellationToken);
+                    _ = server.SendReloadMessageAsync(cancellationToken);
                 }
             }
         }

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
@@ -25,10 +25,39 @@ namespace Microsoft.DotNet.Watcher.Tools
     /// </summary>
     internal sealed class BrowserRefreshServer : IAsyncDisposable
     {
+        private readonly struct BrowserConnection(WebSocket clientSocket, string? sharedSecret, int id) : IAsyncDisposable
+        {
+            public WebSocket ClientSocket { get; } = clientSocket;
+            public string? SharedSecret { get; } = sharedSecret;
+            public int Id { get; } = id;
+
+            internal async Task SendMessageAsync(ReadOnlyMemory<byte> messageBytes, IReporter reporter, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await ClientSocket.SendAsync(messageBytes, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    reporter.Verbose($"Browser connection #{Id} has been terminated.");
+                }
+                catch (Exception e)
+                {
+                    reporter.Verbose($"Failed to send message to browser #{Id}: {e.Message}");
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await ClientSocket.CloseOutputAsync(WebSocketCloseStatus.Empty, null, default);
+                ClientSocket.Dispose();
+            }
+        }
+
         private readonly byte[] ReloadMessage = Encoding.UTF8.GetBytes("Reload");
         private readonly byte[] WaitMessage = Encoding.UTF8.GetBytes("Wait");
         private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
-        private readonly List<(WebSocket clientSocket, string? sharedSecret)> _clientSockets = new();
+        private readonly List<BrowserConnection> _activeConnections = [];
         private readonly RSA _rsa;
 
         private readonly IReporter _reporter;
@@ -50,6 +79,21 @@ namespace Microsoft.DotNet.Watcher.Tools
             _terminateWebSocket = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _clientConnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _environmentHostName = EnvironmentVariables.AutoReloadWSHostName;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _rsa.Dispose();
+
+            foreach (var connection in await GetOpenBrowserConnectionsAsync())
+            {
+                _reporter.Verbose($"Disconnecting from browser #{connection.Id}.");
+                await connection.DisposeAsync();
+            }
+
+            _refreshServer?.Dispose();
+
+            _terminateWebSocket.TrySetResult();
         }
 
         public void SetEnvironmentVariables(EnvironmentVariablesBuilder environmentBuilder)
@@ -147,7 +191,16 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
 
             var clientSocket = await context.WebSockets.AcceptWebSocketAsync(subProtocol);
-            _clientSockets.Add((clientSocket, sharedSecret));
+
+            int connectionId;
+            lock (_activeConnections)
+            {
+                connectionId = _activeConnections.Count;
+                _activeConnections.Add(new BrowserConnection(clientSocket, sharedSecret, connectionId));
+            }
+
+            _reporter.Verbose($"Browser #{connectionId} connected to referesh server web socket.");
+
             _clientConnected.TrySetResult();
             await _terminateWebSocket.Task;
         }
@@ -199,105 +252,76 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
         }
 
-        public ValueTask SendJsonSerlialized<TValue>(TValue value, CancellationToken cancellationToken = default)
+        private async ValueTask<IReadOnlyCollection<BrowserConnection>> GetOpenBrowserConnectionsAsync()
+        {
+            var openConnections = new List<BrowserConnection>();
+            List<BrowserConnection>? lazyConnectionsToDispose = null;
+
+            lock (_activeConnections)
+            {
+                openConnections.AddRange(_activeConnections.Where(b => b.ClientSocket.State == WebSocketState.Open));
+
+                if (openConnections.Count < _activeConnections.Count)
+                {
+                    foreach (var connection in _activeConnections)
+                    {
+                        if (connection.ClientSocket.State != WebSocketState.Open)
+                        {
+                            lazyConnectionsToDispose ??= [];
+                            lazyConnectionsToDispose.Add(connection);
+                        }
+                    }
+
+                    _activeConnections.Clear();
+                    _activeConnections.AddRange(openConnections);
+                }
+            }
+
+            if (lazyConnectionsToDispose != null)
+            {
+                foreach (var connection in lazyConnectionsToDispose)
+                {
+                    await connection.DisposeAsync();
+                    _reporter.Verbose($"Browser #{connection.Id} disconnected.");
+                }
+            }
+
+            return openConnections;
+        }
+
+        public ValueTask SendJsonMessage<TValue>(TValue value, CancellationToken cancellationToken)
         {
             var jsonSerialized = JsonSerializer.SerializeToUtf8Bytes(value, _jsonSerializerOptions);
-            return SendMessage(jsonSerialized, cancellationToken);
+            return Send(jsonSerialized, cancellationToken);
         }
 
-        public async ValueTask SendJsonWithSecret<TValue>(Func<string?, TValue> valueFactory, CancellationToken cancellationToken = default)
+        public async ValueTask SendJsonMessageWithSecret<TValue>(Func<string?, TValue> messageFactory, CancellationToken cancellationToken)
         {
-            try
+            foreach (var connection in await GetOpenBrowserConnectionsAsync())
             {
-                bool messageSent = false;
-
-                for (var i = 0; i < _clientSockets.Count; i++)
-                {
-                    var (clientSocket, secret) = _clientSockets[i];
-                    if (clientSocket.State is not WebSocketState.Open)
-                    {
-                        continue;
-                    }
-
-                    var value = valueFactory(secret);
-                    var messageBytes = JsonSerializer.SerializeToUtf8Bytes(value, _jsonSerializerOptions);
-
-                    await clientSocket.SendAsync(messageBytes, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
-                    messageSent = true;
-                }
-
-                _reporter.Verbose(messageSent ? "Browser message sent." : "Unable to send message to browser, no socket is open.");
-            }
-            catch (TaskCanceledException)
-            {
-                _reporter.Verbose("WebSocket connection has been terminated.");
-            }
-            catch (Exception ex)
-            {
-                _reporter.Verbose($"Refresh server error: {ex}");
+                var message = messageFactory(connection.SharedSecret);
+                var messageBytes = JsonSerializer.SerializeToUtf8Bytes(message, _jsonSerializerOptions);
+                await connection.SendMessageAsync(messageBytes, _reporter, cancellationToken);
             }
         }
 
-        public async ValueTask SendMessage(ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken = default)
+        public async ValueTask Send(ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
         {
-            try
+            foreach (var connection in await GetOpenBrowserConnectionsAsync())
             {
-                bool messageSent = false;
-
-                for (var i = 0; i < _clientSockets.Count; i++)
-                {
-                    var (clientSocket, _) = _clientSockets[i];
-                    if (clientSocket.State is not WebSocketState.Open)
-                    {
-                        continue;
-                    }
-
-                    await clientSocket.SendAsync(messageBytes, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
-                    messageSent = true;
-                }
-
-                _reporter.Verbose(messageSent ? "Browser message sent." : "Unable to send message to browser, no socket is open.");
-            }
-            catch (TaskCanceledException)
-            {
-                _reporter.Verbose("WebSocket connection has been terminated.");
-            }
-            catch (Exception ex)
-            {
-                _reporter.Verbose($"Refresh server error: {ex}");
+                await connection.SendMessageAsync(messageBytes, _reporter, cancellationToken);
             }
         }
 
-        public async ValueTask DisposeAsync()
+        public async ValueTask<TValue> SendAndReceive<TValue>(ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
         {
-            _rsa.Dispose();
-
-            for (var i = 0; i < _clientSockets.Count; i++)
+            foreach (var connection in await GetOpenBrowserConnectionsAsync())
             {
-                var (clientSocket, _) = _clientSockets[i];
-                await clientSocket.CloseOutputAsync(WebSocketCloseStatus.Empty, null, default);
-                clientSocket.Dispose();
-            }
-
-            _refreshServer?.Dispose();
-
-            _terminateWebSocket.TrySetResult();
-        }
-
-        public async ValueTask<ValueWebSocketReceiveResult?> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
-        {
-            for (int i = 0; i < _clientSockets.Count; i++)
-            {
-                var (clientSocket, _) = _clientSockets[i];
-
-                if (clientSocket.State != WebSocketState.Open)
-                {
-                    continue;
-                }
+                await connection.SendMessageAsync(messageBytes, _reporter, cancellationToken);
 
                 try
                 {
-                    var result = await clientSocket.ReceiveAsync(buffer, cancellationToken);
+                    var result = await connection.ReceiveMessageAsync(buffer, cancellationToken);
 
                     if (result.MessageType == WebSocketMessageType.Close)
                     {
@@ -311,13 +335,11 @@ namespace Microsoft.DotNet.Watcher.Tools
                     _reporter.Verbose($"Refresh server error: {ex}");
                 }
             }
-
-            return default;
         }
 
-        public ValueTask ReloadAsync(CancellationToken cancellationToken) => SendMessage(ReloadMessage, cancellationToken);
+        public ValueTask ReloadAsync(CancellationToken cancellationToken) => Send(ReloadMessage, cancellationToken);
 
-        public ValueTask SendWaitMessageAsync(CancellationToken cancellationToken) => SendMessage(WaitMessage, cancellationToken);
+        public ValueTask SendWaitMessageAsync(CancellationToken cancellationToken) => Send(WaitMessage, cancellationToken);
 
         private async Task<bool> SupportsTLS()
         {
@@ -334,18 +356,18 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         public ValueTask RefreshBrowserAsync(CancellationToken cancellationToken)
-            => SendJsonSerlialized(new AspNetCoreHotReloadApplied(), cancellationToken);
+            => SendJsonMessage(new AspNetCoreHotReloadApplied(), cancellationToken);
 
         public ValueTask ReportCompilationErrorsInBrowserAsync(ImmutableArray<string> compilationErrors, CancellationToken cancellationToken)
         {
             _reporter.Verbose($"Updating diagnostics in the browser.");
             if (compilationErrors.IsEmpty)
             {
-                return SendJsonSerlialized(new AspNetCoreHotReloadApplied(), cancellationToken);
+                return SendJsonMessage(new AspNetCoreHotReloadApplied(), cancellationToken);
             }
             else
             {
-                return SendJsonSerlialized(new HotReloadDiagnostics { Diagnostics = compilationErrors }, cancellationToken);
+                return SendJsonMessage(new HotReloadDiagnostics { Diagnostics = compilationErrors }, cancellationToken);
             }
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/AgentMessageSeverity.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/AgentMessageSeverity.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.HotReload;
+
+internal enum AgentMessageSeverity : byte
+{
+    Verbose = 0,
+    Warning = 1,
+    Error = 2,
+}

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     }
                     else
                     {
-                        await browserRefreshServer.SendJsonSerlialized(default(BlazorRequestApplyUpdateCapabilities), cancellationToken);
+                        await browserRefreshServer.SendJsonMessage(default(BlazorRequestApplyUpdateCapabilities), cancellationToken);
 
                         // We'll query the browser and ask it send capabilities.
                         var response = await browserRefreshServer.ReceiveAsync(buffer, cancellationToken);
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return ApplyStatus.AllChangesApplied;
             }
 
-            await browserRefreshServer.SendJsonWithSecret(sharedSecret => new UpdatePayload
+            await browserRefreshServer.SendJsonMessageWithSecret(sharedSecret => new UpdatePayload
             {
                 SharedSecret = sharedSecret,
                 Deltas = updates.Select(update => new UpdateDelta

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         public override async Task WaitForProcessRunningAsync(CancellationToken cancellationToken)
             // Wait for the browser connection to be established as an indication that the process has started.
             // Alternatively, we could inject agent into blazor-devserver.dll and establish a connection on the named pipe.
-            => await browserRefreshServer.WaitForClientConnection(cancellationToken);
+            => await browserRefreshServer.WaitForClientConnectionAsync(cancellationToken);
 
         public override async Task<ImmutableArray<string>> GetApplyUpdateCapabilitiesAsync(CancellationToken cancellationToken)
         {
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 {
                     Reporter.Verbose("Connecting to the browser.");
 
-                    await browserRefreshServer.WaitForClientConnection(cancellationToken);
+                    await browserRefreshServer.WaitForClientConnectionAsync(cancellationToken);
 
                     string capabilities;
                     if (browserRefreshServer.Options.TestFlags.HasFlag(TestFlags.MockBrowser))
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     {
                         string? capabilityString = null;
 
-                        await browserRefreshServer.SendAndReceive(
+                        await browserRefreshServer.SendAndReceiveAsync(
                             request: _ => default(JsonGetApplyUpdateCapabilitiesRequest),
                             response: (value, reporter) =>
                             {
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var loggingLevel = Reporter.IsVerbose ? ResponseLoggingLevel.Verbose : ResponseLoggingLevel.WarningsAndErrors;
 
-            await browserRefreshServer.SendAndReceive(
+            await browserRefreshServer.SendAndReceiveAsync(
                 request: sharedSecret => new JsonApplyHotReloadDeltasRequest
                 {
                     SharedSecret = sharedSecret,
@@ -196,7 +196,10 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             // If no browser is connected we assume the changes have been applied.
             // If at least one browser suceeds we consider the changes successfully applied.
-            // TODO: The refresh server should remember the deltas and apply them to browsers connected in future.
+            // TODO: 
+            // The refresh server should remember the deltas and apply them to browsers connected in future.
+            // Currently the changes are remembered on the dev server and sent over there from the browser.
+            // If no browser is connected the changes are not sent though.
             return (!anySuccess && anyFailure) ? ApplyStatus.Failed : (applicableUpdates.Count < updates.Length) ? ApplyStatus.SomeChangesApplied : ApplyStatus.AllChangesApplied;
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -338,7 +338,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                         if (runningProject.BrowserRefreshServer is { } server)
                         {
                             runningProject.Reporter.Verbose("Refreshing browser.");
-                            await server.RefreshBrowserAsync(cancellationToken);
+                            await server.RefreshBrowser(cancellationToken);
                         }
                     }
                 }
@@ -455,7 +455,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             // report or clear diagnostics in the browser UI
             await ForEachProjectAsync(
                 _runningProjects,
-                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowserAsync(diagnosticsToDisplay.ToImmutableArray(), cancellationToken).AsTask() ?? Task.CompletedTask,
+                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowser(diagnosticsToDisplay.ToImmutableArray(), cancellationToken).AsTask() ?? Task.CompletedTask,
                 cancellationToken);
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -338,7 +338,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                         if (runningProject.BrowserRefreshServer is { } server)
                         {
                             runningProject.Reporter.Verbose("Refreshing browser.");
-                            await server.RefreshBrowser(cancellationToken);
+                            await server.RefreshBrowserAsync(cancellationToken);
                         }
                     }
                 }
@@ -455,7 +455,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             // report or clear diagnostics in the browser UI
             await ForEachProjectAsync(
                 _runningProjects,
-                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowser(diagnosticsToDisplay.ToImmutableArray(), cancellationToken).AsTask() ?? Task.CompletedTask,
+                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowserAsync(diagnosticsToDisplay.ToImmutableArray(), cancellationToken).AsTask() ?? Task.CompletedTask,
                 cancellationToken);
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -101,17 +101,18 @@ namespace Microsoft.DotNet.Watcher.Tools
             _reporter.Report(MessageDescriptor.HotReloadSessionStarted);
         }
 
-        private DeltaApplier CreateDeltaApplier(ProjectGraphNode projectNode, BrowserRefreshServer? browserRefreshServer, IReporter processReporter)
-            => HotReloadProfileReader.InferHotReloadProfile(projectNode, _reporter) switch
+        private static DeltaApplier CreateDeltaApplier(HotReloadProfile profile, Version? targetFramework, BrowserRefreshServer? browserRefreshServer, IReporter processReporter)
+            => profile switch
             {
-                HotReloadProfile.BlazorWebAssembly => new BlazorWebAssemblyDeltaApplier(processReporter, browserRefreshServer!, projectNode.GetTargetFrameworkVersion()),
-                HotReloadProfile.BlazorHosted => new BlazorWebAssemblyHostedDeltaApplier(processReporter, browserRefreshServer!, projectNode.GetTargetFrameworkVersion()),
+                HotReloadProfile.BlazorWebAssembly => new BlazorWebAssemblyDeltaApplier(processReporter, browserRefreshServer!, targetFramework),
+                HotReloadProfile.BlazorHosted => new BlazorWebAssemblyHostedDeltaApplier(processReporter, browserRefreshServer!, targetFramework),
                 _ => new DefaultDeltaApplier(processReporter),
             };
 
         public async Task<RunningProject?> TrackRunningProjectAsync(
             ProjectGraphNode projectNode,
             ProjectOptions projectOptions,
+            HotReloadProfile profile,
             string namedPipeName,
             BrowserRefreshServer? browserRefreshServer,
             ProcessSpec processSpec,
@@ -122,7 +123,8 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             var projectPath = projectNode.ProjectInstance.FullPath;
 
-            var deltaApplier = CreateDeltaApplier(projectNode, browserRefreshServer, processReporter);
+            var targetFramework = projectNode.GetTargetFrameworkVersion();
+            var deltaApplier = CreateDeltaApplier(profile, targetFramework, browserRefreshServer, processReporter);
             var processExitedSource = new CancellationTokenSource();
             var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(processExitedSource.Token, cancellationToken);
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -88,6 +88,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     update.ModuleId,
                     metadataDelta: update.MetadataDelta.ToArray(),
                     ilDelta: update.ILDelta.ToArray(),
+                    pdbDelta: update.PdbDelta.ToArray(),
                     update.UpdatedTypes.ToArray())).ToArray(),
                 responseLoggingLevel: Reporter.IsVerbose ? ResponseLoggingLevel.Verbose : ResponseLoggingLevel.WarningsAndErrors);
 
@@ -143,28 +144,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     return false;
                 }
 
-                foreach (var (message, severity) in UpdatePayload.ReadLog(_pipe))
-                {
-                    switch (severity)
-                    {
-                        case AgentMessageSeverity.Verbose:
-                            Reporter.Verbose(message, emoji: "🕵️");
-                            break;
-
-                        case AgentMessageSeverity.Error:
-                            Reporter.Error(message);
-                            break;
-
-                        case AgentMessageSeverity.Warning:
-                            Reporter.Warn(message, emoji: "⚠");
-                            break;
-
-                        default:
-                            Reporter.Error($"Unexpected message severity: {severity}");
-                            return false;
-                    }
-                }
-
+                ReportLog(Reporter, UpdatePayload.ReadLog(_pipe));
                 return true;
             }
             finally

--- a/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
+using Microsoft.Extensions.HotReload;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -27,6 +28,27 @@ namespace Microsoft.DotNet.Watcher.Tools
         public abstract Task<ApplyStatus> Apply(ImmutableArray<WatchHotReloadService.Update> updates, CancellationToken cancellationToken);
 
         public abstract void Dispose();
+
+        public static void ReportLog(IReporter reporter, IEnumerable<(string message, AgentMessageSeverity severity)> log)
+        {
+            foreach (var (message, severity) in log)
+            {
+                switch (severity)
+                {
+                    case AgentMessageSeverity.Error:
+                        reporter.Error(message);
+                        break;
+
+                    case AgentMessageSeverity.Warning:
+                        reporter.Warn(message, emoji: "⚠");
+                        break;
+
+                    default:
+                        reporter.Verbose(message, emoji: "🕵️");
+                        break;
+                }
+            }
+        }
     }
 
     internal enum ApplyStatus

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.HotReload
                 binaryWriter.Write(delta.ModuleId.ToString());
                 await WriteBytesAsync(binaryWriter, delta.MetadataDelta, cancellationToken);
                 await WriteBytesAsync(binaryWriter, delta.ILDelta, cancellationToken);
+                await WriteBytesAsync(binaryWriter, delta.PdbDelta, cancellationToken);
                 WriteIntArray(binaryWriter, delta.UpdatedTypes);
             }
 
@@ -91,9 +92,10 @@ namespace Microsoft.Extensions.HotReload
                 var moduleId = Guid.Parse(binaryReader.ReadString());
                 var metadataDelta = await ReadBytesAsync(binaryReader, cancellationToken);
                 var ilDelta = await ReadBytesAsync(binaryReader, cancellationToken);
+                var pdbDelta = await ReadBytesAsync(binaryReader, cancellationToken);
                 var updatedTypes = ReadIntArray(binaryReader);
 
-                deltas[i] = new UpdateDelta(moduleId, metadataDelta: metadataDelta, ilDelta: ilDelta, updatedTypes);
+                deltas[i] = new UpdateDelta(moduleId, metadataDelta: metadataDelta, ilDelta: ilDelta, pdbDelta: pdbDelta, updatedTypes);
             }
 
             var responseLoggingLevel = (ResponseLoggingLevel)binaryReader.ReadByte();
@@ -147,22 +149,6 @@ namespace Microsoft.Extensions.HotReload
             {
                 yield return (reader.ReadString(), (AgentMessageSeverity)reader.ReadByte());
             }
-        }
-    }
-
-    internal readonly struct UpdateDelta
-    {
-        public Guid ModuleId { get; }
-        public byte[] MetadataDelta { get; }
-        public byte[] ILDelta { get; }
-        public int[] UpdatedTypes { get; }
-
-        public UpdateDelta(Guid moduleId, byte[] metadataDelta, byte[] ilDelta, int[] updatedTypes)
-        {
-            ModuleId = moduleId;
-            MetadataDelta = metadataDelta;
-            ILDelta = ilDelta;
-            UpdatedTypes = updatedTypes;
         }
     }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -3,19 +3,6 @@
 
 namespace Microsoft.Extensions.HotReload
 {
-    internal enum ResponseLoggingLevel : byte
-    {
-        WarningsAndErrors = 0,
-        Verbose = 1, 
-    }
-
-    internal enum AgentMessageSeverity : byte
-    {
-        Verbose = 0,
-        Warning = 1,
-        Error = 2,
-    }
-
     internal readonly struct UpdatePayload(IReadOnlyList<UpdateDelta> deltas, ResponseLoggingLevel responseLoggingLevel)
     {
         public const byte ApplySuccessValue = 0;

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -47,6 +47,12 @@ internal sealed class ProjectLauncher(
             return null;
         }
 
+        var profile = HotReloadProfileReader.InferHotReloadProfile(projectNode, Reporter);
+
+        // Blazor WASM does not need dotnet applier as all changes are applied in the browser,
+        // the process being launched is a dev server.
+        var injectDeltaApplier = profile != HotReloadProfile.BlazorWebAssembly;
+
         var processSpec = new ProcessSpec
         {
             Executable = EnvironmentOptions.MuxerPath,
@@ -61,10 +67,6 @@ internal sealed class ProjectLauncher(
         var namedPipeName = Guid.NewGuid().ToString();
 
         // Directives:
-
-        environmentBuilder.DotNetStartupHookDirective.Add(DeltaApplier.StartupHookPath);
-        environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
-        environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName, namedPipeName);
 
         // Variables:
 
@@ -84,19 +86,26 @@ internal sealed class ProjectLauncher(
         environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatch, "1");
         environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchIteration, (Iteration + 1).ToString(CultureInfo.InvariantCulture));
 
-        // Do not ask agent to log to stdout until https://github.com/dotnet/sdk/issues/40484 is fixed.
-        // For now we need to set the env variable explicitly when we need to diagnose issue with the agent.
-        // Build targets might launch a process and read it's stdout. If the agent is loaded into such process and starts logging
-        // to stdout it might interfere with the expected output.
-        //if (context.Options.Verbose)
-        //{
-        //    environmentBuilder.SetVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages, "1");
-        //}
+        if (injectDeltaApplier)
+        {
+            environmentBuilder.DotNetStartupHookDirective.Add(DeltaApplier.StartupHookPath);
+            environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
+            environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName, namedPipeName);
 
-        // TODO: workaround for https://github.com/dotnet/sdk/issues/40484
-        var targetPath = projectNode.ProjectInstance.GetPropertyValue("RunCommand");
-        environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchHotReloadTargetProcessPath, targetPath);
-        Reporter.Verbose($"Target process is '{targetPath}'");
+            // Do not ask agent to log to stdout until https://github.com/dotnet/sdk/issues/40484 is fixed.
+            // For now we need to set the env variable explicitly when we need to diagnose issue with the agent.
+            // Build targets might launch a process and read it's stdout. If the agent is loaded into such process and starts logging
+            // to stdout it might interfere with the expected output.
+            //if (context.Options.Verbose)
+            //{
+            //    environmentBuilder.SetVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages, "1");
+            //}
+
+            // TODO: workaround for https://github.com/dotnet/sdk/issues/40484
+            var targetPath = projectNode.ProjectInstance.GetPropertyValue("RunCommand");
+            environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchHotReloadTargetProcessPath, targetPath);
+            Reporter.Verbose($"Target process is '{targetPath}'");
+        }
 
         var browserRefreshServer = await browserConnector.LaunchOrRefreshBrowserAsync(projectNode, processSpec, environmentBuilder, projectOptions, cancellationToken);
         environmentBuilder.ConfigureProcess(processSpec);
@@ -106,6 +115,7 @@ internal sealed class ProjectLauncher(
         return await compilationHandler.TrackRunningProjectAsync(
             projectNode,
             projectOptions,
+            profile,
             namedPipeName,
             browserRefreshServer,
             processSpec,

--- a/src/BuiltInTools/dotnet-watch/HotReload/ResponseLoggingLevel.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ResponseLoggingLevel.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.HotReload;
+
+internal enum ResponseLoggingLevel : byte
+{
+    WarningsAndErrors = 0,
+    Verbose = 1,
+}

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             // referenced project.
             var cssFilePath = Path.GetFileNameWithoutExtension(containingProjectPath) + ".css";
             var message = new UpdateStaticFileMessage { Path = cssFilePath };
-            await browserRefreshServer.SendJsonSerlialized(message, cancellationToken);
+            await browserRefreshServer.SendJsonMessage(message, cancellationToken);
         }
 
         private readonly struct UpdateStaticFileMessage

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             // referenced project.
             var cssFilePath = Path.GetFileNameWithoutExtension(containingProjectPath) + ".css";
             var message = new UpdateStaticFileMessage { Path = cssFilePath };
-            await browserRefreshServer.SendJsonMessage(message, cancellationToken);
+            await browserRefreshServer.SendJsonMessageAsync(message, cancellationToken);
         }
 
         private readonly struct UpdateStaticFileMessage

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 {
                     reporter.Verbose($"Sending static file update request for asset '{path}'");
                     var message = JsonSerializer.SerializeToUtf8Bytes(new UpdateStaticFileMessage { Path = path }, s_jsonSerializerOptions);
-                    await request.Key.SendMessage(message, cancellationToken);
+                    await request.Key.Send(message, cancellationToken);
                 }
             });
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 {
                     reporter.Verbose($"Sending static file update request for asset '{path}'");
                     var message = JsonSerializer.SerializeToUtf8Bytes(new UpdateStaticFileMessage { Path = path }, s_jsonSerializerOptions);
-                    await request.Key.Send(message, cancellationToken);
+                    await request.Key.SendAsync(message, cancellationToken);
                 }
             });
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/UpdateDelta.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/UpdateDelta.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.HotReload;
+
+internal readonly struct UpdateDelta(Guid moduleId, byte[] metadataDelta, byte[] ilDelta, byte[] pdbDelta, int[] updatedTypes)
+{
+    public Guid ModuleId { get; } = moduleId;
+    public byte[] MetadataDelta { get; } = metadataDelta;
+    public byte[] ILDelta { get; } = ilDelta;
+    public byte[] PdbDelta { get; } = pdbDelta;
+    public int[] UpdatedTypes { get; } = updatedTypes;
+}

--- a/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Graph;
+using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watcher;
+
+internal sealed class BrowserSpecificReporter(int browserId, IReporter underlyingReporter) : IReporter
+{
+    private readonly string _prefix = $"[Browser #{browserId}] ";
+
+    public bool IsVerbose
+        => underlyingReporter.IsVerbose;
+
+    public bool EnableProcessOutputReporting
+        => false;
+
+    public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
+        => throw new InvalidOperationException();
+
+    public void ReportProcessOutput(OutputLine line)
+        => throw new InvalidOperationException();
+
+    public void Report(MessageDescriptor descriptor, string prefix, object?[] args)
+        => underlyingReporter.Report(descriptor, _prefix + prefix, args);
+}

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Loader;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Locator;
-using Microsoft.CodeAnalysis.ChangeSignature;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.Extensions.Tools.Internal;

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BlazorWasmHotReloadMiddlewareTest.cs
@@ -3,8 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
-#if F
+
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
     public class BlazorWasmHotReloadMiddlewareTest
@@ -12,55 +11,51 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         [Fact]
         public async Task DeltasAreSavedOnPost()
         {
-            // Arrange
-            var context = new DefaultHttpContext();
-            context.Request.Method = "post";
-            var updates = new BlazorWasmHotReloadMiddleware.Update[]
-            {
-                new()
-                {
-                    SequenceId = 0,
-                    Deltas =
-                    [
-                        new()
-                        {
-                            ModuleId = Guid.NewGuid().ToString(),
-                            ILDelta = "ILDelta1",
-                            PdbDelta = "PDBDelta1",
-                            MetadataDelta = "MetadataDelta1",
-                            UpdatedTypes = [42],
-                        },
-                        new()
-                        {
-                            ModuleId = Guid.NewGuid().ToString(),
-                            ILDelta = "ILDelta2",
-                            PdbDelta = "PDBDelta2",
-                            MetadataDelta = "MetadataDelta2",
-                            UpdatedTypes = [42],
-                        }
-                    ]
-                }
-            };
-            context.Request.Body = GetJson(updates);
-
             var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
 
-            // Act
+            var context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            var update = new BlazorWasmHotReloadMiddleware.Update
+            {
+                Id = 0,
+                Deltas =
+                [
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta1",
+                        PdbDelta = "PDBDelta1",
+                        MetadataDelta = "MetadataDelta1",
+                        UpdatedTypes = [42],
+                    },
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta2",
+                        PdbDelta = "PDBDelta2",
+                        MetadataDelta = "MetadataDelta2",
+                        UpdatedTypes = [42],
+                    }
+                ]
+            };
+
+            context.Request.Body = GetJson(update);
+
             await middleware.InvokeAsync(context);
 
-            // Assert
-            AssertUpdates(updates, middleware.Updates);
+            AssertUpdates([update], middleware.Updates);
         }
 
         [Fact]
         public async Task DuplicateDeltasOnPostAreIgnored()
         {
-            // Arrange
+            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
+
             var updates = new BlazorWasmHotReloadMiddleware.Update[]
             {
                 new()
                 {
-                    SequenceId = 0,
+                    Id = 0,
                     Deltas =
                     [
                         new()
@@ -75,7 +70,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 },
                 new()
                 {
-                    SequenceId = 1,
+                    Id = 1,
                     Deltas =
                     [
                         new()
@@ -92,17 +87,13 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             var context = new DefaultHttpContext();
             context.Request.Method = "post";
-            context.Request.Body = GetJson(updates);
+            context.Request.Body = GetJson(updates[0]);
 
-            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
-
-            // Act 1
             await middleware.InvokeAsync(context);
 
-            // Act 2
             context = new DefaultHttpContext();
             context.Request.Method = "post";
-            context.Request.Body = GetJson(updates);
+            context.Request.Body = GetJson(updates[1]);
             await middleware.InvokeAsync(context);
 
             // Assert
@@ -112,76 +103,67 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         [Fact]
         public async Task MultipleDeltaPayloadsCanBeAccepted()
         {
-            // Arrange
-            var updates = new BlazorWasmHotReloadMiddleware.Update[]
-            {
-                new()
-                {
-                    SequenceId = 0,
-                    Deltas =
-                    [
-                        new()
-                        {
-                            ModuleId = Guid.NewGuid().ToString(),
-                            ILDelta = "ILDelta1",
-                            PdbDelta = "PDBDelta1",
-                            MetadataDelta = "MetadataDelta1",
-                            UpdatedTypes = [42],
-                        }
-                    ]
-                },
-                new()
-                {
-                    SequenceId = 1,
-                    Deltas =
-                    [
-                        new()
-                        {
-                            ModuleId = Guid.NewGuid().ToString(),
-                            ILDelta = "ILDelta2",
-                            PdbDelta = "PDBDelta2",
-                            MetadataDelta = "MetadataDelta2",
-                            UpdatedTypes = [42],
-                        }
-                    ]
-                }
-            };
-            var context = new DefaultHttpContext();
-            context.Request.Method = "post";
-            context.Request.Body = GetJson(updates);
-
             var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
 
-            // Act 1
+            var update = new BlazorWasmHotReloadMiddleware.Update()
+            {
+                Id = 0,
+                Deltas =
+                [
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta1",
+                        PdbDelta = "PDBDelta1",
+                        MetadataDelta = "MetadataDelta1",
+                        UpdatedTypes = [42],
+                    },
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta2",
+                        PdbDelta = "PDBDelta2",
+                        MetadataDelta = "MetadataDelta2",
+                        UpdatedTypes = [42],
+                    }
+                ]
+            };
+
+            var context = new DefaultHttpContext();
+            context.Request.Method = "post";
+            context.Request.Body = GetJson(update);
             await middleware.InvokeAsync(context);
 
-            // Act 2
-            var newUpdate = new  new[]
+            var newUpdate = new BlazorWasmHotReloadMiddleware.Update()
             {
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 3,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta3",
-                    MetadataDelta = "MetadataDelta3",
-                    UpdatedTypes = [42],
-                },
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 4,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta4",
-                    MetadataDelta = "MetadataDelta4",
-                    UpdatedTypes = [42],
-                },
-                    new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 5,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta5",
-                    MetadataDelta = "MetadataDelta5",
-                    UpdatedTypes = [42],
-                },
+                Id = 1,
+                Deltas =
+                [
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta3",
+                        PdbDelta = "PDBDelta3",
+                        MetadataDelta = "MetadataDelta3",
+                        UpdatedTypes = [42],
+                    },
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta4",
+                        PdbDelta = "PDBDelta4",
+                        MetadataDelta = "MetadataDelta4",
+                        UpdatedTypes = [42],
+                    },
+                    new()
+                    {
+                        ModuleId = Guid.NewGuid().ToString(),
+                        ILDelta = "ILDelta5",
+                        PdbDelta = "PDBDelta5",
+                        MetadataDelta = "MetadataDelta5",
+                        UpdatedTypes = [42],
+                    },
+                ]
             };
 
             context = new DefaultHttpContext();
@@ -189,10 +171,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             context.Request.Body = GetJson(newUpdate);
             await middleware.InvokeAsync(context);
 
-            // Assert
-            deltas.AddRange(newUpdate);
-            AssertUpdates(deltas, middleware.Updates);
-            Assert.NotEqual(0, context.Response.Headers["ETag"].Count);
+            AssertUpdates([update, newUpdate], middleware.Updates);
         }
 
         [Fact]
@@ -219,26 +198,33 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             var stream = new MemoryStream();
             context.Response.Body = stream;
             var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
-            var deltas = new List<BlazorWasmHotReloadMiddleware.Update>
+            var updates = new List<BlazorWasmHotReloadMiddleware.Update>
             {
-                new BlazorWasmHotReloadMiddleware.Update
+                new()
                 {
-                    SequenceId = 0,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta1",
-                    MetadataDelta = "MetadataDelta1",
-                    UpdatedTypes = [42],
-                },
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 1,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta2",
-                    MetadataDelta = "MetadataDelta2",
-                    UpdatedTypes = [42],
+                    Id = 0,
+                    Deltas =
+                    [
+                        new()
+                        {
+                            ModuleId = Guid.NewGuid().ToString(),
+                            ILDelta = "ILDelta1",
+                            PdbDelta = "PdbDelta1",
+                            MetadataDelta = "MetadataDelta1",
+                            UpdatedTypes = [42],
+                        },
+                        new()
+                        {
+                            ModuleId = Guid.NewGuid().ToString(),
+                            ILDelta = "ILDelta2",
+                            PdbDelta = "PdbDelta2",
+                            MetadataDelta = "MetadataDelta2",
+                            UpdatedTypes = [42],
+                        }
+                    ]
                 }
             };
-            middleware.Updates.AddRange(deltas);
+            middleware.Updates.AddRange(updates);
 
             // Act
             await middleware.InvokeAsync(context);
@@ -246,132 +232,36 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             // Assert
             Assert.Equal(200, context.Response.StatusCode);
             Assert.Equal(
-                JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web)),
+                JsonSerializer.SerializeToUtf8Bytes(updates, new JsonSerializerOptions(JsonSerializerDefaults.Web)),
                 stream.ToArray());
-            Assert.NotEqual(0, context.Response.Headers[HeaderNames.ETag].Count);
-        }
-
-        [Fact]
-        public async Task GetReturnsNotModified_IfNoneMatchApplies()
-        {
-            // Arrange
-            var context = new DefaultHttpContext();
-            context.Request.Method = "get";
-            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
-            var deltas = new List<BlazorWasmHotReloadMiddleware.Update>
-            {
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 0,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta1",
-                    MetadataDelta = "MetadataDelta1",
-                    UpdatedTypes = [42],
-                },
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 1,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta2",
-                    MetadataDelta = "MetadataDelta2",
-                    UpdatedTypes = [42],
-                }
-            };
-            middleware.Updates.AddRange(deltas);
-
-            // Act 1
-            await middleware.InvokeAsync(context);
-            var etag = context.Response.Headers[HeaderNames.ETag];
-
-            // Act 2
-            context = new DefaultHttpContext();
-            context.Request.Method = "get";
-            context.Request.Headers[HeaderNames.IfNoneMatch] = etag;
-
-            await middleware.InvokeAsync(context);
-
-            // Assert 2
-            Assert.Equal(StatusCodes.Status304NotModified, context.Response.StatusCode);
-        }
-
-        [Fact]
-        public async Task GetReturnsUpdatedResults_IfNoneMatchFails()
-        {
-            // Arrange
-            var context = new DefaultHttpContext();
-            context.Request.Method = "get";
-            var middleware = new BlazorWasmHotReloadMiddleware(context => throw new TimeZoneNotFoundException());
-            var deltas = new List<BlazorWasmHotReloadMiddleware.Update>
-            {
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 0,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta1",
-                    MetadataDelta = "MetadataDelta1",
-                    UpdatedTypes = [42],
-                },
-                new BlazorWasmHotReloadMiddleware.Update
-                {
-                    SequenceId = 1,
-                    ModuleId = Guid.NewGuid().ToString(),
-                    ILDelta = "ILDelta2",
-                    MetadataDelta = "MetadataDelta2",
-                    UpdatedTypes = [42],
-                }
-            };
-            middleware.Updates.AddRange(deltas);
-
-            // Act 1
-            await middleware.InvokeAsync(context);
-            var etag = context.Response.Headers[HeaderNames.ETag];
-
-            // Act 2
-            var update = new BlazorWasmHotReloadMiddleware.Update
-            {
-                SequenceId = 3,
-                ModuleId = Guid.NewGuid().ToString(),
-                ILDelta = "ILDelta3",
-                MetadataDelta = "MetadataDelta3",
-                UpdatedTypes = [42],
-            };
-            deltas.Add(update);
-            middleware.Updates.Add(update);
-            context = new DefaultHttpContext();
-            context.Request.Method = "get";
-            context.Request.Headers[HeaderNames.IfNoneMatch] = etag;
-            var stream = new MemoryStream();
-            context.Response.Body = stream;
-
-            await middleware.InvokeAsync(context);
-
-            // Assert 2
-            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
-            Assert.Equal(
-                JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web)),
-                stream.ToArray());
-            Assert.NotEqual(etag, context.Response.Headers[HeaderNames.ETag]);
         }
 
         private static void AssertUpdates(IReadOnlyList<BlazorWasmHotReloadMiddleware.Update> expected, IReadOnlyList<BlazorWasmHotReloadMiddleware.Update> actual)
         {
             Assert.Equal(expected.Count, actual.Count);
 
-            for (var i = 0; i < expected.Count; i++)
+            for (var u = 0; u < expected.Count; u++)
             {
-                Assert.Equal(expected[i].ILDelta, actual[i].ILDelta);
-                Assert.Equal(expected[i].MetadataDelta, actual[i].MetadataDelta);
-                Assert.Equal(expected[i].ModuleId, actual[i].ModuleId);
-                Assert.Equal(expected[i].SequenceId, actual[i].SequenceId);
-                Assert.Equal(expected[i].UpdatedTypes, actual[i].UpdatedTypes);
+                var expectedUpdate = expected[u];
+                var actualUpdate = actual[u];
+                Assert.Equal(expectedUpdate.Id, actualUpdate.Id);
+                Assert.Equal(expectedUpdate.Deltas.Length, expectedUpdate.Deltas.Length);
+
+                for (var i = 0; i < expectedUpdate.Deltas.Length; i++)
+                {
+                    Assert.Equal(expectedUpdate.Deltas[i].ILDelta, actualUpdate.Deltas[i].ILDelta);
+                    Assert.Equal(expectedUpdate.Deltas[i].PdbDelta, actualUpdate.Deltas[i].PdbDelta);
+                    Assert.Equal(expectedUpdate.Deltas[i].MetadataDelta, actualUpdate.Deltas[i].MetadataDelta);
+                    Assert.Equal(expectedUpdate.Deltas[i].ModuleId, actualUpdate.Deltas[i].ModuleId);
+                    Assert.Equal(expectedUpdate.Deltas[i].UpdatedTypes, actualUpdate.Deltas[i].UpdatedTypes);
+                }
             }
         }
 
-        private Stream GetJson(IReadOnlyList<BlazorWasmHotReloadMiddleware.Update> deltas)
+        private static Stream GetJson(object obj)
         {
-            var bytes = JsonSerializer.SerializeToUtf8Bytes(deltas, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(obj, new JsonSerializerOptions(JsonSerializerDefaults.Web));
             return new MemoryStream(bytes);
         }
     }
 }
-#endif

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
@@ -492,14 +492,12 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             var middleware = new BrowserRefreshMiddleware(async (context) =>
             {
-
                 context.Response.ContentType = "application/json";
                 await context.Response.StartAsync();
                 await context.Response.WriteAsync("{ }");
             }, NullLogger<BrowserRefreshMiddleware>.Instance);
 
-            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateDotnetModifiableAssemblies(middleware) = "true";
-            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateAspnetcoreBrowserTools(middleware) = "true";
+            middleware.Test_SetEnvironment(dotnetModifiableAssemblies: "true", aspnetcoreBrowserTools: "true");
 
             // Act
             await middleware.InvokeAsync(context);
@@ -545,8 +543,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 await context.Response.WriteAsync("{ }");
             }, NullLogger<BrowserRefreshMiddleware>.Instance);
 
-            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateDotnetModifiableAssemblies(middleware) = "true";
-            UnsafeBrowserRefreshMiddlewareAccessor.GetSetPrivateAspnetcoreBrowserTools(middleware) = "true";
+            middleware.Test_SetEnvironment(dotnetModifiableAssemblies: "true", aspnetcoreBrowserTools: "true");
 
             // Act
             await middleware.InvokeAsync(context);
@@ -596,15 +593,6 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             // Assert
             var responseContent = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal("<html><body><h1>Hello world</h1><script src=\"/_framework/aspnetcore-browser-refresh.js\"></script></body></html>", responseContent);
-        }
-
-        private static class UnsafeBrowserRefreshMiddlewareAccessor
-        {
-            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_dotnetModifiableAssemblies")]
-            extern internal static ref string GetSetPrivateDotnetModifiableAssemblies(BrowserRefreshMiddleware middleware);
-
-            [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_aspnetcoreBrowserTools")]
-            extern internal static ref string GetSetPrivateAspnetcoreBrowserTools(BrowserRefreshMiddleware middleware);
         }
 
         private class TestHttpResponseFeature : IHttpResponseFeature, IHttpResponseBodyFeature

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
@@ -45,18 +45,32 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         [Fact]
         public async Task PostBlazorHotReloadMiddlewareWorks()
         {
-            // Arrange
             var requestDelegate = GetRequestDelegate();
             var context = new DefaultHttpContext();
             context.Request.Path = "/_framework/blazor-hotreload";
             context.Request.Method = "POST";
-            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("[]"));
 
-            // Act
+            var updateJson = """
+                {"id":0,"deltas":[{"moduleId":"9BBB9BBD-48F0-4EB2-B7A3-956CFC220CC4","metadataDelta":"","ilDelta":"","pdbDelta":"","updatedTypes":[1,2,3]}]}
+                """;
+
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(updateJson));
+
             await requestDelegate(context);
 
-            // Assert
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+
+            context.Request.Path = "/_framework/blazor-hotreload";
+            context.Request.Method = "GET";
+
+            var body = new MemoryStream();
+            context.Response.Body = body;
+
+            await requestDelegate(context);
+
+            var bodyJson = Encoding.UTF8.GetString(body.ToArray());
+
+            Assert.Equal($"[{updateJson}]", bodyJson);
         }
 
         [Fact]

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -198,6 +198,9 @@ namespace Microsoft.DotNet.Watcher.Tests
             App.AssertOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
             App.AssertOutputContains("dotnet watch ⌚ Launching browser: http://localhost:5000/");
 
+            // shouldn't see any agent messages (agent is not loaded into blazor-devserver):
+            AssertEx.DoesNotContain("🕵️", App.Process.Output);
+
             var newSource = """
                 @page "/"
                 <h1>Updated</h1>

--- a/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
@@ -11,19 +11,20 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task UpdatePayload_CanRoundTrip()
         {
             var initial = new UpdatePayload(
-                new[]
-                {
+                [
                     new UpdateDelta(
                         moduleId: Guid.NewGuid(),
-                        ilDelta: new byte[] { 0, 0, 1 },
-                        metadataDelta: new byte[] { 0, 1, 1 },
-                        updatedTypes: Array.Empty<int>()),
+                        ilDelta: [0, 0, 1],
+                        metadataDelta: [0, 1, 1],
+                        pdbDelta: [2, 3],
+                        updatedTypes: [5, 4]),
                     new UpdateDelta(
                         moduleId: Guid.NewGuid(),
-                        ilDelta: new byte[] { 1, 0, 0 },
-                        metadataDelta: new byte[] { 1, 0, 1 },
-                        updatedTypes: Array.Empty<int>())
-                },
+                        ilDelta: [1, 0, 0],
+                        metadataDelta: [1, 0, 1],
+                        pdbDelta: [7, 8],
+                        updatedTypes: [9])
+                ],
                 responseLoggingLevel: ResponseLoggingLevel.Verbose);
 
             using var stream = new MemoryStream();
@@ -39,19 +40,20 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task UpdatePayload_CanRoundTripUpdatedTypes()
         {
             var initial = new UpdatePayload(
-                new[]
-                {
+                [
                     new UpdateDelta(
                         moduleId: Guid.NewGuid(),
-                        ilDelta: new byte[] { 0, 0, 1 },
-                        metadataDelta: new byte[] { 0, 1, 1 },
-                        updatedTypes: new int[] { 60, 74, 22323 }),
+                        ilDelta: [0, 0, 1],
+                        metadataDelta: [0, 1, 1],
+                        pdbDelta: [],
+                        updatedTypes: [60, 74, 22323]),
                     new UpdateDelta(
                         moduleId: Guid.NewGuid(),
-                        ilDelta: new byte[] { 1, 0, 0 },
-                        metadataDelta: new byte[] { 1, 0, 1 },
-                        updatedTypes: new int[] { -18 })
-                },
+                        ilDelta: [1, 0, 0],
+                        metadataDelta: [1, 0, 1],
+                        pdbDelta: [],
+                        updatedTypes: [-18])
+                ],
                 responseLoggingLevel: ResponseLoggingLevel.WarningsAndErrors);
 
             using var stream = new MemoryStream();
@@ -67,14 +69,14 @@ namespace Microsoft.DotNet.Watcher.Tests
         public async Task UpdatePayload_WithLargeDeltas_CanRoundtrip()
         {
             var initial = new UpdatePayload(
-                new[]
-                {
+                [
                     new UpdateDelta(
                         moduleId: Guid.NewGuid(),
-                        ilDelta: Enumerable.Range(0, 68200).Select(c => (byte)(c%2)).ToArray(),
-                        metadataDelta: new byte[] { 0, 1, 1 },
+                        ilDelta: Enumerable.Range(0, 68200).Select(c => (byte)(c % 2)).ToArray(),
+                        metadataDelta: [0, 1, 1],
+                        pdbDelta: [],
                         updatedTypes: Array.Empty<int>())
-                },
+                ],
                 responseLoggingLevel: ResponseLoggingLevel.Verbose);
 
             using var stream = new MemoryStream();


### PR DESCRIPTION
Improves browser connection management and delta application to WASM.
Includes PDB delta in the update payload.
Sends logs from the client back to dotnet-watch.
Prepares agent code for sharing with ASP.NET.
Fixes issues with delta application when multiple browsers are connected to the same dev server.