### PR TITLE
Pass missing compiler parameters

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -1233,6 +1233,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          NoStandardLib="$(NoCompilerStandardLib)"
          Optimize="$(Optimize)"
          PublicSign="$(PublicSign)"
+         PathMap="$(PathMap)"
+         Features="$(Features)"
          DelaySign="$(DelaySign)"
          Deterministic="$(Deterministic)"
          DisabledWarnings="$(DisabledWarnings)"


### PR DESCRIPTION
Pass a few parameters to `<Csc>` that were missing and impact build reproducibility.

closes #45256