### PR TITLE
Invoke dotnet nuget why directly through API

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 
+using NuGetDocumentedCommand = NuGet.CommandLine.XPlat.Commands.DocumentedCommand;
+
 namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand(string[] helpArgs)
@@ -104,6 +106,11 @@ namespace Microsoft.DotNet.Tools.Help
             if (parsedCommand?.CommandResult?.Command is DocumentedCommand dc)
             {
                 docsLink = dc.DocsLink;
+                return true;
+            }
+            else if (parsedCommand?.CommandResult?.Command is NuGetDocumentedCommand ndc)
+            {
+                docsLink = ndc.HelpUrl;
                 return true;
             }
             docsLink = null;

--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli
             command.Subcommands.Add(GetVerifyCommand());
             command.Subcommands.Add(GetTrustCommand());
             command.Subcommands.Add(GetSignCommand());
-            command.Subcommands.Add(GetWhyCommand());
+            NuGet.CommandLine.XPlat.Commands.Why.WhyCommand.GetWhyCommand(command);
 
             command.SetAction(NuGetCommand.Run);
 
@@ -217,20 +217,6 @@ namespace Microsoft.DotNet.Cli
             signCommand.SetAction(NuGetCommand.Run);
 
             return signCommand;
-        }
-
-        private static CliCommand GetWhyCommand()
-        {
-            DocumentedCommand whyCommand = new("why", "https://learn.microsoft.com/dotnet/core/tools/dotnet-nuget-why");
-            whyCommand.Arguments.Add(new CliArgument<string>("PROJECT|SOLUTION") { Arity = ArgumentArity.ExactlyOne });
-            whyCommand.Arguments.Add(new CliArgument<string>("PACKAGE") { Arity = ArgumentArity.ExactlyOne });
-
-            whyCommand.Options.Add(new ForwardedOption<IEnumerable<string>>("--framework", "-f") { Arity = ArgumentArity.ZeroOrMore }
-                .ForwardAsManyArgumentsEachPrefixedByOption("--framework")
-                .AllowSingleArgPerToken());
-
-            whyCommand.SetAction(NuGetCommand.Run);
-            return whyCommand;
         }
     }
 }

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.CommandLine.XPlat" />
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.NET.HostModel" />

--- a/test/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
+++ b/test/dotnet-nuget.UnitTests/GivenANuGetCommand.cs
@@ -75,9 +75,6 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                                    "--interactive",
                                    "--verbosity", "detailed",
                                    "--format", "json"}, 0)]
-        [InlineData(new[] { "why" }, 0)]
-        [InlineData(new[] { "why", "C:\\path", "Fake.Package" }, 0)]
-        [InlineData(new[] { "why", "C:\\path", "Fake.Package", "--framework", "net472", "-f", "netcoreapp5.0" }, 0)]
 
         public void ItPassesCommandIfSupported(string[] inputArgs, int result)
         {
@@ -109,6 +106,30 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .Fail()
                 .And
                 .HaveStdErrContaining("Required argument missing for option: '-ss'.");
+        }
+
+        [Fact]
+        public void ItHasAWhySubcommand()
+        {
+            var testAssetName = "NewtonSoftDependentProject";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
+
+            new RestoreCommand(testAsset)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr();
+
+            new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute("nuget", "why", "newtonsoft.json")
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("has the following dependency");
         }
     }
 }


### PR DESCRIPTION
The initial version of `dotnet nuget why` required two arguments, the first being the solution, project, or directory to run as. In https://github.com/NuGet/NuGet.Client/pull/5969 I made it optional, using the current directory when not provided. However, this repo has a duplicate of the CLI parser to aid tab-completion. Therefore, even when the command works, there's an error message:

![image](https://github.com/user-attachments/assets/f7679a23-4b2d-4085-be42-302e810db876)

Following https://github.com/NuGet/NuGet.Client/pull/6118, this PR changes the dotnet CLI to get the CLI parser from NuGet directly (this command uses System.CommandLine), so `dotnet nuget why` no longer needs to be invoked though the NuGet.CommandLine.XPlat console app.  Therefore, any future changes to `dotnet nuget why` will apply automatically on NuGet insertion, rather than needing duplicate CLI parsing changes in both repos.