### PR TITLE
[9.0.2xx] Avoid warning about empty NuGetPackageRoot in wpftmp projects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -263,9 +263,10 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' != 'true' and !Exists('$(RoslynTargetsPath)')"
         FormatArguments="$(NETCoreSdkVersion)" />
 
-    <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016. -->
+    <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016.
+         WPF temp projects are ignored (its known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
     <NETSdkWarning ResourceName="MicrosoftNetSdkCompilersToolsetRootEmpty"
-        Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true'" />
+        Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true' and !($(MSBuildProjectFile.EndsWith('_wpftmp.csproj')) or $(MSBuildProjectFile.EndsWith('_wpftmp.vbproj')))" />
   </Target>
 
   <!-- TODO: this target should not check GeneratePackageOnBuild.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -264,7 +264,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         FormatArguments="$(NETCoreSdkVersion)" />
 
     <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016.
-         WPF temp projects are ignored (its known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
+         WPF temp projects are ignored (it's known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
     <NETSdkWarning ResourceName="MicrosoftNetSdkCompilersToolsetRootEmpty"
         Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true' and !($(MSBuildProjectFile.EndsWith('_wpftmp.csproj')) or $(MSBuildProjectFile.EndsWith('_wpftmp.vbproj')))" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/44605.