### PR TITLE
Fix publishing OCI image as tarball

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -31,6 +31,8 @@ internal sealed class DockerCli
     private string? _fullCommandPath;
 #endif
 
+    private const string _blobsPath = "blobs/sha256";
+
     public DockerCli(string? command, ILoggerFactory loggerFactory)
     {
         if (!(command == null ||
@@ -100,8 +102,8 @@ internal sealed class DockerCli
         }
 
         // Create new stream tarball
-
-        await WriteImageToStreamAsync(image, sourceReference, destinationReference, loadProcess.StandardInput.BaseStream, cancellationToken).ConfigureAwait(false);
+        // We want to be able to export to docker, even oci images.
+        await WriteDockerImageToStreamAsync(image, sourceReference, destinationReference, loadProcess.StandardInput.BaseStream, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -267,12 +269,52 @@ internal sealed class DockerCli
 #if NET
     public static async Task WriteImageToStreamAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
     {
+        if (image.Manifest.MediaType == SchemaTypes.DockerManifestV2)
+        {
+            await WriteDockerImageToStreamAsync(image, sourceReference, destinationReference, imageStream, cancellationToken);
+        }
+        else if (image.Manifest.MediaType == SchemaTypes.OciManifestV1)
+        {
+            await WriteOciImageToStreamAsync(image, sourceReference, destinationReference, imageStream, cancellationToken);
+        }
+        else
+        {
+            throw new ArgumentException(Resource.FormatString(nameof(Strings.UnsupportedMediaTypeForTarball), image.Manifest.MediaType));
+        }
+    }
+
+    private static async Task WriteDockerImageToStreamAsync(
+        BuiltImage image,
+        SourceImageReference sourceReference,
+        DestinationImageReference destinationReference,
+        Stream imageStream,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);
 
-
-        // Feed each layer tarball into the stream
         JsonArray layerTarballPaths = new JsonArray();
+        await WriteImageLayers(writer, image, sourceReference, d => $"{d.Substring("sha256:".Length)}/layer.tar", cancellationToken, layerTarballPaths)
+            .ConfigureAwait(false);
+
+        string configTarballPath = $"{image.ImageSha}.json";
+        await WriteImageConfig(writer, image, configTarballPath, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Add manifest
+        await WriteManifestForDockerImage(writer, destinationReference, configTarballPath, layerTarballPaths, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task WriteImageLayers(
+        TarWriter writer,
+        BuiltImage image,
+        SourceImageReference sourceReference,
+        Func<string, string> layerPathFunc,
+        CancellationToken cancellationToken,
+        JsonArray? layerTarballPaths = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
         foreach (var d in image.LayerDescriptors)
         {
@@ -283,9 +325,9 @@ internal sealed class DockerCli
 
                 // Stuff that (uncompressed) tarball into the image tar stream
                 // TODO uncompress!!
-                string layerTarballPath = $"{d.Digest.Substring("sha256:".Length)}/layer.tar";
+                string layerTarballPath = layerPathFunc(d.Digest);
                 await writer.WriteEntryAsync(localPath, layerTarballPath, cancellationToken).ConfigureAwait(false);
-                layerTarballPaths.Add(layerTarballPath);
+                layerTarballPaths?.Add(layerTarballPath);
             }
             else
             {
@@ -295,21 +337,33 @@ internal sealed class DockerCli
                     sourceReference.Registry?.ToString() ?? "<null>"));
             }
         }
+    }
 
-        // add config
-        string configTarballPath = $"{image.ImageSha}.json";
+    private static async Task WriteImageConfig(
+        TarWriter writer,
+        BuiltImage image,
+        string configPath,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
+
         using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(image.Config)))
         {
-            PaxTarEntry configEntry = new(TarEntryType.RegularFile, configTarballPath)
+            PaxTarEntry configEntry = new(TarEntryType.RegularFile, configPath)
             {
                 DataStream = configStream
             };
-
             await writer.WriteEntryAsync(configEntry, cancellationToken).ConfigureAwait(false);
         }
+    }
 
-        // Add manifest
+    private static async Task WriteManifestForDockerImage(
+        TarWriter writer,
+        DestinationImageReference destinationReference,
+        string configTarballPath,
+        JsonArray layerTarballPaths,
+        CancellationToken cancellationToken)
+    {
         JsonArray tagsNode = new();
         foreach (string tag in destinationReference.Tags)
         {
@@ -332,6 +386,100 @@ internal sealed class DockerCli
             };
 
             await writer.WriteEntryAsync(manifestEntry, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteOciImageToStreamAsync(
+        BuiltImage image,
+        SourceImageReference sourceReference,
+        DestinationImageReference destinationReference,
+        Stream imageStream,
+        CancellationToken cancellationToken)
+    {
+        if (destinationReference.Tags.Length > 1)
+        {
+            throw new ArgumentException(Resource.FormatString(nameof(Strings.OciImageMultipleTagsNotSupported)));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);
+
+        await WriteOciLayout(writer, cancellationToken)
+            .ConfigureAwait(false);
+
+        await WriteImageLayers(writer, image, sourceReference, d => $"{_blobsPath}/{d.Substring("sha256:".Length)}", cancellationToken)
+            .ConfigureAwait(false);
+
+        await WriteImageConfig(writer, image, $"{_blobsPath}/{image.ImageSha}", cancellationToken)
+            .ConfigureAwait(false);
+
+        await WriteManifestForOciImage(writer, image, destinationReference, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task WriteOciLayout(TarWriter writer, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string ociLayoutPath = "oci-layout";
+        var ociLayoutContent = "{\"imageLayoutVersion\": \"1.0.0\"}";
+        using (MemoryStream ociLayoutStream = new MemoryStream(Encoding.UTF8.GetBytes(ociLayoutContent)))
+        {
+            PaxTarEntry layoutEntry = new(TarEntryType.RegularFile, ociLayoutPath)
+            {
+                DataStream = ociLayoutStream
+            };
+            await writer.WriteEntryAsync(layoutEntry, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteManifestForOciImage(
+        TarWriter writer,
+        BuiltImage image,
+        DestinationImageReference destinationReference,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string manifestContent = JsonSerializer.SerializeToNode(image.Manifest)!.ToJsonString();
+        string manifestDigest = image.Manifest.GetDigest();
+
+        // 1. add manifest to blobs
+        string manifestPath = $"{_blobsPath}/{manifestDigest.Substring("sha256:".Length)}";
+        using (MemoryStream manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestContent)))
+        {
+            PaxTarEntry manifestEntry = new(TarEntryType.RegularFile, manifestPath)
+            {
+                DataStream = manifestStream
+            };
+            await writer.WriteEntryAsync(manifestEntry, cancellationToken).ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // 2. add index.json
+        var index = new ImageIndexV1
+        {
+            schemaVersion = 2,
+            mediaType = SchemaTypes.OciImageIndexV1,
+            manifests =
+            [
+                new PlatformSpecificOciManifest
+                {
+                    mediaType = SchemaTypes.OciManifestV1,
+                    size = manifestContent.Length,
+                    digest = manifestDigest,
+                    annotations = new Dictionary<string, string> { { "org.opencontainers.image.ref.name", $"{destinationReference.Repository}:{destinationReference.Tags[0]}" } }
+                }
+            ]
+        };
+        using (MemoryStream indexStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.SerializeToNode(index)!.ToJsonString())))
+        {
+            PaxTarEntry indexEntry = new(TarEntryType.RegularFile, "index.json")
+            {
+                DataStream = indexStream
+            };
+            await writer.WriteEntryAsync(indexEntry, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -269,11 +269,11 @@ internal sealed class DockerCli
 #if NET
     public static async Task WriteImageToStreamAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
     {
-        if (image.Manifest.MediaType == SchemaTypes.DockerManifestV2)
+        if (image.ManifestMediaType == SchemaTypes.DockerManifestV2)
         {
             await WriteDockerImageToStreamAsync(image, sourceReference, destinationReference, imageStream, cancellationToken);
         }
-        else if (image.Manifest.MediaType == SchemaTypes.OciManifestV1)
+        else if (image.ManifestMediaType == SchemaTypes.OciManifestV1)
         {
             await WriteOciImageToStreamAsync(image, sourceReference, destinationReference, imageStream, cancellationToken);
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestListV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestListV2.cs
@@ -10,5 +10,6 @@ public record struct ManifestListV2(int schemaVersion, string mediaType, Platfor
 public record struct PlatformInformation(string architecture, string os, string? variant, string[] features, [property: JsonPropertyName("os.version")][field: JsonPropertyName("os.version")] string? version);
 
 public record struct PlatformSpecificManifest(string mediaType, long size, string digest, PlatformInformation platform);
+public record struct ImageIndexV1(int schemaVersion, string mediaType, PlatformSpecificOciManifest[] manifests);
 
-public record struct ImageIndexV1(int schemaVersion, string mediaType, PlatformSpecificManifest[] manifests);
+public record struct PlatformSpecificOciManifest(string mediaType, long size, string digest, PlatformInformation platform, Dictionary<string, string> annotations);

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -74,8 +74,8 @@ Microsoft.NET.Build.Containers.ManifestListV2.schemaVersion.get -> int
 Microsoft.NET.Build.Containers.ManifestListV2.schemaVersion.set -> void
 Microsoft.NET.Build.Containers.ImageIndexV1
 Microsoft.NET.Build.Containers.ImageIndexV1.ImageIndexV1() -> void
-Microsoft.NET.Build.Containers.ImageIndexV1.ImageIndexV1(int schemaVersion, string! mediaType, Microsoft.NET.Build.Containers.PlatformSpecificManifest[]! manifests) -> void
-Microsoft.NET.Build.Containers.ImageIndexV1.manifests.get -> Microsoft.NET.Build.Containers.PlatformSpecificManifest[]!
+Microsoft.NET.Build.Containers.ImageIndexV1.ImageIndexV1(int schemaVersion, string! mediaType, Microsoft.NET.Build.Containers.PlatformSpecificOciManifest[]! manifests) -> void
+Microsoft.NET.Build.Containers.ImageIndexV1.manifests.get -> Microsoft.NET.Build.Containers.PlatformSpecificOciManifest[]!
 Microsoft.NET.Build.Containers.ImageIndexV1.manifests.set -> void
 Microsoft.NET.Build.Containers.ImageIndexV1.mediaType.get -> string!
 Microsoft.NET.Build.Containers.ImageIndexV1.mediaType.set -> void
@@ -118,6 +118,19 @@ Microsoft.NET.Build.Containers.PlatformSpecificManifest.PlatformSpecificManifest
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.PlatformSpecificManifest(string! mediaType, long size, string! digest, Microsoft.NET.Build.Containers.PlatformInformation platform) -> void
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.size.get -> long
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.size.set -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.digest.get -> string!
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.digest.set -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.mediaType.get -> string!
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.mediaType.set -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.platform.get -> Microsoft.NET.Build.Containers.PlatformInformation
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.platform.set -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.size.get -> long
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.size.set -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.PlatformSpecificOciManifest() -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.PlatformSpecificOciManifest(string! mediaType, long size, string! digest, Microsoft.NET.Build.Containers.PlatformInformation platform, System.Collections.Generic.Dictionary<string!, string!>! annotations) -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.annotations.get -> System.Collections.Generic.Dictionary<string!, string!>!
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.annotations.set -> void
 Microsoft.NET.Build.Containers.Port
 Microsoft.NET.Build.Containers.Port.Deconstruct(out int Number, out Microsoft.NET.Build.Containers.PortType Type) -> void
 Microsoft.NET.Build.Containers.Port.Equals(Microsoft.NET.Build.Containers.Port other) -> bool
@@ -239,29 +252,36 @@ static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string? port
 static readonly Microsoft.NET.Build.Containers.KnownLocalRegistryTypes.SupportedLocalRegistryTypes -> string![]!
 ~override Microsoft.NET.Build.Containers.PlatformInformation.ToString() -> string
 ~override Microsoft.NET.Build.Containers.PlatformSpecificManifest.ToString() -> string
+~override Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.ToString() -> string
 static Microsoft.NET.Build.Containers.PlatformInformation.operator !=(Microsoft.NET.Build.Containers.PlatformInformation left, Microsoft.NET.Build.Containers.PlatformInformation right) -> bool
 static Microsoft.NET.Build.Containers.PlatformSpecificManifest.operator !=(Microsoft.NET.Build.Containers.PlatformSpecificManifest left, Microsoft.NET.Build.Containers.PlatformSpecificManifest right) -> bool
+static Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.operator !=(Microsoft.NET.Build.Containers.PlatformSpecificOciManifest left, Microsoft.NET.Build.Containers.PlatformSpecificOciManifest right) -> bool
 static Microsoft.NET.Build.Containers.PlatformInformation.operator ==(Microsoft.NET.Build.Containers.PlatformInformation left, Microsoft.NET.Build.Containers.PlatformInformation right) -> bool
 ~override Microsoft.NET.Build.Containers.ManifestConfig.ToString() -> string
 static Microsoft.NET.Build.Containers.PlatformSpecificManifest.operator ==(Microsoft.NET.Build.Containers.PlatformSpecificManifest left, Microsoft.NET.Build.Containers.PlatformSpecificManifest right) -> bool
+static Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.operator ==(Microsoft.NET.Build.Containers.PlatformSpecificOciManifest left, Microsoft.NET.Build.Containers.PlatformSpecificOciManifest right) -> bool
 override Microsoft.NET.Build.Containers.PlatformInformation.GetHashCode() -> int
 static Microsoft.NET.Build.Containers.ManifestConfig.operator !=(Microsoft.NET.Build.Containers.ManifestConfig left, Microsoft.NET.Build.Containers.ManifestConfig right) -> bool
 override Microsoft.NET.Build.Containers.PlatformSpecificManifest.GetHashCode() -> int
+override Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.GetHashCode() -> int
 static Microsoft.NET.Build.Containers.ManifestConfig.operator ==(Microsoft.NET.Build.Containers.ManifestConfig left, Microsoft.NET.Build.Containers.ManifestConfig right) -> bool
 ~override Microsoft.NET.Build.Containers.PlatformInformation.Equals(object obj) -> bool
 ~override Microsoft.NET.Build.Containers.Descriptor.ToString() -> string
 ~override Microsoft.NET.Build.Containers.ManifestLayer.ToString() -> string
 override Microsoft.NET.Build.Containers.ManifestConfig.GetHashCode() -> int
 ~override Microsoft.NET.Build.Containers.PlatformSpecificManifest.Equals(object obj) -> bool
+~override Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.Equals(object obj) -> bool
 Microsoft.NET.Build.Containers.PlatformInformation.Equals(Microsoft.NET.Build.Containers.PlatformInformation other) -> bool
 ~override Microsoft.NET.Build.Containers.ManifestConfig.Equals(object obj) -> bool
 static Microsoft.NET.Build.Containers.ManifestLayer.operator !=(Microsoft.NET.Build.Containers.ManifestLayer left, Microsoft.NET.Build.Containers.ManifestLayer right) -> bool
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.Equals(Microsoft.NET.Build.Containers.PlatformSpecificManifest other) -> bool
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.Equals(Microsoft.NET.Build.Containers.PlatformSpecificOciManifest other) -> bool
 static Microsoft.NET.Build.Containers.Descriptor.operator !=(Microsoft.NET.Build.Containers.Descriptor left, Microsoft.NET.Build.Containers.Descriptor right) -> bool
 Microsoft.NET.Build.Containers.PlatformInformation.Deconstruct(out string! architecture, out string! os, out string? variant, out string![]! features, out string? version) -> void
 Microsoft.NET.Build.Containers.ManifestConfig.Equals(Microsoft.NET.Build.Containers.ManifestConfig other) -> bool
 static Microsoft.NET.Build.Containers.ManifestLayer.operator ==(Microsoft.NET.Build.Containers.ManifestLayer left, Microsoft.NET.Build.Containers.ManifestLayer right) -> bool
 Microsoft.NET.Build.Containers.PlatformSpecificManifest.Deconstruct(out string! mediaType, out long size, out string! digest, out Microsoft.NET.Build.Containers.PlatformInformation platform) -> void
+Microsoft.NET.Build.Containers.PlatformSpecificOciManifest.Deconstruct(out string! mediaType, out long size, out string! digest, out Microsoft.NET.Build.Containers.PlatformInformation platform, out System.Collections.Generic.Dictionary<string!, string!>! annotations) -> void
 Microsoft.NET.Build.Containers.ManifestConfig.Deconstruct(out string! mediaType, out long size, out string! digest) -> void
 static Microsoft.NET.Build.Containers.Descriptor.operator ==(Microsoft.NET.Build.Containers.Descriptor left, Microsoft.NET.Build.Containers.Descriptor right) -> bool
 override Microsoft.NET.Build.Containers.ManifestLayer.GetHashCode() -> int
@@ -284,4 +304,4 @@ static Microsoft.NET.Build.Containers.ImageIndexV1.operator ==(Microsoft.NET.Bui
 override Microsoft.NET.Build.Containers.ImageIndexV1.GetHashCode() -> int
 ~override Microsoft.NET.Build.Containers.ImageIndexV1.Equals(object obj) -> bool
 Microsoft.NET.Build.Containers.ImageIndexV1.Equals(Microsoft.NET.Build.Containers.ImageIndexV1 other) -> bool
-Microsoft.NET.Build.Containers.ImageIndexV1.Deconstruct(out int schemaVersion, out string! mediaType, out Microsoft.NET.Build.Containers.PlatformSpecificManifest[]! manifests) -> void
+Microsoft.NET.Build.Containers.ImageIndexV1.Deconstruct(out int schemaVersion, out string! mediaType, out Microsoft.NET.Build.Containers.PlatformSpecificOciManifest[]! manifests) -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -15,6 +15,7 @@ namespace Microsoft.NET.Build.Containers;
 internal interface IManifestPicker
 {
     public PlatformSpecificManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificManifest> manifestList, string runtimeIdentifier);
+    public PlatformSpecificOciManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificOciManifest> manifestList, string runtimeIdentifier);
 }
 
 internal sealed class RidGraphManifestPicker : IManifestPicker
@@ -26,6 +27,16 @@ internal sealed class RidGraphManifestPicker : IManifestPicker
         _runtimeGraph = GetRuntimeGraphForDotNet(runtimeIdentifierGraphPath);
     }
     public PlatformSpecificManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificManifest> ridManifestDict, string runtimeIdentifier)
+    {
+        var bestManifestRid = GetBestMatchingRid(_runtimeGraph, runtimeIdentifier, ridManifestDict.Keys);
+        if (bestManifestRid is null)
+        {
+            return null;
+        }
+        return ridManifestDict[bestManifestRid];
+    }
+
+    public PlatformSpecificOciManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificOciManifest> ridManifestDict, string runtimeIdentifier)
     {
         var bestManifestRid = GetBestMatchingRid(_runtimeGraph, runtimeIdentifier, ridManifestDict.Keys);
         if (bestManifestRid is null)
@@ -260,6 +271,20 @@ internal sealed class Registry
         return ridDict;
     }
 
+    private static IReadOnlyDictionary<string, PlatformSpecificOciManifest> GetManifestsByRid(PlatformSpecificOciManifest[] manifestList)
+    {
+        var ridDict = new Dictionary<string, PlatformSpecificOciManifest>();
+        foreach (var manifest in manifestList)
+        {
+            if (CreateRidForPlatform(manifest.platform) is { } rid)
+            {
+                ridDict.TryAdd(rid, manifest);
+            }
+        }
+
+        return ridDict;
+    }
+
     private static string? CreateRidForPlatform(PlatformInformation platform)
     {
         // we only support linux and windows containers explicitly, so anything else we should skip past.
@@ -302,13 +327,21 @@ internal sealed class Registry
     {
         cancellationToken.ThrowIfCancellationRequested();
         var ridManifestDict = GetManifestsByRid(manifestList.manifests);
-        return await PickBestImageFromManifestsAsync(
-            repositoryName,
-            reference,
-            ridManifestDict,
-            runtimeIdentifier,
-            manifestPicker,
-            cancellationToken).ConfigureAwait(false);
+        if (manifestPicker.PickBestManifestForRid(ridManifestDict, runtimeIdentifier) is PlatformSpecificManifest matchingManifest)
+        {
+            return await ReadImageFromManifest(
+                repositoryName,
+                reference,
+                matchingManifest.digest,
+                matchingManifest.mediaType,
+                runtimeIdentifier,
+                ridManifestDict.Keys,
+                cancellationToken);
+        }
+        else
+        {
+            throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, ridManifestDict.Keys);
+        }
     }
 
     private async Task<ImageBuilder> PickBestImageFromImageIndexAsync(
@@ -321,42 +354,43 @@ internal sealed class Registry
     {
         cancellationToken.ThrowIfCancellationRequested();
         var ridManifestDict = GetManifestsByRid(index.manifests);
-        return await PickBestImageFromManifestsAsync(
-            repositoryName,
-            reference,
-            ridManifestDict,
-            runtimeIdentifier,
-            manifestPicker,
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<ImageBuilder> PickBestImageFromManifestsAsync(
-        string repositoryName,
-        string reference,
-        IReadOnlyDictionary<string, PlatformSpecificManifest> knownManifests,
-        string runtimeIdentifier,
-        IManifestPicker manifestPicker,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        if (manifestPicker.PickBestManifestForRid(knownManifests, runtimeIdentifier) is PlatformSpecificManifest matchingManifest)
+        if (manifestPicker.PickBestManifestForRid(ridManifestDict, runtimeIdentifier) is PlatformSpecificOciManifest matchingManifest)
         {
-            using HttpResponseMessage manifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, matchingManifest.digest, cancellationToken).ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested();
-            var manifest = await manifestResponse.Content.ReadFromJsonAsync<ManifestV2>(cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (manifest is null) throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, knownManifests.Keys);
-            manifest.KnownDigest = matchingManifest.digest;
-            return await ReadSingleImageAsync(
+            return await ReadImageFromManifest(
                 repositoryName,
-                manifest,
+                reference,
+                matchingManifest.digest,
                 matchingManifest.mediaType,
-                cancellationToken).ConfigureAwait(false);
+                runtimeIdentifier,
+                ridManifestDict.Keys,
+                cancellationToken);
         }
         else
         {
-            throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, knownManifests.Keys);
+            throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, ridManifestDict.Keys);
         }
+    }
+
+    private async Task<ImageBuilder> ReadImageFromManifest(
+        string repositoryName,
+        string reference,
+        string manifestDigest,
+        string mediaType,
+        string runtimeIdentifier,
+        IEnumerable<string> rids,
+        CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage manifestResponse = await _registryAPI.Manifest.GetAsync(repositoryName, manifestDigest, cancellationToken).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var manifest = await manifestResponse.Content.ReadFromJsonAsync<ManifestV2>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (manifest is null) throw new BaseImageNotFoundException(runtimeIdentifier, repositoryName, reference, rids);
+        manifest.KnownDigest = manifestDigest;
+        return await ReadSingleImageAsync(
+            repositoryName,
+            manifest,
+            mediaType,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.NET.Build.Containers.Resources
-{
+namespace Microsoft.NET.Build.Containers.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,885 +22,743 @@ namespace Microsoft.NET.Build.Containers.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings
-    {
-
+    internal class Strings {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Strings()
-        {
+        internal Strings() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NET.Build.Containers.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER0000: Value for unit test {0}.
         /// </summary>
-        internal static string _Test
-        {
-            get
-            {
+        internal static string _Test {
+            get {
                 return ResourceManager.GetString("_Test", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry..
         /// </summary>
-        internal static string AmazonRegistryFailed
-        {
-            get
-            {
+        internal static string AmazonRegistryFailed {
+            get {
                 return ResourceManager.GetString("AmazonRegistryFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed..
         /// </summary>
-        internal static string AmbiguousTags
-        {
-            get
-            {
+        internal static string AmbiguousTags {
+            get {
                 return ResourceManager.GetString("AmbiguousTags", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand..
         /// </summary>
-        internal static string AppCommandArgsSetNoAppCommand
-        {
-            get
-            {
+        internal static string AppCommandArgsSetNoAppCommand {
+            get {
                 return ResourceManager.GetString("AppCommandArgsSetNoAppCommand", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is &apos;{0}&apos;..
         /// </summary>
-        internal static string AppCommandSetNotUsed
-        {
-            get
-            {
+        internal static string AppCommandSetNotUsed {
+            get {
                 return ResourceManager.GetString("AppCommandSetNotUsed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to local archive at &apos;{0}&apos;.
         /// </summary>
-        internal static string ArchiveRegistry_PushInfo
-        {
-            get
-            {
+        internal static string ArchiveRegistry_PushInfo {
+            get {
                 return ResourceManager.GetString("ArchiveRegistry_PushInfo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to &apos;Entrypoint&apos; if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to &apos;DefaultArgs&apos;..
         /// </summary>
-        internal static string BaseEntrypointOverwritten
-        {
-            get
-            {
+        internal static string BaseEntrypointOverwritten {
+            get {
                 return ResourceManager.GetString("BaseEntrypointOverwritten", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2009: Could not parse {0}: {1}.
         /// </summary>
-        internal static string BaseImageNameParsingFailed
-        {
-            get
-            {
+        internal static string BaseImageNameParsingFailed {
+            get {
                 return ResourceManager.GetString("BaseImageNameParsingFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: &apos;{1}/&lt;image&gt;&apos;..
         /// </summary>
-        internal static string BaseImageNameRegistryFallback
-        {
-            get
-            {
+        internal static string BaseImageNameRegistryFallback {
+            get {
                 return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2013: {0} had spaces in it, replacing with dashes..
         /// </summary>
-        internal static string BaseImageNameWithSpaces
-        {
-            get
-            {
+        internal static string BaseImageNameWithSpaces {
+            get {
                 return ResourceManager.GetString("BaseImageNameWithSpaces", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1011: Couldn&apos;t find matching base image for {0} that matches RuntimeIdentifier {1}..
         /// </summary>
-        internal static string BaseImageNotFound
-        {
-            get
-            {
+        internal static string BaseImageNotFound {
+            get {
                 return ResourceManager.GetString("BaseImageNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1001: Failed to upload blob using {0}; received status code &apos;{1}&apos;..
         /// </summary>
-        internal static string BlobUploadFailed
-        {
-            get
-            {
+        internal static string BlobUploadFailed {
+            get {
                 return ResourceManager.GetString("BlobUploadFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to {1}..
         /// </summary>
-        internal static string ContainerBuilder_ImageUploadedToLocalDaemon
-        {
-            get
-            {
+        internal static string ContainerBuilder_ImageUploadedToLocalDaemon {
+            get {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToLocalDaemon", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to registry &apos;{1}&apos;..
         /// </summary>
-        internal static string ContainerBuilder_ImageUploadedToRegistry
-        {
-            get
-            {
+        internal static string ContainerBuilder_ImageUploadedToRegistry {
+            get {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToRegistry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Building image &apos;{0}&apos; with tags &apos;{1}&apos; on top of base image &apos;{2}&apos;..
         /// </summary>
-        internal static string ContainerBuilder_StartBuildingImage
-        {
-            get
-            {
+        internal static string ContainerBuilder_StartBuildingImage {
+            get {
                 return ResourceManager.GetString("ContainerBuilder_StartBuildingImage", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to CONTAINER1007: Could not deserialize token from JSON..
-        /// </summary>
-        internal static string CouldntDeserializeJsonToken
-        {
-            get
-            {
-                return ResourceManager.GetString("CouldntDeserializeJsonToken", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2012: Could not recognize registry &apos;{0}&apos;..
-        /// </summary>
-        internal static string CouldntRecognizeRegistry
-        {
-            get
-            {
-                return ResourceManager.GetString("CouldntRecognizeRegistry", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to local registry via &apos;{0}&apos;.
-        /// </summary>
-        internal static string DockerCli_PushInfo
-        {
-            get
-            {
-                return ResourceManager.GetString("DockerCli_PushInfo", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}.
-        /// </summary>
-        internal static string DockerInfoFailed
-        {
-            get
-            {
-                return ResourceManager.GetString("DockerInfoFailed", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info: {0}.
-        /// </summary>
-        internal static string DockerInfoFailed_Ex
-        {
-            get
-            {
-                return ResourceManager.GetString("DockerInfoFailed_Ex", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3001: Failed creating {0} process..
         /// </summary>
-        internal static string ContainerRuntimeProcessCreationFailed
-        {
-            get
-            {
+        internal static string ContainerRuntimeProcessCreationFailed {
+            get {
                 return ResourceManager.GetString("ContainerRuntimeProcessCreationFailed", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER1007: Could not deserialize token from JSON..
+        /// </summary>
+        internal static string CouldntDeserializeJsonToken {
+            get {
+                return ResourceManager.GetString("CouldntDeserializeJsonToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2012: Could not recognize registry &apos;{0}&apos;..
+        /// </summary>
+        internal static string CouldntRecognizeRegistry {
+            get {
+                return ResourceManager.GetString("CouldntRecognizeRegistry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to local registry via &apos;{0}&apos;.
+        /// </summary>
+        internal static string DockerCli_PushInfo {
+            get {
+                return ResourceManager.GetString("DockerCli_PushInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}.
+        /// </summary>
+        internal static string DockerInfoFailed {
+            get {
+                return ResourceManager.GetString("DockerInfoFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info: {0}.
+        /// </summary>
+        internal static string DockerInfoFailed_Ex {
+            get {
+                return ResourceManager.GetString("DockerInfoFailed_Ex", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4006: Property &apos;{0}&apos; is empty or contains whitespace and will be ignored..
         /// </summary>
-        internal static string EmptyOrWhitespacePropertyIgnored
-        {
-            get
-            {
+        internal static string EmptyOrWhitespacePropertyIgnored {
+            get {
                 return ResourceManager.GetString("EmptyOrWhitespacePropertyIgnored", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4004: Items &apos;{0}&apos; contain empty item(s) which will be ignored..
         /// </summary>
-        internal static string EmptyValuesIgnored
-        {
-            get
-            {
+        internal static string EmptyValuesIgnored {
+            get {
                 return ResourceManager.GetString("EmptyValuesIgnored", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
         /// </summary>
-        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction
-        {
-            get
-            {
+        internal static string EntrypointAndAppCommandArgsSetNoAppCommandInstruction {
+            get {
                 return ResourceManager.GetString("EntrypointAndAppCommandArgsSetNoAppCommandInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint..
         /// </summary>
-        internal static string EntrypointArgsSetNoEntrypoint
-        {
-            get
-            {
+        internal static string EntrypointArgsSetNoEntrypoint {
+            get {
                 return ResourceManager.GetString("EntrypointArgsSetNoEntrypoint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created..
         /// </summary>
-        internal static string EntrypointArgsSetPreferAppCommandArgs
-        {
-            get
-            {
+        internal static string EntrypointArgsSetPreferAppCommandArgs {
+            get {
                 return ResourceManager.GetString("EntrypointArgsSetPreferAppCommandArgs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction &apos;{0}&apos;..
         /// </summary>
-        internal static string EntrypointConflictAppCommand
-        {
-            get
-            {
+        internal static string EntrypointConflictAppCommand {
+            get {
                 return ResourceManager.GetString("EntrypointConflictAppCommand", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
         /// </summary>
-        internal static string EntrypointSetNoAppCommandInstruction
-        {
-            get
-            {
+        internal static string EntrypointSetNoAppCommandInstruction {
+            get {
                 return ResourceManager.GetString("EntrypointSetNoAppCommandInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1008: Failed retrieving credentials for &quot;{0}&quot;: {1}.
         /// </summary>
-        internal static string FailedRetrievingCredentials
-        {
-            get
-            {
+        internal static string FailedRetrievingCredentials {
+            get {
                 return ResourceManager.GetString("FailedRetrievingCredentials", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to CONTAINER2030: GenerateLabels was disabled but GenerateDigestLabel was enabled - no digest label will be created.
+        ///   Looks up a localized string similar to CONTAINER2030: GenerateLabels was disabled but GenerateDigestLabel was enabled - no digest label will be created..
         /// </summary>
-        internal static string GenerateDigestLabelWithoutGenerateLabels
-        {
-            get
-            {
+        internal static string GenerateDigestLabelWithoutGenerateLabels {
+            get {
                 return ResourceManager.GetString("GenerateDigestLabelWithoutGenerateLabels", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No host object detected..
         /// </summary>
-        internal static string HostObjectNotDetected
-        {
-            get
-            {
+        internal static string HostObjectNotDetected {
+            get {
                 return ResourceManager.GetString("HostObjectNotDetected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1009: Failed to load image from local registry. stdout: {0}.
         /// </summary>
-        internal static string ImageLoadFailed
-        {
-            get
-            {
+        internal static string ImageLoadFailed {
+            get {
                 return ResourceManager.GetString("ImageLoadFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1010: Pulling images from local registry is not supported..
         /// </summary>
-        internal static string ImagePullNotSupported
-        {
-            get
-            {
+        internal static string ImagePullNotSupported {
+            get {
                 return ResourceManager.GetString("ImagePullNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2015: {0}: &apos;{1}&apos; was not a valid Environment Variable. Ignoring..
         /// </summary>
-        internal static string InvalidEnvVar
-        {
-            get
-            {
+        internal static string InvalidEnvVar {
+            get {
                 return ResourceManager.GetString("InvalidEnvVar", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The inferred image name &apos;{0}&apos; contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character..
         /// </summary>
-        internal static string InvalidImageName_EntireNameIsInvalidCharacters
-        {
-            get
-            {
+        internal static string InvalidImageName_EntireNameIsInvalidCharacters {
+            get {
                 return ResourceManager.GetString("InvalidImageName_EntireNameIsInvalidCharacters", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The first character of the image name &apos;{0}&apos; must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _..
         /// </summary>
-        internal static string InvalidImageName_NonAlphanumericStartCharacter
-        {
-            get
-            {
+        internal static string InvalidImageName_NonAlphanumericStartCharacter {
+            get {
                 return ResourceManager.GetString("InvalidImageName_NonAlphanumericStartCharacter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_Number
-        {
-            get
-            {
+        internal static string InvalidPort_Number {
+            get {
                 return ResourceManager.GetString("InvalidPort_Number", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos; and an invalid port type &apos;{1}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_NumberAndType
-        {
-            get
-            {
+        internal static string InvalidPort_NumberAndType {
+            get {
                 return ResourceManager.GetString("InvalidPort_NumberAndType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port type &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
-        internal static string InvalidPort_Type
-        {
-            get
-            {
+        internal static string InvalidPort_Type {
+            get {
                 return ResourceManager.GetString("InvalidPort_Type", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2018: Invalid SDK prerelease version &apos;{0}&apos; - only &apos;rc&apos; and &apos;preview&apos; are supported..
         /// </summary>
-        internal static string InvalidSdkPrereleaseVersion
-        {
-            get
-            {
+        internal static string InvalidSdkPrereleaseVersion {
+            get {
                 return ResourceManager.GetString("InvalidSdkPrereleaseVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2019: Invalid SDK semantic version &apos;{0}&apos;..
         /// </summary>
-        internal static string InvalidSdkVersion
-        {
-            get
-            {
+        internal static string InvalidSdkVersion {
+            get {
                 return ResourceManager.GetString("InvalidSdkVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
-        internal static string InvalidTag
-        {
-            get
-            {
+        internal static string InvalidTag {
+            get {
                 return ResourceManager.GetString("InvalidTag", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
-        internal static string InvalidTags
-        {
-            get
-            {
+        internal static string InvalidTags {
+            get {
                 return ResourceManager.GetString("InvalidTags", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1003: Token response had neither token nor access_token..
         /// </summary>
-        internal static string InvalidTokenResponse
-        {
-            get
-            {
+        internal static string InvalidTokenResponse {
+            get {
                 return ResourceManager.GetString("InvalidTokenResponse", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4005: Item &apos;{0}&apos; contains items without metadata &apos;Value&apos;, and they will be ignored..
         /// </summary>
-        internal static string ItemsWithoutMetadata
-        {
-            get
-            {
+        internal static string ItemsWithoutMetadata {
+            get {
                 return ResourceManager.GetString("ItemsWithoutMetadata", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error while reading daemon config: {0}.
         /// </summary>
-        internal static string LocalDocker_FailedToGetConfig
-        {
-            get
-            {
+        internal static string LocalDocker_FailedToGetConfig {
+            get {
                 return ResourceManager.GetString("LocalDocker_FailedToGetConfig", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The daemon server reported errors: {0}.
         /// </summary>
-        internal static string LocalDocker_LocalDaemonErrors
-        {
-            get
-            {
+        internal static string LocalDocker_LocalDaemonErrors {
+            get {
                 return ResourceManager.GetString("LocalDocker_LocalDaemonErrors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested..
         /// </summary>
-        internal static string LocalRegistryNotAvailable
-        {
-            get
-            {
+        internal static string LocalRegistryNotAvailable {
+            get {
                 return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2004: Unable to download layer with descriptor &apos;{0}&apos; from registry &apos;{1}&apos; because it does not exist..
         /// </summary>
-        internal static string MissingLinkToRegistry
-        {
-            get
-            {
+        internal static string MissingLinkToRegistry {
+            get {
                 return ResourceManager.GetString("MissingLinkToRegistry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2016: ContainerPort item &apos;{0}&apos; does not specify the port number. Please ensure the item&apos;s Include is a port number, for example &apos;&lt;ContainerPort Include=&quot;80&quot; /&gt;&apos;.
         /// </summary>
-        internal static string MissingPortNumber
-        {
-            get
-            {
+        internal static string MissingPortNumber {
+            get {
                 return ResourceManager.GetString("MissingPortNumber", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1004: No RequestUri specified..
         /// </summary>
-        internal static string NoRequestUriSpecified
-        {
-            get
-            {
+        internal static string NoRequestUriSpecified {
+            get {
                 return ResourceManager.GetString("NoRequestUriSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was not a valid container image name, it was normalized to &apos;{1}&apos;.
         /// </summary>
-        internal static string NormalizedContainerName
-        {
-            get
-            {
+        internal static string NormalizedContainerName {
+            get {
                 return ResourceManager.GetString("NormalizedContainerName", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to create tarball for oci image with multiple tags..
+        /// </summary>
+        internal static string OciImageMultipleTagsNotSupported {
+            get {
+                return ResourceManager.GetString("OciImageMultipleTagsNotSupported", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2011: {0} &apos;{1}&apos; does not exist.
         /// </summary>
-        internal static string PublishDirectoryDoesntExist
-        {
-            get
-            {
+        internal static string PublishDirectoryDoesntExist {
+            get {
                 return ResourceManager.GetString("PublishDirectoryDoesntExist", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploaded config to registry..
         /// </summary>
-        internal static string Registry_ConfigUploaded
-        {
-            get
-            {
+        internal static string Registry_ConfigUploaded {
+            get {
                 return ResourceManager.GetString("Registry_ConfigUploaded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploading config to registry at blob &apos;{0}&apos;,.
         /// </summary>
-        internal static string Registry_ConfigUploadStarted
-        {
-            get
-            {
+        internal static string Registry_ConfigUploadStarted {
+            get {
                 return ResourceManager.GetString("Registry_ConfigUploadStarted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Layer &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string Registry_LayerExists
-        {
-            get
-            {
+        internal static string Registry_LayerExists {
+            get {
                 return ResourceManager.GetString("Registry_LayerExists", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Finished uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_LayerUploaded
-        {
-            get
-            {
+        internal static string Registry_LayerUploaded {
+            get {
                 return ResourceManager.GetString("Registry_LayerUploaded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_LayerUploadStarted
-        {
-            get
-            {
+        internal static string Registry_LayerUploadStarted {
+            get {
                 return ResourceManager.GetString("Registry_LayerUploadStarted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploaded manifest to &apos;{0}&apos;..
         /// </summary>
-        internal static string Registry_ManifestUploaded
-        {
-            get
-            {
+        internal static string Registry_ManifestUploaded {
+            get {
                 return ResourceManager.GetString("Registry_ManifestUploaded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploading manifest to registry &apos;{0}&apos; as blob &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_ManifestUploadStarted
-        {
-            get
-            {
+        internal static string Registry_ManifestUploadStarted {
+            get {
                 return ResourceManager.GetString("Registry_ManifestUploadStarted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploaded tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_TagUploaded
-        {
-            get
-            {
+        internal static string Registry_TagUploaded {
+            get {
                 return ResourceManager.GetString("Registry_TagUploaded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uploading tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
-        internal static string Registry_TagUploadStarted
-        {
-            get
-            {
+        internal static string Registry_TagUploadStarted {
+            get {
                 return ResourceManager.GetString("Registry_TagUploadStarted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1017: Unable to communicate with the registry &apos;{0}&apos;..
         /// </summary>
-        internal static string RegistryOperationFailed
-        {
-            get
-            {
+        internal static string RegistryOperationFailed {
+            get {
                 return ResourceManager.GetString("RegistryOperationFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1013: Failed to push to the output registry: {0}.
         /// </summary>
-        internal static string RegistryOutputPushFailed
-        {
-            get
-            {
+        internal static string RegistryOutputPushFailed {
+            get {
                 return ResourceManager.GetString("RegistryOutputPushFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1014: Manifest pull failed..
         /// </summary>
-        internal static string RegistryPullFailed
-        {
-            get
-            {
+        internal static string RegistryPullFailed {
+            get {
                 return ResourceManager.GetString("RegistryPullFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1005: Registry push failed; received status code &apos;{0}&apos;..
         /// </summary>
-        internal static string RegistryPushFailed
-        {
-            get
-            {
+        internal static string RegistryPushFailed {
+            get {
                 return ResourceManager.GetString("RegistryPushFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1015: Unable to access the repository &apos;{0}&apos; at tag &apos;{1}&apos; in the registry &apos;{2}&apos;. Please confirm that this name and tag are present in the registry..
         /// </summary>
-        internal static string RepositoryNotFound
-        {
-            get
-            {
+        internal static string RepositoryNotFound {
+            get {
                 return ResourceManager.GetString("RepositoryNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4003: Required &apos;{0}&apos; items contain empty items..
         /// </summary>
-        internal static string RequiredItemsContainsEmptyItems
-        {
-            get
-            {
+        internal static string RequiredItemsContainsEmptyItems {
+            get {
                 return ResourceManager.GetString("RequiredItemsContainsEmptyItems", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4002: Required &apos;{0}&apos; items were not set..
         /// </summary>
-        internal static string RequiredItemsNotSet
-        {
-            get
-            {
+        internal static string RequiredItemsNotSet {
+            get {
                 return ResourceManager.GetString("RequiredItemsNotSet", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4001: Required property &apos;{0}&apos; was not set or empty..
         /// </summary>
-        internal static string RequiredPropertyNotSetOrEmpty
-        {
-            get
-            {
+        internal static string RequiredPropertyNotSetOrEmpty {
+            get {
                 return ResourceManager.GetString("RequiredPropertyNotSetOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1006: Too many retries, stopping..
         /// </summary>
-        internal static string TooManyRetries
-        {
-            get
-            {
+        internal static string TooManyRetries {
+            get {
                 return ResourceManager.GetString("TooManyRetries", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1016: Unable to access the repository &apos;{0}&apos; in the registry &apos;{1}&apos;. Please confirm your credentials are correct and that you have access to this repository and registry..
         /// </summary>
-        internal static string UnableToAccessRepository
-        {
-            get
-            {
+        internal static string UnableToAccessRepository {
+            get {
                 return ResourceManager.GetString("UnableToAccessRepository", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2021: Unknown AppCommandInstruction &apos;{0}&apos;. Valid instructions are {1}..
         /// </summary>
-        internal static string UnknownAppCommandInstruction
-        {
-            get
-            {
+        internal static string UnknownAppCommandInstruction {
+            get {
                 return ResourceManager.GetString("UnknownAppCommandInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2002: Unknown local registry type &apos;{0}&apos;. Valid local container registry types are {1}..
         /// </summary>
-        internal static string UnknownLocalRegistryType
-        {
-            get
-            {
+        internal static string UnknownLocalRegistryType {
+            get {
                 return ResourceManager.GetString("UnknownLocalRegistryType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message..
         /// </summary>
-        internal static string UnknownMediaType
-        {
-            get
-            {
+        internal static string UnknownMediaType {
+            get {
                 return ResourceManager.GetString("UnknownMediaType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2001: Unrecognized mediaType &apos;{0}&apos;..
         /// </summary>
-        internal static string UnrecognizedMediaType
-        {
-            get
-            {
+        internal static string UnrecognizedMediaType {
+            get {
                 return ResourceManager.GetString("UnrecognizedMediaType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to create tarball for mediaType &apos;{0}&apos;..
+        /// </summary>
+        internal static string UnsupportedMediaTypeForTarball {
+            get {
+                return ResourceManager.GetString("UnsupportedMediaTypeForTarball", resourceCulture);
             }
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -241,6 +241,12 @@
     <value>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</value>
     <comment>{StrBegin="CONTAINER2004: "}</comment>
   </data>
+  <data name="OciImageMultipleTagsNotSupported" xml:space="preserve">
+    <value>Unable to create tarball for oci image with multiple tags.</value>
+  </data>
+  <data name="UnsupportedMediaTypeForTarball" xml:space="preserve">
+    <value>Unable to create tarball for mediaType '{0}'.</value>
+  </data>
   <data name="MissingPortNumber" xml:space="preserve">
     <value>CONTAINER2016: ContainerPort item '{0}' does not specify the port number. Please ensure the item's Include is a port number, for example '&lt;ContainerPort Include="80" /&gt;'</value>
     <comment>{StrBegin="CONTAINER2016: "}</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' nebyl platný název image kontejneru, byl normalizován na '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' neexistuje.</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: Nerozpoznaný typ mediaType '{0}'.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -257,6 +257,11 @@
         <target state="translated">„{0}“ war kein gültiger Containerimagename, er wurde zu „{1}“ normalisiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} „{1}“ ist nicht vorhanden.</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: Unbekannter mediaType „{0}“.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -257,6 +257,11 @@
         <target state="translated">"{0}" no era un nombre de imagen de contenedor válido, se normalizó a "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} "{1}" no existe</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: mediaType "{0}" no reconocido.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' n’était pas un nom d’image conteneur valide, il a été normalisé pour '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' n’existe pas</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: '{0}' mediaType non reconnu.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' non è un nome di immagine contenitore valido, è stato normalizzato in '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' non esiste</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: mediaType '{0}' non riconosciuto.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' は有効なコンテナー イメージ名ではありませんでした。'{1}' に正規化されました</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' が存在しません</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: 認識されない mediaType '{0}' です。</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}'은(는) 유효한 컨테이너 이미지 이름이 아닙니다. '{1}'(으)로 정규화되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}'이(가) 존재하지 않습니다.</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: 미디어 유형 '{0}'을(를) 인식할 수 없습니다.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -257,6 +257,11 @@
         <target state="translated">Nazwa „{0}” nie była prawidłową nazwą obrazu kontenera, została znormalizowana do „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} „{1}” nie istnieje</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: nierozpoznany typ nośnika „{0}”.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' não era um nome de imagem de contêiner válido, foi normalizado para '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' não existe</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: MediaType não reconhecido '{0}'.</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -257,6 +257,11 @@
         <target state="translated">"{0}" не является допустимым именем образа контейнера, оно нормализовано до "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} "{1}" не существует</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: нераспознанный тип мультимедиа "{0}".</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}', geçerli bir kapsayıcı görüntüsü adı değildi, '{1}' olarak normalleştirildi</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' yok</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: Tanınmayan mediaType ('{0}').</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -257,6 +257,11 @@
         <target state="translated">“{0}”不是有效的容器映像名称，已规范化为“{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} {1} 不存在</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: 无法识别 mediaType“{0}”。</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -257,6 +257,11 @@
         <target state="translated">'{0}' 不是有效的容器映像名稱，已標準化為 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="OciImageMultipleTagsNotSupported">
+        <source>Unable to create tarball for oci image with multiple tags.</source>
+        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' 不存在</target>
@@ -376,6 +381,11 @@
         <source>CONTAINER2001: Unrecognized mediaType '{0}'.</source>
         <target state="translated">CONTAINER2001: 無法辨識的 mediaType '{0}'。</target>
         <note>{StrBegin="CONTAINER2001: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedMediaTypeForTarball">
+        <source>Unable to create tarball for mediaType '{0}'.</source>
+        <target state="new">Unable to create tarball for mediaType '{0}'.</target>
+        <note />
       </trans-unit>
       <trans-unit id="_Test">
         <source>CONTAINER0000: Value for unit test {0}</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -235,6 +235,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             telemetry.LogLocalLoadError();
             Log.LogErrorFromException(dle, showStackTrace: false);
         }
+        catch (ArgumentException argEx)
+        {
+            Log.LogErrorFromException(argEx, showStackTrace: false);
+        }
     }
 
     private async Task PushToRemoteRegistryAsync(BuiltImage builtImage, SourceImageReference sourceImageReference,

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Formats.Tar;
 using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Build.Containers.LocalDaemons;
@@ -174,6 +175,135 @@ public class EndToEndTests : IDisposable
                 .Execute()
                 .Should().Pass();
         }
+
+        CheckForDockerTarballStructure(archiveFile);
+    }
+
+    private void CheckForDockerTarballStructure(string tarball)
+    {
+        var layers = new HashSet<string>();
+        int configJson = 0;
+        int manifestJsonCount = 0;
+
+        using (FileStream fs = new FileStream(tarball, FileMode.Open, FileAccess.Read))
+        using (var tarReader = new TarReader(fs))
+        {
+            var entry = tarReader.GetNextEntry();
+
+            while (entry is not null)
+            {
+                if (entry.Name == "manifest.json")
+                {
+                    manifestJsonCount++;
+                }
+                else if (entry.Name.EndsWith(".json"))
+                {
+                    configJson++;
+                }
+                else if (entry.Name.EndsWith("/layer.tar"))
+                {
+                    layers.Add(entry.Name);
+                }
+                else
+                {
+                    Assert.Fail($"Unexpected entry in tarball: {entry.Name}");
+                }
+
+                entry = tarReader.GetNextEntry();
+            }
+        }
+
+        Assert.Equal(1, manifestJsonCount);
+        Assert.Equal(1, configJson);
+        Assert.NotEmpty(layers);
+    }
+
+    [DockerAvailableFact]
+    public async Task ApiEndToEndOciImageWithArchiveWritingAndLoad()
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(ApiEndToEndOciImageWithArchiveWritingAndLoad));
+
+        // Build the image
+
+        Registry registry = new(DockerRegistryManager.LocalRegistry, logger, RegistryMode.Push);
+
+        ImageBuilder imageBuilder = await registry.GetImageManifestAsync(
+            DockerRegistryManager.Nginx,
+            "latest",
+            "linux-x64",
+            ToolsetUtils.RidGraphManifestPicker,
+            cancellationToken: default).ConfigureAwait(false);
+        Assert.NotNull(imageBuilder);
+
+        BuiltImage builtImage = imageBuilder.Build();
+
+        // Write the image to disk
+        var archiveFile = Path.Combine(TestSettings.TestArtifactsDirectory,
+            nameof(ApiEndToEndWithArchiveWritingAndLoad), "nginx.tar.gz");
+        var sourceReference = new SourceImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net7ImageTag);
+        var destinationReference = new DestinationImageReference(new ArchiveFileRegistry(archiveFile), NewImageName(), ["latest"]);
+
+        await destinationReference.LocalRegistry!.LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
+
+        Assert.True(File.Exists(archiveFile), $"File.Exists({archiveFile})");
+
+        // Docker cannot load an OCI image, so we check for Podman
+        if (ContainerCli.IsPodman)
+        {
+            // Load the archive
+            ContainerCli.LoadCommand(_testOutput, "--input", archiveFile)
+                .Execute()
+                .Should().Pass();
+
+            // Run the image
+            foreach (string tag in destinationReference.Tags)
+            {
+                ContainerCli.RunCommand(_testOutput, "--rm", "--tty", $"{NewImageName()}:{tag}")
+                    .Execute()
+                    .Should().Pass();
+            }
+        }
+
+        CheckForOciTarballStructure(archiveFile);
+    }
+
+    private void CheckForOciTarballStructure(string tarball)
+    {
+        var blobs = new HashSet<string>();
+        int ociLayoutCount = 0;
+        int indexJsonCount = 0;
+
+        using (FileStream fs = new FileStream(tarball, FileMode.Open, FileAccess.Read))
+        using (var tarReader = new TarReader(fs))
+        {
+            var entry = tarReader.GetNextEntry();
+
+            while (entry is not null)
+            {
+                if (entry.Name == "oci-layout")
+                {
+                    ociLayoutCount++;
+                }
+                else if (entry.Name == "index.json")
+                {
+                    indexJsonCount++;
+                }
+                else if (entry.Name.StartsWith("blobs/sha256/"))
+                {
+                    blobs.Add(entry.Name);
+                }
+                else
+                {
+                    Assert.Fail($"Unexpected entry in tarball: {entry.Name}");
+                }
+
+                entry = tarReader.GetNextEntry();
+            }
+        }
+
+        Assert.Equal(1, ociLayoutCount);
+        Assert.Equal(1, indexJsonCount);
+        Assert.NotEmpty(blobs);
     }
 
     private string BuildLocalApp([CallerMemberName] string testName = "TestName", string tfm = ToolsetInfo.CurrentTargetFramework, string rid = "linux-x64")

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -181,7 +181,7 @@ public class EndToEndTests : IDisposable
 
     private void CheckForDockerTarballStructure(string tarball)
     {
-        var layers = new HashSet<string>();
+        var layersCount = 0;
         int configJson = 0;
         int manifestJsonCount = 0;
 
@@ -202,7 +202,7 @@ public class EndToEndTests : IDisposable
                 }
                 else if (entry.Name.EndsWith("/layer.tar"))
                 {
-                    layers.Add(entry.Name);
+                    layersCount++;
                 }
                 else
                 {
@@ -215,7 +215,7 @@ public class EndToEndTests : IDisposable
 
         Assert.Equal(1, manifestJsonCount);
         Assert.Equal(1, configJson);
-        Assert.NotEmpty(layers);
+        Assert.True(layersCount > 0);
     }
 
     [DockerAvailableFact]
@@ -269,7 +269,7 @@ public class EndToEndTests : IDisposable
 
     private void CheckForOciTarballStructure(string tarball)
     {
-        var blobs = new HashSet<string>();
+        int blobsCount = 0;
         int ociLayoutCount = 0;
         int indexJsonCount = 0;
 
@@ -290,7 +290,7 @@ public class EndToEndTests : IDisposable
                 }
                 else if (entry.Name.StartsWith("blobs/sha256/"))
                 {
-                    blobs.Add(entry.Name);
+                    blobsCount++;
                 }
                 else
                 {
@@ -303,7 +303,7 @@ public class EndToEndTests : IDisposable
 
         Assert.Equal(1, ociLayoutCount);
         Assert.Equal(1, indexJsonCount);
-        Assert.NotEmpty(blobs);
+        Assert.True(blobsCount > 0);
     }
 
     private string BuildLocalApp([CallerMemberName] string testName = "TestName", string tfm = ToolsetInfo.CurrentTargetFramework, string rid = "linux-x64")


### PR DESCRIPTION
### Context
Currently, when customers use our tooling to publish containers as tarballs, both Docker and OCI images are saved as a tarball  that has Docker tarball format. The produced tarball can be consumed by other tooling like Docker or Podman. However, this is incorrect, as OCI image tarballs should follow a distinct structure specific to the OCI format. The correct OCI tarball can be consumed by Podman and other tooling that understands OCI tarballs.

### Customer impact
Without this change, customers will continue to receive improperly structured OCI tarballs.

### Details
OCI image tarball structure should look like https://github.com/opencontainers/image-spec/blob/main/image-layout.md#oci-layout-file

### Changes
1. Fixed tarball creation for OCI image
2. Added 'annotations' to `ImageIndexV1` manifests entries. (this is needed to set image name and tag in the tarball)

### Testing
1. Added tests that check correct Docker/OCI image tarball structure
2. Tested manually by loading the produced OCI image tarball with Podman.

### Risk
_Low_ - the existing tests ensure that other scenarios were not affected.
