### PR TITLE
Use WebAssemblyHotReloadCapabilities project property

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyDeltaApplier.cs
@@ -3,18 +3,26 @@
 
 using System.Buffers;
 using System.Collections.Immutable;
+using Microsoft.Build.Graph;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
 
 namespace Microsoft.DotNet.Watch
 {
-    internal sealed class BlazorWebAssemblyDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, Version? targetFrameworkVersion) : SingleProcessDeltaApplier(reporter)
+    internal sealed class BlazorWebAssemblyDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, ProjectGraphNode project) : SingleProcessDeltaApplier(reporter)
     {
-        private const string DefaultCapabilities60 = "Baseline";
-        private const string DefaultCapabilities70 = "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes";
-        private const string DefaultCapabilities80 = "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType";
+        private static readonly ImmutableArray<string> s_defaultCapabilities60 =
+            ["Baseline"];
 
-        private ImmutableArray<string> _cachedCapabilities;
-        private readonly SemaphoreSlim _capabilityRetrievalSemaphore = new(initialCount: 1);
+        private static readonly ImmutableArray<string> s_defaultCapabilities70 =
+            ["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "NewTypeDefinition", "ChangeCustomAttributes"];
+
+        private static readonly ImmutableArray<string> s_defaultCapabilities80 =
+            ["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "NewTypeDefinition", "ChangeCustomAttributes",
+             "AddInstanceFieldToExistingType", "GenericAddMethodToExistingType", "GenericUpdateMethod", "UpdateParameters", "GenericAddFieldToExistingType"];
+
+        private static readonly ImmutableArray<string> s_defaultCapabilities90 =
+            s_defaultCapabilities80;
+
         private int _updateId;
 
         public override void Dispose()
@@ -31,109 +39,31 @@ namespace Microsoft.DotNet.Watch
             // Alternatively, we could inject agent into blazor-devserver.dll and establish a connection on the named pipe.
             => await browserRefreshServer.WaitForClientConnectionAsync(cancellationToken);
 
-        public override async Task<ImmutableArray<string>> GetApplyUpdateCapabilitiesAsync(CancellationToken cancellationToken)
+        public override Task<ImmutableArray<string>> GetApplyUpdateCapabilitiesAsync(CancellationToken cancellationToken)
         {
-            var cachedCapabilities = _cachedCapabilities;
-            if (!cachedCapabilities.IsDefault)
+            var capabilities = project.GetWebAssemblyCapabilities();
+
+            if (capabilities.IsEmpty)
             {
-                return cachedCapabilities;
-            }
+                var targetFramework = project.GetTargetFrameworkVersion();
 
-            await _capabilityRetrievalSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                if (_cachedCapabilities.IsDefault)
+                Reporter.Verbose($"Using capabilities based on target framework: '{targetFramework}'.");
+
+                capabilities = targetFramework?.Major switch
                 {
-                    _cachedCapabilities = await RetrieveAsync(cancellationToken);
-                }
-            }
-            finally
-            {
-                _capabilityRetrievalSemaphore.Release();
-            }
-
-            return _cachedCapabilities;
-
-            async Task<ImmutableArray<string>> RetrieveAsync(CancellationToken cancellationToken)
-            {
-                var buffer = ArrayPool<byte>.Shared.Rent(32 * 1024);
-
-                try
-                {
-                    Reporter.Verbose("Connecting to the browser.");
-
-                    await browserRefreshServer.WaitForClientConnectionAsync(cancellationToken);
-
-                    string capabilities;
-                    if (browserRefreshServer.Options.TestFlags.HasFlag(TestFlags.MockBrowser))
-                    {
-                        // When testing return default capabilities without connecting to an actual browser.
-                        capabilities = GetDefaultCapabilities(targetFrameworkVersion);
-                    }
-                    else
-                    {
-                        string? capabilityString = null;
-
-                        await browserRefreshServer.SendAndReceiveAsync(
-                            request: _ => default(JsonGetApplyUpdateCapabilitiesRequest),
-                            response: (value, reporter) =>
-                            {
-                                var str = Encoding.UTF8.GetString(value);
-                                if (str.StartsWith('!'))
-                                {
-                                    reporter.Verbose($"Exception while reading WASM runtime capabilities: {str[1..]}");
-                                }
-                                else if (str.Length == 0)
-                                {
-                                    reporter.Verbose($"Unable to read WASM runtime capabilities");
-                                }
-                                else if (capabilityString == null)
-                                {
-                                    capabilityString = str;
-                                }
-                                else if (capabilityString != str)
-                                {
-                                    reporter.Verbose($"Received different capabilities from different browsers:{Environment.NewLine}'{str}'{Environment.NewLine}'{capabilityString}'");
-                                }
-                            },
-                            cancellationToken);
-
-                        if (capabilityString != null)
-                        {
-                            capabilities = capabilityString;
-                        }
-                        else
-                        {
-                            capabilities = GetDefaultCapabilities(targetFrameworkVersion);
-                            Reporter.Verbose($"Falling back to default WASM capabilities: '{capabilities}'");
-                        }
-                    }
-
-                    // Capabilities are expressed a space-separated string.
-                    // e.g. https://github.com/dotnet/runtime/blob/14343bdc281102bf6fffa1ecdd920221d46761bc/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs#L87
-                    return capabilities.Split(' ').ToImmutableArray();
-                }
-                catch (Exception e) when (!cancellationToken.IsCancellationRequested)
-                {
-                    Reporter.Error($"Failed to read capabilities: {e.Message}");
-
-                    // Do not attempt to retrieve capabilities again if it fails once, unless the operation is canceled.
-                    return [];
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(buffer);
-                }
-            }
-
-            static string GetDefaultCapabilities(Version? targetFrameworkVersion)
-                => targetFrameworkVersion?.Major switch
-                {
-                    >= 8 => DefaultCapabilities80,
-                    >= 7 => DefaultCapabilities70,
-                    >= 6 => DefaultCapabilities60,
-                    _ => string.Empty,
+                    9 => s_defaultCapabilities90,
+                    8 => s_defaultCapabilities80,
+                    7 => s_defaultCapabilities70,
+                    6 => s_defaultCapabilities60,
+                    _ => [],
                 };
+            }
+            else
+            {
+                Reporter.Verbose($"Project specifies capabilities.");
+            }
+
+            return Task.FromResult(capabilities);
         }
 
         public override async Task<ApplyStatus> Apply(ImmutableArray<WatchHotReloadService.Update> updates, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/BlazorWebAssemblyHostedDeltaApplier.cs
@@ -3,13 +3,14 @@
 
 
 using System.Collections.Immutable;
+using Microsoft.Build.Graph;
 using Microsoft.CodeAnalysis.ExternalAccess.Watch.Api;
 
 namespace Microsoft.DotNet.Watch
 {
-    internal sealed class BlazorWebAssemblyHostedDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, Version? targetFrameworkVersion) : DeltaApplier(reporter)
+    internal sealed class BlazorWebAssemblyHostedDeltaApplier(IReporter reporter, BrowserRefreshServer browserRefreshServer, ProjectGraphNode project) : DeltaApplier(reporter)
     {
-        private readonly BlazorWebAssemblyDeltaApplier _wasmApplier = new(reporter, browserRefreshServer, targetFrameworkVersion);
+        private readonly BlazorWebAssemblyDeltaApplier _wasmApplier = new(reporter, browserRefreshServer, project);
         private readonly DefaultDeltaApplier _hostApplier = new(reporter);
 
         public override void Dispose()

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -99,11 +99,11 @@ namespace Microsoft.DotNet.Watch
             _reporter.Report(MessageDescriptor.HotReloadSessionStarted);
         }
 
-        private static DeltaApplier CreateDeltaApplier(HotReloadProfile profile, Version? targetFramework, BrowserRefreshServer? browserRefreshServer, IReporter processReporter)
+        private static DeltaApplier CreateDeltaApplier(HotReloadProfile profile, ProjectGraphNode project, BrowserRefreshServer? browserRefreshServer, IReporter processReporter)
             => profile switch
             {
-                HotReloadProfile.BlazorWebAssembly => new BlazorWebAssemblyDeltaApplier(processReporter, browserRefreshServer!, targetFramework),
-                HotReloadProfile.BlazorHosted => new BlazorWebAssemblyHostedDeltaApplier(processReporter, browserRefreshServer!, targetFramework),
+                HotReloadProfile.BlazorWebAssembly => new BlazorWebAssemblyDeltaApplier(processReporter, browserRefreshServer!, project),
+                HotReloadProfile.BlazorHosted => new BlazorWebAssemblyHostedDeltaApplier(processReporter, browserRefreshServer!, project),
                 _ => new DefaultDeltaApplier(processReporter),
             };
 
@@ -121,8 +121,7 @@ namespace Microsoft.DotNet.Watch
         {
             var projectPath = projectNode.ProjectInstance.FullPath;
 
-            var targetFramework = projectNode.GetTargetFrameworkVersion();
-            var deltaApplier = CreateDeltaApplier(profile, targetFramework, browserRefreshServer, processReporter);
+            var deltaApplier = CreateDeltaApplier(profile, projectNode, browserRefreshServer, processReporter);
             var processExitedSource = new CancellationTokenSource();
             var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(processExitedSource.Token, cancellationToken);
 

--- a/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.Cli;
 
@@ -16,6 +17,9 @@ internal static class ProjectGraphNodeExtensions
 
     public static Version? GetTargetFrameworkVersion(this ProjectGraphNode projectNode)
         => EnvironmentVariableNames.TryParseTargetFrameworkVersion(projectNode.ProjectInstance.GetPropertyValue("TargetFrameworkVersion"));
+
+    public static ImmutableArray<string> GetWebAssemblyCapabilities(this ProjectGraphNode projectNode)
+        => [.. projectNode.ProjectInstance.GetPropertyValue("WebAssemblyHotReloadCapabilities").Split(';').Select(static c => c.Trim()).Where(static c => c != "")];
 
     public static bool IsTargetFrameworkVersionOrNewer(this ProjectGraphNode projectNode, Version minVersion)
         => GetTargetFrameworkVersion(projectNode) is { } version && version >= minVersion;


### PR DESCRIPTION
... to determine WASM capabilities instead of querying the runtime, which might not be loaded yet.

Contributes to a fix of https://github.com/dotnet/aspnetcore/issues/59027
Related: https://github.com/dotnet/aspnetcore/pull/59094