### PR TITLE
[LoongArch64]: Add loongarch64 R2R resolve

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -41,6 +41,9 @@ namespace Microsoft.NET.Build.Tasks
                                       RuntimeIdentifier.EndsWith("-x86") || RuntimeIdentifier.Contains("-x86-") ? Architecture.X86 :
                                       RuntimeIdentifier.EndsWith("-arm64") || RuntimeIdentifier.Contains("-arm64-") ? Architecture.Arm64 :
                                       RuntimeIdentifier.EndsWith("-arm") || RuntimeIdentifier.Contains("-arm-") ? Architecture.Arm :
+#if !NETFRAMEWORK
+                                      RuntimeIdentifier.EndsWith("-loongarch64") || RuntimeIdentifier.Contains("-loongarch64-") ? Architecture.LoongArch64 :
+#endif
                                       throw new ArgumentException(nameof (RuntimeIdentifier));
 
             BundleOptions options = BundleOptions.None;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -263,6 +263,11 @@ namespace Microsoft.NET.Build.Tasks
                 case "x86":
                     architecture = Architecture.X86;
                     break;
+#if !NETFRAMEWORK
+                case "loongarch64":
+                    architecture = Architecture.LoongArch64;
+                    break;
+#endif
                 default:
                     return false;
             }
@@ -424,6 +429,9 @@ namespace Microsoft.NET.Build.Tasks
                 Architecture.X64 => "x64",
                 Architecture.Arm => "arm",
                 Architecture.Arm64 => "arm64",
+#if !NETFRAMEWORK
+                Architecture.LoongArch64 => "loongarch64",
+#endif
                 _ => null
             };
         }


### PR DESCRIPTION
Crossgen2 tool now able to work on LoongArch64 .NET SDK 8.0. This PR enable LoongArch64 .NET SDK 8.0 can publish optimized DLL with the command below.

```shell
dotnet publish -p:PublishReadyToRun=true
```

@shushanhf