### PR TITLE
[dotnet-watch] Separate build from run

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,6 +91,10 @@
     <MicrosoftDotNetDarcLibVersion>1.1.0-beta.24367.3</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependency from https://github.com/dotnet/aspire -->
+    <AspirePackageVersion>9.1.0-preview.1.24555.3</AspirePackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>9.0.0-rc.2.24474.1</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>

--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -104,11 +104,11 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
 
             var projectOptions = GetProjectOptions(projectLaunchInfo);
             var sessionId = Interlocked.Increment(ref _sessionIdDispenser).ToString(CultureInfo.InvariantCulture);
-            await StartProjectAsync(dcpId, sessionId, projectOptions, build: false, isRestart: false, cancellationToken);
+            await StartProjectAsync(dcpId, sessionId, projectOptions, isRestart: false, cancellationToken);
             return sessionId;
         }
 
-        public async ValueTask<RunningProject> StartProjectAsync(string dcpId, string sessionId, ProjectOptions projectOptions, bool build, bool isRestart, CancellationToken cancellationToken)
+        public async ValueTask<RunningProject> StartProjectAsync(string dcpId, string sessionId, ProjectOptions projectOptions, bool isRestart, CancellationToken cancellationToken)
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
 
@@ -125,9 +125,8 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                     var writeResult = outputChannel.Writer.TryWrite(line);
                     Debug.Assert(writeResult);
                 },
-                restartOperation: (build, cancellationToken) =>
-                    StartProjectAsync(dcpId, sessionId, projectOptions, build, isRestart: true, cancellationToken),
-                build: build,
+                restartOperation: cancellationToken =>
+                    StartProjectAsync(dcpId, sessionId, projectOptions, isRestart: true, cancellationToken),
                 cancellationToken);
 
             if (runningProject == null)

--- a/src/BuiltInTools/dotnet-watch/FileItem.cs
+++ b/src/BuiltInTools/dotnet-watch/FileItem.cs
@@ -7,12 +7,14 @@ namespace Microsoft.DotNet.Watcher
 {
     internal readonly record struct FileItem
     {
-        public string FilePath { get; init; }
+        public required string FilePath { get; init; }
 
         /// <summary>
         /// List of all projects that contain this file (does not contain duplicates).
+        /// Empty if <see cref="Change"/> is <see cref="ChangeKind.Add"/> and the
+        /// item has not been assigned to a project yet.
         /// </summary>
-        public List<string> ContainingProjectPaths { get; init; }
+        public required List<string> ContainingProjectPaths { get; init; }
 
         public string? StaticWebAssetPath { get; init; }
 

--- a/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Filters/BuildEvaluator.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
@@ -87,7 +88,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 await FileWatcher.WaitForFileChangeAsync(
                     rootProjectFileSetFactory.RootProjectFile,
                     context.Reporter,
-                    startedWatching: () => context.Reporter.Warn("Fix the error to continue or press Ctrl+C to exit."),
+                    startedWatching: () => context.Reporter.Report(MessageDescriptor.FixBuildError),
                     cancellationToken);
             }
         }

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             Dispose();
         }
 
-        public ValueTask RestartSessionAsync(IReadOnlySet<ProjectId> projectsToBeRebuilt, CancellationToken cancellationToken)
+        public ValueTask RestartSessionAsync(ImmutableDictionary<ProjectId, string> projectsToBeRebuilt, CancellationToken cancellationToken)
         {
             // Remove previous updates to all modules that were affected by rude edits.
             // All running projects that statically reference these modules have been terminated.
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             lock (_runningProjectsAndUpdatesGuard)
             {
-                _previousUpdates = _previousUpdates.RemoveAll(update => projectsToBeRebuilt.Contains(update.ProjectId));
+                _previousUpdates = _previousUpdates.RemoveAll(update => projectsToBeRebuilt.ContainsKey(update.ProjectId));
             }
 
             _hotReloadService.EndSession();
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             }
         }
 
-        public async ValueTask<(IReadOnlySet<ProjectId> projectsToBeRebuilt, IEnumerable<RunningProject> terminatedProjects)> HandleFileChangesAsync(
+        public async ValueTask<(ImmutableDictionary<ProjectId, string> projectsToRebuild, ImmutableArray<RunningProject> terminatedProjects)> HandleFileChangesAsync(
             Func<IEnumerable<Project>, CancellationToken, Task> restartPrompt,
             CancellationToken cancellationToken)
         {
@@ -292,14 +292,14 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 // If Hot Reload is blocked (due to compilation error) we ignore the current
                 // changes and await the next file change.
-                return (ImmutableHashSet<ProjectId>.Empty, []);
+                return (ImmutableDictionary<ProjectId, string>.Empty, []);
             }
 
             if (updates.Status == ModuleUpdateStatus.RestartRequired)
             {
                 if (!anyProcessNeedsRestart)
                 {
-                    return (ImmutableHashSet<ProjectId>.Empty, []);
+                    return (ImmutableDictionary<ProjectId, string>.Empty, []);
                 }
 
                 await restartPrompt.Invoke(updates.ProjectsToRestart, cancellationToken);
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 // except for the root process, which will terminate later on.
                 var terminatedProjects = await TerminateNonRootProcessesAsync(updates.ProjectsToRestart.Select(p => p.FilePath!), cancellationToken);
 
-                return (updates.ProjectsToRebuild.Select(p => p.Id).ToHashSet(), terminatedProjects);
+                return (updates.ProjectsToRebuild.ToImmutableDictionary(keySelector: p => p.Id, elementSelector: p => p.FilePath!), terminatedProjects);
             }
 
             Debug.Assert(updates.Status == ModuleUpdateStatus.Ready);
@@ -348,7 +348,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                 }
             }, cancellationToken);
 
-            return (ImmutableHashSet<ProjectId>.Empty, []);
+            return (ImmutableDictionary<ProjectId, string>.Empty, []);
         }
 
         private async ValueTask DisplayResultsAsync(WatchHotReloadService.Updates updates, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -31,7 +31,6 @@ internal sealed class ProjectLauncher(
         CancellationTokenSource processTerminationSource,
         Action<OutputLine>? onOutput,
         RestartOperation restartOperation,
-        bool build,
         CancellationToken cancellationToken)
     {
         var projectNode = projectMap.TryGetProjectNode(projectOptions.ProjectPath, projectOptions.TargetFramework);
@@ -58,9 +57,7 @@ internal sealed class ProjectLauncher(
             Executable = EnvironmentOptions.MuxerPath,
             WorkingDirectory = projectOptions.WorkingDirectory,
             OnOutput = onOutput,
-            Arguments = build || !CommandLineOptions.IsCodeExecutionCommand(projectOptions.Command)
-                ? [projectOptions.Command, .. projectOptions.CommandArguments]
-                : [projectOptions.Command, "--no-build", .. projectOptions.CommandArguments]
+            Arguments = [projectOptions.Command, "--no-build", .. projectOptions.CommandArguments]
         };
 
         var environmentBuilder = EnvironmentVariablesBuilder.FromCurrentEnvironment();

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectNodeMap.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectNodeMap.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Watcher.Tools
     {
         public readonly ProjectGraph Graph = graph;
 
+        // full path of proj file to list of nodes representing all target frameworks of the project:
         public readonly IReadOnlyDictionary<string, IReadOnlyList<ProjectGraphNode>> Map = 
             graph.ProjectNodes.GroupBy(n => n.ProjectInstance.FullPath).ToDictionary(
                 keySelector: static g => g.Key,

--- a/src/BuiltInTools/dotnet-watch/HotReload/RunningProject.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RunningProject.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher.Tools
 {
-    internal delegate ValueTask<RunningProject> RestartOperation(bool build, CancellationToken cancellationToken);
+    internal delegate ValueTask<RunningProject> RestartOperation(CancellationToken cancellationToken);
 
     internal sealed class RunningProject(
         ProjectGraphNode projectNode,
@@ -68,7 +68,6 @@ namespace Microsoft.DotNet.Watcher.Tools
         public async ValueTask WaitForProcessRunningAsync(CancellationToken cancellationToken)
         {
             await DeltaApplier.WaitForProcessRunningAsync(cancellationToken);
-            Reporter.Report(MessageDescriptor.BuildCompleted);
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher.cs
@@ -100,6 +100,12 @@ namespace Microsoft.DotNet.Watcher.Internal
         private static string EnsureTrailingSlash(string path)
             => (path is [.., var last] && last != Path.DirectorySeparatorChar) ? path + Path.DirectorySeparatorChar : path;
 
+        public Task<ChangedFile?> WaitForFileChangeAsync(Action? startedWatching, CancellationToken cancellationToken)
+           => WaitForFileChangeAsync(
+               changeFilter: (path, kind) => new ChangedFile(new FileItem() { FilePath = path, ContainingProjectPaths = [] }, kind),
+               startedWatching,
+               cancellationToken);
+
         public Task<ChangedFile?> WaitForFileChangeAsync(IReadOnlyDictionary<string, FileItem> fileSet, Action? startedWatching, CancellationToken cancellationToken)
             => WaitForFileChangeAsync(
                 changeFilter: (path, kind) => fileSet.TryGetValue(path, out var fileItem) ? new ChangedFile(fileItem, kind) : null,
@@ -142,7 +148,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             watcher.WatchDirectories([Path.GetDirectoryName(filePath)!]);
 
             var fileChange = await watcher.WaitForFileChangeAsync(
-                changeFilter: (path, kind) => path == filePath ? new ChangedFile(new FileItem { FilePath = path }, kind) : null,
+                changeFilter: (path, kind) => path == filePath ? new ChangedFile(new FileItem { FilePath = path, ContainingProjectPaths = [] }, kind) : null,
                 startedWatching,
                 cancellationToken);
 

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -62,9 +62,8 @@ namespace Microsoft.Extensions.Tools.Internal
         public static readonly MessageDescriptor KillingProcess = new("Killing process {0}", "⌚", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor HotReloadChangeHandled = new("Hot reload change handled in {0}ms.", "🔥", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor HotReloadSucceeded = new("Hot reload succeeded.", "🔥", MessageSeverity.Output, s_id++);
-        public static readonly MessageDescriptor BuildCompleted = new("Build completed.", "⌚", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor UpdatesApplied = new("Updates applied: {0} out of {1}.", "🔥", MessageSeverity.Verbose, s_id++);
-        public static readonly MessageDescriptor WaitingForFileChangeBeforeRestarting = new("Waiting for a file to change before restarting dotnet...", "⏳", MessageSeverity.Warning, s_id++);
+        public static readonly MessageDescriptor WaitingForFileChangeBeforeRestarting = new("Waiting for a file to change before restarting ...", "⏳", MessageSeverity.Warning, s_id++);
         public static readonly MessageDescriptor WatchingWithHotReload = new("Watching with Hot Reload.", "⌚", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor RestartInProgress = new("Restart in progress.", "🔄", MessageSeverity.Output, s_id++);
         public static readonly MessageDescriptor RestartRequested = new("Restart requested.", "🔄", MessageSeverity.Output, s_id++);

--- a/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/PhysicalConsole.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Extensions.Tools.Internal
                 {
                     CtrlC => new ConsoleKeyInfo('C', ConsoleKey.C, shift: false, alt: false, control: true),
                     CtrlR => new ConsoleKeyInfo('R', ConsoleKey.R, shift: false, alt: false, control: true),
-                    >= 'A' and <= 'Z' => new ConsoleKeyInfo(c, ConsoleKey.A + (c - 'A'), shift: false, alt: false, control: false),
+                    >= 'a' and <= 'z' => new ConsoleKeyInfo(c, ConsoleKey.A + (c - 'a'), shift: false, alt: false, control: false),
+                    >= 'A' and <= 'Z' => new ConsoleKeyInfo(c, ConsoleKey.A + (c - 'A'), shift: true, alt: false, control: false),
                     _ => default
                 };
 

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,10 +2,13 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--list",
-      "workingDirectory": "C:\\sdk\\artifacts\\tmp\\Debug\\BlazorWasm_Ap---8DA5F107",
+      "commandLineArgs": "--verbose /bl:DotnetRun.binlog",
+      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
       "environmentVariables": {
-        "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)"
+        "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)",
+        "DCP_IDE_REQUEST_TIMEOUT_SECONDS": "100000",
+        "DCP_IDE_NOTIFICATION_TIMEOUT_SECONDS": "100000",
+        "DCP_IDE_NOTIFICATION_KEEPALIVE_SECONDS": "100000"
       }
     }
   }

--- a/src/BuiltInTools/dotnet-watch/Utilities/BuildUtilities.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/BuildUtilities.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Watcher.Internal;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.DotNet.Watch;
+
+internal static partial class BuildUtilities
+{
+    private static readonly Regex s_buildDiagnosticRegex = GetBuildDiagnosticRegex();
+
+    [GeneratedRegex(@"[^:]+: (error|warning) [A-Za-z]+[0-9]+: .+")]
+    private static partial Regex GetBuildDiagnosticRegex();
+
+    public static void ReportBuildOutput(IReporter reporter, IEnumerable<OutputLine> buildOutput, bool verboseOutput)
+    {
+        const string BuildEmoji = "🔨";
+
+        foreach (var (line, isError) in buildOutput)
+        {
+            if (isError)
+            {
+                reporter.Error(line);
+            }
+            else if (s_buildDiagnosticRegex.Match(line) is { Success: true } match)
+            {
+                if (match.Groups[1].Value == "error")
+                {
+                    reporter.Error(line);
+                }
+                else
+                {
+                    reporter.Warn(line);
+                }
+            }
+            else if (verboseOutput)
+            {
+                reporter.Verbose(line, BuildEmoji);
+            }
+            else
+            {
+                reporter.Output(line, BuildEmoji);
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -34,8 +34,8 @@
       <_Parameter2>$(MicrosoftAspNetCoreAppRefPackageVersion)</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" >
-      <_Parameter1>MicrosoftNETSdkAspireManifest80100PackageVersion</_Parameter1>
-      <_Parameter2>$(MicrosoftNETSdkAspireManifest80100PackageVersion)</_Parameter2>
+      <_Parameter1>AspirePackageVersion</_Parameter1>
+      <_Parameter2>$(AspirePackageVersion)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/WatchAspire.AppHost.csproj
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/WatchAspire.AppHost.csproj
@@ -1,4 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="$(AspirePackageVersion)" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,8 +8,6 @@
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>ad800ccc-954c-40cc-920b-2e09fc9eee7a</UserSecretsId>
-    <!-- workaround -->
-    <AspireHostingSDKVersion>9.0.0</AspireHostingSDKVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="$(MicrosoftNETSdkAspireManifest80100PackageVersion)" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="$(AspirePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.ServiceDefaults/WatchAspire.ServiceDefaults.csproj
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.ServiceDefaults/WatchAspire.ServiceDefaults.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="$(MicrosoftNETSdkAspireManifest80100PackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspirePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -380,15 +380,10 @@ namespace Microsoft.DotNet.Watcher.Tests
             var testAsset = TestAssets.CopyTestAsset("WatchAspire")
                 .WithSource();
 
-            var workloadInstallCommandSpec = new DotnetCommand(Logger, ["workload", "install", "aspire", "--include-previews"])
-            {
-                WorkingDirectory = testAsset.Path,
-            };
-
-            var result = workloadInstallCommandSpec.Execute();
-            Assert.Equal(0, result.ExitCode);
-
             var serviceSourcePath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "Program.cs");
+            var serviceProjectPath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "WatchAspire.ApiService.csproj");
+            var originalSource = File.ReadAllText(serviceSourcePath, Encoding.UTF8);
+
             App.Start(testAsset, ["-lp", "http"], relativeProjectDirectory: "WatchAspire.AppHost", testFlags: TestFlags.ReadKeyFromStdin);
 
             await App.AssertWaitingForChanges();
@@ -399,9 +394,10 @@ namespace Microsoft.DotNet.Watcher.Tests
             // wait until after DCP session started:
             await App.WaitUntilOutputContains("dotnet watch ⭐ Session started: #1");
 
-            var newSource = File.ReadAllText(serviceSourcePath, Encoding.UTF8);
-            newSource = newSource.Replace("Enumerable.Range(1, 5)", "Enumerable.Range(1, 10)");
-            UpdateSourceFile(serviceSourcePath, newSource);
+            // valid code change:
+            UpdateSourceFile(
+                serviceSourcePath,
+                originalSource.Replace("Enumerable.Range(1, 5)", "Enumerable.Range(1, 10)"));
 
             await App.AssertOutputLineStartsWith("dotnet watch 🔥 Hot reload change handled");
 
@@ -411,7 +407,60 @@ namespace Microsoft.DotNet.Watcher.Tests
 
             // Only one browser should be launched (dashboard). The child process shouldn't launch a browser.
             Assert.Equal(1, App.Process.Output.Count(line => line.StartsWith("dotnet watch ⌚ Launching browser: ")));
+            App.Process.ClearOutput();
 
+#if TODO // needs Roslyn update
+            // rude edit with build error:
+            UpdateSourceFile(
+                serviceSourcePath,
+                originalSource.Replace("record WeatherForecast", "record WeatherForecast2"));
+
+            await App.AssertOutputLineStartsWith("  ❔ Do you want to restart these projects? Yes (y) / No (n) / Always (a) / Never (v)");
+
+            App.AssertOutputContains("dotnet watch ⌚ Unable to apply hot reload, restart is needed to apply the changes.");
+            App.AssertOutputContains("error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
+            App.AssertOutputContains("dotnet watch ⌚ Affected projects:");
+            App.AssertOutputContains("dotnet watch ⌚   WatchAspire.ApiService");
+            App.Process.ClearOutput();
+
+            App.SendKey('y');
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.FixBuildError, failure: _ => false);
+
+            // We don't have means to gracefully terminate process on Windows, see https://github.com/dotnet/runtime/issues/109432
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                App.AssertOutputContains("dotnet watch ❌ [WatchAspire.ApiService (net9.0)] Exited with error code -1");
+            }
+            else
+            {
+                App.AssertOutputContains("dotnet watch ⌚ [WatchAspire.ApiService (net9.0)] Exited");
+            }
+
+            App.AssertOutputContains($"dotnet watch ⌚ Building '{serviceProjectPath}' ...");
+            App.AssertOutputContains("error CS0246: The type or namespace name 'WeatherForecast' could not be found");
+            App.Process.ClearOutput();
+
+            // TODO: remove
+            Log("dotnet build-server shutdown");
+            var workloadInstallCommandSpec = new DotnetCommand(Logger, ["build-server", "shutdown"])
+            {
+                WorkingDirectory = testAsset.Path,
+            };
+
+            var result = workloadInstallCommandSpec.Execute();
+            Assert.Equal(0, result.ExitCode);
+
+            // fix build error:
+            UpdateSourceFile(
+                serviceSourcePath,
+                originalSource.Replace("WeatherForecast", "WeatherForecast2"));
+
+            await App.AssertOutputLineStartsWith("dotnet watch ⌚ [WatchAspire.ApiService (net9.0)] Capabilities");
+
+            App.AssertOutputContains("dotnet watch ⌚ Build succeeded.");
+            App.AssertOutputContains($"dotnet watch ⭐ Starting project: {serviceProjectPath}");
+#endif
             App.SendControlC();
 
             await App.AssertOutputLineStartsWith("dotnet watch 🛑 Shutdown requested. Press Ctrl+C again to force exit.");

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -37,14 +37,13 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         };
 
         RestartOperation? startOp = null;
-        startOp = new RestartOperation(async (build, cancellationToken) =>
+        startOp = new RestartOperation(async cancellationToken =>
         {
             var result = await service.ProjectLauncher.TryLaunchProcessAsync(
                 projectOptions,
                 new CancellationTokenSource(),
                 onOutput: null,
                 restartOperation: startOp!,
-                build,
                 cancellationToken);
 
             Assert.NotNull(result);
@@ -54,7 +53,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             return result;
         });
 
-        return await startOp(build: false, cancellationToken);
+        return await startOp(cancellationToken);
     }
 
     [Theory]
@@ -171,7 +170,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         {
         }
 
-        Assert.Equal(4, launchedProcessCount);
+        Assert.Equal(6, launchedProcessCount);
 
         // Hot Reload shared dependency - should update both service projects
         async Task MakeValidDependencyChange()
@@ -252,7 +251,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
             Assert.True(hasUpdateSource.Task.IsCompletedSuccessfully);
 
-            Assert.Equal(4, launchedProcessCount);
+            Assert.Equal(6, launchedProcessCount);
         }
     }
 

--- a/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
+++ b/test/dotnet-watch.Tests/MSBuildEvaluationFilterTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Test.csproj" }, ChangeKind.Update), CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Test.csproj", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
         }
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
             Assert.False(evaluator.RequiresRevaluation);
             Assert.Equal(1, counter);
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
             evaluator.RequiresRevaluation = false;
 
-            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
+            await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
             Assert.Equal(2, counter);
@@ -93,8 +93,8 @@ namespace Microsoft.DotNet.Watcher.Tools
             var result = new EvaluationResult(
                 new Dictionary<string, FileItem>()
                 {
-                    { "Controlller.cs", new FileItem { FilePath = "Controlller.cs" } },
-                    { "Proj.csproj", new FileItem { FilePath = "Proj.csproj" } },
+                    { "Controlller.cs", new FileItem { FilePath = "Controlller.cs", ContainingProjectPaths = []} },
+                    { "Proj.csproj", new FileItem { FilePath = "Proj.csproj", ContainingProjectPaths = [] } },
                 },
                 projectGraph: null);
 
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             evaluator.RequiresRevaluation = false;
             evaluator.Timestamps["Proj.csproj"] = new DateTime(1007);
 
-            await evaluator.EvaluateAsync(new(new() { FilePath = "Controller.cs" }, ChangeKind.Update), CancellationToken.None);
+            await evaluator.EvaluateAsync(new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
             Assert.True(evaluator.RequiresRevaluation);
         }

--- a/test/dotnet-watch.Tests/Utilities/TestReporter.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestReporter.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Extensions.Tools.Internal
         public bool EnableProcessOutputReporting
             => true;
 
+        public bool IsVerbose
+            => true;
+
         public event Action<string, OutputLine>? OnProjectProcessOutput;
         public event Action<OutputLine>? OnProcessOutput;
 

--- a/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
+++ b/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             App.DotnetWatchArgs.Clear();
             App.Start(testAsset, ["--list"]);
             var lines = await App.Process.GetAllOutputLinesAsync(CancellationToken.None);
-            var files = lines.Where(l => !l.StartsWith("watch :"));
+            var files = lines.Where(l => !l.StartsWith("dotnet watch ⌚") && l.Trim() != "");
 
             AssertEx.EqualFileList(
                 testAsset.Path,

--- a/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Watcher.Tests
         /// </summary>
         public async Task<string> AssertOutputLineStartsWith(string expectedPrefix, Predicate<string> failure = null)
         {
-            Logger.WriteLine($"Test waiting for output: '{expectedPrefix}'");
+            Logger.WriteLine($"[TEST] Test waiting for output: '{expectedPrefix}'");
 
             var line = await Process.GetOutputLineAsync(
                 success: line => line.StartsWith(expectedPrefix, StringComparison.Ordinal),
@@ -128,6 +128,11 @@ namespace Microsoft.DotNet.Watcher.Tests
             commandSpec.WithEnvironmentVariable("__DOTNET_WATCH_TEST_FLAGS", testFlags.ToString());
             commandSpec.WithEnvironmentVariable("__DOTNET_WATCH_TEST_OUTPUT_DIR", testOutputPath);
             commandSpec.WithEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", testOutputPath);
+
+            // suppress all DCP timeouts:
+            commandSpec.WithEnvironmentVariable("DCP_IDE_REQUEST_TIMEOUT_SECONDS", "100000");
+            commandSpec.WithEnvironmentVariable("DCP_IDE_NOTIFICATION_TIMEOUT_SECONDS", "100000");
+            commandSpec.WithEnvironmentVariable("DCP_IDE_NOTIFICATION_KEEPALIVE_SECONDS", "100000");
 
             foreach (var env in EnvironmentVariables)
             {


### PR DESCRIPTION
Update tests to use a recent Aspire package that does not require workload installation.

Use combination of `dotnet build` and `dotnet run --no-build` instead of `dotnet run`.
This has two benefits:
- separates build output (only printed out to dotnet-watch console output on build error or in verbose mode) from application output (sent to Aspire console for Aspire resources) 
- when restarting subset of processes impacted by rude edit we can build all affected projects first and only when the build succeeds restart the processes.

Use regex to match errors and warnings in `dotnet build` output (`dotnet build` prints all output to stdout).

Fixes https://github.com/dotnet/sdk/issues/44543