### PR TITLE
Workaround for issue 40015: nuget restore uses 'resource' instead of 'resources'

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -70,6 +70,11 @@ namespace Microsoft.NET.Build.Tasks
             {
                 Asset = AssetType.Resources;
             }
+            // Workaround for issue 40015: nuget restore uses 'resource' instead of 'resources'
+            else if (assetType.Equals("resource", StringComparison.OrdinalIgnoreCase))
+            {
+                Asset = AssetType.Resources;
+            }
             else
             {
                 throw new InvalidOperationException($"Unrecognized AssetType '{assetType}' for {SourcePath}");


### PR DESCRIPTION
Fixes #40015

Tested locally with a project manifesting the issue (throwing `System.InvalidOperationException: Unrecognized AssetType 'resource'`), and with the new `Microsoft.NET.Build.Tasks.dll` it doesn't happen