### PR TITLE
Revert "Update triggers for SB sdk diff and license scan pipelines" (#43011)

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -18,7 +18,6 @@ resources:
       branches:
         include:
           - refs/heads/release/*.0.1xx-preview*
-          - refs/heads/release/9.0.1xx
           - refs/heads/internal/release/*.0.1xx*
 
 pr: none

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -9,7 +9,6 @@ schedules:
     include:
     - main
     - release/*.0.1xx-preview*
-    - release/9.0.1xx
     - internal/release/*.0.1xx*
 
 pr: none
@@ -20,7 +19,6 @@ trigger:
     include:
     - main
     - release/*.0.1xx-preview*
-    - release/9.0.1xx
     - internal/release/*.0.1xx*
   paths:
     include:


### PR DESCRIPTION
Port of https://github.com/dotnet/sdk/pull/44819 to release/9.0.1xx

Fixes https://github.com/dotnet/source-build/issues/4582