### PR TITLE
tool-install: Fix NuGet Feed test

### DIFF
--- a/test/TestAssets/TestProjects/NuGetConfigRandomPackageSources/NuGet.config
+++ b/test/TestAssets/TestProjects/NuGetConfigRandomPackageSources/NuGet.config
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="invalid_source" value="https://api.nuget.org/v3/invalid.json" />
-    <add key="invalid_source_2" value="https://api.nuget.org/v3/invalid-2.json" />
+    <clear />
+    <add key="example_source" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -106,6 +106,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         [Fact]
         public void WhenDuplicateSourceIsPassedIgnore()
         {
+            var duplicateSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json";
             var testAsset = _testAssetsManager
                 .CopyTestAsset("NuGetConfigRandomPackageSources", allowCopyIfPresent: true)
                 .WithSource();
@@ -113,16 +114,16 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var packageSourceLocation = new PackageSourceLocation(
                 nugetConfig: new FilePath(Path.Combine(testAsset.Path, "NuGet.config")),
                 rootConfigDirectory: new DirectoryPath(testAsset.Path),
-                additionalSourceFeeds: ["https://api.nuget.org/v3/invalid.json"]);
+                additionalSourceFeeds: [duplicateSource]);
             var nuGetPackageDownloader = new NuGetPackageDownloader(new DirectoryPath(testAsset.Path));
 
             var sources = nuGetPackageDownloader.LoadNuGetSources(new ToolPackage.PackageId(PackageId), packageSourceLocation);
             // There should only be one source
-            sources.Where(s => s.SourceUri == new Uri("https://api.nuget.org/v3/invalid.json"))
+            sources.Where(s => s.SourceUri == new Uri(duplicateSource))
                 .Should().HaveCount(1);
             // It should be the source from the NuGet.config file
-            sources.Where(s => s.SourceUri == new Uri("https://api.nuget.org/v3/invalid.json")).Single().Name
-                .Should().Be("invalid_source");
+            sources.Where(s => s.SourceUri == new Uri(duplicateSource)).Single().Name
+                .Should().Be("example_source");
         }
 
         [Fact]


### PR DESCRIPTION
This fixes a test introduced in https://github.com/dotnet/sdk/pull/44853 that checks if a source included in both a NuGet.config file and the --add-source flag is not duplicated