### PR TITLE
Write APICompat suppressions when baseline suppressions aren't empty

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/SuppressionFileHelper.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ApiCompat
                 return;
             }
 
-            if (suppressionEngine.WriteSuppressionsToFile(suppressionOutputFile, preserveUnnecessarySuppressions).Count > 0)
+            if (suppressionEngine.WriteSuppressionsToFile(suppressionOutputFile, preserveUnnecessarySuppressions).SuppressionFileUpdated)
             {
                 log.LogMessage(MessageImportance.High,
                     string.Format(CommonResources.WroteSuppressions, suppressionOutputFile));

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/ISuppressionEngine.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         /// </summary>
         /// <param name="suppressionOutputFile">The path to the file to be written.</param>
         /// <param name="preserveUnnecessarySuppressions">If <see langword="true"/>, preserves unnecessary suppressions.</param>
-        /// <returns>Returns the set of suppressions written.</returns>
-        IReadOnlyCollection<Suppression> WriteSuppressionsToFile(string suppressionOutputFile, bool preserveUnnecessarySuppressions = false);
+        /// <returns>Returns a boolean indicating whether the suppression file got updated and the set of suppressions written.</returns>
+        (bool SuppressionFileUpdated, IReadOnlyCollection<Suppression> UpdatedSuppressions) WriteSuppressionsToFile(string suppressionOutputFile, bool preserveUnnecessarySuppressions = false);
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -104,19 +104,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         public void AddSuppression(Suppression suppression) => _suppressions.Add(suppression);
 
         /// <inheritdoc/>
-        public IReadOnlyCollection<Suppression> WriteSuppressionsToFile(string suppressionOutputFile, bool preserveUnnecessarySuppressions = false)
+        public (bool SuppressionFileUpdated, IReadOnlyCollection<Suppression> UpdatedSuppressions)
+            WriteSuppressionsToFile(string suppressionOutputFile, bool preserveUnnecessarySuppressions = false)
         {
             // If unnecessary suppressions should be preserved in the suppression file, union the
             // baseline suppressions with the set of actual suppressions. Duplicates are ignored.
-            HashSet<Suppression> suppressionsToSerialize = new(_suppressions);
+            HashSet<Suppression> suppressionsToSerialize = [.. _suppressions];
             if (preserveUnnecessarySuppressions)
             {
                 suppressionsToSerialize.UnionWith(_baselineSuppressions);
             }
 
-            if (suppressionsToSerialize.Count == 0)
+            // If there aren't any suppressions and baseline suppressions, skip writing the
+            // suppression file.
+            if (suppressionsToSerialize.Count == 0 && _baselineSuppressions.Count == 0)
             {
-                return Array.Empty<Suppression>();
+                return (false, []);
             }
 
             Suppression[] orderedSuppressions = suppressionsToSerialize
@@ -138,7 +141,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
             CreateXmlSerializer().Serialize(xmlWriter, orderedSuppressions);
             AfterWritingSuppressionsCallback(stream);
 
-            return orderedSuppressions;
+            return (true, orderedSuppressions);
         }
 
         /// <inheritdoc/>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
         {
             // If unnecessary suppressions should be preserved in the suppression file, union the
             // baseline suppressions with the set of actual suppressions. Duplicates are ignored.
-            HashSet<Suppression> suppressionsToSerialize = [.. _suppressions];
+            HashSet<Suppression> suppressionsToSerialize = new(_suppressions);
             if (preserveUnnecessarySuppressions)
             {
                 suppressionsToSerialize.UnionWith(_baselineSuppressions);

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -233,11 +233,5 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.False(engine.IsErrorSuppressed(new Suppression("CP1232", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
         }
-
-        [Fact]
-        public void SuppressionEngine_X_Y()
-        {
-
-        }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -98,7 +98,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(filePath).UpdatedSuppressions);
+
+            var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath);
+
+            Assert.True(suppressionFileUpdated);
+            Assert.Empty(updatedSuppressions);
         }
 
         [Fact]
@@ -127,18 +131,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.AddSuppression(usedSuppression);
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            IReadOnlyCollection<Suppression> writtenSuppressions = suppressionEngine.WriteSuppressionsToFile(filePath).UpdatedSuppressions;
+            var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath);
 
-            Assert.Equal(new Suppression[] { usedSuppression }, writtenSuppressions);
+            Assert.True(suppressionFileUpdated);
+            Assert.Equal([usedSuppression], updatedSuppressions);
         }
 
         [Fact]
         public void SuppressionEngine_WriteSuppressionsToFile_ReturnsEmptyWithEmptyFilePath()
         {
             EmptyTestSuppressionEngine suppressionEngine = new();
-
             Assert.Empty(suppressionEngine.Suppressions);
-            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(string.Empty, preserveUnnecessarySuppressions: true).UpdatedSuppressions);
+
+            var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(string.Empty, preserveUnnecessarySuppressions: true);
+            Assert.False(suppressionFileUpdated);
+            Assert.Empty(updatedSuppressions);
         }
 
         [Fact]
@@ -190,7 +197,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.AddSuppression(newSuppression);
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            Assert.NotEmpty(suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true).UpdatedSuppressions);
+
+            var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true);
+
+            Assert.True(suppressionFileUpdated);
+            Assert.NotEmpty(updatedSuppressions);
 
             XmlSerializer xmlSerializer = new(typeof(Suppression[]), new XmlRootAttribute("Suppressions"));
             Suppression[] deserializedSuppressions = xmlSerializer.Deserialize(stream) as Suppression[];
@@ -221,6 +232,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
             Assert.False(engine.IsErrorSuppressed(new Suppression("CP1232", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
+        }
+
+        [Fact]
+        public void SuppressionEngine_X_Y()
+        {
+
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -60,8 +60,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            IReadOnlyCollection<Suppression> writtenSuppressions = suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true);
+            var (suppressionFileUpdated, writtenSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true);
 
+            Assert.True(suppressionFileUpdated);
             Assert.NotEmpty(writtenSuppressions);
 
             // Trimming away the comment as the serializer doesn't preserve them.
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(filePath));
+            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(filePath).UpdatedSuppressions);
         }
 
         [Fact]
@@ -126,7 +127,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.AddSuppression(usedSuppression);
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            IReadOnlyCollection<Suppression> writtenSuppressions = suppressionEngine.WriteSuppressionsToFile(filePath);
+            IReadOnlyCollection<Suppression> writtenSuppressions = suppressionEngine.WriteSuppressionsToFile(filePath).UpdatedSuppressions;
 
             Assert.Equal(new Suppression[] { usedSuppression }, writtenSuppressions);
         }
@@ -137,7 +138,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             EmptyTestSuppressionEngine suppressionEngine = new();
 
             Assert.Empty(suppressionEngine.Suppressions);
-            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(string.Empty, preserveUnnecessarySuppressions: true));
+            Assert.Empty(suppressionEngine.WriteSuppressionsToFile(string.Empty, preserveUnnecessarySuppressions: true).UpdatedSuppressions);
         }
 
         [Fact]
@@ -189,7 +190,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.AddSuppression(newSuppression);
 
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
-            Assert.NotEmpty(suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true));
+            Assert.NotEmpty(suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true).UpdatedSuppressions);
 
             XmlSerializer xmlSerializer = new(typeof(Suppression[]), new XmlRootAttribute("Suppressions"));
             Suppression[] deserializedSuppressions = xmlSerializer.Deserialize(stream) as Suppression[];


### PR DESCRIPTION
When there aren't any suppressions but baseline suppressions exist, write to the suppression file to make it empty.

Pass information back to the caller so that even if an empty collection of suppression are written to the file, still log a message to indicate that the suppression file got updated.