### PR TITLE
VMR: Use pipelineArtifact upload method for final join outputs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -1389,19 +1389,19 @@ stages:
       templateContext:
         outputParentDirectory: $(Build.ArtifactStagingDirectory)/artifacts
         outputs:
-        - output: buildArtifacts
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/MergedManifest.xml
-          ArtifactName: AssetManifests
+        - output: pipelineArtifact
+          targetPath: $(Build.ArtifactStagingDirectory)/artifacts/MergedManifest.xml
+          artifactName: AssetManifests
           displayName: Publish Merged Manifest
           sbomEnabled: false
-        - output: buildArtifacts
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/assets
-          ArtifactName: BlobArtifacts
+        - output: pipelineArtifact
+          targetPath: $(Build.ArtifactStagingDirectory)/artifacts/assets
+          artifactName: BlobArtifacts
           displayName: Publish Blob Artifacts
           sbomEnabled: false
-        - output: buildArtifacts
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/packages
-          ArtifactName: PackageArtifacts
+        - output: pipelineArtifact
+          targetPath: $(Build.ArtifactStagingDirectory)/artifacts/packages
+          artifactName: PackageArtifacts
           displayName: Publish Package Artifacts
           sbomEnabled: false
       steps:


### PR DESCRIPTION
As far as I know we don't need to mutate these artifacts anymore so we can move to the recommended pipelineArtifact upload method.