### PR TITLE
Workaround for MSBuildProjectLoader.LoadProjectInfoAsync throwing on unrecognized project language

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -38,7 +38,17 @@ internal class IncrementalMSBuildWorkspace : Workspace
 
         var loader = new MSBuildProjectLoader(this);
         var projectMap = ProjectMap.Create();
-        var projectInfos = await loader.LoadProjectInfoAsync(rootProjectPath, projectMap, progress: null, msbuildLogger: null, cancellationToken).ConfigureAwait(false);
+
+        ImmutableArray<ProjectInfo> projectInfos;
+        try
+        {
+            projectInfos = await loader.LoadProjectInfoAsync(rootProjectPath, projectMap, progress: null, msbuildLogger: null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException)
+        {
+            // TODO: workaround for https://github.com/dotnet/roslyn/issues/75956
+            projectInfos = [];
+        }
 
         var oldProjectIdsByPath = oldSolution.Projects.ToDictionary(keySelector: static p => p.FilePath!, elementSelector: static p => p.Id);
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -98,12 +98,13 @@ namespace Microsoft.DotNet.Watcher
                     // use normalized MSBuild path so that we can index into the ProjectGraph
                     rootProjectOptions = rootProjectOptions with { ProjectPath = rootProject.ProjectInstance.FullPath };
 
-                    if (rootProject.GetCapabilities().Contains(AspireServiceFactory.AppHostProjectCapability))
+                    var rootProjectCapabilities = rootProject.GetCapabilities();
+                    if (rootProjectCapabilities.Contains(AspireServiceFactory.AppHostProjectCapability))
                     {
                         runtimeProcessLauncherFactory ??= AspireServiceFactory.Instance;
                         Context.Reporter.Verbose("Using Aspire process launcher.");
                     }
-
+                    
                     await using var browserConnector = new BrowserConnector(Context);
                     var projectMap = new ProjectNodeMap(evaluationResult.ProjectGraph, Context.Reporter);
                     compilationHandler = new CompilationHandler(Context.Reporter);
@@ -234,6 +235,16 @@ namespace Microsoft.DotNet.Watcher
                         if (changedFiles is [])
                         {
                             continue;
+                        }
+
+                        if (!rootProjectCapabilities.Contains("SupportsHotReload"))
+                        {
+                            Context.Reporter.Warn($"Project '{rootProject.GetDisplayName()}' does not support Hot Reload and must be rebuilt.");
+
+                            // file change already detected
+                            waitForFileChangeBeforeRestarting = false;
+                            iterationCancellationSource.Cancel();
+                            break;
                         }
 
                         HotReloadEventSource.Log.HotReloadStart(HotReloadEventSource.StartType.Main);

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -115,12 +115,12 @@ namespace Microsoft.DotNet.Watcher.Tests
             UpdateSourceFile(sourcePath, content => content.Replace("Waiting", "<Updated>"));
 
             await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
-            App.AssertOutputContains("<Updated>");
+            await App.AssertOutputLineStartsWith("<Updated>");
 
             UpdateSourceFile(sourcePath, content => content.Replace("<Updated>", "<Updated2>"));
 
             await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
-            App.AssertOutputContains("<Updated2>");
+            await App.AssertOutputLineStartsWith("<Updated2>");
         }
 
         // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -69,6 +69,21 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.AssertOutputLineStartsWith("Changed!");
         }
 
+        [Fact]
+        public async Task ChangeFileInFSharpProject()
+        {
+            var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")
+                .WithSource();
+
+            App.Start(testAsset, []);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            UpdateSourceFile(Path.Combine(testAsset.Path, "Program.fs"), content => content.Replace("Hello World!", "<Updated>"));
+
+            await App.AssertOutputLineStartsWith("<Updated>");
+        }
+
         // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
         [CoreMSBuildOnlyFact]
         public async Task HandleTypeLoadFailure()

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -84,6 +84,45 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.AssertOutputLineStartsWith("<Updated>");
         }
 
+        [Fact]
+        public async Task ChangeFileInFSharpProjectWithLoop()
+        {
+            var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")
+                .WithSource();
+
+            var source = """
+            module ConsoleApplication.Program
+
+            open System
+            open System.Threading
+
+            [<EntryPoint>]
+            let main argv =
+                while true do
+                    printfn "Waiting"
+                    Thread.Sleep(200)
+                0
+            """;
+
+            var sourcePath = Path.Combine(testAsset.Path, "Program.fs");
+
+            File.WriteAllText(sourcePath, source);
+
+            App.Start(testAsset, []);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges);
+
+            UpdateSourceFile(sourcePath, content => content.Replace("Waiting", "<Updated>"));
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+            App.AssertOutputContains("<Updated>");
+
+            UpdateSourceFile(sourcePath, content => content.Replace("<Updated>", "<Updated2>"));
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+            App.AssertOutputContains("<Updated2>");
+        }
+
         // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
         [CoreMSBuildOnlyFact]
         public async Task HandleTypeLoadFailure()


### PR DESCRIPTION
Implements workaround for https://github.com/dotnet/roslyn/issues/75956.

Fixes https://github.com/dotnet/sdk/issues/44908