### PR TITLE
Update Source-Build SDK Diff Tests Baselines

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkContentTests/MsftToSbSdkFiles.diff
@@ -45,14 +45,6 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./sdk-manifests/
- ./sdk-manifests/x.y.z/
- ./sdk-manifests/x.y.z/
--./sdk-manifests/x.y.z/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/WorkloadManifest.Aspire.targets
-@@ ------------ @@
  ./sdk/x.y.z/Microsoft.Build.NuGetSdkResolver.dll
  ./sdk/x.y.z/Microsoft.Build.Tasks.Core.dll
  ./sdk/x.y.z/Microsoft.Build.Utilities.Core.dll


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4738

Related to https://github.com/dotnet/sdk/pull/41929/files/b208803566f75bfb55423bece48503a2b368272a#diff-00077fe4d5b7ea26deac2e5aaac3f3fddbee757f6fdd8fc84e8df567848c818a

The microsoft sdk has removed the .NET 9 RC 2 manifests in `sdk-manifests/`: https://github.com/dotnet/sdk/pull/44845