### PR TITLE
Allow ProjectReferences to not have the _GetRequiredWorkloads Target

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
@@ -42,14 +42,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--  This target is not part of the build. Only used by dotnet workload restore command. Global property "SkipResolvePackageAssets"
-        need to be set to "true" to avoid requiring restore (which would likely fail if the required workloads aren't already installed).-->
+        need to be set to "true" to avoid requiring restore (which would likely fail if the required workloads aren't already installed).
+        In addition, since this is a target that is called on potentially-unsupported project types like esproj, we need to not fail
+        if the Target is missing. -->
   <Target Name="_GetRequiredWorkloads" DependsOnTargets="GetSuggestedWorkloads;PrepareProjectReferences" Returns="@(_ResolvedSuggestedWorkload)">
     <MSBuild
       Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="_GetRequiredWorkloads"
       BuildInParallel="$(BuildInParallel)"
       Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
-      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences);TargetFramework;TargetFrameworks">
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences);TargetFramework;TargetFrameworks"
+      SkipNonexistentProjects="true" >
       <Output TaskParameter="TargetOutputs" ItemName="SuggestedWorkloadFromReference"/>
     </MSBuild>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
@@ -52,7 +52,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       BuildInParallel="$(BuildInParallel)"
       Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences);TargetFramework;TargetFrameworks"
-      SkipNonexistentProjects="true" >
+      SkipNonexistentTargets="true" >
       <Output TaskParameter="TargetOutputs" ItemName="SuggestedWorkloadFromReference"/>
     </MSBuild>
 

--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/App.csproj
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/App.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="./Lib.esproj" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/Lib.esproj
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/Lib.esproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.VisualStudio.JavaScript.SDK/1.0.1948920" />

--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/package-lock.json
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "lib",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lib",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/package.json
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "lib",
+  "version": "1.0.0",
+  "description": "A test project to verify .NET SDK compatibility for workload restore and non-Managed projects",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/test/dotnet-workload-restore.Tests/GivenDotnetWorkloadRestore.cs
+++ b/test/dotnet-workload-restore.Tests/GivenDotnetWorkloadRestore.cs
@@ -10,6 +10,7 @@ public class GivenDotnetWorkloadRestore : SdkTest
     }
 
     public static string DcProjAssetName = "SolutionWithAppAndDcProj";
+    public static string TransitiveReferenceNoWorkloadsAssetName = "ProjectWithEsProjReference";
 
     [Fact]
     public void ProjectsThatDoNotSupportWorkloadsAreNotInspected()
@@ -25,6 +26,23 @@ public class GivenDotnetWorkloadRestore : SdkTest
         .Execute()
         .Should()
         // if we did try to restore the dcproj in this TestAsset we would fail, so passing means we didn't!
+        .Pass();
+    }
+
+    [Fact]
+    public void ProjectsThatDoNotSupportWorkloadsAndAreTransitivelyReferencedDoNotBreakTheBuild()
+    {
+        var projectPath =
+            _testAssetsManager
+                .CopyTestAsset(TransitiveReferenceNoWorkloadsAssetName)
+                .WithSource()
+                .Path;
+
+        new DotnetWorkloadCommand(Log, "restore")
+        .WithWorkingDirectory(projectPath)
+        .Execute()
+        .Should()
+        // if we did try to restore the esproj in this TestAsset we would fail, so passing means we didn't!
         .Pass();
     }
 }


### PR DESCRIPTION
This prevents a ProjectReference to an esproj project (and other project types) from failing when `dotnet workload restore` is called on a .NET project.

Fixes https://github.com/dotnet/sdk/issues/44587

I would want to backport to 8.0.x after merging because 8.x is LTS.