### PR TITLE
Do not automatically add nuget.org as a package source when it is absent from nuget.config Fixes #44312

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -2,11 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Utils;
+using NuGet.Configuration;
 
 namespace Microsoft.DotNet.Tools.Common
 {
     public static class PathUtility
     {
+        public static bool CheckForNuGetInNuGetConfig()
+        {
+            var otherFiles = SettingsUtility.GetEnabledSources(Settings.LoadDefaultSettings(Directory.GetCurrentDirectory()));
+            return otherFiles.Any(source => source.SourceUri.Equals("https://api.nuget.org/v3/index.json"));
+        }
+
         public static bool IsPlaceholderFile(string path)
         {
             return string.Equals(Path.GetFileName(path), "_._", StringComparison.Ordinal);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/NuGet/NugetApiManager.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/NuGet/NugetApiManager.cs
@@ -34,9 +34,13 @@ namespace Microsoft.TemplateEngine.Cli.NuGet
             PackageSource? sourceFeed = null,
             CancellationToken cancellationToken = default)
         {
-            if (sourceFeed == null)
+            if (sourceFeed == null && Microsoft.DotNet.Tools.Common.PathUtility.CheckForNuGetInNuGetConfig())
             {
                 sourceFeed = _nugetOrgSource;
+            }
+            else if (sourceFeed is null)
+            {
+                return null;
             }
 
             SourceRepository repository = GetSourceRepository(sourceFeed);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Constraints;
 using Microsoft.TemplateEngine.Abstractions.Installer;
@@ -436,7 +437,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
             else
             {
-                IEnumerable<PackageSource> packageSources = LoadNuGetSources(additionalSources, true);
+                IEnumerable<PackageSource> packageSources = LoadNuGetSources(additionalSources, includeNuGetFeed: PathUtility.CheckForNuGetInNuGetConfig());
 
                 nuGetPackageMetadata = await GetPackageMetadataFromMultipleFeedsAsync(packageSources, nugetApiManager, packageIdentity, packageVersion, cancellationToken).ConfigureAwait(false);
                 if (nuGetPackageMetadata != null && nuGetPackageMetadata.Source.Source.Equals(NugetOrgFeed))

--- a/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
@@ -197,7 +197,9 @@
     <comment>Table lable</comment>
   </data>
   <data name="NeedNuGetInConfig" xml:space="preserve">
-    <value>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</value>
-    <comment>Do not translate 'dotnet tool search' or 'nuget.config'</comment>
+    <value>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</value>
+    <comment>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</comment>
   </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/LocalizableStrings.resx
@@ -196,4 +196,8 @@
     <value>Version</value>
     <comment>Table lable</comment>
   </data>
+  <data name="NeedNuGetInConfig" xml:space="preserve">
+    <value>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</value>
+    <comment>Do not translate 'dotnet tool search' or 'nuget.config'</comment>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/ToolSearchCommand.cs
@@ -5,6 +5,8 @@ using System.CommandLine;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.NugetSearch;
+using Microsoft.DotNet.Tools.Common;
+using NuGet.Configuration;
 
 namespace Microsoft.DotNet.Tools.Tool.Search
 {
@@ -26,6 +28,12 @@ namespace Microsoft.DotNet.Tools.Tool.Search
         public override int Execute()
         {
             var isDetailed = _parseResult.GetValue(ToolSearchCommandParser.DetailOption);
+            if (!PathUtility.CheckForNuGetInNuGetConfig())
+            {
+                Reporter.Output.WriteLine(LocalizableStrings.NeedNuGetInConfig);
+                return 0;
+            }
+
             NugetSearchApiParameter nugetSearchApiParameter = new(_parseResult);
             IReadOnlyCollection<SearchResultPackage> searchResultPackages =
                 NugetSearchApiResultDeserializer.Deserialize(

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nejnovější verze</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Nenašly se žádné výsledky.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.cs.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Aktuelle Version</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Es wurden keine Ergebnisse gefunden.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.de.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Última versión</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">No se encontró ningún resultado.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Dernière version</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Résultats introuvables.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Ultima versione</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Non è stato possibile trovare risultati.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.it.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">最新バージョン</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">結果が見つかりませんでした。</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">최신 버전</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">결과를 찾을 수 없습니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Najnowsza wersja</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Nie można znaleźć żadnych wyników.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pl.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Última Versão</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Não foi possível localizar nenhum resultado.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.pt-BR.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Последняя версия</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Ничего не найдено.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.ru.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">En Son Sürüm</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">Sonuç bulunamadı.</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.tr.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">最新版本</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">找不到任何结果。</target>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hans.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
@@ -48,9 +48,13 @@
         <note>Table lable</note>
       </trans-unit>
       <trans-unit id="NeedNuGetInConfig">
-        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
-        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
-        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.
+    This can be done with this command:
+  dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'. Do not localize the last line at all.</note>
       </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>

--- a/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-tool/search/xlf/LocalizableStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">最新版本</target>
         <note>Table lable</note>
       </trans-unit>
+      <trans-unit id="NeedNuGetInConfig">
+        <source>The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</source>
+        <target state="new">The 'dotnet tool search' command unconditionally accesses nuget.org to find tools, but it is not present in your nuget.config. Add it to run this command.</target>
+        <note>Do not translate 'dotnet tool search' or 'nuget.config'</note>
+      </trans-unit>
       <trans-unit id="NoResult">
         <source>Could not find any results.</source>
         <target state="translated">找不到任何結果。</target>

--- a/test/dotnet-new.Tests/DotnetNewDetailsTest.Approval.cs
+++ b/test/dotnet-new.Tests/DotnetNewDetailsTest.Approval.cs
@@ -31,14 +31,27 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         [Fact]
         public Task CanDisplayDetails_RemotePackage_NuGetFeedNoVersion()
         {
-            CommandResult commandResult = new DotnetNewCommand(_log, "details", _nuGetPackageId)
-            .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
-                .WithWorkingDirectory(CreateTemporaryFolder())
+            var folder = CreateTemporaryFolder();
+
+            var createCommandResult = () => new DotnetNewCommand(_log, "details", _nuGetPackageId)
+                .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
+                .WithWorkingDirectory(folder)
                 .Execute();
 
-            commandResult
-                .Should()
-                .Pass();
+            createCommandResult().Should().Fail();
+
+            File.WriteAllText(Path.Combine(folder, "NuGet.Config"), @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" />
+  </packageSources>
+</configuration>
+");
+
+            var commandResult = createCommandResult();
+
+            commandResult.Should().Pass();
 
             return Verify(commandResult.StdOut);
         }


### PR DESCRIPTION
Fixes #44312

If a user doesn't have nuget.org as a source in their nuget.config, we shouldn't assume they want it. This sends a message for dotnet tool search if nuget.org is absent, as it is needed for dotnet tool search to work properly, instead of running the command. For other commands like dotnet new details, it does not automatically add nuget.org to the sources.

![image](https://github.com/user-attachments/assets/48083b8f-1b16-4e53-a26e-960e198343e2)

![image](https://github.com/user-attachments/assets/39b13466-76bf-4404-99b4-5d231fa2d195)

(Neither command implicitly went to nuget.org.)