### PR TITLE
Remove global usings from projects building source packages

### DIFF
--- a/sdk.sln
+++ b/sdk.sln
@@ -514,7 +514,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebTools.AspireSe
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.HotReload.Agent", "src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.shproj", "{418B10BD-CA42-49F3-8F4A-D8CC90C8A17D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.HotReload.Agent.Package", "src\BuiltInTools\HotReloadAgent.Package\Microsoft.DotNet.HotReload.Agent.Package.csproj", "{2FF79F82-60C1-349A-4726-7783D5A6D5DF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.HotReload.Agent.Package", "src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.Package.csproj", "{2FF79F82-60C1-349A-4726-7783D5A6D5DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1172,7 +1172,6 @@ Global
 		src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems*{0a3c9afd-f6e6-4a5d-83fb-93bf66732696}*SharedItemsImports = 5
 		src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems*{1bbfa19c-03f0-4d27-9d0d-0f8172642107}*SharedItemsImports = 5
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{1f0b4b3c-dc88-4740-b04f-1707102e9930}*SharedItemsImports = 5
-		src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems*{2ff79f82-60c1-349a-4726-7783d5a6d5df}*SharedItemsImports = 5
 		src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems*{418b10bd-ca42-49f3-8f4a-d8cc90c8a17d}*SharedItemsImports = 13
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{445efbd5-6730-4f09-943d-278e77501ffd}*SharedItemsImports = 5
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{94c8526e-dcc2-442f-9868-3dd0ba2688be}*SharedItemsImports = 13

--- a/src/BuiltInTools/AspireService/AspireServerService.cs
+++ b/src/BuiltInTools/AspireService/AspireServerService.cs
@@ -1,12 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -81,7 +86,7 @@ internal partial class AspireServerService : IAsyncDisposable
         _certificateEncodedBytes = Convert.ToBase64String(certBytes);
 
         // Kick of the web server.
-        _requestListener = StartListening();
+        _requestListener = StartListeningAsync();
     }
 
     public async ValueTask DisposeAsync()
@@ -178,7 +183,7 @@ internal partial class AspireServerService : IAsyncDisposable
     /// Waits for a connection so that it can get the WebSocket that will be used to send messages tio the client. It accepts messages via Restful http
     /// calls.
     /// </summary>
-    private Task StartListening()
+    private Task StartListeningAsync()
     {
         var builder = WebApplication.CreateSlimBuilder();
 

--- a/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
+++ b/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
 namespace Aspire.Tools.Service;
 
 internal interface IAspireServerEvents

--- a/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
+++ b/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 

--- a/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Aspire.Tools.Service;
 
 internal static class ExceptionExtensions

--- a/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
+++ b/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
+++ b/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
+++ b/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Net.WebSockets;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Microsoft.WebTools.AspireService.Package.csproj
+++ b/src/BuiltInTools/AspireService/Microsoft.WebTools.AspireService.Package.csproj
@@ -22,4 +22,9 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
+  <!-- Make sure the shared source files do not require any global usings -->
+  <ItemGroup>
+    <Using Remove="@(Using)"/>
+  </ItemGroup>
 </Project>

--- a/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
+++ b/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/HotReloadAgent.Package/Microsoft.DotNet.HotReload.Agent.Package.csproj
+++ b/src/BuiltInTools/HotReloadAgent.Package/Microsoft.DotNet.HotReload.Agent.Package.csproj
@@ -22,5 +22,11 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
+  <!-- Make sure the shared source files do not require any global usings -->
+  <ItemGroup>
+    <Using Remove="@(Using)" />
+  </ItemGroup>
+
   <Import Project="..\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems" Label="Shared" />
 </Project>

--- a/src/BuiltInTools/HotReloadAgent/AgentReporter.cs
+++ b/src/BuiltInTools/HotReloadAgent/AgentReporter.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.DotNet.HotReload;
 
 internal sealed class AgentReporter

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Threading;
 
 namespace Microsoft.DotNet.HotReload;
 

--- a/src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj
+++ b/src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj
@@ -27,6 +27,4 @@
   <ItemGroup>
     <Using Remove="@(Using)" />
   </ItemGroup>
-
-  <Import Project="..\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems" Label="Shared" />
 </Project>

--- a/src/BuiltInTools/HotReloadAgent/UpdateDelta.cs
+++ b/src/BuiltInTools/HotReloadAgent/UpdateDelta.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.DotNet.Watch;
+
 internal readonly struct UpdateDelta(Guid moduleId, byte[] metadataDelta, byte[] ilDelta, byte[] pdbDelta, int[] updatedTypes)
 {
     public Guid ModuleId { get; } = moduleId;

--- a/src/BuiltInTools/dotnet-watch.slnf
+++ b/src/BuiltInTools/dotnet-watch.slnf
@@ -7,7 +7,7 @@
       "src\\BuiltInTools\\BrowserRefresh\\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj",
       "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\DotNetWatchTasks\\DotNetWatchTasks.csproj",
-      "src\\BuiltInTools\\HotReloadAgent.Package\\Microsoft.DotNet.HotReload.Agent.Package.csproj",
+      "src\\BuiltInTools\\HotReloadAgent\\Microsoft.DotNet.HotReload.Agent.Package.csproj",
       "src\\BuiltInTools\\HotReloadAgent\\Microsoft.DotNet.HotReload.Agent.shproj",
       "src\\BuiltInTools\\dotnet-watch\\dotnet-watch.csproj",
       "test\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj",


### PR DESCRIPTION
We do not want the code to be forced to use global usings when it adds reference to the source package.