### PR TITLE
Extend build server shutdown tracing

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -41,11 +41,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
             _process.EnableRaisingEvents = true;
 
-#if DEBUG
-            var sw = Stopwatch.StartNew();
+            Stopwatch sw = null;
+            if (CommandLoggingContext.IsVerbose)
+            {
+                sw = Stopwatch.StartNew();
 
-            Reporter.Verbose.WriteLine($"> {FormatProcessInfo(_process.StartInfo)}".White());
-#endif
+                Reporter.Verbose.WriteLine($"> {FormatProcessInfo(_process.StartInfo)}".White());
+            }
+
             using (var reaper = new ProcessReaper(_process))
             {
                 _process.Start();
@@ -69,21 +72,22 @@ namespace Microsoft.DotNet.Cli.Utils
 
             var exitCode = _process.ExitCode;
 
-#if DEBUG
-            var message = string.Format(
-                LocalizableStrings.ProcessExitedWithCode,
-                FormatProcessInfo(_process.StartInfo),
-                exitCode,
-                sw.ElapsedMilliseconds);
-            if (exitCode == 0)
+            if (CommandLoggingContext.IsVerbose)
             {
-                Reporter.Verbose.WriteLine(message.Green());
+                var message = string.Format(
+                    LocalizableStrings.ProcessExitedWithCode,
+                    FormatProcessInfo(_process.StartInfo),
+                    exitCode,
+                    sw.ElapsedMilliseconds);
+                if (exitCode == 0)
+                {
+                    Reporter.Verbose.WriteLine(message.Green());
+                }
+                else
+                {
+                    Reporter.Verbose.WriteLine(message.Red().Bold());
+                }
             }
-            else
-            {
-                Reporter.Verbose.WriteLine(message.Red().Bold());
-            }
-#endif
 
             return new CommandResult(
                 _process.StartInfo,

--- a/src/Cli/dotnet/BuildServer/VBCSCompilerServer.cs
+++ b/src/Cli/dotnet/BuildServer/VBCSCompilerServer.cs
@@ -40,13 +40,16 @@ namespace Microsoft.DotNet.BuildServer
             execute(_commandFactory.Create("exec", [VBCSCompilerPath, s_shutdownArg]), ref errors);
 
             // Shutdown toolset compilers.
+            Reporter.Verbose.WriteLine($"Shutting down '{s_toolsetPackageName}' compilers.");
             var nuGetPackageRoot = SettingsUtility.GetGlobalPackagesFolder(Settings.LoadDefaultSettings(root: null));
             var toolsetPackageDirectory = Path.Join(nuGetPackageRoot, s_toolsetPackageName);
+            Reporter.Verbose.WriteLine($"Enumerating '{toolsetPackageDirectory}'.");
             if (Directory.Exists(toolsetPackageDirectory))
             {
                 foreach (var versionDirectory in Directory.EnumerateDirectories(toolsetPackageDirectory))
                 {
                     var vbcsCompilerPath = Path.Join(versionDirectory, s_vbcsCompilerExeFileName);
+                    Reporter.Verbose.WriteLine($"Found '{vbcsCompilerPath}'.");
                     if (File.Exists(vbcsCompilerPath))
                     {
                         execute(CommandFactoryUsingResolver.Create(vbcsCompilerPath, [s_shutdownArg]), ref errors);


### PR DESCRIPTION
The output might look something like this:

```log
❯ & "D:\sdk-3\.dotnet\dotnet.exe" exec D:\sdk-3\artifacts\bin\dotnet\Debug\net10.0\dotnet.dll build-server shutdown --vbcscompiler
Telemetry is: Disabled
Shutting down VB/C# compiler server...
Running D:\sdk-3\.dotnet\dotnet.exe exec D:\sdk-3\artifacts\bin\dotnet\Debug\net10.0\Roslyn\bincore\VBCSCompiler.dll -shutdown
> D:\sdk-3\.dotnet\dotnet.exe exec D:\sdk-3\artifacts\bin\dotnet\Debug\net10.0\Roslyn\bincore\VBCSCompiler.dll -shutdown
Process ID: 43340
< D:\sdk-3\.dotnet\dotnet.exe exec D:\sdk-3\artifacts\bin\dotnet\Debug\net10.0\Roslyn\bincore\VBCSCompiler.dll -shutdown exited with -2147450751 in 21 ms.
Shutting down 'microsoft.net.sdk.compilers.toolset' compilers.
Enumerating 'C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset'.
Found 'C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.100-preview.7.24365.12\VBCSCompiler.exe'.
Running C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.100-preview.7.24365.12\VBCSCompiler.exe -shutdown
> C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.100-preview.7.24365.12\VBCSCompiler.exe -shutdown
Process ID: 22744
< C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.100-preview.7.24365.12\VBCSCompiler.exe -shutdown exited with 0 in 112 ms.
Found 'C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.101\VBCSCompiler.exe'.
Running C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.101\VBCSCompiler.exe -shutdown
> C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.101\VBCSCompiler.exe -shutdown
Process ID: 23660
< C:\.tools\.nuget\packages\microsoft.net.sdk.compilers.toolset\9.0.101\VBCSCompiler.exe -shutdown exited with 0 in 113 ms.
```