### PR TITLE
Refresh browser for all transitively referencing projects

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -348,7 +348,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             switch (updates.Status)
             {
                 case ModuleUpdateStatus.None:
-                    _reporter.Output("No hot reload changes to apply.");
+                    _reporter.Output("No C# changes to apply.");
                     break;
 
                 case ModuleUpdateStatus.Ready:

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Diagnostics;
 using Microsoft.Build.Graph;
+using Microsoft.Build.Framework;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Tools.Internal;
 
@@ -52,41 +53,61 @@ namespace Microsoft.DotNet.Watcher.Tools
                 }
             }
 
-            var logger = reporter.IsVerbose ? new[] { new Build.Logging.ConsoleLogger() } : null;
-
-            var tasks = projectsToRefresh.Select(async projectNode =>
+            if (!hasApplicableFiles)
             {
-                if (!projectNode.ProjectInstance.DeepCopy().Build(BuildTargetName, logger))
+                return;
+            }
+
+            var logger = reporter.IsVerbose ? new[] { new Build.Logging.ConsoleLogger(LoggerVerbosity.Minimal) } : null;
+
+            var buildTasks = projectsToRefresh.Select(projectNode => Task.Run(() =>
+            {
+                try
                 {
-                    return false;
+                    if (!projectNode.ProjectInstance.DeepCopy().Build(BuildTargetName, logger))
+                    {
+                        return null;
+                    }
+                }
+                catch (Exception e)
+                {
+                    reporter.Error($"[{projectNode.GetDisplayName()}] Target {BuildTargetName} failed to build: {e}");
+                    return null;
                 }
 
+                return projectNode;
+            }));
+
+            var buildResults = await Task.WhenAll(buildTasks).WaitAsync(cancellationToken);
+
+            var browserRefreshTasks = buildResults.Where(p => p != null)!.GetTransitivelyReferencingProjects().Select(async projectNode =>
+            {
                 if (browserConnector.TryGetRefreshServer(projectNode, out var browserRefreshServer))
                 {
+                    reporter.Verbose($"[{projectNode.GetDisplayName()}] Refreshing browser.");
                     await HandleBrowserRefresh(browserRefreshServer, projectNode.ProjectInstance.FullPath, cancellationToken);
-                }
-
-                return true;
-            });
-
-            var results = await Task.WhenAll(tasks).WaitAsync(cancellationToken);
-
-            if (hasApplicableFiles)
-            {
-                var successfulCount = results.Sum(r => r ? 1 : 0);
-
-                if (successfulCount == results.Length)
-                {
-                    reporter.Output("Hot reload of scoped css succeeded.", emoji: "🔥");
-                }
-                else if (successfulCount > 0)
-                {
-                    reporter.Output($"Hot reload of scoped css partially succeeded: {successfulCount} project(s) out of {results.Length} were updated.", emoji: "🔥");
                 }
                 else
                 {
-                    reporter.Output("Hot reload of scoped css failed.", emoji: "🔥");
+                    reporter.Verbose($"[{projectNode.GetDisplayName()}] No refresh server.");
                 }
+            });
+
+            await Task.WhenAll(browserRefreshTasks).WaitAsync(cancellationToken);
+
+            var successfulCount = buildResults.Sum(r => r != null ? 1 : 0);
+
+            if (successfulCount == buildResults.Length)
+            {
+                reporter.Output("Hot reload of scoped css succeeded.", emoji: "🔥");
+            }
+            else if (successfulCount > 0)
+            {
+                reporter.Output($"Hot reload of scoped css partially succeeded: {successfulCount} project(s) out of {buildResults.Length} were updated.", emoji: "🔥");
+            }
+            else
+            {
+                reporter.Output("Hot reload of scoped css failed.", emoji: "🔥");
             }
         }
 

--- a/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
@@ -31,4 +31,28 @@ internal static class ProjectGraphNodeExtensions
 
     public static IEnumerable<string> GetCapabilities(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetItems("ProjectCapability").Select(item => item.EvaluatedInclude);
+
+    public static IEnumerable<ProjectGraphNode> GetTransitivelyReferencingProjects(this IEnumerable<ProjectGraphNode> projects)
+    {
+        var visited = new HashSet<ProjectGraphNode>();
+        var queue = new Queue<ProjectGraphNode>();
+        foreach (var project in projects)
+        {
+            queue.Enqueue(project);
+        }
+
+        while (queue.Count > 0)
+        {
+            var project = queue.Dequeue();
+            if (visited.Add(project))
+            {
+                foreach (var referencingProject in project.ReferencingProjects)
+                {
+                    queue.Enqueue(referencingProject);
+                }
+            }
+        }
+
+        return visited;
+    }
 }


### PR DESCRIPTION
We only looked for browser refresh server associated with the project containing changes, but we also need to look for browser refresh server on all transitively referencing projects.

Fixes regression https://github.com/dotnet/sdk/issues/45011
Port of https://github.com/dotnet/sdk/pull/45095 w/o test (necessary test infra isn't in 1xx branch)

## Customer Impact

Changes made to Razor component did not trigger the web page to be refreshed.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

One-liner to fix read buffer bounds.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A