### PR TITLE
tool-install: Fix NuGet Feed test

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -412,7 +412,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 }
             }
 
-            return defaultSources;
+            return defaultSources.ToList();
         }
 
         public IEnumerable<PackageSource> LoadNuGetSources(PackageId packageId, PackageSourceLocation packageSourceLocation = null, PackageSourceMapping packageSourceMapping = null)


### PR DESCRIPTION
This fixes a test introduced in #44853 that checks if a source included in both a NuGet.config file and the `--add-source` flag is not duplicated