### PR TITLE
Cherry-pick 44859 into release/9.0.2xx:  Fix failing tests because of "UseUwpTools" property

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -463,6 +463,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "net9.0-windows10.0.22621.0"
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -484,6 +485,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "netstandard2.0"
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
@@ -505,6 +507,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = "net9.0-windows10.0.22621.0"
             };
             testProjectA.AdditionalProperties["UseUwp"] = "true";
+            testProjectA.AdditionalProperties["UseUwpTools"] = "false";
 
             TestProject testProjectB = new()
             {
@@ -579,6 +582,7 @@ namespace Microsoft.NET.Build.Tests
                 }
             };
             testProject.AdditionalProperties["UseUwp"] = "true";
+            testProject.AdditionalProperties["UseUwpTools"] = "false";
 
             // Temporary until new projections flow to tests
             testProject.AdditionalProperties["WindowsSdkPackageVersion"] = "10.0.22621.39";


### PR DESCRIPTION
See #44859.