### PR TITLE
Enable test timeout dump collection

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -98,12 +98,14 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             // Should instead make this a full path to dotnet
             string processPath = Environment.ProcessPath;
-            if (!processPath.EndsWith("dotnet" + Constants.ExeSuffix, StringComparison.OrdinalIgnoreCase))
+            string hostName = "dotnet" + Constants.ExeSuffix;
+
+            if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
             {
                 var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
                 if (!string.IsNullOrEmpty(dotnetHostPath))
                 {
-                    processPath = dotnetHostPath;
+                    processPath = dotnetHostPath+ Path.DirectorySeparatorChar + hostName;
                 }
             }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -100,17 +100,13 @@ namespace Microsoft.DotNet.Cli.Utils
             string processPath = Environment.ProcessPath;
             if (!processPath.EndsWith("dotnet" + Constants.ExeSuffix, StringComparison.OrdinalIgnoreCase))
             {
-                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
                 if (!string.IsNullOrEmpty(dotnetHostPath))
                 {
                     processPath = dotnetHostPath;
                 }
-                else
-                {
-                    var environmentBlock = string.Join(Environment.NewLine, Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().Select(e => $"{e.Key}={e.Value}"));
-                    throw new Exception($"Failed to find dotnet host. Environment Block: {Environment.NewLine}{environmentBlock}");
-                }
             }
+
             return processPath;
         }
     }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -4,6 +4,7 @@
 #if NET
 
 using System.Diagnostics;
+using System.Collections;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -96,7 +97,21 @@ namespace Microsoft.DotNet.Cli.Utils
         private string GetHostExeName()
         {
             // Should instead make this a full path to dotnet
-            return Environment.ProcessPath;
+            string processPath = Environment.ProcessPath;
+            if (!processPath.EndsWith("dotnet" + Constants.ExeSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+                if (!string.IsNullOrEmpty(dotnetHostPath))
+                {
+                    processPath = dotnetHostPath;
+                }
+                else
+                {
+                    var environmentBlock = string.Join(Environment.NewLine, Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().Select(e => $"{e.Key}={e.Value}"));
+                    throw new Exception($"Failed to find dotnet host. Environment Block: {Environment.NewLine}{environmentBlock}");
+                }
+            }
+            return processPath;
         }
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using System.Diagnostics;
-using System.Collections;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -94,23 +93,7 @@ namespace Microsoft.DotNet.Cli.Utils
             return this;
         }
 
-        private string GetHostExeName()
-        {
-            // Should instead make this a full path to dotnet
-            string processPath = Environment.ProcessPath;
-            string hostName = "dotnet" + Constants.ExeSuffix;
-
-            if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
-            {
-                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
-                if (!string.IsNullOrEmpty(dotnetHostPath))
-                {
-                    processPath = dotnetHostPath+ Path.DirectorySeparatorChar + hostName;
-                }
-            }
-
-            return processPath;
-        }
+        private string GetHostExeName() => new Muxer().MuxerPath;
     }
 }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -41,7 +41,6 @@ namespace Microsoft.DotNet.Cli.Utils
 #else
             string processPath = Process.GetCurrentProcess().MainModule.FileName;
 #endif
-            string hostName = "dotnet" + Constants.ExeSuffix;
 
             // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
             if (!Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -34,10 +34,16 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public Muxer()
         {
+            // Best-effort search for muxer.
+            // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
 #if NET6_0_OR_GREATER
             string processPath = Environment.ProcessPath;
+#else
+            string processPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
             string hostName = "dotnet" + Constants.ExeSuffix;
 
+            // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
             if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
             {
                 var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
@@ -46,10 +52,8 @@ namespace Microsoft.DotNet.Cli.Utils
                     processPath = dotnetHostPath + Path.DirectorySeparatorChar + hostName;
                 }
             }
+
             _muxerPath = processPath;
-#else
-            _muxerPath = Process.GetCurrentProcess().MainModule.FileName;
-#endif
         }
 
         public static string GetDataFromAppDomain(string propertyName)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli.Utils
             string hostName = "dotnet" + Constants.ExeSuffix;
 
             // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
-            if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
+            if (!Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
             {
 	            // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
 	            processPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -35,7 +35,18 @@ namespace Microsoft.DotNet.Cli.Utils
         public Muxer()
         {
 #if NET6_0_OR_GREATER
-            _muxerPath = Environment.ProcessPath;
+            string processPath = Environment.ProcessPath;
+            string hostName = "dotnet" + Constants.ExeSuffix;
+
+            if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
+            {
+                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
+                if (!string.IsNullOrEmpty(dotnetHostPath))
+                {
+                    processPath = dotnetHostPath + Path.DirectorySeparatorChar + hostName;
+                }
+            }
+            _muxerPath = processPath;
 #else
             _muxerPath = Process.GetCurrentProcess().MainModule.FileName;
 #endif

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -46,11 +46,17 @@ namespace Microsoft.DotNet.Cli.Utils
             // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
             if (!processPath.EndsWith(hostName, StringComparison.OrdinalIgnoreCase))
             {
-                var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? Environment.GetEnvironmentVariable("DOTNET_ROOT");
-                if (!string.IsNullOrEmpty(dotnetHostPath))
-                {
-                    processPath = dotnetHostPath + Path.DirectorySeparatorChar + hostName;
-                }
+	            // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
+	            processPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+	            if (processPath is null)
+	            {
+	                // fallback to DOTNET_ROOT which typically holds some dotnet executable
+	                var root = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+	                if (root is not null)
+	                {
+	                    processPath = Path.Combine(root, $"dotnet{Constants.ExeSuffix}");
+	                }
+	            }
             }
 
             _muxerPath = processPath;

--- a/test/ArgumentForwarding.Tests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwarding.Tests/ArgumentForwardingTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
 
             Console.WriteLine($"STDERR: {commandResult.StdErr}");
 
-            commandResult.ExitCode.Should().Be(0);
+            commandResult.ExitCode.Should().Be(0, $"STDOUT: {commandResult.StdOut} STDERR: {commandResult.StdErr}");
 
             return ParseReflectorOutput(commandResult.StdOut);
         }

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             internal static void Build(string assemblyPath, int methodLimit, List<TypeInfo> typeInfoList, out List<Partition> partitionList, out List<AssemblyPartitionInfo> assemblyInfoList, bool netFramework = false)
             {
                 var hasEventListenerGuard = typeInfoList.Any(x => x.FullName == EventListenerGuardFullName);
-                var builder = new AssemblyInfoBuilder(assemblyPath, methodLimit, hasEventListenerGuard, netFramework);
+                var builder = new AssemblyInfoBuilder(assemblyPath, methodLimit, hasEventListenerGuard);
                 builder.Build(typeInfoList);
                 partitionList = builder._partitionList;
                 assemblyInfoList = builder._assemblyInfoList;

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -79,16 +79,14 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             private readonly string _assemblyPath;
             private readonly int _methodLimit;
             private readonly bool _hasEventListenerGuard;
-            private readonly bool _netFramework;
             private int _currentId;
             private List<TypeInfo> _currentTypeInfoList = new();
 
-            private AssemblyInfoBuilder(string assemblyPath, int methodLimit, bool hasEventListenerGuard, bool netFramework = false)
+            private AssemblyInfoBuilder(string assemblyPath, int methodLimit, bool hasEventListenerGuard)
             {
                 _assemblyPath = assemblyPath;
                 _methodLimit = methodLimit;
                 _hasEventListenerGuard = hasEventListenerGuard;
-                _netFramework = netFramework;
             }
 
             internal static void Build(string assemblyPath, int methodLimit, List<TypeInfo> typeInfoList, out List<Partition> partitionList, out List<AssemblyPartitionInfo> assemblyInfoList, bool netFramework = false)
@@ -107,19 +105,13 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var typeInfo in typeInfoList)
                 {
                     _currentTypeInfoList.Add(typeInfo);
-                    if (_netFramework)
-                    {
-                        if (_builder.Length > 0)
-                        {
-                            _builder.Append("|");
-                        }
-                        _builder.Append($@"{typeInfo.FullName}");
 
-                    }
-                    else
+                    if (_builder.Length > 0)
                     {
-                        _builder.Append($@"-class ""{typeInfo.FullName}"" ");
+                        _builder.Append("|");
                     }
+                    _builder.Append($@"{typeInfo.FullName}");
+
                     CheckForPartitionLimit(done: false);
                 }
 

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             }
 
             var scheduler = new AssemblyScheduler(methodLimit: !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TestFullMSBuild")) ? 32 : 16);
-            var assemblyPartitionInfos = scheduler.Schedule(targetPath, netFramework: netFramework);
+            var assemblyPartitionInfos = scheduler.Schedule(targetPath);
 
             var partitionedWorkItem = new List<ITaskItem>();
             foreach (var assemblyPartitionInfo in assemblyPartitionInfos)

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -159,8 +159,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 }
                 else
                 {
-                    command = $"{driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
+                    command = $"{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} --blame-hang --blame-hang-timeout 30m {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -121,11 +121,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             // These tests have to be executed slightly differently and we give them a different Identity so ADO can tell them apart
             var runtimeTargetFrameworkParsed = NuGetFramework.Parse(runtimeTargetFramework);
             var testIdentityDifferentiator = "";
-            bool netFramework = false;
             if (runtimeTargetFrameworkParsed.Framework == ".NETFramework")
             {
                 testIdentityDifferentiator = ".netfx";
-                netFramework = true;
             }
             else if (runtimeTargetFrameworkParsed.Framework != ".NETCoreApp")
             {

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             // but on Windows, if we running against working item diretory, we would hit long path.
             string testExecutionDirectory = IsPosixShell ? "-e DOTNET_SDK_TEST_EXECUTION_DIRECTORY=$TestExecutionDirectory" : "-e DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%";
 
-            string msbuildAdditionalSdkResolverFolder = IsPosixShell ? "" : "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r;
+            string msbuildAdditionalSdkResolverFolder = IsPosixShell ? "" : "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r";
 
             if (ExcludeAdditionalParameters.Equals("true"))
             {

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
                 var testFilter = string.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
                 command = $"{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                            $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .\\ --logger trx --blame-hang --blame-hang-timeout 30m {testFilter} -- {arguments}";
+                            $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --blame-hang --blame-hang-timeout 30m {testFilter} -- {arguments}";
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 


### PR DESCRIPTION
I do not know the history on why we launch our tests with dotnet-exec. We may hae to change the arguments to match the above commands that we use on netfx (and simplify to just use one).

I'm starting with this just to see if it'll work.

Also open question is where will the dump end up.