### PR TITLE
Support Interactive without setting verbosity explicitly in dotnet tool restore Fixes #22987

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -698,6 +698,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             try
             {
                 SourceRepository repository = GetSourceRepository(source);
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGetConsoleLogger(), !_restoreActionConfig.Interactive);
                 PackageMetadataResource resource = await repository
                     .GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
 

--- a/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             _configFilePath = result.GetValue(ToolRestoreCommandParser.ConfigOption);
             _sources = result.GetValue(ToolRestoreCommandParser.AddSourceOption);
             _verbosity = result.GetValue(ToolRestoreCommandParser.VerbosityOption);
-            if (!result.HasOption(ToolRestoreCommandParser.VerbosityOption))
+            if (!result.HasOption(ToolRestoreCommandParser.VerbosityOption) && result.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption))
             {
                 _verbosity = VerbosityOptions.minimal;
             }

--- a/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolManifest;
@@ -24,6 +25,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
         private readonly string[] _sources;
         private readonly IToolPackageDownloader _toolPackageDownloader;
         private readonly VerbosityOptions _verbosity;
+        private readonly RestoreActionConfig _restoreActionConfig;
 
         public ToolRestoreCommand(
             ParseResult result,
@@ -61,6 +63,15 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             _configFilePath = result.GetValue(ToolRestoreCommandParser.ConfigOption);
             _sources = result.GetValue(ToolRestoreCommandParser.AddSourceOption);
             _verbosity = result.GetValue(ToolRestoreCommandParser.VerbosityOption);
+            if (!result.HasOption(ToolRestoreCommandParser.VerbosityOption))
+            {
+                _verbosity = VerbosityOptions.minimal;
+            }
+
+            _restoreActionConfig = new RestoreActionConfig(DisableParallel: result.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+                NoCache: result.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption) || result.GetValue(ToolCommandRestorePassThroughOptions.NoHttpCacheOption),
+                IgnoreFailedSources: result.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
+                Interactive: result.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
         }
 
         public override int Execute()
@@ -130,7 +141,11 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                             nugetConfig: configFile,
                             additionalFeeds: _sources,
                             rootConfigDirectory: package.FirstEffectDirectory),
-                        package.PackageId, verbosity: _verbosity, ToVersionRangeWithOnlyOneVersion(package.Version), targetFramework
+                        package.PackageId,
+                        verbosity: _verbosity,
+                        ToVersionRangeWithOnlyOneVersion(package.Version),
+                        targetFramework,
+                        restoreActionConfig: _restoreActionConfig
                         );
 
                 if (!ManifestCommandMatchesActualInPackage(package.CommandNames, [toolPackage.Command]))


### PR DESCRIPTION
Fixes #22987

We don't currently pass a RestoreActionConfig from ToolRestoreCommand to the ToolPackageDownloader (and by extension the NuGetPackageDownloader) we actually use to install the tool. This corrects that error.

Additionally, the default verbosity is quiet. When the interactive flag is passed, that effectively suppresses it. This increases the default verbosity from quiet to minimal when interactive is requested.