### PR TITLE
Pass the `--ci` argument to `darc` in SDK's CI

### DIFF
--- a/.devcontainer/vmr/init.sh
+++ b/.devcontainer/vmr/init.sh
@@ -25,6 +25,6 @@ vmr_branch=$(git -C "$sdk_dir" log --pretty=format:'%D' HEAD^ \
   | sed 's@origin/@@' \
   | sed 's@,.*@@')
 
-"$workspace_dir/synchronize-vmr.sh" --branch "$vmr_branch" --debug
+"$workspace_dir/synchronize-vmr.sh" --branch "$vmr_branch" --ci --debug
 
 cd "$vmr_dir"

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -53,6 +53,7 @@ steps:
     --remote "sdk:$(Agent.BuildDirectory)/sdk"
     --component-template $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/Component.template.md
     --tpn-template $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
+    --ci
     --debug
     ||
     (echo "##vso[task.logissue type=error]Failed to synchronize the VMR" && exit 1)
@@ -76,6 +77,7 @@ steps:
     # -remote "sdk:$(Agent.BuildDirectory)/sdk"
     -componentTemplate $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/Component.template.md `
     -tpnTemplate $(Agent.BuildDirectory)/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt `
+    -ci
     -debugOutput
 
     if ($LASTEXITCODE -ne 0) {

--- a/eng/vmr-sync.ps1
+++ b/eng/vmr-sync.ps1
@@ -65,6 +65,9 @@ Optional. Path to the dotnet/dotnet repository. When null, gets cloned to the te
 
 .PARAMETER debugOutput
 Optional. Enables debug logging in the darc vmr command.
+
+.PARAMETER ci
+Optional. Denotes that the script is running in a CI environment.
 #>
 param (
   [Parameter(Mandatory=$true, HelpMessage="Path to the temporary folder where repositories will be cloned")]
@@ -77,6 +80,7 @@ param (
   [string]$tpnTemplate = "src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt",
   [string]$azdevPat,
   [string][Alias('v', 'vmr')]$vmrDir,
+  [switch]$ci,
   [switch]$debugOutput
 )
 
@@ -189,10 +193,14 @@ $darcArgs = (
     "--discard-patches",
     "--generate-credscansuppressions",
     $repository
-)  
+)
 
 if ($recursive) {
   $darcArgs += ("--recursive")
+}
+
+if ($ci) {
+  $darcArgs += ("--ci")
 }
 
 if ($additionalRemotes) {

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -107,6 +107,7 @@ verbosity=verbose
 component_template="$sdk_dir/src/VirtualMonoRepo/Component.template.md"
 tpn_template="$sdk_dir/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
 azdev_pat=''
+ci=false
 
 # If sdk is a repo, we're in an sdk and not in the dotnet/dotnet repo
 if [[ -d "$sdk_dir/.git" ]]; then
@@ -150,6 +151,9 @@ while [[ $# -gt 0 ]]; do
     --azdev-pat)
       azdev_pat=$2
       shift
+      ;;
+    --ci)
+      ci=true
       ;;
     -d|--debug)
       verbosity=debug
@@ -259,6 +263,11 @@ if [[ -n "$azdev_pat" ]]; then
   azdev_pat="--azdev-pat $azdev_pat"
 fi
 
+ci_arg=''
+if [[ "$ci" == "true" ]]; then
+  ci_arg="--ci"
+fi
+
 # Synchronize the VMR
 
 "$dotnet" darc vmr update                    \
@@ -267,6 +276,7 @@ fi
   $azdev_pat                                 \
   --$verbosity                               \
   $recursive_arg                             \
+  $ci_arg                                    \
   $additional_remotes                        \
   --component-template "$component_template" \
   --tpn-template "$tpn_template"             \


### PR DESCRIPTION
We never really needed to pass it because we don't auth against anything but it did appear recently and we should probably just do it so that we don't break later