### PR TITLE
randomize GetTestDestinationDirectoryPath

### DIFF
--- a/test/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/test/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -203,12 +203,16 @@ namespace Microsoft.NET.TestFramework
 #if CI_BUILD
             if (!allowCopyIfPresent && Directory.Exists(directoryPath))
             {
-                //Arcade test retry reuses the machine so the directory might already be present in CI
-                directoryPath = Directory.Exists(directoryPath+"_1") ? directoryPath+"_2" : directoryPath+"_1";
-                if (Directory.Exists(directoryPath))
+                // Arcade test retry reuses the machine so the directory might already be present in CI
+                int suffix = 1;
+                string newDirectoryPath;
+                do
                 {
-                    throw new Exception($"Test dir {directoryPath} already exists");
-                }
+                    newDirectoryPath = $"{directoryPath}_{suffix}";
+                    suffix++;
+                } while (Directory.Exists(newDirectoryPath));
+
+                directoryPath = newDirectoryPath;
             }
 #endif
 


### PR DESCRIPTION
lots of failures in theory tests such as

```
Microsoft.DotNet.Cli.Sln.List.Tests.GivenDotnetSlnList.WhenInvalidSolutionIsPassedItPrintsErrorAndUsage(solutionCommand: "sln") [FAIL]
      System.Exception : Test dir /private/tmp/helix/working/AD1509AD/w/BB910A35/e/testExecutionDirectory/WhenInvalidSo---F1406920_2 already exists
```