### PR TITLE
Pass down PublicBaseURL for aspnetcore to direct it to download assets from the local artifacts assets path

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -12,6 +12,7 @@
 
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:TargetRuntimeIdentifier=$(TargetRid)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:PublicBaseURL=file:%2F%2F$(ArtifactsAssetsDir)</BuildArgs>
     <ForceDotNetMSBuildEngine>false</ForceDotNetMSBuildEngine>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>


### PR DESCRIPTION
Required to consume https://github.com/dotnet/aspnetcore/pull/58820 in the VMR.

Is a no-op until that is merged, so we can merge it beforehand to avoid blocking codeflow.