### PR TITLE
Clean up namespaces

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -12,9 +12,10 @@ parameters:
     runTestsAsTool: true
     # This job uses the build step for testing, so the extra test step is not necessary.
     runTests: false
-  - categoryName: TemplateEngine
-    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
-    publishXunitResults: true
+  # Turn off template engine runs on Windows temporarily until agent images are updated
+  #- categoryName: TemplateEngine
+  #  testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+  #  publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true
   ### LINUX ###

--- a/src/BuiltInTools/AspireService/AspireServerService.cs
+++ b/src/BuiltInTools/AspireService/AspireServerService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Net;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
@@ -13,13 +12,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.WebTools.AspireServer.Contracts;
-using Microsoft.WebTools.AspireServer.Helpers;
-using Microsoft.WebTools.AspireServer.Models;
-using Microsoft.WebTools.AspireService.Helpers;
 using IAsyncDisposable = System.IAsyncDisposable;
 
-namespace Microsoft.WebTools.AspireServer;
+namespace Aspire.Tools.Service;
 
 /// <summary>
 /// Implementation of the AspireServerService. A new instance of this service will be created for each

--- a/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
+++ b/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.WebTools.AspireServer.Contracts;
+namespace Aspire.Tools.Service;
 
 internal interface IAspireServerEvents
 {

--- a/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
+++ b/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
@@ -4,7 +4,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Microsoft.WebTools.AspireServer;
+namespace Aspire.Tools.Service;
 
 internal static class CertGenerator
 {

--- a/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
-namespace Microsoft.WebTools.AspireServer.Helpers;
+namespace Aspire.Tools.Service;
 
 internal static class ExceptionExtensions
 {

--- a/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
@@ -1,14 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.WebTools.AspireServer.Contracts;
-using Microsoft.WebTools.AspireServer.Models;
 
-namespace Microsoft.WebTools.AspireServer.Helpers;
+namespace Aspire.Tools.Service;
 
 internal static class HttpContextExtensions
 {

--- a/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
+++ b/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.WebTools.AspireService.Helpers;
+namespace Aspire.Tools.Service;
 
 internal sealed class LoggerProvider(Action<string> reporter) : ILoggerProvider
 {

--- a/src/BuiltInTools/AspireService/Helpers/SocketConnectionManager.cs
+++ b/src/BuiltInTools/AspireService/Helpers/SocketConnectionManager.cs
@@ -7,7 +7,7 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.WebTools.AspireServer;
+namespace Aspire.Tools.Service;
 
 /// <summary>
 /// Manages the set of active socket connections. Since it registers to be notified when a socket has gone bad,

--- a/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
+++ b/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
@@ -1,13 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
-namespace Microsoft.WebTools.AspireServer.Helpers;
+namespace Aspire.Tools.Service;
 
 internal class SocketUtilities
 {

--- a/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
+++ b/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
@@ -1,12 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Net.WebSockets;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Microsoft.WebTools.AspireServer;
+namespace Aspire.Tools.Service;
 
 /// <summary>
 /// Used by the SocketConnectionManager to track one socket connection. It needs to be disposed when done with it

--- a/src/BuiltInTools/AspireService/Models/ErrorResponse.cs
+++ b/src/BuiltInTools/AspireService/Models/ErrorResponse.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.WebTools.AspireServer.Models;
+namespace Aspire.Tools.Service;
 
 /// <summary>
 /// Detailed error information serialized into the body of the response

--- a/src/BuiltInTools/AspireService/Models/InfoResponse.cs
+++ b/src/BuiltInTools/AspireService/Models/InfoResponse.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.WebTools.AspireServer.Models;
+namespace Aspire.Tools.Service;
 
 /// <summary>
 /// Response when asked for /info

--- a/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
+++ b/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
@@ -1,15 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json.Serialization;
-using Microsoft.WebTools.AspireServer.Contracts;
 
-namespace Microsoft.WebTools.AspireServer.Models;
+namespace Aspire.Tools.Service;
 
 internal class EnvVar
 {

--- a/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
+++ b/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
@@ -4,7 +4,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.WebTools.AspireServer.Models;
+namespace Aspire.Tools.Service;
 
 internal static class NotificationType
 {

--- a/src/BuiltInTools/DotNetDeltaApplier/AgentReporter.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/AgentReporter.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class AgentReporter
 {

--- a/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 #if NET
 [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Hot reload is only expected to work when trimming is disabled.")]

--- a/src/BuiltInTools/DotNetDeltaApplier/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/MetadataUpdateHandlerInvoker.cs
@@ -3,7 +3,7 @@
 
 using System.Reflection;
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 /// <summary>
 /// Finds and invokes metadata update handlers.

--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO.Pipes;
-using Microsoft.DotNet.Watcher;
-using Microsoft.Extensions.HotReload;
+
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class StartupHook
 {

--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Pipes;
+using Microsoft.DotNet.Watch;
 
-namespace Microsoft.DotNet.Watch;
-
+/// <summary>
+/// The runtime startup hook looks for top-level type named "StartupHook".
+/// </summary>
 internal sealed class StartupHook
 {
     private static readonly bool s_logToStandardOutput = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages) == "1";

--- a/src/BuiltInTools/DotNetWatchTasks/FileSetSerializer.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/FileSetSerializer.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.Serialization.Json;
 using Microsoft.Build.Framework;
-using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.DotNet.Watch;
 using Task = Microsoft.Build.Utilities.Task;
 
 namespace DotNetWatchTasks

--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -5,14 +5,10 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Channels;
+using Aspire.Tools.Service;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-using Microsoft.WebTools.AspireServer;
-using Microsoft.WebTools.AspireServer.Contracts;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
 {

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnection.cs
@@ -4,9 +4,8 @@
 
 using System.Buffers;
 using System.Net.WebSockets;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch;
 
 internal readonly struct BrowserConnection : IAsyncDisposable
 {

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -6,10 +6,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed partial class BrowserConnector(DotNetWatchContext context) : IAsyncDisposable
     {

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
@@ -16,9 +16,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// Communicates with aspnetcore-browser-refresh.js loaded in the browser.

--- a/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLineOptions.cs
@@ -9,11 +9,9 @@ using System.Data;
 using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Tools.Run;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 using NuGet.Common;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class CommandLineOptions
 {

--- a/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatchContext.cs
@@ -1,9 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class DotNetWatchContext
     {

--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -4,11 +4,8 @@
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class DotNetWatcher(DotNetWatchContext context, MSBuildFileSetFactory fileSetFactory) : Watcher(context, fileSetFactory)
     {

--- a/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentOptions.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     [Flags]
     internal enum TestFlags

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariables.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariables.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal static partial class EnvironmentVariables
 {

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class EnvironmentVariablesBuilder
     {

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariables_StartupHook.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariables_StartupHook.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal static partial class EnvironmentVariables
 {

--- a/src/BuiltInTools/dotnet-watch/EvaluationResult.cs
+++ b/src/BuiltInTools/dotnet-watch/EvaluationResult.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Build.Graph;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class EvaluationResult(IReadOnlyDictionary<string, FileItem> files, ProjectGraph? projectGraph)
 {

--- a/src/BuiltInTools/dotnet-watch/FileItem.cs
+++ b/src/BuiltInTools/dotnet-watch/FileItem.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal readonly record struct FileItem
     {

--- a/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
@@ -3,10 +3,8 @@
 
 
 using System.Diagnostics;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal class BuildEvaluator(DotNetWatchContext context, MSBuildFileSetFactory rootProjectFileSetFactory)
     {

--- a/src/BuiltInTools/dotnet-watch/GlobalOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/GlobalOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class GlobalOptions
 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/AgentMessageSeverity.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/AgentMessageSeverity.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 internal enum AgentMessageSeverity : byte
 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -4,10 +4,8 @@
 using System.Buffers;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.Extensions.HotReload;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class BlazorWebAssemblyDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, Version? targetFrameworkVersion) : SingleProcessDeltaApplier(reporter)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -4,9 +4,8 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class BlazorWebAssemblyHostedDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, Version? targetFrameworkVersion) : DeltaApplier(reporter)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -9,10 +9,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class CompilationHandler : IDisposable
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -7,10 +7,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO.Pipes;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.Extensions.HotReload;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class DefaultDeltaApplier(IReporter reporter) : SingleProcessDeltaApplier(reporter)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DeltaApplier.cs
@@ -4,10 +4,8 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.Extensions.HotReload;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal abstract class DeltaApplier(IReporter reporter) : IDisposable
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadEventSource.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics.Tracing;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     [EventSource(Name = "HotReload")]
     internal sealed class HotReloadEventSource : EventSource

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfile.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal enum HotReloadProfile
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadProfileReader.cs
@@ -4,9 +4,8 @@
 
 using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal static class HotReloadProfileReader
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncher.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 /// <summary>
 /// Process launcher that triggers process launches at runtime of the watched application,

--- a/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Build.Graph;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 /// <summary>
 /// Creates <see cref="IRuntimeProcessLauncher"/> for a given root project.

--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -8,10 +8,8 @@ using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch;
 
 internal class IncrementalMSBuildWorkspace : Workspace
 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.HotReload
+namespace Microsoft.DotNet.Watch
 {
     internal readonly struct UpdatePayload(IReadOnlyList<UpdateDelta> deltas, ResponseLoggingLevel responseLoggingLevel)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -3,11 +3,8 @@
 
 using System.Globalization;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal delegate ValueTask ProcessExitAction(int processId, int? exitCode);
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectNodeMap.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectNodeMap.cs
@@ -3,9 +3,8 @@
 
 
 using Microsoft.Build.Graph;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal readonly struct ProjectNodeMap(ProjectGraph graph, IReporter reporter)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/ResponseLoggingLevel.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ResponseLoggingLevel.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 internal enum ResponseLoggingLevel : byte
 {

--- a/src/BuiltInTools/dotnet-watch/HotReload/RestartPrompt.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RestartPrompt.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Tasks;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class RestartPrompt(IReporter reporter, ConsoleInputReader requester, bool? noPrompt)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/RunningProject.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RunningProject.cs
@@ -4,9 +4,8 @@
 
 using System.Collections.Immutable;
 using Microsoft.Build.Graph;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal delegate ValueTask<RunningProject> RestartOperation(CancellationToken cancellationToken);
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-using System.Collections;
-using System.Diagnostics;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class ScopedCssFileHandler(IReporter reporter, ProjectNodeMap projectMap, BrowserConnector browserConnector)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/SingleProcessDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/SingleProcessDeltaApplier.cs
@@ -5,9 +5,8 @@
 using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal abstract class SingleProcessDeltaApplier(IReporter reporter) : DeltaApplier(reporter)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StaticFileHandler.cs
@@ -2,15 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-using System.Collections;
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.CodeAnalysis.StackTraceExplorer;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class StaticFileHandler(IReporter reporter, ProjectNodeMap projectMap, BrowserConnector browserConnector)
     {

--- a/src/BuiltInTools/dotnet-watch/HotReload/UpdateDelta.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/UpdateDelta.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.HotReload;
+namespace Microsoft.DotNet.Watch;
 
 internal readonly struct UpdateDelta(Guid moduleId, byte[] metadataDelta, byte[] ilDelta, byte[] pdbDelta, int[] updatedTypes)
 {

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -3,14 +3,9 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
-using Microsoft.DotNet.Watch;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed partial class HotReloadDotNetWatcher : Watcher
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class BrowserSpecificReporter(int browserId, IReporter underlyingReporter) : IReporter
 {

--- a/src/BuiltInTools/dotnet-watch/Internal/CommandLineUtilities.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/CommandLineUtilities.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Copied from dotnet/runtime/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal static class CommandLineUtilities
 {

--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleInputReader.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleInputReader.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class ConsoleInputReader(IConsole console, bool quiet, bool suppressEmojis)
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// This API supports infrastructure and is not intended to be used

--- a/src/BuiltInTools/dotnet-watch/Internal/Ensure.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/Ensure.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal static class Ensure
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class FileWatcher(IReporter reporter) : IDisposable
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/ChangeKind.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/ChangeKind.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Internal;
+namespace Microsoft.DotNet.Watch;
 
 internal enum ChangeKind
 {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/EventBasedDirectoryWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/EventBasedDirectoryWatcher.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class EventBasedDirectoryWatcher : IDirectoryWatcher
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal static class FileWatcherFactory
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IDirectoryWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IDirectoryWatcher.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal interface IDirectoryWatcher : IDisposable
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingDirectoryWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/PollingDirectoryWatcher.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class PollingDirectoryWatcher : IDirectoryWatcher
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IConsole.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// This API supports infrastructure and is not intended to be used

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -4,11 +4,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Graph;
-using Microsoft.Build.Tasks;
-using Microsoft.DotNet.Watcher;
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal enum MessageSeverity
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/MSBuildFileSetResult.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MSBuildFileSetResult.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     [DataContract]
     internal sealed class MSBuildFileSetResult

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -4,11 +4,8 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watch;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// Used to collect a set of files to watch.

--- a/src/BuiltInTools/dotnet-watch/Internal/MsBuildProjectFinder.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/MsBuildProjectFinder.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal class MsBuildProjectFinder
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// This API supports infrastructure and is not intended to be used

--- a/src/BuiltInTools/dotnet-watch/Internal/OutputLine.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/OutputLine.cs
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Internal;
+namespace Microsoft.DotNet.Watch;
 
 internal readonly record struct OutputLine(string Content, bool IsError);

--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher;
-
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch
 {
     /// <summary>
     /// This API supports infrastructure and is not intended to be used

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -3,9 +3,8 @@
 
 
 using System.Diagnostics;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class ProcessRunner
     {

--- a/src/BuiltInTools/dotnet-watch/Internal/ProjectSpecificReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProjectSpecificReporter.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed class ProjectSpecificReporter(ProjectGraphNode node, IReporter underlyingReporter) : IReporter
 {

--- a/src/BuiltInTools/dotnet-watch/Internal/ReporterTraceListener.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ReporterTraceListener.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal class ReporterTraceListener(IReporter reporter, string emoji) : TraceListener
 {

--- a/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
+++ b/src/BuiltInTools/dotnet-watch/LaunchSettingsProfile.cs
@@ -4,9 +4,8 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class LaunchSettingsProfile
     {

--- a/src/BuiltInTools/dotnet-watch/ProcessLaunchResult.cs
+++ b/src/BuiltInTools/dotnet-watch/ProcessLaunchResult.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class ProcessLaunchResult
     {

--- a/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
+++ b/src/BuiltInTools/dotnet-watch/ProcessSpec.cs
@@ -1,9 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class ProcessSpec
     {

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -5,14 +5,9 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Loader;
-using Microsoft.Build.Graph;
 using Microsoft.Build.Locator;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-using IConsole = Microsoft.Extensions.Tools.Internal.IConsole;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal sealed class Program(IConsole console, IReporter reporter, ProjectOptions rootProjectOptions, CommandLineOptions options, EnvironmentOptions environmentOptions)
     {

--- a/src/BuiltInTools/dotnet-watch/ProjectOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/ProjectOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal sealed record ProjectOptions
 {

--- a/src/BuiltInTools/dotnet-watch/Utilities/BuildUtilities.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/BuildUtilities.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watch;
 

--- a/src/BuiltInTools/dotnet-watch/Utilities/Disposables.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/Disposables.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal readonly record struct Disposables(List<IDisposable> disposables) : IDisposable
 {

--- a/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.Cli;
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal static class ProjectGraphNodeExtensions
 {

--- a/src/BuiltInTools/dotnet-watch/Utilities/Versions.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/Versions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch;
 
 internal static class Versions
 {

--- a/src/BuiltInTools/dotnet-watch/Watcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Watcher.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Tools;
 
-namespace Microsoft.DotNet.Watcher
+namespace Microsoft.DotNet.Watch
 {
     internal abstract class Watcher(DotNetWatchContext context, MSBuildFileSetFactory rootFileSetFactory)
     {

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>exe</OutputType>
     <Description>Command line tool to watch for source file changes during development and restart the dotnet command.</Description>
-    <RootNamespace>Microsoft.DotNet.Watcher.Tools</RootNamespace>
+    <RootNamespace>Microsoft.DotNet.Watch</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <UseAppHost>false</UseAppHost>
     <RuntimeIdentifier />

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
-using Microsoft.Extensions.HotReload;
 using Moq;
 
-namespace Microsoft.Extensions.DotNetDeltaApplier
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class HotReloadAgentTest
     {

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StartupHookTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StartupHookTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.DotNetDeltaApplier
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class StartupHookTests
     {

--- a/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
@@ -9,10 +9,8 @@ using System.Net.Http.Headers;
 using System.Net.WebSockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
-using Microsoft.WebTools.AspireServer.Helpers;
-using Microsoft.WebTools.AspireServer.Models;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 public class AspireServerServiceTests(ITestOutputHelper output)
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/Helpers.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/Helpers.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Net;
 using System.Net.Sockets;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 public static class Helpers
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-using Microsoft.WebTools.AspireServer.Contracts;
 using Moq;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 internal class IAspireServerEventsMock : MockFactory<IAspireServerEvents>
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/IServiceProviderMock.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/IServiceProviderMock.cs
@@ -3,7 +3,7 @@
 
 using Moq;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 internal class IServiceProviderMock : MockFactory<IServiceProvider>
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/MockFactory.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/MockFactory.cs
@@ -3,7 +3,7 @@
 
 using Moq;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 public interface IMockFactory
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/Mocks.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/Mocks.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using Moq;
 
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 public class Mocks
 {

--- a/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
@@ -3,9 +3,7 @@
 
 #nullable disable
 
-using Microsoft.WebTools.AspireServer.Models;
-
-namespace Microsoft.WebTools.AspireServer.UnitTests;
+namespace Aspire.Tools.Service.UnitTests;
 
 public class RunSessionRequestTests
 {

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class CommandLineOptionsTests
     {

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class ReporterTests
     {

--- a/test/dotnet-watch.Tests/FileSetSerializerTests.cs
+++ b/test/dotnet-watch.Tests/FileSetSerializerTests.cs
@@ -1,14 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization.Json;
 using System.Text.Json;
 using DotNetWatchTasks;
-using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.NET.Build.Tasks.UnitTests;
 
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class FileSetSerializerTests(ITestOutputHelper output)
 {

--- a/test/dotnet-watch.Tests/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcherTests.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Testing;
-using Microsoft.DotNet.Watcher.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class FileWatcherTests(ITestOutputHelper output)
     {

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class ApplyDeltaTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
     {

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -3,10 +3,7 @@
 
 #nullable enable
 
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
 {

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -3,10 +3,7 @@
 
 #nullable enable
 
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
 {

--- a/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/UpdatePayloadTests.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.HotReload;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class UpdatePayloadTests
     {

--- a/test/dotnet-watch.Tests/Internal/EnvironmentVariablesBuilderTest.cs
+++ b/test/dotnet-watch.Tests/Internal/EnvironmentVariablesBuilderTest.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Tools;
-
-namespace Microsoft.DotNet.Watcher.Internal
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class EnvironmentVariablesBuilderTest
     {

--- a/test/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
+++ b/test/dotnet-watch.Tests/LaunchSettingsProfileTest.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class LaunchSettingsProfileTest
 {

--- a/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
+++ b/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class MSBuildEvaluationFilterTest
     {

--- a/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -3,11 +3,7 @@
 
 #nullable enable
 
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
-using Xunit.Sdk;
-
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class MsBuildFileSetFactoryTest(ITestOutputHelper output)
     {

--- a/test/dotnet-watch.Tests/NoRestoreTests.cs
+++ b/test/dotnet-watch.Tests/NoRestoreTests.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class NoRestoreTests
     {

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -4,7 +4,7 @@
 using System.Collections;
 using Xunit.Sdk;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal static class AssertEx
     {

--- a/test/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
+++ b/test/dotnet-watch.Tests/Utilities/AwaitableProcess.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Threading.Tasks.Dataflow;
 
-namespace Microsoft.DotNet.Watcher.Tools
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal class AwaitableProcess(DotnetCommand spec, ITestOutputHelper logger) : IDisposable
     {

--- a/test/dotnet-watch.Tests/Utilities/DebugTestOutputLogger.cs
+++ b/test/dotnet-watch.Tests/Utilities/DebugTestOutputLogger.cs
@@ -5,7 +5,7 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.DotNet.Watcher.Tests;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class DebugTestOutputLogger(ITestOutputHelper logger) : ITestOutputHelper
 {

--- a/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
+++ b/test/dotnet-watch.Tests/Utilities/MockFileSetFactory.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal class MockFileSetFactory() : MSBuildFileSetFactory(
     rootProjectFile: "test.csproj",

--- a/test/dotnet-watch.Tests/Utilities/MockReporter.cs
+++ b/test/dotnet-watch.Tests/Utilities/MockReporter.cs
@@ -4,10 +4,8 @@
 #nullable enable
 
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher.Internal;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tools;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal class MockReporter : IReporter
 {

--- a/test/dotnet-watch.Tests/Utilities/TaskExtensions.cs
+++ b/test/dotnet-watch.Tests/Utilities/TaskExtensions.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.AspNetCore.Testing
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal static class TaskExtensions
     {

--- a/test/dotnet-watch.Tests/Utilities/TestConsole.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestConsole.cs
@@ -5,7 +5,7 @@
 
 using System.Reflection;
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal class TestConsole : IConsole
     {

--- a/test/dotnet-watch.Tests/Utilities/TestOptions.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestOptions.cs
@@ -3,9 +3,7 @@
 
 #nullable enable
 
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal static class TestOptions
 {

--- a/test/dotnet-watch.Tests/Utilities/TestReporter.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestReporter.cs
@@ -5,10 +5,8 @@
 
 using System.Diagnostics;
 using Microsoft.Build.Graph;
-using Microsoft.DotNet.Watcher;
-using Microsoft.DotNet.Watcher.Internal;
 
-namespace Microsoft.Extensions.Tools.Internal
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal class TestReporter(ITestOutputHelper output) : IReporter
     {

--- a/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
@@ -5,7 +5,7 @@
 
 using Microsoft.Build.Graph;
 
-namespace Microsoft.DotNet.Watcher.Tests;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal class TestRuntimeProcessLauncher(ProjectLauncher projectLauncher) : IRuntimeProcessLauncher
 {

--- a/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class BrowserLaunchTests : DotNetWatchTestBase
     {

--- a/test/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.Tests/Watch/DotNetWatcherTests.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Microsoft.Extensions.Tools.Internal;
 
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class DotNetWatcherTests : DotNetWatchTestBase
     {

--- a/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
+++ b/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Tools;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class GlobbingAppTests : DotNetWatchTestBase
     {

--- a/test/dotnet-watch.Tests/Watch/NoDepsAppTests.cs
+++ b/test/dotnet-watch.Tests/Watch/NoDepsAppTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class NoDepsAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
     {

--- a/test/dotnet-watch.Tests/Watch/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/Watch/ProgramTests.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class ProgramTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
     {

--- a/test/dotnet-watch.Tests/Watch/Utilities/DotNetWatchTestBase.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/DotNetWatchTestBase.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watcher.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests;
+namespace Microsoft.DotNet.Watch.UnitTests;
 
 /// <summary>
 /// Base class for all tests that create dotnet watch process.

--- a/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -1,12 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using Microsoft.DotNet.Watcher.Tools;
-using Microsoft.Extensions.Tools.Internal;
-
-namespace Microsoft.DotNet.Watcher.Tests
+namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal sealed class WatchableApp(ITestOutputHelper logger) : IDisposable
     {


### PR DESCRIPTION
Use `Aspire.Tools.Service` namespace for shared Aspire code, `Microsoft.DotNet.Watch` for dotnet-watch code and `Microsoft.DotNet.Watch.UnitTests` for dotnet-watch unit tests.