### PR TITLE
Fix failing tests because of "UseUwpTools" property

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -463,6 +463,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "net9.0-windows10.0.22621.0"
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -484,6 +485,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "netstandard2.0"
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -505,6 +507,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "net9.0-windows10.0.22621.0"
             };
             testProjectA.AdditionalProperties["UseUwp"] = "true";
+            testProjectA.AdditionalProperties["UseUwpTools"] = "false";
 
             TestProject testProjectB = new()
             {
@@ -579,6 +582,7 @@ namespace Microsoft.NET.Build.Tests
                 }
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             // Temporary until new projections flow to tests
             testProject.AdditionalProperties["WindowsSdkPackageVersion"] = "10.0.22621.39";


### PR DESCRIPTION
This PR updates the UWP .NET 9 tests to disable "UseUwpTools", which otherwise fails to build because of the missing 26100 SDK. Additionally, here we don't want to build UWP libraries anyway, just plain .NET ones. The break is likely caused by the CI image upgrading to VS 17.12, which then brought [this change](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/582570) in, which in turn affected the tests. In theory just disabling that opt-out switch should do the trick.

### Fixes #44807, #44827