### PR TITLE
Make sure that sdk manifest has RepoOrigin attribute

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -14,7 +14,6 @@
     <SdkAssetManifestFileName>$(OS)-$(PlatformName)-SdkAssets$(SdkAssetManifestBuildPass).xml</SdkAssetManifestFileName>
     <SdkAssetsManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(SdkAssetManifestFileName)</SdkAssetsManifestFilePath>
 
-    <TempWorkingDirectory>$(ArtifactsDir)\AssetsTmpDir\$([System.Guid]::NewGuid())</TempWorkingDirectory>
     <PublishBinariesAndBadge Condition=" '$(PublishBinariesAndBadge)' == '' ">true</PublishBinariesAndBadge>
 
     <IsStableBuild>false</IsStableBuild>
@@ -102,16 +101,15 @@
       <ItemsToSignPostBuild Include="@(ToolsetAssetsToPublish->'%(Filename)%(Extension)')" />
     </ItemGroup>
 
-    <MakeDir Directories="$(TempWorkingDirectory)" />
-
     <PushToBuildStorage
+      PublishFlatContainer="true"
       AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
       AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
       AzureDevOpsBuildId="$(BUILD_BUILDID)"
       ItemsToPush="@(ToolsetAssetsToPushToBlobFeed)"
       ItemsToSign="@(ItemsToSignPostBuild)"
-      CertificatesSignInfo="@(CertificatesSignInfo)"
       StrongNameSignInfo="@(StrongNameSignInfo)"
+      CertificatesSignInfo="@(CertificatesSignInfo)"
       FileSignInfo="@(FileSignInfo)"
       FileExtensionSignInfo="@(FileExtensionSignInfo)"
       ManifestBuildData="@(ManifestBuildData)"
@@ -119,37 +117,31 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
-      PublishFlatContainer="true"
-      AssetManifestPath="$(SdkAssetsManifestFilePath)"
-      AssetsTemporaryDirectory="$(TempWorkingDirectory)"
+      ManifestRepoOrigin="$(GitHubRepositoryName)"
       IsStableBuild="$(IsStableBuild)"
+      PublishingVersion="$(PublishingVersion)"
+      AssetManifestPath="$(SdkAssetsManifestFilePath)"
+      IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"
       PushToLocalStorage="$(PushToLocalStorage)"
       AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
       ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"
       NonShippingPackagesLocalStorageDir="$(SourceBuiltNonShippingPackagesDir)"
       AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)" />
-
-    <Copy SourceFiles="$(SdkAssetsManifestFilePath)" DestinationFolder="$(TempWorkingDirectory)\$(SdkAssetManifestFileName)" />
-
-    <Message Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDirectory)/$(SdkAssetManifestFileName)" Importance="high" />
   </Target>
 
   <PropertyGroup>
-      <!--
-        Because we may be building in a container, we should use an asset manifest file path that exists in the container. Disambiguate the manifests via available properties.
-        AGENT_OS and SYSTEM_PHASENAME are present on Azure DevOps agents. AssetManifestOS will also be used by arcade to generate the name of the manifest file name for the built in publishing.
-      -->
-      <AssetManifestOS Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)</AssetManifestOS>
-      <AssetManifestOS Condition="'$(AGENT_OS)' == ''">$(OS)</AssetManifestOS>
-      <AssetManifestOS Condition="'$(SYSTEM_PHASENAME)' != ''">$(AssetManifestOS)-$(SYSTEM_PHASENAME)</AssetManifestOS>
-      <BaseAssetManifestFileName>$(AssetManifestOS)</BaseAssetManifestFileName>
-      <BaseAssetManifestFileName Condition="'$(SYSTEM_PHASENAME)' == '' and '$(Architecture)' != ''">$(AssetManifestOS)-$(Architecture)</BaseAssetManifestFileName>
-      <InstallersAssetManifestFileName>$(BaseAssetManifestFileName)-installers$(SdkAssetManifestBuildPass)</InstallersAssetManifestFileName>
-      <!-- Property AssetManifestFilePath would be reassigned by the Arcade SDK, so use a different name (InstallersAssetManifestFilePath) -->
-      <InstallersAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(InstallersAssetManifestFileName).xml</InstallersAssetManifestFilePath>
-
-      <DotnetTempWorkingDirectory>$(ArtifactsDir)..\DotnetAssetsTmpDir\$([System.Guid]::NewGuid())</DotnetTempWorkingDirectory>
-      <ChecksumTempWorkingDirectory>$(ArtifactsDir)..\ChecksumAssetsTmpDir\$([System.Guid]::NewGuid())</ChecksumTempWorkingDirectory>
+    <!--
+      Because we may be building in a container, we should use an asset manifest file path that exists in the container. Disambiguate the manifests via available properties.
+      AGENT_OS and SYSTEM_PHASENAME are present on Azure DevOps agents. AssetManifestOS will also be used by arcade to generate the name of the manifest file name for the built in publishing.
+    -->
+    <AssetManifestOS Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)</AssetManifestOS>
+    <AssetManifestOS Condition="'$(AGENT_OS)' == ''">$(OS)</AssetManifestOS>
+    <AssetManifestOS Condition="'$(SYSTEM_PHASENAME)' != ''">$(AssetManifestOS)-$(SYSTEM_PHASENAME)</AssetManifestOS>
+    <BaseAssetManifestFileName>$(AssetManifestOS)</BaseAssetManifestFileName>
+    <BaseAssetManifestFileName Condition="'$(SYSTEM_PHASENAME)' == '' and '$(Architecture)' != ''">$(AssetManifestOS)-$(Architecture)</BaseAssetManifestFileName>
+    <InstallersAssetManifestFileName>$(BaseAssetManifestFileName)-installers$(SdkAssetManifestBuildPass)</InstallersAssetManifestFileName>
+    <!-- Property AssetManifestFilePath would be reassigned by the Arcade SDK, so use a different name (InstallersAssetManifestFilePath) -->
+    <InstallersAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(InstallersAssetManifestFileName).xml</InstallersAssetManifestFilePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -222,23 +214,26 @@
     </ItemGroup>
 
     <PushToBuildStorage
+      PublishFlatContainer="true"
       AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
       AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
       AzureDevOpsBuildId="$(BUILD_BUILDID)"
       ItemsToPush="@(SdkAssetsToPushToBlobFeed);@(ChecksumsToPushToBlobFeed)"
       ItemsToSign="@(ItemsToSignPostBuild)"
-      CertificatesSignInfo="@(CertificatesSignInfo)"
       StrongNameSignInfo="@(StrongNameSignInfo)"
+      CertificatesSignInfo="@(CertificatesSignInfo)"
       FileSignInfo="@(FileSignInfo)"
       FileExtensionSignInfo="@(FileExtensionSignInfo)"
       ManifestBuildData="@(ManifestBuildData)"
-      ManifestRepoName="$(BUILD_REPOSITORY_NAME)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
-      AssetManifestPath="$(InstallersAssetManifestFilePath)"
-      PublishFlatContainer="true"
+      ManifestRepoOrigin="$(GitHubRepositoryName)"
       IsStableBuild="$(IsStableBuild)"
+      PublishingVersion="$(PublishingVersion)"
+      AssetManifestPath="$(InstallersAssetManifestFilePath)"
+      IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"
       PushToLocalStorage="$(PushToLocalStorage)"
       AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
       ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -542,7 +542,7 @@
     <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="'$(LogManifestNotFoundError)' == 'true' and '$(MinimalConsoleLogOutput)' == 'true' and Exists('$(RepoConsoleLogFile)')" />
     <Error Text="No repository asset manifest files found at '$(RepoAssetManifestsDir)*.xml'. This often means the build failed but did not log an error." Condition="'$(LogManifestNotFoundError)' == 'true'" />
 
-    <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifest)" RepoOrigin="$(RepositoryName)">
+    <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifest)">
       <Output TaskParameter="KnownPackages" ItemName="ProducedPackage" />
       <Output TaskParameter="KnownBlobs" ItemName="ProducedAsset" />
     </GetKnownArtifactsFromAssetManifests>
@@ -555,7 +555,7 @@
       </ProducedPackage>
 
       <!-- When building from source, the Private.SourceBuilt.Artifacts archive already contains the nuget packages. -->
-      <BinPlaceFile Include="@(ProducedPackage->'$(ArtifactsPackagesDir)%(ShippingFolder)/%(RepoOrigin)/%(Identity).%(Version).nupkg')" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+      <BinPlaceFile Include="@(ProducedPackage->'$(ArtifactsPackagesDir)%(ShippingFolder)/$(RepositoryName)/%(Identity).%(Version).nupkg')" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <BinPlaceFile Include="@(ProducedAsset->'$(ArtifactsAssetsDir)%(Identity)')" />
     </ItemGroup>
 


### PR DESCRIPTION
And update GetProducedPackages target to not depend on that attribute when just looking at the repo manifest files.

I also updated the `PushToBuildStorage` task invocations so that they are in sync with the Arcade one (in Publish.proj). These should eventually just get removed, they aren't necessary.

Excerpt from a vertical manifest **before** this change:
```xml
<Blob Id="Runtime/10.0.0-alpha.1.24610.2/productVersion.txt" DotNetReleaseShipping="true" RepoOrigin="runtime"/>
<Blob Id="Runtime/10.0.0-alpha.1.24610.2/runtime-productVersion.txt" DotNetReleaseShipping="true" RepoOrigin="runtime"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-100templates-10.0.100-alpha.1.24612.1-win-x86.msi" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-100templates-10.0.100-alpha.1.24612.1-win-x86.msi.wixpack.zip" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdk-10.0.100-alpha.1.24612.1-win-x86.zip" DotNetReleaseShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdk-10.0.100-alpha.1.24612.1-win-x86.zip.sha512" DotNetReleaseShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdk-internal-10.0.100-alpha.1.24612.1-win-x86.msi" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdk-internal-10.0.100-alpha.1.24612.1-win-x86.msi.wixpack.zip" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdkplaceholder-10.0.100-alpha.1.24612.1-win-x86.msi" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-sdkplaceholder-10.0.100-alpha.1.24612.1-win-x86.msi.wixpack.zip" NonShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-toolset-internal-10.0.100-alpha.1.24612.1.zip"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/dotnet-toolset-langpack-10.0.100-alpha.1.24612.1.zip"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/productCommit-win-x86.json" DotNetReleaseShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/productCommit-win-x86.txt" DotNetReleaseShipping="true"/>
<Blob Id="Sdk/10.0.100-alpha.1.24612.1/win_x86_Release_version_badge.svg" DotNetReleaseShipping="true"/>
<Blob Id="WindowsDesktop/10.0.0-alpha.1.24607.1/productVersion.txt" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop"/>
<Blob Id="WindowsDesktop/10.0.0-alpha.1.24607.1/windowsdesktop-productVersion.txt" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop"/>
```

**This fixes the broken "Final Build Pass" step in the VMR official build. See https://dnceng.visualstudio.com/internal/_build/results?buildId=2600419&view=results as an example.**