### PR TITLE
Update source build prebuilts tarball

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -25,7 +25,7 @@
     -->
     <PrivateSourceBuiltSdkVersion>10.0.100-alpha.1.24556.1</PrivateSourceBuiltSdkVersion>
     <PrivateSourceBuiltArtifactsVersion>10.0.100-alpha.1.24556.1</PrivateSourceBuiltArtifactsVersion>
-    <PrivateSourceBuiltPrebuiltsVersion>0.1.0-10.0.100-5</PrivateSourceBuiltPrebuiltsVersion>
+    <PrivateSourceBuiltPrebuiltsVersion>0.1.0-10.0.100-6</PrivateSourceBuiltPrebuiltsVersion>
     <!-- command-line-api dependencies -->
     <SystemCommandLineVersion>2.0.0-beta4.24126.1</SystemCommandLineVersion>
     <!-- msbuild dependencies -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4724

Adds the following prebuilts to the tarball:

* microsoft.aspnetcore.app.runtime.linux-arm64.9.0.0-rc.2.24474.3.nupkg
* microsoft.aspnetcore.app.runtime.linux-musl-x64.9.0.0-rc.2.24474.3.nupkg
* microsoft.netcore.app.crossgen2.linux-arm64.9.0.0-rc.2.24473.5.nupkg
* microsoft.netcore.app.crossgen2.linux-musl-x64.9.0.0-rc.2.24473.5.nupkg
* microsoft.netcore.app.host.linux-arm64.9.0.0-rc.2.24473.5.nupkg
* microsoft.netcore.app.host.linux-musl-x64.9.0.0-rc.2.24473.5.nupkg
* microsoft.netcore.app.runtime.linux-arm64.9.0.0-rc.2.24473.5.nupkg
* microsoft.netcore.app.runtime.linux-musl-x64.9.0.0-rc.2.24473.5.nupkg