### PR TITLE
Make dotnet-watch tests TFM agnostic

### DIFF
--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             Assert.Matches(
                 @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1\.0\.0\.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
-                App.Process.Output);
+                string.Join(Environment.NewLine, App.Process.Output));
         }
 
         [Theory]
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             Assert.Matches(
                 @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Exception from 'System.Action`1\[System.Type\[\]\]': System.InvalidOperationException: Bug!",
-                App.Process.Output);
+                string.Join(Environment.NewLine, App.Process.Output));
 
             if (verbose)
             {

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -127,8 +127,8 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            AssertEx.Contains(
-                "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
+            Assert.Matches(
+                @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1\.0\.0\.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
                 App.Process.Output);
         }
 
@@ -168,13 +168,13 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            AssertEx.Contains(
-                "dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!",
+            Assert.Matches(
+                @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Exception from 'System.Action`1\[System.Type\[\]\]': System.InvalidOperationException: Bug!",
                 App.Process.Output);
 
             if (verbose)
             {
-                AssertEx.Contains("dotnet watch 🕵️ [WatchHotReloadApp (net9.0)] Deltas applied.", App.Process.Output);
+                AssertEx.ContainsRegex(@"dotnet watch 🕵️ \[WatchHotReloadApp \(net\d+\.\d+\)\] Deltas applied.", App.Process.Output);
             }
             else
             {

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -127,9 +127,9 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            Assert.Matches(
+            AssertEx.ContainsRegex(
                 @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Expected to find a static method 'ClearCache' or 'UpdateApplication' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1\.0\.0\.0, Culture=neutral, PublicKeyToken=null' but neither exists.",
-                string.Join(Environment.NewLine, App.Process.Output));
+                App.Process.Output);
         }
 
         [Theory]
@@ -168,9 +168,9 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             await App.AssertOutputLineStartsWith("Updated");
 
-            Assert.Matches(
+            AssertEx.ContainsRegex(
                 @"dotnet watch ⚠ \[WatchHotReloadApp \(net\d+\.\d+\)\] Exception from 'System.Action`1\[System.Type\[\]\]': System.InvalidOperationException: Bug!",
-                string.Join(Environment.NewLine, App.Process.Output));
+                App.Process.Output);
 
             if (verbose)
             {

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Text.RegularExpressions;
 using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Watcher.Tools
@@ -232,6 +233,26 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             var message = new StringBuilder();
             message.AppendLine($"'{expected}' not found in:");
+
+            foreach (var item in items)
+            {
+                message.AppendLine($"'{item}'");
+            }
+
+            Fail(message.ToString());
+        }
+
+        public static void ContainsRegex(string pattern, IEnumerable<string> items)
+        {
+            var regex = new Regex(pattern, RegexOptions.Compiled);
+
+            if (items.Any(item => regex.IsMatch(item)))
+            {
+                return;
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine($"Pattern '{pattern}' not found in:");
 
             foreach (var item in items)
             {


### PR DESCRIPTION
next thing to unblock https://github.com/dotnet/sdk/pull/43015


```
[m[37m      'dotnet watch ⚠ [WatchHotReloadApp (net9.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!' not found in:
...
37m      'dotnet watch ⚠ [WatchHotReloadApp (net10.0)] Exception from 'System.Action`1[System.Type[]]': System.InvalidOperationException: Bug!'
[m[37m      '   at AppUpdateHandler.ClearCache(Type[] types)'

```