### PR TITLE
Enable ASP.NET Core installers on Linux in the VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -13,7 +13,7 @@
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)BuildInstallers</BuildActions>
     <BuildActions Condition="'$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-installers</BuildActions>
     <!-- In a source-only build, we don't pass -all, so we need to explicitly opt-in to managed components here. -->
-    <BuildActions Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(BuildOS)' == 'linux'">$(FlagParameterPrefix)build-managed</BuildActions>
+    <BuildActions Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-managed</BuildActions>
 
     <!-- aspnetcore must be built with desktop msbuild but defaults to dotnet build. -->
     <BuildArgs Condition="'$(BuildOS)' == 'windows'">$(BuildArgs) -msbuildEngine vs</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -12,6 +12,8 @@
     <!-- Enable building installers on Windows and Linux. ASP.NET Core doesn't produce installers on Mac -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)BuildInstallers</BuildActions>
     <BuildActions Condition="'$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-installers</BuildActions>
+    <!-- In a source-only build, we don't pass -all, so we need to explicitly opt-in to managed components here. -->
+    <BuildActions Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(BuildOS)' == 'linux'">$(FlagParameterPrefix)build-managed</BuildActions>
 
     <!-- aspnetcore must be built with desktop msbuild but defaults to dotnet build. -->
     <BuildArgs Condition="'$(BuildOS)' == 'windows'">$(BuildArgs) -msbuildEngine vs</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -9,9 +9,9 @@
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) -NativeToolsOnMachine</BuildActions>
     <!-- On non-windows, we don't have the JDK available and don't need to build those projects anyway because they are not consumed downstream. -->
     <BuildActions Condition="'$(BuildOS)' != 'windows'">$(BuildActions) $(FlagParameterPrefix)no-build-java</BuildActions>
-    <!-- Enable building installers on Windows. We can't build installers on Linux until https://github.com/dotnet/aspnetcore/pull/58612 as been merged and flows -->
+    <!-- Enable building installers on Windows and Linux. ASP.NET Core doesn't produce installers on Mac -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)BuildInstallers</BuildActions>
-    <!-- <BuildActions Condition="'$(BuildOS)' != 'windows'">$(BuildActions) $(FlagParameterPrefix)build-installers</BuildActions> -->
+    <BuildActions Condition="'$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-installers</BuildActions>
 
     <!-- aspnetcore must be built with desktop msbuild but defaults to dotnet build. -->
     <BuildArgs Condition="'$(BuildOS)' == 'windows'">$(BuildArgs) -msbuildEngine vs</BuildArgs>


### PR DESCRIPTION
The new tooling has flowed, so we can enable this now.

Fixes dotnet/source-build#4692