### PR TITLE
Better search versions error experience

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.DotNet.Workloads.Workload;
 using Microsoft.DotNet.Workloads.Workload.Search;
 using LocalizableStrings = Microsoft.DotNet.Workloads.Workload.Search.LocalizableStrings;
 
@@ -58,8 +59,7 @@ namespace Microsoft.DotNet.Cli
                 var versionArgument = result.GetValue(WorkloadVersionArgument);
                 if (versionArgument is not null)
                 {
-                    var coreComponents = versionArgument.Split(['-', '+'], 2)[0].Split('.');
-                    if (coreComponents.Length != 3 && coreComponents.Length != 4)
+                    if (!WorkloadSetVersion.IsWorkloadSetPackageVersion(versionArgument))
                     {
                         result.AddError(string.Format(CommandLineValidation.LocalizableStrings.UnrecognizedCommandOrArgument, versionArgument));
                     }

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
@@ -53,6 +53,19 @@ namespace Microsoft.DotNet.Cli
                 }
             });
 
+            command.Validators.Add(result =>
+            {
+                var versionArgument = result.GetValue(WorkloadVersionArgument);
+                if (versionArgument is not null)
+                {
+                    var coreComponents = versionArgument.Split(['-', '+'], 2)[0].Split('.');
+                    if (coreComponents.Length != 3 && coreComponents.Length != 4)
+                    {
+                        result.AddError(string.Format(CommandLineValidation.LocalizableStrings.UnrecognizedCommandOrArgument, versionArgument));
+                    }
+                }
+            });
+
             command.SetAction(parseResult => new WorkloadSearchVersionsCommand(parseResult).Execute());
 
             return command;

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
@@ -57,12 +57,9 @@ namespace Microsoft.DotNet.Cli
             command.Validators.Add(result =>
             {
                 var versionArgument = result.GetValue(WorkloadVersionArgument);
-                if (versionArgument is not null)
+                if (versionArgument is not null && !WorkloadSetVersion.IsWorkloadSetPackageVersion(versionArgument))
                 {
-                    if (!WorkloadSetVersion.IsWorkloadSetPackageVersion(versionArgument))
-                    {
-                        result.AddError(string.Format(CommandLineValidation.LocalizableStrings.UnrecognizedCommandOrArgument, versionArgument));
-                    }
+                    result.AddError(string.Format(CommandLineValidation.LocalizableStrings.UnrecognizedCommandOrArgument, versionArgument));
                 }
             });
 

--- a/src/Common/WorkloadSetVersion.cs
+++ b/src/Common/WorkloadSetVersion.cs
@@ -8,9 +8,20 @@ namespace Microsoft.DotNet.Workloads.Workload
 {
     static class WorkloadSetVersion
     {
+        public static bool IsWorkloadSetPackageVersion(string workloadSetVersion)
+        {
+
+            string[] sections = workloadSetVersion.Split(['-', '+'], 2);
+            string versionCore = sections[0];
+            string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
+
+            string[] coreComponents = versionCore.Split('.');
+            return coreComponents.Length >= 3 && coreComponents.Length <= 4;
+        }
+
         public static string ToWorkloadSetPackageVersion(string workloadSetVersion, out SdkFeatureBand sdkFeatureBand)
         {
-            string[] sections = workloadSetVersion.Split(new char[] { '-', '+' }, 2);
+            string[] sections = workloadSetVersion.Split(['-', '+'], 2);
             string versionCore = sections[0];
             string? preReleaseOrBuild = sections.Length > 1 ? sections[1] : null;
 

--- a/test/dotnet-workload-search.Tests/GivenDotnetWorkloadSearch.cs
+++ b/test/dotnet-workload-search.Tests/GivenDotnetWorkloadSearch.cs
@@ -28,6 +28,22 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
             _reporter = new BufferedReporter();
         }
 
+        [Theory]
+        [InlineData("--invalidArgument")]
+        [InlineData("notAVersion")]
+        [InlineData("1.2")] // too short
+        [InlineData("1.2.3.4.5")] // too long
+        [InlineData("1.2-3.4")] // numbers after [-, +] don't count
+        public void GivenInvalidArgumentToWorkloadSearchVersionItFailsCleanly(string argument)
+        {
+            _reporter.Clear();
+            var parseResult = Parser.Instance.Parse($"dotnet workload search version {argument}");
+            var workloadResolver = new MockWorkloadResolver(Enumerable.Empty<WorkloadResolver.WorkloadInfo>());
+            var workloadResolverFactory = new MockWorkloadResolverFactory(dotnetPath: null, "9.0.100", workloadResolver);
+            var command = () => new WorkloadSearchVersionsCommand(parseResult, _reporter, workloadResolverFactory);
+            command.Should().Throw<CommandParsingException>();
+        }
+
         [Fact]
         public void GivenNoWorkloadsAreInstalledSearchIsEmpty()
         {


### PR DESCRIPTION
If you try `dotnet workload search version` and then put anything after that that it doesn't recognize, it assumes it's a workload version argument. Often, it isn't. For instance, `dotnet workload search version --include-previews` tries to parse --include-previews as a version incorrectly, fails, and throws a garbage error. This makes the error experience more useful.