### PR TITLE
Enable debug logging from middleware in --verbose mode

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BlazorWasmHotReloadMiddleware.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
@@ -35,8 +36,9 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
 
-        public BlazorWasmHotReloadMiddleware(RequestDelegate next)
+        public BlazorWasmHotReloadMiddleware(RequestDelegate next, ILogger<BlazorWasmHotReloadMiddleware> logger)
         {
+            logger.LogDebug("Middleware loaded");
         }
 
         internal List<Update> Updates { get; } = [];

--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             _next = next;
             _logger = logger;
 
-            logger.LogDebug("Middleware loaded");
+            logger.LogDebug("Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES={ModifiableAssemblies}, __ASPNETCORE_BROWSER_TOOLS={BrowserTools}", _dotnetModifiableAssemblies, _aspnetcoreBrowserTools);
         }
 
         private static string? GetNonEmptyEnvironmentVariableValue(string name)

--- a/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
+++ b/src/BuiltInTools/BrowserRefresh/HostingStartup.cs
@@ -44,11 +44,11 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                         app.Map(ApplicationPaths.BlazorHotReloadMiddleware, static app => app.UseMiddleware<BlazorWasmHotReloadMiddleware>());
 
                         app.Map(ApplicationPaths.BrowserRefreshJS,
-                            static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBrowserRefreshJS()));
+                            static app => app.UseMiddleware<BrowserScriptMiddleware>(ApplicationPaths.BrowserRefreshJS, BrowserScriptMiddleware.GetBrowserRefreshJS()));
 
                         // backwards compat only:
                         app.Map(ApplicationPaths.BlazorHotReloadJS,
-                            static app => app.UseMiddleware<BrowserScriptMiddleware>(BrowserScriptMiddleware.GetBlazorHotReloadJS()));
+                            static app => app.UseMiddleware<BrowserScriptMiddleware>(ApplicationPaths.BlazorHotReloadJS, BrowserScriptMiddleware.GetBlazorHotReloadJS()));
                     });
 
                 app.UseMiddleware<BrowserRefreshMiddleware>();

--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserRefreshServer.cs
@@ -83,6 +83,12 @@ namespace Microsoft.DotNet.Watch
 
             environmentBuilder.DotNetStartupHookDirective.Add(Path.Combine(AppContext.BaseDirectory, "middleware", "Microsoft.AspNetCore.Watch.BrowserRefresh.dll"));
             environmentBuilder.AspNetCoreHostingStartupAssembliesVariable.Add("Microsoft.AspNetCore.Watch.BrowserRefresh");
+
+            if (_reporter.IsVerbose)
+            {
+                // enable debug logging from middleware:
+                environmentBuilder.SetVariable("Logging__LogLevel__Microsoft.AspNetCore.Watch", "Debug");
+            }
         }
 
         public string GetServerKey()

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -80,10 +80,16 @@ internal sealed class ProjectLauncher(
         environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatch, "1");
         environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchIteration, (Iteration + 1).ToString(CultureInfo.InvariantCulture));
 
+        // Note:
+        // Microsoft.AspNetCore.Components.WebAssembly.Server.ComponentWebAssemblyConventions and Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware
+        // expect DOTNET_MODIFIABLE_ASSEMBLIES to be set in the blazor-devserver process, even though we are not performing Hot Reload in this process.
+        // The value is converted to DOTNET-MODIFIABLE-ASSEMBLIES header, which is in turn converted back to environment variable in Mono browser runtime loader:
+        // https://github.com/dotnet/runtime/blob/342936c5a88653f0f622e9d6cb727a0e59279b31/src/mono/browser/runtime/loader/config.ts#L330
+        environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
+
         if (injectDeltaApplier)
         {
             environmentBuilder.DotNetStartupHookDirective.Add(DeltaApplier.StartupHookPath);
-            environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
             environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName, namedPipeName);
 
             // Do not ask agent to log to stdout until https://github.com/dotnet/sdk/issues/40484 is fixed.

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserScriptMiddlewareTest.cs
@@ -2,26 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 {
     public class BrowserScriptMiddlewareTest
     {
         private readonly RequestDelegate _next = (context) => Task.CompletedTask;
+        private readonly ILogger<BrowserScriptMiddleware> _logger;
+
+        public BrowserScriptMiddlewareTest()
+        {
+            var loggerFactory = LoggerFactory.Create(_ => { });
+            _logger = loggerFactory.CreateLogger<BrowserScriptMiddleware>();
+        }
 
         [Fact]
         public async Task InvokeAsync_ReturnsScript()
         {
-            // Arrange
             var context = new DefaultHttpContext();
             var stream = new MemoryStream();
             context.Response.Body = stream;
-            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"));
+            var middleware = new BrowserScriptMiddleware(
+                _next,
+                new PathString("/script.js"),
+                BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"),
+                _logger);
 
-            // Act
             await middleware.InvokeAsync(context);
 
-            // Assert
             stream.Position = 0;
             var script = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Contains("// dotnet-watch browser reload script", script);
@@ -32,15 +41,16 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         [Fact]
         public async Task InvokeAsync_ConfiguresHeaders()
         {
-            // Arrange
             var context = new DefaultHttpContext();
             context.Response.Body = new MemoryStream();
-            var middleware = new BrowserScriptMiddleware(_next, BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"));
+            var middleware = new BrowserScriptMiddleware(
+                _next,
+                new PathString("/script.js"),
+                BrowserScriptMiddleware.GetWebSocketClientJavaScript("some-host", "test-key"),
+                _logger);
 
-            // Act
             await middleware.InvokeAsync(context);
 
-            // Assert
             var response = context.Response;
             Assert.Collection(
                 response.Headers.OrderBy(h => h.Key),

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -244,7 +244,16 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             App.AssertOutputContains(MessageDescriptor.ConfiguredToUseBrowserRefresh);
             App.AssertOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
-            App.AssertOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}/");
+
+            // Browser is launched based on blazor-devserver output "Now listening on: ...".
+            await App.WaitUntilOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}/");
+
+            // Middleware should have been loaded to blazor-devserver before the browser is launched:
+            App.AssertOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]");
+            App.AssertOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]");
+            App.AssertOutputContains("Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js");
+            App.AssertOutputContains("Middleware loaded. Script /_framework/blazor-hotreload.js");
+            App.AssertOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware");
 
             // shouldn't see any agent messages (agent is not loaded into blazor-devserver):
             AssertEx.DoesNotContain("🕵️", App.Process.Output);

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -254,6 +254,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             App.AssertOutputContains("Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js");
             App.AssertOutputContains("Middleware loaded. Script /_framework/blazor-hotreload.js");
             App.AssertOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware");
+            App.AssertOutputContains("Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true");
 
             // shouldn't see any agent messages (agent is not loaded into blazor-devserver):
             AssertEx.DoesNotContain("🕵️", App.Process.Output);


### PR DESCRIPTION
Automatically include middleware log messages in the output of `dotnet watch --verbose`:

```
dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]
      Middleware loaded
dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]
      Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js (16067 B).
dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]
      Middleware loaded. Script /_framework/blazor-hotreload.js (799 B).
dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware[0]
      Middleware loaded
dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]
      Script injected: /_framework/aspnetcore-browser-refresh.js
```

Set `DOTNET_MODIFIABLE_ASSEMBLIES` even for client-only Blazor WASM apps (revert to behavior prior to https://github.com/dotnet/sdk/pull/44539/commits/0c37ca5d6c8cbc32e359295ed06d4674a73939f5).