### PR TITLE
vmr to macos-13

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -93,7 +93,7 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
-    value: macos-12
+    value: macos-13
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64.open
 - ${{ else }}:


### PR DESCRIPTION
ios simulator build was failing
```
##[error]The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721
,##[error]The remote provider was unable to process the request.
```
https://github.com/dotnet/runtime/pull/109454 @jkoritzinsky