### PR TITLE
[9.0.1xx] Avoid warning about empty NuGetPackageRoot in wpftmp projects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -263,9 +263,10 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' != 'true' and !Exists('$(RoslynTargetsPath)')"
         FormatArguments="$(NETCoreSdkVersion)" />
 
-    <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016. -->
+    <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016.
+         WPF temp projects are ignored (its known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
     <NETSdkWarning ResourceName="MicrosoftNetSdkCompilersToolsetRootEmpty"
-        Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true'" />
+        Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true' and !($(MSBuildProjectFile.EndsWith('_wpftmp.csproj')) or $(MSBuildProjectFile.EndsWith('_wpftmp.vbproj')))" />
   </Target>
 
   <!-- TODO: this target should not check GeneratePackageOnBuild.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -264,7 +264,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         FormatArguments="$(NETCoreSdkVersion)" />
 
     <!-- Warn if $(NuGetPackageRoot) is empty. See https://github.com/dotnet/sdk/issues/43016.
-         WPF temp projects are ignored (its known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
+         WPF temp projects are ignored (it's known their NuGetPackageRoot is empty and user cannot fix that anyway). -->
     <NETSdkWarning ResourceName="MicrosoftNetSdkCompilersToolsetRootEmpty"
         Condition="'$(_MicrosoftNetSdkCompilersToolsetPackageRootEmpty)' == 'true' and !($(MSBuildProjectFile.EndsWith('_wpftmp.csproj')) or $(MSBuildProjectFile.EndsWith('_wpftmp.vbproj')))" />
   </Target>


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/44688.
Fixes https://github.com/dotnet/sdk/issues/44605.

## Approval template

### Description

Conditions a warning so it's not reported for wpftmp projects (those are automatically generated during .NET Framework WPF builds). The warning would always be reported when building in torn SDK state (older MSBuild/VS, newer SDK) and the user can do nothing about it because it's an automatically generated project. (We cannot fix the wpftmp project because it's part of .NET Framework targets.)

### Customer impact

Reported in https://github.com/dotnet/sdk/issues/44605. Affects anyone building WPF projects targeting .NET Framework, using MSBuild.exe or Visual Studio and having newer SDK installed than their MSBuild/VS version.

### Regression?

Yes, in the sense that the same build was succeeding previously and now reports a warning (which can break the build if it has enabled "warnings as errors").

### Testing

Unit tests and manual local testing.

### Risk

Very low. This is just a condition on a warning, so the only risk would be a false negative, i.e., not reporting the warning where it should have been reported - but it's a new warning introduced in .NET 9 preview 7.