### PR TITLE
[FIX MAIN] Update the tests to reflect the new templates.

### DIFF
--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
@@ -16,13 +16,16 @@ ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]
 Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
 Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
 Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class                                         class                         [C#],VB     Common                        
 Class Library                                 classlib                      [C#],F#,VB  Common/Library                
 Console App                                   console                       [C#],F#,VB  Common/Console                
 dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
 dotnet gitignore file                         gitignore,.gitignore                      Config                        
 Dotnet local tool manifest file               tool-manifest                             Config                        
 EditorConfig file                             editorconfig,.editorconfig                Config                        
+Enum                                          enum                          [C#],VB     Common                        
 global.json file                              globaljson,global.json                    Config                        
+Interface                                     interface                     [C#],VB     Common                        
 MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
 MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
 MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
@@ -41,7 +44,9 @@ Razor Class Library                           razorclasslib                 [C#]
 Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
 Razor Page                                    page                          [C#]        Web/ASP.NET                   
 Razor View                                    view                          [C#]        Web/ASP.NET                   
+Record                                        record                        [C#]        Common                        
 Solution File                                 sln,solution                              Solution                      
+Struct                                        struct,structure              [C#],VB     Common                        
 Web Config                                    webconfig                                 Config                        
 Worker Service                                worker                        [C#],F#     Common/Worker/Web             
 xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
@@ -16,13 +16,16 @@ ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]
 Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
 Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
 Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class                                         class                         [C#],VB     Common                        
 Class Library                                 classlib                      [C#],F#,VB  Common/Library                
 Console App                                   console                       [C#],F#,VB  Common/Console                
 dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
 dotnet gitignore file                         gitignore,.gitignore                      Config                        
 Dotnet local tool manifest file               tool-manifest                             Config                        
 EditorConfig file                             editorconfig,.editorconfig                Config                        
+Enum                                          enum                          [C#],VB     Common                        
 global.json file                              globaljson,global.json                    Config                        
+Interface                                     interface                     [C#],VB     Common                        
 MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
 MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
 MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
@@ -41,7 +44,9 @@ Razor Class Library                           razorclasslib                 [C#]
 Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
 Razor Page                                    page                          [C#]        Web/ASP.NET                   
 Razor View                                    view                          [C#]        Web/ASP.NET                   
+Record                                        record                        [C#]        Common                        
 Solution File                                 sln,solution                              Solution                      
+Struct                                        struct,structure              [C#],VB     Common                        
 Web Config                                    webconfig                                 Config                        
 Worker Service                                worker                        [C#],F#     Common/Worker/Web             
 xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
@@ -1,54 +1,54 @@
 ﻿Warning: use of 'dotnet new --list' is deprecated. Use 'dotnet new list' instead.
-For more information, run: 
+For more information, run:
    dotnet new list -h
 
-These templates matched your input: 
+These templates matched your input:
 
-Template Name                                 Short Name                    Language    Tags                          
+Template Name                                 Short Name                    Language    Tags
 --------------------------------------------  ----------------------------  ----------  ------------------------------
-API Controller                                apicontroller                 [C#]        Web/ASP.NET                   
-ASP.NET Core Empty                            web                           [C#],F#     Web/Empty                     
-ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service          
+API Controller                                apicontroller                 [C#]        Web/ASP.NET
+ASP.NET Core Empty                            web                           [C#],F#     Web/Empty
+ASP.NET Core gRPC Service                     grpc                          [C#]        Web/gRPC/API/Service
 ASP.NET Core Web API                          webapi                        [C#],F#     Web/Web API/API/Service/WebAPI
-ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service       
-ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC                       
-ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages           
-Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
-Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
-Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
-Class Library                                 classlib                      [C#],F#,VB  Common/Library                
-Console App                                   console                       [C#],F#,VB  Common/Console                
-dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
-dotnet gitignore file                         gitignore,.gitignore                      Config                        
-Dotnet local tool manifest file               tool-manifest                             Config                        
-EditorConfig file                             editorconfig,.editorconfig                Config                        
-global.json file                              globaljson,global.json                    Config                        
-MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
-MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
-MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
-MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright        
-MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest                   
-MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest                   
-MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET                   
-MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET                   
-MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET                   
-NuGet Config                                  nugetconfig,nuget.config                  Config                        
-NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit                    
-NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit                    
-NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright         
-Protocol Buffer File                          proto                                     Web/gRPC                      
-Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library             
-Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
-Razor Page                                    page                          [C#]        Web/ASP.NET                   
-Razor View                                    view                          [C#]        Web/ASP.NET                   
-Solution File                                 sln,solution                              Solution                      
-Web Config                                    webconfig                                 Config                        
-Windows Forms App                             winforms                      [C#],VB     Common/WinForms               
-Windows Forms Class Library                   winformslib                   [C#],VB     Common/WinForms               
-Windows Forms Control Library                 winformscontrollib            [C#],VB     Common/WinForms               
-Worker Service                                worker                        [C#],F#     Common/Worker/Web             
-WPF Application                               wpf                           [C#],VB     Common/WPF                    
-WPF Class Library                             wpflib                        [C#],VB     Common/WPF                    
-WPF Custom Control Library                    wpfcustomcontrollib           [C#],VB     Common/WPF                    
-WPF User Control Library                      wpfusercontrollib             [C#],VB     Common/WPF                    
-xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit                    
+ASP.NET Core Web API (native AOT)             webapiaot                     [C#]        Web/Web API/API/Service
+ASP.NET Core Web App (Model-View-Controller)  mvc                           [C#],F#     Web/MVC
+ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]        Web/MVC/Razor Pages
+Blazor Server App                             blazorserver                  [C#]        Web/Blazor
+Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly
+Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA
+Class Library                                 classlib                      [C#],F#,VB  Common/Library
+Console App                                   console                       [C#],F#,VB  Common/Console
+dotnet gitattributes file                     gitattributes,.gitattributes              Config
+dotnet gitignore file                         gitignore,.gitignore                      Config
+Dotnet local tool manifest file               tool-manifest                             Config
+EditorConfig file                             editorconfig,.editorconfig                Config
+global.json file                              globaljson,global.json                    Config
+MSBuild Directory.Build.props file            buildprops                                MSBuild/props
+MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props
+MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM
+MSTest Playwright Test Project                mstest-playwright             [C#]        Test/MSTest/Playwright
+MSTest Test Class                             mstest-class                  [C#],F#,VB  Test/MSTest
+MSTest Test Project                           mstest                        [C#],F#,VB  Test/MSTest
+MVC Controller                                mvccontroller                 [C#]        Web/ASP.NET
+MVC ViewImports                               viewimports                   [C#]        Web/ASP.NET
+MVC ViewStart                                 viewstart                     [C#]        Web/ASP.NET
+NuGet Config                                  nugetconfig,nuget.config                  Config
+NUnit 3 Test Item                             nunit-test                    [C#],F#,VB  Test/NUnit
+NUnit 3 Test Project                          nunit                         [C#],F#,VB  Test/NUnit
+NUnit Playwright Test Project                 nunit-playwright              [C#]        Test/NUnit/Playwright
+Protocol Buffer File                          proto                                     Web/gRPC
+Razor Class Library                           razorclasslib                 [C#]        Web/Razor/Library
+Razor Component                               razorcomponent                [C#]        Web/ASP.NET
+Razor Page                                    page                          [C#]        Web/ASP.NET
+Razor View                                    view                          [C#]        Web/ASP.NET
+Solution File                                 sln,solution                              Solution
+Web Config                                    webconfig                                 Config
+Windows Forms App                             winforms                      [C#],VB     Common/WinForms
+Windows Forms Class Library                   winformslib                   [C#],VB     Common/WinForms
+Windows Forms Control Library                 winformscontrollib            [C#],VB     Common/WinForms
+Worker Service                                worker                        [C#],F#     Common/Worker/Web
+WPF Application                               wpf                           [C#],VB     Common/WPF
+WPF Class Library                             wpflib                        [C#],VB     Common/WPF
+WPF Custom Control Library                    wpfcustomcontrollib           [C#],VB     Common/WPF
+WPF User Control Library                      wpfusercontrollib             [C#],VB     Common/WPF
+xUnit Test Project                            xunit                         [C#],F#,VB  Test/xUnit

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
@@ -12,13 +12,16 @@ ASP.NET Core Web App (Razor Pages)            webapp,razor                  [C#]
 Blazor Server App                             blazorserver                  [C#]        Web/Blazor                    
 Blazor Web App                                blazor                        [C#]        Web/Blazor/WebAssembly        
 Blazor WebAssembly Standalone App             blazorwasm                    [C#]        Web/Blazor/WebAssembly/PWA    
+Class                                         class                         [C#],VB     Common                        
 Class Library                                 classlib                      [C#],F#,VB  Common/Library                
 Console App                                   console                       [C#],F#,VB  Common/Console                
 dotnet gitattributes file                     gitattributes,.gitattributes              Config                        
 dotnet gitignore file                         gitignore,.gitignore                      Config                        
 Dotnet local tool manifest file               tool-manifest                             Config                        
 EditorConfig file                             editorconfig,.editorconfig                Config                        
+Enum                                          enum                          [C#],VB     Common                        
 global.json file                              globaljson,global.json                    Config                        
+Interface                                     interface                     [C#],VB     Common                        
 MSBuild Directory.Build.props file            buildprops                                MSBuild/props                 
 MSBuild Directory.Build.targets file          buildtargets                              MSBuild/props                 
 MSBuild Directory.Packages.props file         packagesprops                             MSBuild/packages/props/CPM    
@@ -37,7 +40,9 @@ Razor Class Library                           razorclasslib                 [C#]
 Razor Component                               razorcomponent                [C#]        Web/ASP.NET                   
 Razor Page                                    page                          [C#]        Web/ASP.NET                   
 Razor View                                    view                          [C#]        Web/ASP.NET                   
+Record                                        record                        [C#]        Common                        
 Solution File                                 sln,solution                              Solution                      
+Struct                                        struct,structure              [C#],VB     Common                        
 Web Config                                    webconfig                                 Config                        
 Windows Forms App                             winforms                      [C#],VB     Common/WinForms               
 Windows Forms Class Library                   winformslib                   [C#],VB     Common/WinForms               


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/45283

Ok so the template engine uses 'Verify' which I dont see elsewhere in the SDK -- What this does is store a txt snapshot of the last test result.

![image](https://github.com/user-attachments/assets/8ccda291-8888-4588-9ac8-7e847b0bb5e1)


It looks like Class, Record, Enum, Struct, etc may be new templates added in net 10 that need to be added to the test logic. https://github.com/dotnet/sdk/pull/29655
They were actually added in 7.0.200.  I dont know why but the last test result didnt have the templates added in 7.0.200 for net 10, maybe they were not updated and it got temporarily removed. I couldnt find that in the history, though, so I've added them now that theyre showing up.

I dont think this test will pass because there is a whitespace output change as well. Im not sure if that applies to mac and linux or not. `DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt` will have to be updated and `DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt` will have to be with the new templates, if those fail, otherwise if the legacy tests also fail, they will have to be updated with the new templates and new whitespace.
You could just run the test in a vm and copy paste, worst case.