### PR TITLE
improve SDK incremental builds by not running redist-installer layout generation on inner loop builds

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,7 +4,9 @@ echo %* | findstr /C:"-pack" >nul
 if %errorlevel%==0 (
     set PackInstaller=
 ) else (
+    REM disable crossgen for inner-loop builds to save a ton of time
     set PackInstaller=/p:PackInstaller=false
+    set DISABLE_CROSSGEN=true
 )
 powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -nativeToolsOnMachine -msbuildEngine dotnet %PackInstaller% %*"
 exit /b %ErrorLevel%

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,8 @@ done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 if [[ "$@" != *"-pack"* ]]; then
+  # disable crossgen for inner-loop builds to save a ton of time
+  export DISABLE_CROSSGEN=true
   packInstallerFlag="/p:PackInstaller=false"
 else
   packInstallerFlag=

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -619,11 +619,13 @@
                             CrossgenLayout;
                             LayoutAppHostTemplate;
                             ReplaceBundledRuntimePackFilesWithSymbolicLinks"
-          BeforeTargets="AfterBuild" />
+          BeforeTargets="AfterBuild"
+          Condition="'$(PackInstaller)' != false" />
 
   <Target Name="GenerateInternalLayout"
           DependsOnTargets="GenerateLayout"
-          BeforeTargets="AfterBuild">
+          BeforeTargets="AfterBuild"
+          Condition="'$(PackInstaller)' != false" >
     <RemoveDir Directories="$(SdkInternalLayoutPath)" />
     <MakeDir Directories="$(SdkInternalLayoutPath)" />
 

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -619,13 +619,11 @@
                             CrossgenLayout;
                             LayoutAppHostTemplate;
                             ReplaceBundledRuntimePackFilesWithSymbolicLinks"
-          BeforeTargets="AfterBuild"
-          Condition="'$(PackInstaller)' != false" />
+          BeforeTargets="AfterBuild" />
 
   <Target Name="GenerateInternalLayout"
           DependsOnTargets="GenerateLayout"
-          BeforeTargets="AfterBuild"
-          Condition="'$(PackInstaller)' != false" >
+          BeforeTargets="AfterBuild" >
     <RemoveDir Directories="$(SdkInternalLayoutPath)" />
     <MakeDir Directories="$(SdkInternalLayoutPath)" />
 


### PR DESCRIPTION
@SimaTian reported very long incremental build times, and @ViktorHofer pointed out it's because Crossgen was being run even on builds where the installer was not packaged (aka builds where `-pack` was not passed). While we condition several of the packaging-related redist-installer target imports on `PackInstaller` conditions, Crossgen was not. However, simply conditioning the Import of the Crossgen.targets wouldn't work, because merely building redist-installer.csproj was invoking Crossgen.

One potential solution is to not call the redist-installer's layout logic unless building installers, but there are probably other approaches that could be taken as well.

Simply not doing these layouts results in incremental builds that take 30s on my machine.