### PR TITLE
Add projects, .config, and .nuspec to .editorconfig

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
+# Xml project files
+[*.{csproj,fsproj,vbproj,proj}]
+indent_size = 2
+
 # Xml config files
 [*.{props,targets,config,nuspec}]
 indent_size = 2

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
@@ -5,7 +5,11 @@ root = true
 indent_style = space
 
 # Xml files
-[*.{xml,props,targets}]
+[*.xml]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
 indent_size = 2
 
 # C# files

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
+# Xml project files
+[*.{csproj,fsproj,vbproj,proj}]
+indent_size = 2
+
 # Xml config files
 [*.{props,targets,config,nuspec}]
 indent_size = 2

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
@@ -5,7 +5,11 @@
 indent_style = space
 
 # Xml files
-[*.{xml,props,targets}]
+[*.xml]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
 indent_size = 2
 
 # C# files


### PR DESCRIPTION
This change aligns the .editorconfig with what I observe from dotnet repos:

1. Adds *.config and *.nuspec to the XML section
2. Moves *.props, *.targets, *.config, *.nuspec out of the XML proper section and into its own section so that devs that have strong feelings about .xml can modify that independently
3. Added *.csproj, *.vbproj, *.fsproj, *.proj into a new section (I didn't add vcxproj since this focused on .NET development, but happy to add)