### PR TITLE
Update SB dev container image

### DIFF
--- a/src/SourceBuild/content/.devcontainer/devcontainer.json
+++ b/src/SourceBuild/content/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // Container contains checked-out source code only
 {
     "name": "Default",
-    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41",
     "hostRequirements": {
         // A completely source built .NET is >64 GB with all the repos/artifacts
         "storage": "128gb"

--- a/src/SourceBuild/content/.devcontainer/prebuilt-sdk/devcontainer.json
+++ b/src/SourceBuild/content/.devcontainer/prebuilt-sdk/devcontainer.json
@@ -1,7 +1,7 @@
 // Container contains a pre-built SDK
 {
     "name": "Pre-built .NET SDK",
-    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41",
     "hostRequirements": {
         // A completely source built .NET is >64 GB with all the repos/artifacts
         "storage": "128gb"


### PR DESCRIPTION
Updates the container image to a supported Fedora version. See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1255