### PR TITLE
Remove unsupported _AggressiveAttributeTrimming switch

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -524,11 +524,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                                     Value="$(VerifyDependencyInjectionOpenGenericServiceTrimmability)"
                                     Trim="true" />
 
-    <RuntimeHostConfigurationOption Include="System.AggressiveAttributeTrimming"
-                                    Condition="'$(_AggressiveAttributeTrimming)' != ''"
-                                    Value="$(_AggressiveAttributeTrimming)"
-                                    Trim="true" />
-
     <RuntimeHostConfigurationOption Include="System.ComponentModel.DefaultValueAttribute.IsSupported"
                                     Condition="'$(_DefaultValueAttributeSupport)' != ''"
                                     Value="$(_DefaultValueAttributeSupport)"

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithAllFeatures.cs
@@ -57,7 +57,6 @@ namespace Microsoft.NET.Publish.Tests
     ""runtimeOptions"": {
         ""configProperties"": {
             ""Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability"": true,
-            ""System.AggressiveAttributeTrimming"": true,
             ""System.ComponentModel.DefaultValueAttribute.IsSupported"": true,
             ""System.ComponentModel.Design.IDesignerHost.IsSupported"": true,
             ""System.ComponentModel.TypeConverter.EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization"": false,

--- a/test/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
+++ b/test/TestAssets/TestProjects/KitchenSink/TestApp/TestApp.csproj
@@ -10,7 +10,6 @@
        Keep this list in the same order as the configProperties in GivenThatWeWantToPublishAProjectWithAllFeatures. -->
   <PropertyGroup>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
-    <_AggressiveAttributeTrimming>true</_AggressiveAttributeTrimming>
     <_DefaultValueAttributeSupport>true</_DefaultValueAttributeSupport>
     <_DesignerHostSupport>true</_DesignerHostSupport>
     <EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>


### PR DESCRIPTION
Companion to https://github.com/dotnet/runtime/pull/109994. See https://github.com/dotnet/runtime/issues/88805 for context.