### PR TITLE
Revert "[main] Update dependencies from dotnet/arcade (#44712)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -593,34 +593,34 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.24556.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.24555.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>662841251075524f81c205ab4595bf0b9da74475</Sha>
+      <Sha>78eb939933628c20c88ddd88536a70f02ecc2945</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="System.Reflection.MetadataLoadContext" Version="10.0.0-alpha.1.24557.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -284,10 +284,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/arcade -->
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.24556.2</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetSignToolVersion>10.0.0-beta.24556.2</MicrosoftDotNetSignToolVersion>
-    <MicrosoftDotNetXliffTasksVersion>10.0.0-beta.24556.2</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.24556.2</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.24555.1</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetSignToolVersion>10.0.0-beta.24555.1</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetXliffTasksVersion>10.0.0-beta.24555.1</MicrosoftDotNetXliffTasksVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.24555.1</MicrosoftDotNetXUnitExtensionsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sourcelink -->

--- a/global.json
+++ b/global.json
@@ -17,8 +17,8 @@
     "cmake": "latest"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24556.2",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.24556.2",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24555.1",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.24555.1",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.DotNet.CMake.Sdk": "9.0.0-beta.24217.1"
   }


### PR DESCRIPTION
Need to fix the VMR sync by reverting this change for now.

Related to https://github.com/dotnet/source-build/issues/4723