### PR TITLE
Add .npmrc to prevent npmjs usage, even accidentally

### DIFF
--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/.npmrc
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/.npmrc
@@ -1,5 +1,5 @@
 # this file is never used during the tests that test esproj support,
-# but is placed here to satisfy compilance rules for NPM usage.
+# but is placed here to satisfy compliance rules for NPM usage.
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
 
 always-auth=true

--- a/test/TestAssets/TestProjects/ProjectWithEsProjReference/.npmrc
+++ b/test/TestAssets/TestProjects/ProjectWithEsProjReference/.npmrc
@@ -1,0 +1,5 @@
+# this file is never used during the tests that test esproj support,
+# but is placed here to satisfy compilance rules for NPM usage.
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+
+always-auth=true


### PR DESCRIPTION
This should potentially resolve some compliance issues raised by our internal scanning.