### PR TITLE
Use temp directory as TestExecutionDirectory in RunTestsOnHelix.sh

### DIFF
--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -36,3 +36,5 @@ dotnet nuget remove source dotnet-tools-transport --configfile $TestExecutionDir
 dotnet nuget remove source dotnet-libraries --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet-eng --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
+
+env

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -9,8 +9,7 @@ export MicrosoftNETBuildExtensionsTargets=$HELIX_CORRELATION_PAYLOAD/ex/msbuildE
 export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/d
 export PATH=$DOTNET_ROOT:$PATH
 
-export TestExecutionDirectory=$(pwd)/testExecutionDirectory
-mkdir $TestExecutionDirectory
+export TestExecutionDirectory=$(mktemp -d "${TMPDIR:-/tmp}"/dotnetSdkTests.XXXXXXXX)
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
 cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -36,5 +36,3 @@ dotnet nuget remove source dotnet-tools-transport --configfile $TestExecutionDir
 dotnet nuget remove source dotnet-libraries --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet-eng --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
-
-env

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -9,7 +9,7 @@ export MicrosoftNETBuildExtensionsTargets=$HELIX_CORRELATION_PAYLOAD/ex/msbuildE
 export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/d
 export PATH=$DOTNET_ROOT:$PATH
 
-export TestExecutionDirectory=$(mktemp -d "${TMPDIR:-/tmp}"/dotnetSdkTests.XXXXXXXX)
+export TestExecutionDirectory=$(realpath "$(mktemp -d "${TMPDIR:-/tmp}"/dotnetSdkTests.XXXXXXXX)")
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
 cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateMSDeployScript.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateMSDeployScript.cs
@@ -21,14 +21,14 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
         {
             if (!File.Exists(ScriptFullPath))
             {
-                File.Create(ScriptFullPath);
+                File.Create(ScriptFullPath).Close();
             }
 
             File.WriteAllLines(ScriptFullPath, GetReplacedFileContents(Resources.MsDeployBatchFile));
 
             if (!File.Exists(ReadMeFullPath))
             {
-                File.Create(ReadMeFullPath);
+                File.Create(ReadMeFullPath).Close();
             }
 
             File.WriteAllLines(ReadMeFullPath, GetReplacedFileContents(Resources.MsDeployReadMe));

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateManifestFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateManifestFile.cs
@@ -106,7 +106,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                     {
                         if (!File.Exists(ManifestFile))
                         {
-                            File.Create(ManifestFile);
+                            File.Create(ManifestFile).Close();
                         }
                         WriteManifestsToFile(Log, m_manifests, ManifestFile);
                     }

--- a/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateParameterFile.cs
+++ b/src/WebSdk/Publish/Tasks/Tasks/MsDeploy/CreateParameterFile.cs
@@ -286,7 +286,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.MsDeploy
                 {
                     if (!File.Exists(DeclareSetParameterFile))
                     {
-                        File.Create(DeclareSetParameterFile);
+                        File.Create(DeclareSetParameterFile).Close();
                     }
 
                     if (!string.IsNullOrEmpty(DeclareParameterFile))

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -157,8 +157,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 }
                 else
                 {
-                    command = $"{driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
+                    command = $"strace -f --trace=file {driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml -method Microsoft.DotNet.Cli.Workload.Update.Tests.GivenDotnetWorkloadUpdate.GivenWorkloadUpdateAcrossFeatureBandsItUpdatesPacks {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -157,8 +157,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 }
                 else
                 {
-                    command = $"strace -f --trace=file {driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml -class Microsoft.DotNet.Cli.Workload.Update.Tests.GivenDotnetWorkloadUpdate {arguments}";
+                    command = $"{driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml {assemblyPartitionInfo.ClassListArgumentString} {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 else
                 {
                     command = $"strace -f --trace=file {driver} exec {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml -method Microsoft.DotNet.Cli.Workload.Update.Tests.GivenDotnetWorkloadUpdate.GivenWorkloadUpdateAcrossFeatureBandsItUpdatesPacks {arguments}";
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} -xml testResults.xml -class Microsoft.DotNet.Cli.Workload.Update.Tests.GivenDotnetWorkloadUpdate {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -132,8 +132,6 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 throw new NotImplementedException("does not support non support the runtime specified");
             }
 
-            // On mac due to https://github.com/dotnet/sdk/issues/3923, we run against workitem directory
-            // but on Windows, if we running against working item diretory, we would hit long path.
             string testExecutionDirectory = netFramework ? "-e DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%" : IsPosixShell ? "-testExecutionDirectory $TestExecutionDirectory" : "-testExecutionDirectory %TestExecutionDirectory%";
 
             string msbuildAdditionalSdkResolverFolder = netFramework ? "-e DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\\r" : IsPosixShell ? "" : "-msbuildAdditionalSdkResolverFolder %HELIX_CORRELATION_PAYLOAD%\\r";

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [Fact]
         public void ItDoesNotReturnNullDotnetRootOnExtraPathSeparator()
         {
-            File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe"));
+            File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe")).Close();
             Func<string, string> getPathEnvVarFunc = (input) => input.Equals("PATH") ? $"fake{Path.PathSeparator}" : string.Empty;
             var result = NativeWrapper.EnvironmentProvider.GetDotnetExeDirectory(getPathEnvVarFunc);
             result.Should().NotBeNullOrWhiteSpace();

--- a/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             {
                 string path = Path.Combine(dotnetRoot, "metadata", "workloads", version.ToString(), "InstalledWorkloads");
                 Directory.CreateDirectory(path);
-                File.Create(Path.Combine(path, "6.0.100"));
+                File.Create(Path.Combine(path, "6.0.100")).Close();
             }
 
             IEnumerable<SdkFeatureBand> featureBands = installer.GetWorkloadInstallationRecordRepository().GetFeatureBandsWithInstallationRecords();
@@ -357,7 +357,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write workload install record
             var workloadsRecordPath = Path.Combine(dotnetRoot, "metadata", "workloads", version, "InstalledWorkloads");
             Directory.CreateDirectory(workloadsRecordPath);
-            File.Create(Path.Combine(workloadsRecordPath, "android-sdk-workload"));
+            File.Create(Path.Combine(workloadsRecordPath, "android-sdk-workload")).Close();
 
             var downloads = installer.GetDownloads(new[] { new WorkloadId("android-sdk-workload"), new WorkloadId("android-buildtools-workload") }, new SdkFeatureBand(version), false).ToList();
 
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write mock cache
             Directory.CreateDirectory(cachePath);
             var nupkgPath = Path.Combine(cachePath, $"{packId}.{packVersion}.nupkg");
-            File.Create(nupkgPath);
+            File.Create(nupkgPath).Close();
 
             CliTransaction.RunNew(context => installer.InstallWorkloads(new[] { new WorkloadId("android-sdk-workload") }, new SdkFeatureBand(version), context, new DirectoryPath(cachePath)));
             var mockNugetInstaller = nugetInstaller as MockNuGetPackageDownloader;

--- a/test/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
+++ b/test/dotnet-workload-install.Tests/GivenWorkloadManifestUpdater.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         {
             (var manifestUpdater, var nugetDownloader, var sentinelPath) = GetTestUpdater();
 
-            File.Create(sentinelPath);
+            File.Create(sentinelPath).Close();
             var createTime = DateTime.Now;
 
             await manifestUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             {
                 offlineCacheDir = Path.Combine(testDir, "offlineCache");
                 Directory.CreateDirectory(offlineCacheDir);
-                File.Create(Path.Combine(offlineCacheDir, $"{testManifestName}.Manifest-6.0.200.nupkg"));
+                File.Create(Path.Combine(offlineCacheDir, $"{testManifestName}.Manifest-6.0.200.nupkg")).Close();
 
                 await manifestUpdater.UpdateAdvertisingManifestsAsync(includePreviews: true, offlineCache: new DirectoryPath(offlineCacheDir));
             }
@@ -550,8 +550,8 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write multiple manifest packages to the offline cache
             var offlineCache = Path.Combine(testDir, "cache");
             Directory.CreateDirectory(offlineCache);
-            File.Create(Path.Combine(offlineCache, $"{manifestId}.manifest-{featureBand}.2.0.0.nupkg"));
-            File.Create(Path.Combine(offlineCache, $"{manifestId}.manifest-{featureBand}.3.0.0.nupkg"));
+            File.Create(Path.Combine(offlineCache, $"{manifestId}.manifest-{featureBand}.2.0.0.nupkg")).Close();
+            File.Create(Path.Combine(offlineCache, $"{manifestId}.manifest-{featureBand}.3.0.0.nupkg")).Close();
 
             var workloadManifestProvider = new MockManifestProvider(new string[] { Path.Combine(installedManifestDir, manifestId, _manifestFileName) });
             var nugetDownloader = new MockNuGetPackageDownloader(dotnetRoot);

--- a/test/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
+++ b/test/dotnet-workload-install.Tests/WorkloadGarbageCollectionTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write workload install record for 6.0.300
             var workloadsRecordPath = Path.Combine(_dotnetRoot, "metadata", "workloads", sdkVersions[1], "InstalledWorkloads");
             Directory.CreateDirectory(workloadsRecordPath);
-            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build"));
+            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build")).Close();
 
             installer.GarbageCollect(getResolver);
 
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write workload install record for xamarin-android-build workload for 6.0.300
             var workloadsRecordPath = Path.Combine(_dotnetRoot, "metadata", "workloads", "6.0.300", "InstalledWorkloads");
             Directory.CreateDirectory(workloadsRecordPath);
-            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build"));
+            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build")).Close();
 
             //  These packs are referenced by xamarin-android-build from the 3.0 manifest, which is the latest one and therefore the one that will be kept
             var packsToKeep = new PackInfo[]
@@ -210,7 +210,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             // Write workload install record for xamarin-android-build workload for 6.0.300
             var workloadsRecordPath = Path.Combine(_dotnetRoot, "metadata", "workloads", "6.0.300", "InstalledWorkloads");
             Directory.CreateDirectory(workloadsRecordPath);
-            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build"));
+            File.Create(Path.Combine(workloadsRecordPath, "xamarin-android-build")).Close();
 
             //  These packs are referenced by xamarin-android-build from the 2.0 manifest, which is the one that should be kept due to the install state
             var packsToKeep = new PackInfo[]

--- a/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -209,6 +209,11 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             var sdkFeatureVersion = "6.0.100";
             var installingWorkload = "simple-workload";
 
+            //  Mock up a 5.0.1xx SDK install so that the installation records for that feature band won't be deleted
+            string dotnetDllPath = Path.Combine(dotnetRoot, "sdk", "5.0.110", "dotnet.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(dotnetDllPath));
+            File.Create(dotnetDllPath).Close();
+
             string installRoot = userLocal ? userProfileDir : dotnetRoot;
             if (userLocal)
             {

--- a/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet-workload-update.Tests/GivenDotnetWorkloadUpdate.cs
@@ -228,12 +228,12 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             foreach (var pack in workloadPacks)
             {
                 Directory.CreateDirectory(Path.Combine(packRecordDir, pack.Id, pack.Version));
-                File.Create(Path.Combine(packRecordDir, pack.Id, pack.Version, oldFeatureBand));
+                File.Create(Path.Combine(packRecordDir, pack.Id, pack.Version, oldFeatureBand)).Close();
             }
             Directory.CreateDirectory(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads"));
             Directory.CreateDirectory(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads"));
-            File.Create(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads", installingWorkload));
-            File.Create(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads", installingWorkload));
+            File.Create(Path.Combine(installRoot, "metadata", "workloads", oldFeatureBand, "InstalledWorkloads", installingWorkload)).Close();
+            File.Create(Path.Combine(installRoot, "metadata", "workloads", sdkFeatureVersion, "InstalledWorkloads", installingWorkload)).Close();
 
             // Update workload (without installing any workloads to this feature band)
             var updateParseResult = Parser.Instance.Parse(new string[] { "dotnet", "workload", "update", "--from-previous-sdk" });


### PR DESCRIPTION
I looked into using the temp directory on Unix like we do on Windows and it uncovered two issues (https://github.com/dotnet/sdk/issues/3923 was an earlier report)

1) Helix sets `$TMPDIR` to `/tmp/helix` but on macOS `/tmp` is a symlink to `/private/tmp` and a bunch of tests then fail since parts of the sdk see `/tmp` and other parts see the resolved `/private/tmp` path and checks for path equality and other similar logic fails (see also https://github.com/dotnet/sdk/issues/37687)
-> this was relatively easy to solve by making sure we use the resolved path as the TestExecutionDirectory. Ideally we'd solve the underlying symlink equality issue but that's a bigger change.

2) the test `GivenWorkloadUpdateAcrossFeatureBandsItUpdatesPacks` started failing in CI but only on Linux. I tried reproducing it locally but it always passed. Then I stepped through it under the debugger and noticed that I got this exception [here](https://github.com/dotnet/sdk/blob/7ad934d3ac49c0dabaa500b5f9de73493292807b/src/Cli/dotnet/commands/dotnet-workload/install/WorkloadInstallCommand.cs#L258-L263):
 
    > System.IO.IOException : The process cannot access the file '/Users/alexander/dev/sdk/artifacts/tmp/Debug/GivenWorkload---B940FC6C/dotnet/metadata/workloads/InstalledPacks/v1/mock-pack-2/2.0.0/5.0.100' because it is being used by another process.

    ... but we're swallowing the exception so the test accidentally passed because the workload GC was aborted.

    I tracked it down to us not closing the file stream created by File.Create() during the test, once I fixed that the test now consistently failed everywhere (it asserts that the file should exist but it gets deleted during workload GC). This was fixed by mocking up a 5.0.1xx SDK install so that the installation records for that feature band won't be deleted.

We're now correctly closing all file streams created by File.Create() in the codebase.