### PR TITLE
Add option to include/exclude previews to workload search version command Fixes #43890

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommand.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
         private readonly string _workloadSetOutputFormat;
         private readonly FileBasedInstaller _installer;
         private readonly string _workloadVersion;
+        private readonly bool _includePreviews;
 
         public WorkloadSearchVersionsCommand(
             ParseResult result,
@@ -64,6 +65,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
                 );
 
             _workloadVersion = result.GetValue(WorkloadSearchVersionsCommandParser.WorkloadVersionArgument);
+
+            _includePreviews = result.HasOption(WorkloadSearchVersionsCommandParser.IncludePreviewsOption) ?
+                result.GetValue(WorkloadSearchVersionsCommandParser.IncludePreviewsOption) :
+                new SdkFeatureBand(_sdkVersion).IsPrerelease;
         }
 
         public override int Execute()
@@ -76,7 +81,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
                 List<string> versions;
                 try
                 {
-                    versions = PackageDownloader.GetLatestPackageVersions(packageId, _numberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: !string.IsNullOrWhiteSpace(_sdkVersion.Prerelease))
+                    versions = PackageDownloader.GetLatestPackageVersions(packageId, _numberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: _includePreviews)
                         .GetAwaiter().GetResult()
                         .Select(version => WorkloadSetVersion.FromWorkloadSetPackageVersion(featureBand, version.ToString()))
                         .ToList();

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchVersionsCommandParser.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.Cli
             Description = LocalizableStrings.FormatOptionDescription
         };
 
+        public static readonly CliOption<bool> IncludePreviewsOption = new("--include-previews");
+
         private static readonly CliCommand Command = ConstructCommand();
 
         public static CliCommand GetCommand()
@@ -36,6 +38,7 @@ namespace Microsoft.DotNet.Cli
             command.Arguments.Add(WorkloadVersionArgument);
             command.Options.Add(FormatOption);
             command.Options.Add(TakeOption);
+            command.Options.Add(IncludePreviewsOption);
 
             TakeOption.Validators.Add(optionResult =>
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkFeatureBand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
         }
 
+        public bool IsPrerelease => !string.IsNullOrEmpty(_featureBand.Prerelease);
         public int Major => _featureBand.Major;
         public int Minor => _featureBand.Minor;
 


### PR DESCRIPTION
This also changes the default to look at the feature band.

Fixes #43890