### PR TITLE
Update dotnet-watch argument parsing to use forward options from child commands

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -34,7 +34,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
 
         private readonly ProjectLauncher _projectLauncher;
         private readonly AspireServerService _service;
-        private readonly IReadOnlyList<(string name, string value)> _buildProperties;
+        private readonly IReadOnlyList<string> _buildArguments;
 
         /// <summary>
         /// Lock to access:
@@ -47,10 +47,10 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
         private int _sessionIdDispenser;
         private volatile bool _isDisposed;
 
-        public SessionManager(ProjectLauncher projectLauncher, IReadOnlyList<(string name, string value)> buildProperties)
+        public SessionManager(ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments)
         {
             _projectLauncher = projectLauncher;
-            _buildProperties = buildProperties;
+            _buildArguments = buildArguments;
 
             _service = new AspireServerService(
                 this,
@@ -239,7 +239,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                 IsRootProject = false,
                 ProjectPath = projectLaunchInfo.ProjectPath,
                 WorkingDirectory = _projectLauncher.EnvironmentOptions.WorkingDirectory, // TODO: Should DCP protocol specify?
-                BuildProperties = _buildProperties, // TODO: Should DCP protocol specify?
+                BuildArguments = _buildArguments, // TODO: Should DCP protocol specify?
                 Command = "run",
                 CommandArguments = arguments,
                 LaunchEnvironmentVariables = projectLaunchInfo.Environment?.Select(kvp => (kvp.Key, kvp.Value)).ToArray() ?? [],
@@ -255,8 +255,8 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
     public static readonly AspireServiceFactory Instance = new();
     public const string AppHostProjectCapability = "Aspire";
 
-    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<(string name, string value)> buildProperties)
+    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments)
         => projectNode.GetCapabilities().Contains(AppHostProjectCapability)
-            ? new SessionManager(projectLauncher, buildProperties)
+            ? new SessionManager(projectLauncher, buildArguments)
             : null;
 }

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -223,9 +223,9 @@ namespace Microsoft.DotNet.Watcher.Tools
                 return false;
             }
 
-            if (projectOptions.Command != "run")
+            if (!CommandLineOptions.IsCodeExecutionCommand(projectOptions.Command))
             {
-                reporter.Verbose("Browser refresh is only supported for run commands.");
+                reporter.Verbose($"Command '{projectOptions.Command}' does not support browser refresh.");
                 return false;
             }
 

--- a/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             if (!context.EnvironmentOptions.SuppressMSBuildIncrementalism &&
                 iteration > 0 &&
-                context.RootProjectOptions.Command is "run" or "test")
+                CommandLineOptions.IsCodeExecutionCommand(context.RootProjectOptions.Command))
             {
                 if (RequiresRevaluation)
                 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
@@ -12,5 +12,5 @@ namespace Microsoft.DotNet.Watcher;
 /// </summary>
 internal interface IRuntimeProcessLauncherFactory
 {
-    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<(string name, string value)> buildProperties);
+    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments);
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -52,7 +52,7 @@ internal sealed class ProjectLauncher(
             Executable = EnvironmentOptions.MuxerPath,
             WorkingDirectory = projectOptions.WorkingDirectory,
             OnOutput = onOutput,
-            Arguments = build || projectOptions.Command is not ("run" or "test")
+            Arguments = build || !CommandLineOptions.IsCodeExecutionCommand(projectOptions.Command)
                 ? [projectOptions.Command, .. projectOptions.CommandArguments]
                 : [projectOptions.Command, "--no-build", .. projectOptions.CommandArguments]
         };

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Watcher
 
                     var rootProjectNode = evaluationResult.ProjectGraph.GraphRoots.Single();
 
-                    runtimeProcessLauncher = runtimeProcessLauncherFactory?.TryCreate(rootProjectNode, projectLauncher, rootProjectOptions.BuildProperties);
+                    runtimeProcessLauncher = runtimeProcessLauncherFactory?.TryCreate(rootProjectNode, projectLauncher, rootProjectOptions.BuildArguments);
                     if (runtimeProcessLauncher != null)
                     {
                         var launcherEnvironment = runtimeProcessLauncher.GetEnvironmentVariables();

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -20,8 +20,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     /// </summary>
     internal class MSBuildFileSetFactory(
         string rootProjectFile,
-        string? targetFramework,
-        IReadOnlyList<(string name, string value)> buildProperties,
+        IEnumerable<string> buildArguments,
         EnvironmentOptions environmentOptions,
         IReporter reporter)
     {
@@ -170,7 +169,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 arguments.Add("/bl:DotnetWatch.GenerateWatchList.binlog");
             }
 
-            arguments.AddRange(buildProperties.Select(p => $"/p:{p.name}={p.value}"));
+            arguments.AddRange(buildArguments);
 
             // Set dotnet-watch reserved properties after the user specified propeties,
             // so that the former take precedence.
@@ -178,11 +177,6 @@ namespace Microsoft.DotNet.Watcher.Tools
             if (environmentOptions.SuppressHandlingStaticContentFiles)
             {
                 arguments.Add("/p:DotNetWatchContentFiles=false");
-            }
-
-            if (targetFramework != null)
-            {
-                arguments.Add("/p:TargetFramework=" + targetFramework);
             }
 
             arguments.Add("/p:_DotNetWatchListFile=" + watchListFilePath);
@@ -215,12 +209,8 @@ namespace Microsoft.DotNet.Watcher.Tools
         internal ProjectGraph? TryLoadProjectGraph(bool projectGraphRequired)
         {
             var globalOptions = new Dictionary<string, string>();
-            if (targetFramework != null)
-            {
-                globalOptions.Add("TargetFramework", targetFramework);
-            }
 
-            foreach (var (name, value) in buildProperties)
+            foreach (var (name, value) in CommandLineOptions.ParseBuildProperties(buildArguments))
             {
                 globalOptions[name] = value;
             }

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -172,8 +172,7 @@ namespace Microsoft.DotNet.Watcher
 
             var fileSetFactory = new MSBuildFileSetFactory(
                 rootProjectOptions.ProjectPath,
-                rootProjectOptions.TargetFramework,
-                rootProjectOptions.BuildProperties,
+                rootProjectOptions.BuildArguments,
                 environmentOptions,
                 reporter);
 
@@ -211,8 +210,7 @@ namespace Microsoft.DotNet.Watcher
         {
             var fileSetFactory = new MSBuildFileSetFactory(
                 rootProjectOptions.ProjectPath,
-                rootProjectOptions.TargetFramework,
-                rootProjectOptions.BuildProperties,
+                rootProjectOptions.BuildArguments,
                 environmentOptions,
                 reporter);
 

--- a/src/BuiltInTools/dotnet-watch/ProjectOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/ProjectOptions.cs
@@ -9,7 +9,7 @@ internal sealed record ProjectOptions
     public required string ProjectPath { get; init; }
     public required string WorkingDirectory { get; init; }
     public required string? TargetFramework { get; init; }
-    public required IReadOnlyList<(string name, string value)> BuildProperties { get; init; }
+    public required IReadOnlyList<string> BuildArguments { get; init; }
     public required bool NoLaunchProfile { get; init; }
     public required string? LaunchProfileName { get; init; }
 

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose /bl:DotnetRun.binlog",
-      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
+      "commandLineArgs": "--verbose --verbose --property TestProperty=123 build /t:TestTarget",
+      "workingDirectory": "C:\\sdk1\\artifacts\\tmp\\Debug\\MSBuildComman---24FA0250",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"
       }

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose --verbose --property TestProperty=123 build /t:TestTarget",
-      "workingDirectory": "C:\\sdk1\\artifacts\\tmp\\Debug\\MSBuildComman---24FA0250",
+      "commandLineArgs": "--verbose /bl:DotnetRun.binlog",
+      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"
       }

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -17,10 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\Common\EnvironmentVariableNames.cs" Link="Common\EnvironmentVariableNames.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" />
     <Content Include="DotNetWatch.targets" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
@@ -45,6 +41,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\Cli\dotnet\dotnet.csproj"/>
+
     <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj"
                       PrivateAssets="All"
                       ReferenceOutputAssembly="false"

--- a/src/Cli/dotnet/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/OptionForwardingExtensions.cs
@@ -77,15 +77,17 @@ namespace Microsoft.DotNet.Cli
             return option;
         }
 
+        internal static Dictionary<CliOption, Dictionary<CliCommand, string>> HelpDescriptionCustomizations = new();
+
         public static CliOption<T> WithHelpDescription<T>(this CliOption<T> option, CliCommand command, string helpText)
         {
-            if (Parser.HelpDescriptionCustomizations.ContainsKey(option))
+            if (HelpDescriptionCustomizations.ContainsKey(option))
             {
-                Parser.HelpDescriptionCustomizations[option].Add(command, helpText);
+                HelpDescriptionCustomizations[option].Add(command, helpText);
             }
             else
             {
-                Parser.HelpDescriptionCustomizations.Add(option, new Dictionary<CliCommand, string>() { { command, helpText } });
+                HelpDescriptionCustomizations.Add(option, new Dictionary<CliCommand, string>() { { command, helpText } });
             }
 
             return option;

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Cli
             Directives = { new DiagramDirective(), new SuggestDirective(), new EnvironmentVariablesDirective() }
         };
 
-        internal static Dictionary<CliOption, Dictionary<CliCommand, string>> HelpDescriptionCustomizations = new();
-
         public static readonly CliCommand InstallSuccessCommand = InternalReportinstallsuccessCommandParser.GetCommand();
 
         // Subcommands
@@ -224,11 +222,11 @@ namespace Microsoft.DotNet.Cli
 
             private static void SetHelpCustomizations(HelpBuilder builder)
             {
-                foreach (var option in HelpDescriptionCustomizations.Keys)
+                foreach (var option in OptionForwardingExtensions.HelpDescriptionCustomizations.Keys)
                 {
                     Func<HelpContext, string> descriptionCallback = (HelpContext context) =>
                     {
-                        foreach (var (command, helpText) in HelpDescriptionCustomizations[option])
+                        foreach (var (command, helpText) in OptionForwardingExtensions.HelpDescriptionCustomizations[option])
                         {
                             if (context.ParseResult.CommandResult.Command.Equals(command))
                             {

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -123,6 +123,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="SDDLTests" />
+    <InternalsVisibleTo Include="dotnet-watch" />
+    <InternalsVisibleTo Include="dotnet-watch.Tests" />
   </ItemGroup>
 
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">

--- a/test/TestAssets/TestProjects/WatchNoDepsApp/WatchNoDepsApp.csproj
+++ b/test/TestAssets/TestProjects/WatchNoDepsApp/WatchNoDepsApp.csproj
@@ -13,6 +13,8 @@
       actually an important failure, so don't error out here.
     -->
     <WarningsNotAsErrors>CS9057</WarningsNotAsErrors>
+
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <Target Name="TestTarget">

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -52,15 +52,15 @@ namespace Microsoft.DotNet.Watcher.Tools
         }
 
         [Theory]
-        [InlineData("P=V", "P", "V")]
-        [InlineData("P==", "P", "=")]
-        [InlineData("P=A=B", "P", "A=B")]
-        [InlineData(" P\t = V ", "P", " V ")]
-        [InlineData("P=", "P", "")]
+        [InlineData("-p:P=V", "P", "V")]
+        [InlineData("-p:P==", "P", "=")]
+        [InlineData("-p:P=A=B", "P", "A=B")]
+        [InlineData("-p: P\t = V ", "P", " V ")]
+        [InlineData("-p:P=", "P", "")]
         public void BuildProperties_Valid(string argValue, string name, string value)
         {
-            var options = VerifyOptions(["--property", argValue]);
-            Assert.Equal([(name, value)], options.BuildProperties);
+            var properties = CommandLineOptions.ParseBuildProperties([argValue]);
+            AssertEx.SequenceEqual([(name, value)], properties);
         }
 
         [Theory]
@@ -68,10 +68,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         [InlineData("=P3")]
         [InlineData("=")]
         [InlineData("==")]
-        public void BuildProperties_Invalid(string value)
+        public void BuildProperties_Invalid(string argValue)
         {
-            var options = VerifyOptions(["--property", value]);
-            Assert.Empty(options.BuildProperties);
+            var properties = CommandLineOptions.ParseBuildProperties([argValue]);
+            AssertEx.SequenceEqual([], properties);
         }
 
         [Fact]
@@ -290,9 +290,9 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             Assert.Equal("P", options.ProjectPath);
             Assert.Equal("F", options.TargetFramework);
-            Assert.Equal([("P1", "V1"), ("P2", "V2")], options.BuildProperties);
+            Assert.Equal(["-property:TargetFramework=F", "--property:P1=V1", "--property:P2=V2"], options.BuildArguments);
 
-            Assert.Equal(["--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
+            Assert.Equal(["--project", "P", "--framework", "F", "--property:P1=V1", "--property:P2=V2"], options.CommandArguments);
         }
 
         public enum ArgPosition
@@ -341,10 +341,10 @@ namespace Microsoft.DotNet.Watcher.Tools
         public void MultiplePropertyValues()
         {
             var options = VerifyOptions(["--property", "P1=V1", "run", "--property", "P2=V2"]);
-            AssertEx.SequenceEqual(["P1=V1", "P2=V2"], options.BuildProperties.Select(p => $"{p.name}={p.value}"));
+            AssertEx.SequenceEqual(["--property:P1=V1", "--property:P2=V2"], options.BuildArguments);
 
             // options must be repeated since --property does not support multiple args
-            AssertEx.SequenceEqual(["--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
+            AssertEx.SequenceEqual(["--property:P1=V1", "--property:P2=V2"], options.CommandArguments);
         }
 
         [Theory]
@@ -407,6 +407,29 @@ namespace Microsoft.DotNet.Watcher.Tools
         {
             var options = VerifyOptions(["-lp", "CustomLaunchProfile"]);
             Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
+        }
+
+        /// <summary>
+        /// Validates that options that the "run" command forwards to "build" command are forwarded by dotnet-watch.
+        /// </summary>
+        [Theory]
+        [InlineData(new[] { "--configuration", "release" }, new[] { "-property:Configuration=release" })]
+        [InlineData(new[] { "--framework", "net9.0" }, new[] { "-property:TargetFramework=net9.0" })]
+        [InlineData(new[] { "--runtime", "arm64" }, new[] { "-property:RuntimeIdentifier=arm64","-property:_CommandLineDefinedRuntimeIdentifier=true" })]
+        [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1" })]
+        [InlineData(new[] { "--interactive" }, new[] { "-property:NuGetInteractive=true" })]
+        [InlineData(new[] { "--no-restore" }, new[] { "-restore:false" })]
+        [InlineData(new[] { "--sc" }, new[] { "-property:SelfContained=True", "-property:_CommandLineDefinedSelfContained=true"})]
+        [InlineData(new[] { "--self-contained" }, new[] { "-property:SelfContained=True", "-property:_CommandLineDefinedSelfContained=true" })]
+        [InlineData(new[] { "--no-self-contained" }, new[] { "-property:SelfContained=False","-property:_CommandLineDefinedSelfContained=true"})]
+        [InlineData(new[] { "--verbosity", "q" }, new[] { "-verbosity:q" })]
+        [InlineData(new[] { "--arch", "arm", "--os", "win" }, new[] { "-property:RuntimeIdentifier=win-arm" })]
+        [InlineData(new[] { "--disable-build-servers" }, new[] { "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
+        [InlineData(new[] { "--artifacts-path", @"C:\x\y" }, new[] { @"-property:ArtifactsPath=C:\x\y" })]
+        public void ForwardedBuildOptions(string[] args, string[] buildArgs)
+        {
+            var options = VerifyOptions(["run", .. args]);
+            AssertEx.SequenceEqual(buildArgs, options.BuildArguments);
         }
     }
 }

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -425,9 +425,20 @@ namespace Microsoft.DotNet.Watcher.Tools
         [InlineData(new[] { "--verbosity", "q" }, new[] { "-verbosity:q" })]
         [InlineData(new[] { "--arch", "arm", "--os", "win" }, new[] { "-property:RuntimeIdentifier=win-arm" })]
         [InlineData(new[] { "--disable-build-servers" }, new[] { "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
-        [InlineData(new[] { "--artifacts-path", @"C:\x\y" }, new[] { @"-property:ArtifactsPath=C:\x\y" })]
         public void ForwardedBuildOptions(string[] args, string[] buildArgs)
         {
+            var options = VerifyOptions(["run", .. args]);
+            AssertEx.SequenceEqual(buildArgs, options.BuildArguments);
+        }
+
+        [Fact]
+        public void ForwardedBuildOptions_ArtifactsPath()
+        {
+            var path = TestContext.Current.TestAssetsDirectory;
+
+            var args = new[] { "--artifacts-path", path };
+            var buildArgs = new[] { @"-property:ArtifactsPath=" + path };
+
             var options = VerifyOptions(["run", .. args]);
             AssertEx.SequenceEqual(buildArgs, options.BuildArguments);
         }

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -25,8 +25,7 @@ public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTest
 
         var factory = new MSBuildFileSetFactory(
             rootProjectFile: options.ProjectPath,
-            targetFramework: null,
-            buildProperties: [],
+            buildArguments: [],
             environmentOptions: new EnvironmentOptions(Environment.CurrentDirectory, "dotnet"),
             reporter);
 

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -24,7 +24,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             IsRootProject = false,
             ProjectPath = projectPath,
             WorkingDirectory = workingDirectory,
-            BuildProperties = [],
+            BuildArguments = [],
             Command = "run",
             CommandArguments = ["--project", projectPath],
             LaunchEnvironmentVariables = [],

--- a/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -336,7 +336,7 @@ $@"<ItemGroup>
             var output = new List<string>();
             _reporter.OnProcessOutput += line => output.Add(line.Content);
 
-            var filesetFactory = new MSBuildFileSetFactory(projectA, targetFramework: null, buildProperties: [("_DotNetWatchTraceOutput", "true")], options, _reporter);
+            var filesetFactory = new MSBuildFileSetFactory(projectA, buildArguments: ["/p:_DotNetWatchTraceOutput=true"], options, _reporter);
 
             var result = await filesetFactory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.NotNull(result);
@@ -397,7 +397,7 @@ $@"<ItemGroup>
             var output = new List<string>();
             _reporter.OnProcessOutput += line => output.Add($"{(line.IsError ? "[stderr]" : "[stdout]")} {line.Content}");
 
-            var factory = new MSBuildFileSetFactory(project1Path, targetFramework: null, buildProperties: [], options, _reporter);
+            var factory = new MSBuildFileSetFactory(project1Path, buildArguments: [], options, _reporter);
             var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.Null(result);
 
@@ -416,7 +416,7 @@ $@"<ItemGroup>
                 MuxerPath: MuxerPath,
                 WorkingDirectory: Path.GetDirectoryName(projectPath)!);
 
-            var factory = new MSBuildFileSetFactory(projectPath, targetFramework: null, buildProperties: [], options, _reporter);
+            var factory = new MSBuildFileSetFactory(projectPath, buildArguments: [], options, _reporter);
             var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.NotNull(result);
             return result;

--- a/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
+++ b/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
@@ -7,8 +7,7 @@ namespace Microsoft.DotNet.Watcher.Tools;
 
 internal class MockFileSetFactory() : MSBuildFileSetFactory(
     rootProjectFile: "test.csproj",
-    targetFramework: null,
-    buildProperties: [],
+    buildArguments: [],
     new EnvironmentOptions(Environment.CurrentDirectory, "dotnet"),
     NullReporter.Singleton)
 {

--- a/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
@@ -11,7 +11,7 @@ internal class TestRuntimeProcessLauncher(ProjectLauncher projectLauncher) : IRu
 {
     public class Factory(Action<TestRuntimeProcessLauncher>? initialize = null) : IRuntimeProcessLauncherFactory
     {
-        public IRuntimeProcessLauncher TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<(string name, string value)> buildProperties)
+        public IRuntimeProcessLauncher TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments)
         {
             var service = new TestRuntimeProcessLauncher(projectLauncher);
             initialize?.Invoke(service);

--- a/test/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tests
 {

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("XunitMulti")
                 .WithSource();
 
-            App.Start(testAsset, ["--verbose", "--framework", ToolsetInfo.CurrentTargetFramework, "test", "--list-tests", "/p:VSTestUseMSBuildOutput=false"]);
+            App.Start(testAsset, ["--verbose", "test", "--framework", ToolsetInfo.CurrentTargetFramework, "--list-tests", "/p:VSTestUseMSBuildOutput=false"]);
 
             await App.AssertOutputLineEquals("The following Tests are available:");
             await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
@@ -228,7 +228,89 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             App.Start(testAsset, ["--verbose", "--property", "TestProperty=123", "build", "/t:TestTarget"]);
 
-            await App.AssertOutputLine(line => line.Contains("warning : The value of property is '123'", StringComparison.Ordinal));
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            // evaluation affected by -c option:
+            Assert.Contains("TestProperty", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
+
+            App.AssertOutputContains("dotnet watch ⌚ Command 'build' does not support Hot Reload.");
+            App.AssertOutputContains("dotnet watch ⌚ Command 'build' does not support browser refresh.");
+            App.AssertOutputContains("warning : The value of property is '123'");
+        }
+
+        [Fact]
+        public async Task MSBuildCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
+                .WithSource();
+
+            App.Start(testAsset, ["--verbose", "/p:TestProperty=123", "msbuild", "/t:TestTarget"]);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            // TestProperty is not passed to evaluation since msbuild command doesn't include it in forward options:
+            Assert.DoesNotContain("TestProperty", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
+
+            App.AssertOutputContains("dotnet watch ⌚ Command 'msbuild' does not support Hot Reload.");
+            App.AssertOutputContains("dotnet watch ⌚ Command 'msbuild' does not support browser refresh.");
+            App.AssertOutputContains("warning : The value of property is '123'");
+        }
+
+        [Fact]
+        public async Task PackCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
+                .WithSource();
+
+            App.Start(testAsset, ["--verbose", "pack", "-c", "Release"]);
+
+            var packagePath = Path.Combine(testAsset.Path, "bin", "Release", "WatchNoDepsApp.1.0.0.nupkg");
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            // evaluation affected by -c option:
+            Assert.Contains("-property:Configuration=Release", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
+
+            App.AssertOutputContains("dotnet watch ⌚ Command 'pack' does not support Hot Reload.");
+            App.AssertOutputContains("dotnet watch ⌚ Command 'pack' does not support browser refresh.");
+            App.AssertOutputContains($"Successfully created package '{packagePath}'");
+        }
+
+        [Fact]
+        public async Task PublishCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
+                .WithSource();
+
+            App.Start(testAsset, ["--verbose", "publish", "-c", "Release"]);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            // evaluation affected by -c option:
+            Assert.Contains("-property:Configuration=Release", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
+            
+            App.AssertOutputContains("dotnet watch ⌚ Command 'publish' does not support Hot Reload.");
+            App.AssertOutputContains("dotnet watch ⌚ Command 'publish' does not support browser refresh.");
+
+            App.AssertOutputContains(Path.Combine("Release", ToolsetInfo.CurrentTargetFramework, "publish"));
+        }
+
+        [Fact]
+        public async Task FormatCommand()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
+                .WithSource();
+
+            App.DotnetWatchArgs.Clear();
+            App.Start(testAsset, ["--verbose", "format", "--verbosity", "detailed"]);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            App.AssertOutputContains("dotnet watch ⌚ Command 'format' does not support Hot Reload.");
+            App.AssertOutputContains("dotnet watch ⌚ Command 'format' does not support browser refresh.");
+
+            App.AssertOutputContains("format --verbosity detailed");
+            App.AssertOutputContains("Format complete in");
         }
 
         [Fact]


### PR DESCRIPTION
dotnet-watch consumes some command line options, forwards others to dotnet run/build/msbuild processes it launches and to the actual application process.

The parsing is rather complex. This change simplifies the parsing a bit by leveraging the `IForwardedOption` interface. We take the dotnet-run command's options that implement `IForwardedOption` and include them in dotnet-watch option set. This will ensure that these options are parsed and forwarded exactly like they would be in dotnet-run and dotnet-build. This approach also ensures any options newly introduced to dotnet-run are automatically forwarded without having to update dotnet-watch.

This will also allow us to run dotnet-build from dotnet-watch separately from dotnet-run when needed.

Related: https://github.com/dotnet/sdk/issues/44655