### PR TITLE
Don't publish PrivateAssets Fixes #39400

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -22,6 +22,7 @@ namespace Microsoft.NET.Build.Tasks
         private Dictionary<string, List<ReferenceInfo>> _compileReferences;
         private Dictionary<string, List<ResolvedFile>> _resolvedNuGetFiles;
         private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
+        private IEnumerable<string> _excludeFromPublishPackageIds;
         private Dictionary<string, List<RuntimePackAssetInfo>> _runtimePackAssets;
         private CompilationOptions _compilationOptions;
         private string _referenceAssembliesPath;
@@ -201,6 +202,12 @@ namespace Microsoft.NET.Build.Tasks
         public DependencyContextBuilder WithReferenceProjectInfos(Dictionary<string, SingleProjectInfo> referenceProjectInfos)
         {
             _referenceProjectInfos = referenceProjectInfos;
+            return this;
+        }
+
+        public DependencyContextBuilder WithExcludeFromPublishAssets(IEnumerable<string> excludeFromPublishPackageIds)
+        {
+            _excludeFromPublishPackageIds = excludeFromPublishPackageIds;
             return this;
         }
 
@@ -813,6 +820,38 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var packageToExcludeFromRuntime in runtimeExclusionList)
             {
                 _dependencyLibraries[packageToExcludeFromRuntime].ExcludeFromRuntime = true;
+            }
+
+            //  Include transitive dependencies of all top-level dependencies
+            Dictionary<string, DependencyLibrary> includedDependencies = new(StringComparer.OrdinalIgnoreCase);
+            Stack<string> dependencyListToWalk = new(_mainProjectDependencies);
+
+            while (dependencyListToWalk.Count != 0)
+            {
+                var dependencyName = dependencyListToWalk.Pop();
+                if (!includedDependencies.ContainsKey(dependencyName) && _excludeFromPublishPackageIds?.Contains(dependencyName) != true)
+                {
+                    //  There may not be a library in the assets file if a referenced project has
+                    //  PrivateAssets="all" for a package reference, and there is a package in the graph
+                    //  that depends on the same package.
+                    if (_dependencyLibraries.TryGetValue(dependencyName, out var dependencyLibrary))
+                    {
+                        includedDependencies.Add(dependencyName, dependencyLibrary);
+                        foreach (var newDependency in _libraryDependencies[dependencyName])
+                        {
+                            dependencyListToWalk.Push(newDependency.Name);
+                        }
+                    }
+                }
+            }
+
+            foreach (var dependencyLibrary in _dependencyLibraries.Values)
+            {
+                if (!includedDependencies.ContainsKey(dependencyLibrary.Name))
+                {
+                    dependencyLibrary.ExcludeFromCompilation = true;
+                    dependencyLibrary.ExcludeFromRuntime = true;
+                }
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -829,18 +829,17 @@ namespace Microsoft.NET.Build.Tasks
             while (dependencyListToWalk.Count != 0)
             {
                 var dependencyName = dependencyListToWalk.Pop();
-                if (!includedDependencies.ContainsKey(dependencyName) && _excludeFromPublishPackageIds?.Contains(dependencyName) != true)
+                //  There may not be a library in the assets file if a referenced project has
+                //  PrivateAssets="all" for a package reference, and there is a package in the graph
+                //  that depends on the same package.
+                if (!includedDependencies.ContainsKey(dependencyName) &&
+                    _excludeFromPublishPackageIds?.Contains(dependencyName) != true &&
+                    _dependencyLibraries.TryGetValue(dependencyName, out var dependencyLibrary))
                 {
-                    //  There may not be a library in the assets file if a referenced project has
-                    //  PrivateAssets="all" for a package reference, and there is a package in the graph
-                    //  that depends on the same package.
-                    if (_dependencyLibraries.TryGetValue(dependencyName, out var dependencyLibrary))
+                    includedDependencies.Add(dependencyName, dependencyLibrary);
+                    foreach (var newDependency in _libraryDependencies[dependencyName])
                     {
-                        includedDependencies.Add(dependencyName, dependencyLibrary);
-                        foreach (var newDependency in _libraryDependencies[dependencyName])
-                        {
-                            dependencyListToWalk.Push(newDependency.Name);
-                        }
+                        dependencyListToWalk.Push(newDependency.Name);
                     }
                 }
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -64,6 +64,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public ITaskItem CompilerOptions { get; set; }
 
+        public ITaskItem[] ExcludeFromPublishPackageReferences { get; set; } = Array.Empty<ITaskItem>();
+
         public ITaskItem[] RuntimeStorePackages { get; set; }
 
         // NuGet compilation assets
@@ -232,6 +234,7 @@ namespace Microsoft.NET.Build.Tasks
                 .WithDirectReferences(directReferences)
                 .WithDependencyReferences(dependencyReferences)
                 .WithReferenceProjectInfos(referenceProjects)
+                .WithExcludeFromPublishAssets(PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences))
                 .WithRuntimePackAssets(runtimePackAssets)
                 .WithCompilationOptions(compilationOptions)
                 .WithReferenceAssembliesPath(FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath())

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1236,6 +1236,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       RuntimeFrameworks="@(RuntimeFramework)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
+                      ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
                       RuntimeStorePackages="@(RuntimeStorePackages)"
                       CompileReferences="@(ResolvedCompileFileDefinitions)"
                       ResolvedNuGetFiles="@(_ResolvedNuGetFilesForPublish)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -338,6 +338,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       RuntimeFrameworks="@(RuntimeFramework)"
                       CompilerOptions="@(DependencyFileCompilerOptions)"
+                      ExcludeFromPublishPackageReferences="@(_ExcludeFromPublishPackageReference)"
                       CompileReferences="@(ResolvedCompileFileDefinitions)"
                       ResolvedNuGetFiles="@(NativeCopyLocalItems);@(ResourceCopyLocalItems);@(RuntimeCopyLocalItems)"
                       UserRuntimeAssemblies="@(UserRuntimeAssembly)"

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -225,6 +225,32 @@ public class NETFramework
             }
         }
 
+        [Theory]
+        [InlineData("RazorSimpleMvc22", "netcoreapp2.2", "SimpleMvc22")]
+        [InlineData("DesktopReferencingNetStandardLibrary", "net46", "Library")]
+        public void PackageReferences_with_private_assets_do_not_appear_in_deps_file(string asset, string targetFramework, string exeName)
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(asset)
+                .WithSource();
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().Pass();
+
+            using (var depsJsonFileStream = File.OpenRead(Path.Combine(buildCommand.GetOutputDirectory(targetFramework).FullName, exeName + ".deps.json")))
+            {
+                var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
+                if (asset.Equals("DesktopReferencingNetStandardLibrary"))
+                {
+                    dependencyContext.CompileLibraries.Any(l => l.Name.Equals("Library")).Should().BeTrue();
+                }
+                else
+                {
+                    dependencyContext.CompileLibraries.Any(l => l.Name.Equals("Microsoft.AspNetCore.App")).Should().BeFalse();
+                }
+            }
+        }
+
         [WindowsOnlyFact]
         public void It_resolves_assembly_conflicts_with_a_NETFramework_library()
         {

--- a/test/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
@@ -113,9 +113,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             depsFile.Should().Exist();
             var dependencyContext = ReadDependencyContext(depsFile.FullName);
 
-            // Ensure some compile references exist
-            var packageReference = dependencyContext.CompileLibraries.First(l => l.Name == "System.Runtime.CompilerServices.Unsafe");
-            packageReference.Assemblies.Should().NotBeEmpty();
+            // Ensure compile references from a PrivateAssets="all" PackageReference don't exist
+            var packageReference = dependencyContext.CompileLibraries.FirstOrDefault(l => l.Name == "System.Runtime.CompilerServices.Unsafe", defaultValue: null);
+            packageReference.Should().BeNull();
 
             var projectReference = dependencyContext.CompileLibraries.First(l => l.Name == TestProjectName);
             projectReference.Assemblies.Should().NotBeEmpty();

--- a/test/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/MvcBuildIntegrationTestLegacy.cs
@@ -113,9 +113,18 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             depsFile.Should().Exist();
             var dependencyContext = ReadDependencyContext(depsFile.FullName);
 
-            // Ensure compile references from a PrivateAssets="all" PackageReference don't exist
-            var packageReference = dependencyContext.CompileLibraries.FirstOrDefault(l => l.Name == "System.Runtime.CompilerServices.Unsafe", defaultValue: null);
-            packageReference.Should().BeNull();
+            if (TargetFramework.Equals("netcoreapp2.2"))
+            {
+                // Ensure compile references from a PrivateAssets="all" PackageReference don't exist
+                var packageReference = dependencyContext.CompileLibraries.FirstOrDefault(l => l.Name == "System.Runtime.CompilerServices.Unsafe", defaultValue: null);
+                packageReference.Should().BeNull();
+            }
+            else
+            {
+                // Ensure some compile references exist
+                var packageReference = dependencyContext.CompileLibraries.First(l => l.Name == "System.Runtime.CompilerServices.Unsafe");
+                packageReference.Assemblies.Should().NotBeEmpty();
+            }
 
             var projectReference = dependencyContext.CompileLibraries.First(l => l.Name == TestProjectName);
             projectReference.Assemblies.Should().NotBeEmpty();


### PR DESCRIPTION
Fixes #39400

PrivateAssets="all" still permitted things to appear in the deps.json file. That probably shouldn't be true, especially since they aren't actually in the assets. This makes it so things that shouldn't be published are excluded from that file. the screenshot below is  from the deps.json file created when using the provided repro in #39400 but with these changes.

![image](https://github.com/user-attachments/assets/db4e6529-61c3-4d5a-b4b7-fa5e7ebc6373)

As you can see, Nerdbank.GitVersioning is absent.

See #3348 as it deleted some of the code added in this PR.