### PR TITLE
Remove AspNET substraction logic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,22 +40,6 @@
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>
   </PropertyGroup>
-  <PropertyGroup Label="AspNetCore template versioning">
-    <!-- Automated versions for asp.net templates -->
-    <MicrosoftNETSdkPatchVersion>$(VersionFeature)</MicrosoftNETSdkPatchVersion>
-    <!--
-      Between branding and shipping, the templates should stay at last month's version.
-      If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.
-      Therefore we stay at last month's version.
-      We also need to special case the 1st patch release, because the incoming SDK version will never be 2 versions behind us in that case.
-      Instead the indicator is that the incoming SDK version is not RTM or greater yet.
-      Preview releases already use -1 versionining so don't subtract one for that version.
-      In public builds, we always use the 2 month old version.
-    -->
-    <SubtractOneFromTemplateVersions Condition="'$(SYSTEM_TEAMPROJECT)' != 'internal'">true</SubtractOneFromTemplateVersions>
-    <SubtractOneFromTemplateVersions Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPatchVersion))) &gt;= 2">true</SubtractOneFromTemplateVersions>
-    <SubtractOneFromTemplateVersions Condition="$(VersionFeature) &gt;= 1 AND ! $(PreReleaseVersionLabel.Contains('rtm')) AND ! $(PreReleaseVersionLabel.Contains('servicing'))">true</SubtractOneFromTemplateVersions>
-  </PropertyGroup>
   <PropertyGroup Label="Restore feeds">
     <!-- In an orchestrated build, this may be overridden to other Azure feeds. -->
     <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetbuilds.blob.core.windows.net/public/</DotNetAssetRootUrl>


### PR DESCRIPTION
We removed the downlevel templates from 9.0.1xx but there was some cruft left behind likely from a merge. Let's clear this out.