### PR TITLE
Fix manifest artifacts reading

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
@@ -4,89 +4,107 @@
 
 #nullable enable
 
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-namespace Microsoft.DotNet.UnifiedBuild.Tasks
+namespace Microsoft.DotNet.UnifiedBuild.Tasks;
+
+/// <summary>
+/// Get a list of MSBuild Items that represent the packages described in the asset manifests.
+/// </summary>
+public sealed class GetKnownArtifactsFromAssetManifests : Build.Utilities.Task
 {
+    // Common metadata
+    private const string IdAttributeName = "Id";
+    private const string RepoOriginAttributeName = "RepoOrigin";
+    private const string NonShippingAttributeName = "NonShipping";
+    private const string DotNetReleaseShippingAttributeName = "DotNetReleaseShipping";
+
+    // Package metadata
+    private const string PackageElementName = "Package";
+    private const string PackageVersionAttributeName = "Version";
+
+    // Blob metadata
+    private const string BlobElementName = "Blob";
+
     /// <summary>
-    /// Get a list of MSBuild Items that represent the packages described in the asset manifests.
+    /// A list of asset manifests to read.
     /// </summary>
-    public sealed class GetKnownArtifactsFromAssetManifests : Build.Utilities.Task
+    [Required]
+    public required ITaskItem[] AssetManifests { get; set; }
+
+    /// <summary>
+    /// If provided, only artifacts from that repository will be returned.
+    /// </summary>
+    public string? RepoOrigin { get; set; }
+
+    /// <summary>
+    /// The list of known packages including their versions as metadata.
+    /// </summary>
+    [Output]
+    public ITaskItem[]? KnownPackages { get; set; }
+
+    /// <summary>
+    /// The list of known blobs.
+    /// </summary>
+    [Output]
+    public ITaskItem[]? KnownBlobs { get; set; }
+
+    public override bool Execute()
     {
-        // Common metadata
-        private const string IdAttributeName = "Id";
-        private const string RepoOriginAttributeName = "RepoOrigin";
-        private const string NonShippingAttributeName = "NonShipping";
-        private const string DotNetReleaseShippingAttributeName = "DotNetReleaseShipping";
-        
-        // Package metadata
-        private const string PackageElementName = "Package";
-        private const string PackageVersionAttributeName = "Version";
+        XDocument[] xDocuments = AssetManifests
+            .Select(manifest => XDocument.Load(manifest.ItemSpec))
+            .ToArray();
 
-        // Blob metadata
-        private const string BlobElementName = "Blob";
+        KnownPackages = xDocuments
+            .SelectMany(doc => doc.Root!.Descendants(PackageElementName))
+            .Where(ShouldIncludeElement)
+            .Select(package => new TaskItem(package.Attribute(IdAttributeName)!.Value, new Dictionary<string, string>
+            {
+                { PackageVersionAttributeName, package.Attribute(PackageVersionAttributeName)!.Value },
+                { RepoOriginAttributeName, package.Attribute(RepoOriginAttributeName)?.Value ?? string.Empty },
+                { NonShippingAttributeName, package.Attribute(NonShippingAttributeName)?.Value ?? string.Empty },
+                { DotNetReleaseShippingAttributeName, package.Attribute(DotNetReleaseShippingAttributeName)?.Value ?? string.Empty }
+            }))
+            .Distinct(TaskItemManifestEqualityComparer.Instance)
+            .ToArray();
 
-        /// <summary>
-        /// A list of asset manifests to read.
-        /// </summary>
-        [Required]
-        public required ITaskItem[] AssetManifests { get; set; }
+        KnownBlobs = xDocuments
+            .SelectMany(doc => doc.Root!.Descendants(BlobElementName))
+            .Where(ShouldIncludeElement)
+            .Select(blob => new TaskItem(blob.Attribute(IdAttributeName)!.Value, new Dictionary<string, string>
+            {
+                { RepoOriginAttributeName, blob.Attribute(RepoOriginAttributeName)?.Value ?? string.Empty },
+                { NonShippingAttributeName, blob.Attribute(NonShippingAttributeName)?.Value ?? string.Empty },
+                { DotNetReleaseShippingAttributeName, blob.Attribute(DotNetReleaseShippingAttributeName)?.Value ?? string.Empty }
+            }))
+            .Distinct(TaskItemManifestEqualityComparer.Instance)
+            .ToArray();
 
-        /// <summary>
-        /// If provided, only artifacts from that repository will be returned.
-        /// </summary>
-        public string? RepoOrigin { get; set; }
+        return true;
+    }
 
-        /// <summary>
-        /// The list of known packages including their versions as metadata.
-        /// </summary>
-        [Output]
-        public ITaskItem[]? KnownPackages { get; set; }
+    private bool ShouldIncludeElement(XElement element) => string.IsNullOrEmpty(RepoOrigin) || element.Attribute(RepoOriginAttributeName)?.Value == RepoOrigin;
 
-        /// <summary>
-        /// The list of known blobs.
-        /// </summary>
-        [Output]
-        public ITaskItem[]? KnownBlobs { get; set; }
+    sealed class TaskItemManifestEqualityComparer : IEqualityComparer<TaskItem>
+    {
+        public static TaskItemManifestEqualityComparer Instance { get; } = new TaskItemManifestEqualityComparer();
 
-        public override bool Execute()
+        public bool Equals(TaskItem? x, TaskItem? y)
         {
-            XDocument[] xDocuments = AssetManifests
-                .Select(manifest => XDocument.Load(manifest.ItemSpec))
-                .ToArray();
+            if (ReferenceEquals(x, y)) return true;
 
-            KnownPackages = xDocuments
-                .SelectMany(doc => doc.Root!.Descendants(PackageElementName))
-                .Where(ShouldIncludeElement)
-                .Distinct()
-                .Select(package => new TaskItem(package.Attribute(IdAttributeName)!.Value, new Dictionary<string, string>
-                {
-                    { PackageVersionAttributeName, package.Attribute(PackageVersionAttributeName)!.Value },
-                    { RepoOriginAttributeName, package.Attribute(RepoOriginAttributeName)?.Value ?? string.Empty },
-                    { NonShippingAttributeName, package.Attribute(NonShippingAttributeName)?.Value ?? string.Empty },
-                    { DotNetReleaseShippingAttributeName, package.Attribute(DotNetReleaseShippingAttributeName)?.Value ?? string.Empty }
-                }))
-                .ToArray();
+            if (x is null || y is null) return false;
 
-            KnownBlobs = xDocuments
-                .SelectMany(doc => doc.Root!.Descendants(BlobElementName))
-                .Where(ShouldIncludeElement)
-                .Distinct()
-                .Select(blob => new TaskItem(blob.Attribute(IdAttributeName)!.Value, new Dictionary<string, string>
-                {
-                    { RepoOriginAttributeName, blob.Attribute(RepoOriginAttributeName)?.Value ?? string.Empty },
-                    { NonShippingAttributeName, blob.Attribute(NonShippingAttributeName)?.Value ?? string.Empty },
-                    { DotNetReleaseShippingAttributeName, blob.Attribute(DotNetReleaseShippingAttributeName)?.Value ?? string.Empty }
-                }))
-                .ToArray();
+            // For blobs, there's no version metadata so these will be empty.
+            string xVersion = x.GetMetadata(PackageVersionAttributeName);
+            string yVersion = x.GetMetadata(PackageVersionAttributeName);
 
-            return true;
+            return x.ItemSpec == y.ItemSpec && xVersion == yVersion;
         }
 
-        private bool ShouldIncludeElement(XElement element) => RepoOrigin == null || element.Attribute(RepoOriginAttributeName)?.Value == RepoOrigin;
+        public int GetHashCode([DisallowNull] TaskItem obj) => HashCode.Combine(obj.ItemSpec, obj.GetMetadata(PackageVersionAttributeName));
     }
 }

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
**Hide whitespace changes when reviewing**

Fixes the failures in https://dev.azure.com/dnceng/internal/_build/results?buildId=2598401&view=logs&j=012d8f49-bbe9-5cff-0c2d-eb37469742f3&t=a088a11a-052c-5a48-307b-2470eb67bf36

Artifacts were missing from the payload folders because they accidentally got filtered out by the `GetKnownArtifactsFromAssetManifests` task.

Pass a custom equality comparer in so that Distinct actually compares the ItemSpec and the Version metadata instead of just reference equality.

Also change the ShouldIncludeElement method to not filter out when an empty RepoOrigin string is passed in.