### PR TITLE
[Static Web Assets] Fix relative path matching

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -116,7 +116,16 @@ public partial class DefineStaticWebAssets : Task
                         var normalizedDirectoryPath = Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
                         if (normalizedAssetPath.StartsWith(normalizedDirectoryPath))
                         {
-                            var result = normalizedAssetPath.Substring(normalizedDirectoryPath.Length);
+                            var directoryPathLength = normalizedDirectoryPath switch
+                            {
+                                null => 0,
+                                "" => 0,
+#pragma warning disable IDE0056 // Indexers are not available. in .NET Framework
+                                var withSeparator when withSeparator[withSeparator.Length - 1] == Path.DirectorySeparatorChar || withSeparator[withSeparator.Length - 1] == Path.AltDirectorySeparatorChar => normalizedDirectoryPath.Length,
+                                _ => normalizedDirectoryPath.Length + 1
+                            };
+#pragma warning restore IDE0056
+                            var result = normalizedAssetPath.Substring(directoryPathLength);
                             Log.LogMessage(MessageImportance.Low, "FullPath '{0}' starts with content root '{1}' for candidate '{2}'. Using '{3}' as relative path.", normalizedAssetPath, normalizedDirectoryPath, candidate.ItemSpec, result);
                             candidateMatchPath = result;
                         }

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -110,6 +110,17 @@ public partial class DefineStaticWebAssets : Task
                 if (SourceType == StaticWebAsset.SourceTypes.Discovered)
                 {
                     var candidateMatchPath = GetDiscoveryCandidateMatchPath(candidate);
+                    if (Path.IsPathRooted(candidateMatchPath) && candidateMatchPath == candidate.ItemSpec)
+                    {
+                        var normalizedAssetPath = Path.GetFullPath(candidate.GetMetadata("FullPath"));
+                        var normalizedDirectoryPath = Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
+                        if (normalizedAssetPath.StartsWith(normalizedDirectoryPath))
+                        {
+                            var result = normalizedAssetPath.Substring(normalizedDirectoryPath.Length);
+                            Log.LogMessage(MessageImportance.Low, "FullPath '{0}' starts with content root '{1}' for candidate '{2}'. Using '{3}' as relative path.", normalizedAssetPath, normalizedDirectoryPath, candidate.ItemSpec, result);
+                            candidateMatchPath = result;
+                        }
+                    }
                     relativePathCandidate = candidateMatchPath;
                     if (matcher != null && string.IsNullOrEmpty(candidate.GetMetadata("RelativePath")))
                     {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -777,7 +777,7 @@ for path 'candidate.js'");
             buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
                 .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
             buildEngine.SetupGet(e => e.ProjectFileOfTaskNode)
-                .Returns("/home/user/work/Repo/Project/");
+                .Returns("/home/user/work/Repo/Project/Project.csproj");
 
             var task = new DefineStaticWebAssets
             {
@@ -802,6 +802,7 @@ for path 'candidate.js'");
             task.Assets.Length.Should().Be(1);
             task.Assets[0].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Components/Dropdown/Dropdown.razor.js");
             task.Assets[0].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Project");
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.ContentRoot)).Should().Be("/home/user/work/Repo/Project/");
         }
 
         private static TaskLoggingHelper CreateLogger()

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -778,9 +778,8 @@ for path 'candidate.js'");
             buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
                 .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
             buildEngine.SetupGet(e => e.ProjectFileOfTaskNode)
-                .Returns(Path.Combine(Environment.CurrentDirectory, "Debug", "TestProject.csproj"));
+                .Returns("/home/user/work/Repo/Project/");
 
-            var debugDir = Path.Combine(Environment.CurrentDirectory, "Debug");
             var task = new DefineStaticWebAssets
             {
                 BuildEngine = buildEngine.Object,

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -769,7 +769,8 @@ for path 'candidate.js'");
             task.Assets[1].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
         }
 
-        [Fact]
+        [ConditionalFact]
+        [SkipOnPlatform(TestPlatforms.Windows, "Uses Unix-style paths")]
         public void ComputesRelativePath_ForAssets_ExplicitPaths()
         {
             var errorMessages = new List<string>();

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -776,6 +776,8 @@ for path 'candidate.js'");
             var buildEngine = new Mock<IBuildEngine>();
             buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
                 .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+            buildEngine.SetupGet(e => e.ProjectFileOfTaskNode)
+                .Returns(Path.Combine(Environment.CurrentDirectory, "Debug", "TestProject.csproj"));
 
             var debugDir = Path.Combine(Environment.CurrentDirectory, "Debug");
             var task = new DefineStaticWebAssets

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -769,8 +769,7 @@ for path 'candidate.js'");
             task.Assets[1].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
         }
 
-        [ConditionalFact]
-        [SkipOnPlatform(TestPlatforms.Windows, "Uses Unix-style paths")]
+        [LinuxOnlyFact]
         public void ComputesRelativePath_ForAssets_ExplicitPaths()
         {
             var errorMessages = new List<string>();

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -688,6 +688,121 @@ for path 'candidate.js'");
                 File.Delete(manifestPath);
             }
         }
+
+        [Fact]
+        public void ComputesRelativePath_ForDiscoveredAssetsWithFullPath()
+        {
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+            buildEngine.SetupGet(e => e.ProjectFileOfTaskNode)
+                .Returns(Path.Combine(Environment.CurrentDirectory, "Debug", "TestProject.csproj"));
+
+            var debugDir = Path.Combine(Environment.CurrentDirectory, "Debug", "wwwroot");
+            var task = new DefineStaticWebAssets
+            {
+                BuildEngine = buildEngine.Object,
+                CandidateAssets = [
+                    new TaskItem(Path.Combine(debugDir, "Microsoft.AspNetCore.Components.CustomElements.lib.module.js"),
+                        new Dictionary<string,string>{ ["Integrity"] = "integrity", ["Fingerprint"] = "fingerprint"}),
+                    new TaskItem(Path.Combine(debugDir, "Microsoft.AspNetCore.Components.CustomElements.lib.module.js.map"),
+                        new Dictionary<string,string>{ ["Integrity"] = "integrity", ["Fingerprint"] = "fingerprint"})
+                ],
+                RelativePathPattern = "wwwroot/**",
+                SourceType = "Discovered",
+                SourceId = "Microsoft.AspNetCore.Components.CustomElements",
+                ContentRoot = debugDir,
+                BasePath = "_content/Microsoft.AspNetCore.Components.CustomElements",
+                TestResolveFileDetails = _testResolveFileDetails,
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue($"Errors: {Environment.NewLine}  {string.Join($"{Environment.NewLine}  ", errorMessages)}");
+            task.Assets.Length.Should().Be(2);
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Microsoft.AspNetCore.Components.CustomElements.lib.module.js");
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
+            task.Assets[1].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Microsoft.AspNetCore.Components.CustomElements.lib.module.js.map");
+            task.Assets[1].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
+        }
+
+        [Fact]
+        public void ComputesRelativePath_WorksForItemsWithRelativePaths()
+        {
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+            buildEngine.SetupGet(e => e.ProjectFileOfTaskNode)
+                .Returns(Path.Combine(Environment.CurrentDirectory, "Debug", "TestProject.csproj"));
+
+            var debugDir = Path.Combine(Environment.CurrentDirectory, "Debug", "wwwroot");
+            var task = new DefineStaticWebAssets
+            {
+                BuildEngine = buildEngine.Object,
+                CandidateAssets = [
+                    new TaskItem(Path.Combine("wwwroot", "Microsoft.AspNetCore.Components.CustomElements.lib.module.js"),
+                        new Dictionary<string,string>{ ["Integrity"] = "integrity", ["Fingerprint"] = "fingerprint"}),
+                    new TaskItem(Path.Combine("wwwroot", "Microsoft.AspNetCore.Components.CustomElements.lib.module.js.map"),
+                        new Dictionary<string,string>{ ["Integrity"] = "integrity", ["Fingerprint"] = "fingerprint"})
+                ],
+                RelativePathPattern = "wwwroot/**",
+                SourceType = "Discovered",
+                SourceId = "Microsoft.AspNetCore.Components.CustomElements",
+                ContentRoot = debugDir,
+                BasePath = "_content/Microsoft.AspNetCore.Components.CustomElements",
+                TestResolveFileDetails = _testResolveFileDetails,
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue($"Errors: {Environment.NewLine}  {string.Join($"{Environment.NewLine}  ", errorMessages)}");
+            task.Assets.Length.Should().Be(2);
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Microsoft.AspNetCore.Components.CustomElements.lib.module.js");
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
+            task.Assets[1].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Microsoft.AspNetCore.Components.CustomElements.lib.module.js.map");
+            task.Assets[1].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Microsoft.AspNetCore.Components.CustomElements");
+        }
+
+        [Fact]
+        public void ComputesRelativePath_ForAssets_ExplicitPaths()
+        {
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var debugDir = Path.Combine(Environment.CurrentDirectory, "Debug");
+            var task = new DefineStaticWebAssets
+            {
+                BuildEngine = buildEngine.Object,
+                CandidateAssets = [
+                    new TaskItem("/home/user/work/Repo/Project/Components/Dropdown/Dropdown.razor.js",
+                        new Dictionary<string,string>{ ["Integrity"] = "integrity", ["Fingerprint"] = "fingerprint"}),
+                ],
+                RelativePathPattern = "**",
+                SourceType = "Discovered",
+                SourceId = "Project",
+                ContentRoot = "/home/user/work/Repo/Project",
+                BasePath = "_content/Project",
+                TestResolveFileDetails = _testResolveFileDetails,
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue($"Errors: {Environment.NewLine}  {string.Join($"{Environment.NewLine}  ", errorMessages)}");
+            task.Assets.Length.Should().Be(1);
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("Components/Dropdown/Dropdown.razor.js");
+            task.Assets[0].GetMetadata(nameof(StaticWebAsset.BasePath)).Should().Be("_content/Project");
+        }
+
         private static TaskLoggingHelper CreateLogger()
         {
             var errorMessages = new List<string>();


### PR DESCRIPTION
When discovering assets we also need to account for the case where the asset was provided with a full path (rare but happens) and make the path relative against the project folder before we process it.

Fixes #49038