### PR TITLE
Improve error experience for Restore command without a project

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs
@@ -50,10 +50,12 @@ namespace Microsoft.DotNet.Workloads.Workload.Restore
 
             recorder.Run(() =>
             {
-                // First update manifests and install a workload set as necessary
+                // First discover projects. This may return an error if no projects are found, and we shouldn't delay until after Update if that's the case.
+                var allProjects = DiscoverAllProjects(Directory.GetCurrentDirectory(), _slnOrProjectArgument).Distinct();
+
+                // Then update manifests and install a workload set as necessary
                 new WorkloadUpdateCommand(_result, recorder: recorder, isRestoring: true).Execute();
 
-                var allProjects = DiscoverAllProjects(Directory.GetCurrentDirectory(), _slnOrProjectArgument).Distinct();
                 List<WorkloadId> allWorkloadId = RunTargetToGetWorkloadIds(allProjects);
                 Reporter.WriteLine(string.Format(LocalizableStrings.InstallingWorkloads, string.Join(" ", allWorkloadId)));
 


### PR DESCRIPTION
Restoring without a project currently wastes a lot of time running Update then (correctly) realizes it needs a project and fails. This makes it search for a project first to get a faster error.