### PR TITLE
[release/9.0.2xx] Use the static factory for creating a logger

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -480,8 +480,12 @@ namespace Microsoft.DotNet.Tools.Run
         static ILogger MakeTerminalLogger(VerbosityOptions? verbosity)
         {
             var msbuildVerbosity = ToLoggerVerbosity(verbosity);
-            var thing = Assembly.Load("MSBuild").GetType("Microsoft.Build.Logging.TerminalLogger.TerminalLogger")!.GetConstructor([typeof(LoggerVerbosity)])!.Invoke([msbuildVerbosity]) as ILogger;
-            return thing!;
+            var logger = Assembly.Load("MSBuild")
+                .GetType("Microsoft.Build.Logging.TerminalLogger.TerminalLogger")!
+                .GetMethod("CreateTerminalOrConsoleLogger")!
+                .Invoke(null, [msbuildVerbosity]) as ILogger;
+
+            return logger!;
         }
 
         static string ComputeRunArgumentsTarget = "ComputeRunArguments";


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10998

### Summary
`dotnet run` directly creates an instance of `TerminalLogger`, bypassing all checks. This can lead to situations where ANSI escape sequences are emitted to the terminal, even if the terminal does not support them. These escape sequences are also emitted when the standard output is redirected, which can break a CI build that relies on the command's output.

### Changes Made
Added a static factory that can return instance of Terminal or Console logger based on current environment. The usage of `TerminalLogger` in this scenario can be explicitly disabled by using of already existing env. variable, which wasn't possible before.

This SDK update uses this factory to pass the appropriate logger to MSBuild.

### Customer Impact
Some customers reported unexpected behavior of `dotnet run` command and CI builds failures.

### Regression?
Yes.

### Testing
Manual testing with locally updated SDK.

### Notes
This PR depends on https://github.com/dotnet/msbuild/pull/11016. Until the MSBuild PR is merged and inserted, this fix will not work.