### PR TITLE
[release/9.0.1xx] Using ConsoleLogger to prevent unexpected behavior

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs
@@ -480,7 +480,9 @@ namespace Microsoft.DotNet.Tools.Run
         static ILogger MakeTerminalLogger(VerbosityOptions? verbosity)
         {
             var msbuildVerbosity = ToLoggerVerbosity(verbosity);
-            var thing = Assembly.Load("MSBuild").GetType("Microsoft.Build.Logging.TerminalLogger.TerminalLogger")!.GetConstructor([typeof(LoggerVerbosity)])!.Invoke([msbuildVerbosity]) as ILogger;
+
+            // Temporary fix for 9.0.1xx. 9.0.2xx will use the TerminalLogger in the safe way.
+            var thing = new ConsoleLogger(msbuildVerbosity);
             return thing!;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10998

### Summary
`dotnet run` directly creates an instance of `TerminalLogger`, bypassing all checks. This can lead to situations where ANSI escape sequences are emitted to the terminal, even if the terminal does not support them. These escape sequences are also emitted when the standard output is redirected, which can break a CI build that relies on the command's output.

### Changes Made
Minimal hotfix: The `ConsoleLogger` is used instead of `TerminalLogger` for this SDK version.

### Customer Impact
Some customers reported unexpected behavior of `dotnet run` command and CI builds failures.

### Regression?
Yes.

### Testing
Manual testing with locally updated SDK.

### Notes
There is a proper fix created for 9.0.2xx. This change shouldn't flow to higher versions.