### PR TITLE
fix(cli): dotnet help new link opening

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/ICommandDocument.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/ICommandDocument.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Microsoft.TemplateEngine.Cli.Commands;
+
+/// <summary>
+/// If a <see cref="CliCommand"/> implements this interface, it can open
+/// its documentation page online.
+/// </summary>
+public interface ICommandDocument
+{
+    /// <summary>
+    /// The URL to the documentation page for this command.
+    /// </summary>
+    string DocsLink { get; }
+}

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.TemplateEngine.Edge.Settings;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
-    internal partial class NewCommand : BaseCommand<NewCommandArgs>, ICustomHelp
+    internal partial class NewCommand : BaseCommand<NewCommandArgs>, ICustomHelp, ICommandDocument
     {
         internal NewCommand(
             string commandName,
@@ -43,6 +43,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Options.Add(SharedOptions.NoUpdateCheckOption);
             Options.Add(SharedOptions.ProjectPathOption);
         }
+
+        public string DocsLink { get; } = "https://aka.ms/dotnet-new";
 
         internal static CliOption<string?> DebugCustomSettingsLocationOption { get; } = new("--debug:custom-hive")
         {

--- a/src/Cli/dotnet/DocumentedCommand.cs
+++ b/src/Cli/dotnet/DocumentedCommand.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Cli
 {
-    public class DocumentedCommand : CliCommand
+    public class DocumentedCommand : CliCommand, ICommandDocument
     {
-        public string DocsLink { get; set; }
+        public string DocsLink { get; }
 
         public DocumentedCommand(string name, string docsLink, string description = null) : base(name, description)
         {

--- a/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Tools.Help
 {
@@ -101,7 +102,7 @@ namespace Microsoft.DotNet.Tools.Help
         private bool TryGetDocsLink(string[] command, out string docsLink)
         {
             var parsedCommand = Parser.Instance.Parse(["dotnet", .. command]);
-            if (parsedCommand?.CommandResult?.Command is DocumentedCommand dc)
+            if (parsedCommand?.CommandResult?.Command is ICommandDocument dc)
             {
                 docsLink = dc.DocsLink;
                 return true;


### PR DESCRIPTION
closes #45231 

This PR fixes the issue where the `dotnet help new` command does not open the online documentation. 

The solution was adding an interface `ICommandDocument` that both `DocumentedCommand` and `NewCommand` could implement and then use this to validate the existence of a link.