### PR TITLE
Revert "[main] Update dependencies from dotnet/arcade-services"

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.24530.2",
+      "version": "1.1.0-beta.24367.3",
       "commands": [
         "darc"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -633,13 +633,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c4d7f7c6f2e2f34f07e64c6caa3bf9b2ce915cc1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.24530.2">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.24367.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>3741e4a558b370d5713951f009ccdcbc38dbe2e9</Sha>
+      <Sha>47e3672c762970073e4282bd563233da86bcca3e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.24530.2">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.24367.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>3741e4a558b370d5713951f009ccdcbc38dbe2e9</Sha>
+      <Sha>47e3672c762970073e4282bd563233da86bcca3e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ScenarioTests.SdkTemplateTests" Version="10.0.0-preview.24517.1">
       <Uri>https://github.com/dotnet/scenario-tests</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,7 +95,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.24530.2</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.24367.3</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->


### PR DESCRIPTION
Reverts dotnet/sdk#44554 because of https://github.com/dotnet/source-build/issues/4713#issuecomment-2450797676