### PR TITLE
Fix updating KnownWebAssemblySdkPack when creating test layout

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -12,8 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
 <!-- This file contains a list of the windows target platform versions that are supported by this SDK for .NET. Supported versions are processed in _NormalizeTargetPlatformVersion -->
 <Project>
-  
-    <!-- These will be added to the BundledVersions.props that's generated in dotnet/installer.  So only add them here if we don't have that change yet -->
+
+    <!-- These will be added to the BundledVersions.props that's generated in dotnet/sdk.  So only add them here if we don't have that change yet -->
     <ItemGroup Condition="'@(WindowsSdkSupportedTargetPlatformVersion)' == ''">
         <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="10.0.19041.16" MinimumNETVersion="5.0" />
         <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="10.0.18362.16" MinimumNETVersion="5.0" />

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest60.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest60.cs
@@ -10,12 +10,12 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         : IsolatedNuGetPackageFolderAspNetSdkBaselineTest(log, nameof(BlazorLegacyIntegrationTest60))
     {
 
-        protected override string EmbeddedResourcePrefix => 
+        protected override string EmbeddedResourcePrefix =>
             string.Join('.', "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
 
         protected override string ComputeBaselineFolder() =>
             Path.Combine(TestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
-            
+
         [CoreMSBuildOnlyFact]
         public void Build60Hosted_Works()
         {
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             new FileInfo(Path.Combine(serverBuildOutputDirectory, $"{testAsset}.Shared.dll")).Should().Exist();
         }
 
-        [WindowsOnlyRequiresMSBuildVersionFact("17.13", Reason = "Needs System.Text.Json 8.0.5")] // https://github.com/dotnet/sdk/issues/44886
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX, "https://github.com/dotnet/sdk/issues/42145")]
         public void Publish60Hosted_Works()
         {


### PR DESCRIPTION
We missed adding KnownWebAssemblySdkPack into OverrideAndCreateBundledNETCoreAppPackageVersion so it was pointing to an older version in the BundledVersion.props in the test layout.

Fix that and add some checks so we don't miss this again the next time we add a Known*Pack entry.

Fixes https://github.com/dotnet/sdk/issues/44886