### PR TITLE
Fix `Change failed to apply (error code: ...)` intermittent failures

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/DefaultDeltaApplier.cs
@@ -136,10 +136,11 @@ namespace Microsoft.DotNet.Watcher.Tools
             var status = ArrayPool<byte>.Shared.Rent(1);
             try
             {
-                var statusBytesRead = await _pipe.ReadAsync(status, cancellationToken);
+                var statusBytesRead = await _pipe.ReadAsync(status, offset: 0, count: 1, cancellationToken);
                 if (statusBytesRead != 1 || status[0] != UpdatePayload.ApplySuccessValue)
                 {
-                    Reporter.Error($"Change failed to apply (error code: '{BitConverter.ToString(status, 0, statusBytesRead)}'). Further changes won't be applied to this process.");
+                    var message = (statusBytesRead == 0) ? "received no data" : $"received status 0x{status[0]:x2}";
+                    Reporter.Error($"Change failed to apply ({message}). Further changes won't be applied to this process.");
                     return false;
                 }
 

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
                 var testFilter = string.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
                 command = $"{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                            $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --blame-hang --blame-hang-timeout 30m {testFilter} -- {arguments}";
+                          $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout 30m {testFilter} -- {arguments}";
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Watcher.Tests
             await App.AssertOutputLineStartsWith("Changed!");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/issues/45457")]
         public async Task ChangeFileInFSharpProject()
         {
             var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")


### PR DESCRIPTION
Porting fix already in 9.0.2xx: https://github.com/dotnet/sdk/pull/44786/commits/d54f4f6aabf836c249fe8b2367159748c43ba34f

## Customer Impact

Hot Reload intermittently fails to apply changes.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

One-liner to fix read buffer bounds.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A