### PR TITLE
allow reading all mcr image names

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -297,11 +297,11 @@ public sealed class ComputeDotnetBaseImageAndTag : Microsoft.Build.Utilities.Tas
         };
     }
 
-    private bool UserImageIsMicrosoftBaseImage => UserBaseImage?.StartsWith("mcr.microsoft.com/dotnet") ?? false;
+    private bool UserImageIsMicrosoftBaseImage => UserBaseImage?.StartsWith("mcr.microsoft.com/") ?? false;
 
     private void LogNoInferencePerformedTelemetry()
     {
-        // we should only log the base image, tag, containerFamily if we _know_ they are .NET's MCR images
+        // we should only log the base image, tag, containerFamily if we _know_ they are MCR images
         string? userBaseImage = null;
         string? userTag = null;
         string? containerFamily = null;


### PR DESCRIPTION
Fixes #44732

The original check was just a bit too strict - other tools may use MCR-provided images that aren't from `dotnet/`, like `azure-functions/`, so in order to categorize that usage we need to loosen the check just a bit.