### PR TITLE
Workaround for MSbuildProjectLoader.LoadProjectInfoAsync throwing on unrecognized project language

### DIFF
--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Watcher
 
         public void ConfigureProcess(ProcessSpec processSpec)
         {
-            processSpec.Arguments = [.. GetCommandLineDirectives(), .. processSpec.Arguments];
+            processSpec.Arguments = [.. GetCommandLineDirectives(), .. processSpec.Arguments ?? []];
             AddToEnvironment(processSpec.EnvironmentVariables);
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -38,7 +38,17 @@ internal class IncrementalMSBuildWorkspace : Workspace
 
         var loader = new MSBuildProjectLoader(this);
         var projectMap = ProjectMap.Create();
-        var projectInfos = await loader.LoadProjectInfoAsync(rootProjectPath, projectMap, progress: null, msbuildLogger: null, cancellationToken).ConfigureAwait(false);
+
+        ImmutableArray<ProjectInfo> projectInfos;
+        try
+        {
+            projectInfos = await loader.LoadProjectInfoAsync(rootProjectPath, projectMap, progress: null, msbuildLogger: null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException)
+        {
+            // TODO: workaround for https://github.com/dotnet/roslyn/issues/75956
+            projectInfos = [];
+        }
 
         var oldProjectIdsByPath = oldSolution.Projects.ToDictionary(keySelector: static p => p.FilePath!, elementSelector: static p => p.Id);
 

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -68,6 +68,21 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.AssertOutputLineStartsWith("Changed!");
         }
 
+        [Fact]
+        public async Task ChangeFileInFSharpProject()
+        {
+            var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")
+                .WithSource();
+
+            App.Start(testAsset, []);
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+
+            UpdateSourceFile(Path.Combine(testAsset.Path, "Program.fs"), content => content.Replace("Hello World!", "<Updated>"));
+
+            await App.AssertOutputLineStartsWith("<Updated>");
+        }
+
         // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
         [CoreMSBuildOnlyFact]
         public async Task HandleTypeLoadFailure()


### PR DESCRIPTION
Port of https://github.com/dotnet/sdk/pull/44927 to 1xx

Fixes https://github.com/dotnet/sdk/issues/44908

## Customer Impact

dotnet-watch fails to automatically switch to "auto-rebuild" mode for F# projects, which do not support Hot Reload. Restores 8.0 behavior.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

One-liner to fix read buffer bounds.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

