### PR TITLE
VMR: move DevVersions jobs to a separate stage

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -348,7 +348,7 @@ stages:
         #     - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
 
 #### VERTICAL BUILD (Validation) ####
-- ${{ if and(not(parameters.isSourceOnlyBuild), not(parameters.isBuiltFromVmr) }}:
+- ${{ if and(not(parameters.isSourceOnlyBuild), not(parameters.isBuiltFromVmr)) }}:
   - stage: VMR_Vertical_Build_Validation
     displayName: VMR Vertical Build Validation
     dependsOn: []

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -348,7 +348,7 @@ stages:
         #     - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
 
 #### VERTICAL BUILD (Validation) ####
-- ${{ if and(not(parameters.isSourceOnlyBuild), not(parameters.isBuiltFromVmr)) }}:
+- ${{ if and(not(parameters.isSourceOnlyBuild), or(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.TeamProject'], 'internal'))) }}:
   - stage: VMR_Vertical_Build_Validation
     displayName: VMR Vertical Build Validation
     dependsOn: []

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -347,10 +347,10 @@ stages:
         #     reuseBuildArtifactsFrom:
         #     - ${{ format('{0}_Mono_Offline_MsftSdk_x64', variables.centOSStreamName) }}
 
-#### VERTICAL BUILD ####
-- ${{ if not(parameters.isSourceOnlyBuild) }}:
-  - stage: VMR_Vertical_Build
-    displayName: VMR Vertical Build
+#### VERTICAL BUILD (Validation) ####
+- ${{ if and(not(parameters.isSourceOnlyBuild), not(parameters.isBuiltFromVmr) }}:
+  - stage: VMR_Vertical_Build_Validation
+    displayName: VMR Vertical Build Validation
     dependsOn: []
     variables:
     - template: ../variables/vmr-build.yml
@@ -368,7 +368,7 @@ stages:
         container: ${{ variables.ubuntuContainer }}
         targetOS: linux
         targetArchitecture: x64
-        useDevVersions: true # Use dev versions for CI validation of the experience. If we decide to ship assets from this leg, then we should remove this option.
+        useDevVersions: true # Use dev versions for CI validation of the experience.
         runTests: false # Temporarily do not run tests. The nuget comparison fails for some non-obvious reason and needs further investigation. Mostly, I'm not sure why it ever passed. https://github.com/dotnet/sdk/issues/42920
 
     - template: ../jobs/vmr-build.yml
@@ -391,8 +391,19 @@ stages:
         pool: ${{ parameters.pool_Windows }}
         targetOS: windows
         targetArchitecture: x64
-        useDevVersions: true # Use dev versions for CI validation of the experience. If we decide to ship assets from this leg, then we should remove this option.
+        useDevVersions: true # Use dev versions for CI validation of the experience.
         runTests: false # Temporarily do not run tests. The nuget comparison fails for some non-obvious reason and needs further investigation. Mostly, I'm not sure why it ever passed. https://github.com/dotnet/sdk/issues/42920
+
+#### VERTICAL BUILD (Official) ####
+- ${{ if not(parameters.isSourceOnlyBuild) }}:
+  - stage: VMR_Vertical_Build
+    displayName: VMR Vertical Build
+    dependsOn: []
+    variables:
+    - template: ../variables/vmr-build.yml
+      parameters:
+        vmrBranch: ${{ parameters.vmrBranch }}
+    jobs:
 
     - template: ../jobs/vmr-build.yml
       parameters:


### PR DESCRIPTION
Don't run the validation jobs during the official build.

Fixes https://github.com/dotnet/source-build/issues/4769