### PR TITLE
Don't download Windows SDK ref pack for C++ projects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -22,8 +22,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="ProcessFrameworkReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="ResolveAppHosts" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
+
+  <!-- Don't add Windows SDK framework reference for C++ by default, as C++ doesn't use it and it would be an unnecessary download for possible
+       transitive framework references. -->
   <Target Name="AddWindowsSdkKnownFrameworkReferences"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'Windows'">
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'Windows'
+                     And ('$(Language)' != 'C++' Or '$(IncludeWindowsSDKRefFrameworkReferences)' == 'true')">
 
     <!-- Remove Windows SDK KnownFrameworkReference items from BundledVersions.props (they will eventually be removed, but that is in a different repo so
          we can't do the change atomically). -->

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildACppCliProject.cs
@@ -54,16 +54,32 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager
                 .CopyTestAsset("NetCoreCsharpAppReferenceCppCliLib")
                 .WithSource()
-                .WithProjectChanges((projectPath, project) => ConfigureProject(projectPath, project, targetFramework, new string[] { "_EnablePackageReferencesInVCProjects", "IncludeWindowsSDKRefFrameworkReferences" }));
+                .WithProjectChanges((projectPath, project) =>
+                    {
+                        ConfigureProject(projectPath, project, targetFramework, new string[] { "_EnablePackageReferencesInVCProjects", "IncludeWindowsSDKRefFrameworkReferences" });
+
+                        var ns = project.Root.Name.Namespace;
+                        //  Use project-specific global packages folder so we can check what was downloaded
+                        project.Root.Element(ns + "PropertyGroup")
+                            .Add(new XElement(ns + "RestorePackagesPath", @"$(MSBuildProjectDirectory)\packages"));
+
+                    });
 
             new BuildCommand(testAsset, "NETCoreCppCliTest")
-                .Execute("-p:Platform=x64")
+                .WithWorkingDirectory(testAsset.TestRoot)
+                .Execute("-p:Platform=x64", "/bl")
                 .Should()
                 .Pass();
 
             var cppnProjProperties = GetPropertyValues(testAsset.TestRoot, "NETCoreCppCliTest", targetFramework: targetFramework);
             Assert.True(cppnProjProperties["_EnablePackageReferencesInVCProjects"] == "true");
             Assert.True(cppnProjProperties["IncludeWindowsSDKRefFrameworkReferences"] == "");
+
+            var packagesFolder = Path.Combine(testAsset.TestRoot, "NETCoreCppCliTest", "packages");
+            if (Directory.Exists(packagesFolder))
+            {
+                new DirectoryInfo(packagesFolder).Should().NotHaveSubDirectories("microsoft.windows.sdk.net.ref");
+            }
         }
 
         [FullMSBuildOnlyFact]


### PR DESCRIPTION
The Microsoft.Windows.SDK.NET.Ref pack is not needed for C++ projects.  This change prevents it from being downloaded for C++ projects on the assumption that it might be needed for a transitive Framework Reference.