### PR TITLE
Initialization Stopwatch class

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
             _process.EnableRaisingEvents = true;
 
-            Stopwatch sw = null;
+            Stopwatch sw = new Stopwatch();
             if (CommandLoggingContext.IsVerbose)
             {
                 sw = Stopwatch.StartNew();


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4803

This is a regression caused by https://github.com/dotnet/sdk/pull/45393