### PR TITLE
Remove prep-source-build.sh invocation from vmr devcontainer config

### DIFF
--- a/.devcontainer/vmr/init.sh
+++ b/.devcontainer/vmr/init.sh
@@ -27,4 +27,4 @@ vmr_branch=$(git -C "$sdk_dir" log --pretty=format:'%D' HEAD^ \
 
 "$workspace_dir/synchronize-vmr.sh" --branch "$vmr_branch" --debug
 
-(cd "$vmr_dir" && ./prep-source-build.sh)
+cd "$vmr_dir"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,8 +102,9 @@
 /test/dotnet-format.Tests @dotnet/roslyn-ide
 
 # Area: VMR & SourceBuild
-/.devcontainer/ @dotnet/source-build
+/.devcontainer/ @dotnet/source-build @dotnet/product-construction
 /eng/pipelines/ @dotnet/source-build @dotnet/product-construction
+/eng/DotNetBuild.props @dotnet/source-build @dotnet/product-construction
 /eng/SourceBuild* @dotnet/source-build
 /src/SourceBuild/ @dotnet/source-build @dotnet/product-construction
 /src/VirtualMonoRepo/ @dotnet/product-construction


### PR DESCRIPTION
The docs explicitly mention that the prep-source-build.sh script needs to be invoked for source-build scenarios: https://github.com/dotnet/sdk/blob/main/.devcontainer/vmr/README.md#build-the-sdk

Remove the invocation in init.sh as otherwise non-source-only builds fail to build inside the VMR (roslyn is missing a winmd file).

---

Also update CODEOWNERS file