### PR TITLE
Enable dotnet/sdk debs and rpms in the VMR

### DIFF
--- a/documentation/package-table.md
+++ b/documentation/package-table.md
@@ -163,21 +163,6 @@ Reference notes:
 [linux-arm64-targz-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
-[rhel-6-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
-[rhel-6-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
-
-[rhel-6-badge-9.0.2XX]: https://aka.ms/dotnet/9.0.2xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
-[rhel-6-version-9.0.2XX]: https://aka.ms/dotnet/9.0.2xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-9.0.2XX]: https://aka.ms/dotnet/9.0.2xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-9.0.2XX]: https://aka.ms/dotnet/9.0.2xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
-
-[rhel-6-badge-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
-[rhel-6-version-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-9.0.1XX]: https://aka.ms/dotnet/9.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
-
 [linux-musl-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-musl-x64.txt
 [linux-musl-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz

--- a/src/Installer/pkg/dotnet-sdk.proj
+++ b/src/Installer/pkg/dotnet-sdk.proj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <SkipBuild Condition="'$(BuildSdkDeb)' != 'true' and '$(IsRPMBasedDistro)' != 'true'">true</SkipBuild>
+    <BuildSdkRpm Condition="'$(BuildSdkRpm)' == '' and '$(IsRPMBasedDistro)' == 'true'">true</BuildSdkRpm>
+    <SkipBuild Condition="'$(BuildSdkDeb)' != 'true' and '$(BuildSdkRpm)' != 'true'">true</SkipBuild>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <GenerateInstallers>true</GenerateInstallers>
     <BuildDebPackage Condition="'$(BuildSdkDeb)' == 'true'">true</BuildDebPackage>
-    <BuildRpmPackage Condition="'$(IsRPMBasedDistro)' == 'true'">true</BuildRpmPackage>
+    <BuildRpmPackage Condition="'$(BuildSdkRpm)' == 'true'">true</BuildRpmPackage>
     <UseArcadeRpmTooling>true</UseArcadeRpmTooling>
     <ProductBrandPrefix>Microsoft .NET</ProductBrandPrefix>
     <LicenseFile>$(RepoRoot)LICENSE.TXT</LicenseFile>

--- a/src/Installer/redist-installer/targets/Badge.targets
+++ b/src/Installer/redist-installer/targets/Badge.targets
@@ -20,7 +20,6 @@
   <Target Name="SetBadgeProps" DependsOnTargets="GetCurrentRuntimeInformation">
     <PropertyGroup>
       <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition=" '$(Rid)' == 'rhel.6-x64' ">rhel.6_x64</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(Rid)' == 'linux-musl-x64' ">linux_musl_x64</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IslinuxPortable)' == 'true' ">linux_$(Architecture)</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true' ">all_linux_distros_native_installer</VersionBadgeMoniker>

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -154,7 +154,6 @@
         linux-musl-x64;
         linux-x64;
         osx-x64;
-        rhel.6-x64;
         tizen.4.0.0-armel;
         tizen.5.0.0-armel;
         win-arm;
@@ -440,8 +439,7 @@
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
 
       <_KnownRuntimeIdentiferPlatforms Include="any;aot;freebsd;illumos;solaris;unix" />
-      <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6;tizen.4.0.0;tizen.5.0.0" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
-      <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6" Condition="'$(DotNetBuildSourceOnly)' == 'true' and !$(ProductMonikerRid.StartsWith('rhel.6-'))" />
+      <_ExcludedKnownRuntimeIdentiferPlatforms Include="tizen.4.0.0;tizen.5.0.0" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
       <_ExcludedKnownRuntimeIdentiferPlatforms Include="tizen.4.0.0" Condition="'$(DotNetBuildSourceOnly)' == 'true' and !$(ProductMonikerRid.StartsWith('tizen.4.0.0-'))" />
       <_ExcludedKnownRuntimeIdentiferPlatforms Include="tizen.5.0.0" Condition="'$(DotNetBuildSourceOnly)' == 'true' and !$(ProductMonikerRid.StartsWith('tizen.5.0.0-'))" />
     </ItemGroup>

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -84,7 +84,6 @@
       <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
 
       <AspNetCoreInstallerRid Condition="'$(AspNetCoreInstallerRid)' == ''">$(SharedFrameworkRid)</AspNetCoreInstallerRid>
-      <AspNetCoreInstallerRid Condition="'$(SharedFrameworkRid)' == 'rhel.6-x64'">linux-x64</AspNetCoreInstallerRid>
       <AspNetCoreArchiveRid>$(AspNetCoreInstallerRid)</AspNetCoreArchiveRid>
       <AspNetCoreInstallerRid Condition="('$(InstallerExtension)' == '.deb' OR '$(InstallerExtension)' == '.rpm') AND '$(Architecture)' != 'arm64'">x64</AspNetCoreInstallerRid>
       <AspNetCoreInstallerRid Condition="'$(InstallerExtension)' == '.rpm' AND '$(Architecture)' == 'arm64'">aarch64</AspNetCoreInstallerRid>

--- a/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
+++ b/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
@@ -38,22 +38,15 @@
       <PortableProductMonikerRid Condition=" '$(PortableProductMonikerRid)' == '' ">$(PortableRid)</PortableProductMonikerRid>
 
       <ArtifactNameSdk>dotnet-sdk-internal$(PgoTerm)</ArtifactNameSdk>
-      <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 
       <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
-      <ArtifactNameWithVersionMSBuildExtensions>dotnet-standard-support-vs2015-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionMSBuildExtensions>
-      <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
+      <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
       <!-- Warning: changing the value "ProductBandCombinedHostHostFxrFrameworkSdkName" can only occur on a product-band boundary [CliProductBandVersion],
                Changing "ProductBandCombinedHostHostFxrFrameworkSdkName" mid-product-band will break the upgradability of the SDK bundle installer. -->
       <ProductBandCombinedHostHostFxrFrameworkSdkName>Dotnet SDK Bundle Installer $(CliProductBandVersion) $(ProductMonikerRid)</ProductBandCombinedHostHostFxrFrameworkSdkName>
 
       <InstallerTargetArchitecture>$(Architecture)</InstallerTargetArchitecture>
       <InstallerTargetArchitecture Condition=" '$(IsRPMBasedDistro)' == 'true' and '$(Architecture)' == 'Arm64' ">aarch64</InstallerTargetArchitecture>
-
-      <DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-$(InstallerTargetArchitecture)</DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
-      <!-- Mariner RPM names -->
-      <MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.1-$(InstallerTargetArchitecture)</MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
-      <Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.2-$(InstallerTargetArchitecture)</Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
     </PropertyGroup>
   </Target>
 

--- a/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
+++ b/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
@@ -26,9 +26,9 @@
 
     <PropertyGroup>
       <IsDebianBaseDistro Condition=" $(HostRid.StartsWith('ubuntu')) OR $(HostRid.StartsWith('debian')) ">true</IsDebianBaseDistro>
-      <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
+      <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel'))">true</IsRPMBasedDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('centos')) ">true</IsRPMBasedDistro>
-      <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND !$(Rid.StartsWith('linux-musl'))">true</PublishNativeInstallers>
+      <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND !$(Rid.StartsWith('linux-musl'))">true</PublishNativeInstallers>
       <PublishArchives Condition=" '$(IslinuxPortable)' == 'true' OR ('$(IsDebianBaseDistro)' != 'true' AND '$(IsRPMBasedDistro)' != 'true') ">true</PublishArchives>
     </PropertyGroup>
 

--- a/src/Installer/redist-installer/targets/SetBuildDefaults.targets
+++ b/src/Installer/redist-installer/targets/SetBuildDefaults.targets
@@ -2,17 +2,13 @@
 
   <Target Name="SetBuildDefaults" DependsOnTargets="GetCurrentRuntimeInformation">
     <PropertyGroup>
-      <!-- Currently, 'arm*' SDK's do not include the LZMA for performance upon extraction of the NuGet archive. -->
-      <!-- https://github.com/dotnet/cli/issues/8800 -->
       <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND
-        ($(Rid.StartsWith('rhel.6'))
-        OR $(Rid.StartsWith('freebsd'))
+        ($(Rid.StartsWith('freebsd'))
         OR $(Rid.StartsWith('illumos'))
-        OR $(Rid.StartsWith('linux-musl'))
-        OR $(Rid.StartsWith('ubuntu.18.04')))">true</SkipBuildingInstallers>
+        OR $(Rid.StartsWith('linux-musl')))">true</SkipBuildingInstallers>
       <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
 
-      <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'True' AND '$(Rid)' != 'rhel.6-x64' AND !$(Rid.StartsWith('linux-musl')) ">true</UsePortableLinuxSharedFramework>
+      <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'True' AND !$(Rid.StartsWith('linux-musl')) ">true</UsePortableLinuxSharedFramework>
       <HighEntropyVA>true</HighEntropyVA>
 
       <PathListSeparator>:</PathListSeparator>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -212,16 +212,17 @@
 
   <!-- Additional pseudo-versions that some repos depend on -->
   <ItemGroup>
-    <!-- we don't produce the Windows version of this package but that's the one core-sdk keys off of for the ASP.NET version -->
+    <!-- we don't produce the Windows version of this package but that's the one sdk keys off of for the ASP.NET version -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimewinx64PackageVersion" Version="%24(MicrosoftAspNetCoreAppRefPackageVersion)" />
     <!-- same thing here for CLI -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimewinx64Version" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
     <!-- same thing here for toolset -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimewinx64PackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
-    <!-- same thing here for core-sdk -->
+    <!-- same thing here for sdk -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimePackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimeVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppHostPackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppHostwinx64PackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
 
     <!-- Used by windowsdesktop to determine msi version -->
     <ExtraPackageVersionPropsPackageInfo Include="VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -29,8 +29,8 @@
     <!-- sdk always wants to build portable on FreeBSD etc. -->
     <BuildArgs Condition="('$(TargetOS)' == 'freebsd' or '$(TargetOS)' == 'solaris') and '$(DotNetBuildSourceOnly)' == 'true'">$(BuildArgs) /p:PortableBuild=true</BuildArgs>
     <BuildArgs Condition="'$(TargetOS)' != 'windows'">$(BuildArgs) /p:NetRuntimeRid=$(TargetRid)</BuildArgs>
-    <!-- https://github.com/dotnet/source-build/issues/4138 -->
-    <BuildArgs Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'osx'">$(BuildArgs) /p:SkipBuildingInstallers=true</BuildArgs>
+
+    <BuildArgs Condition="'$(TargetRid)' == 'linux-x64' or '$(TargetRid)' == 'linux-arm64' ">$(BuildArgs) /p:BuildSdkDeb=true /p:BuildSdkRpm=true</BuildArgs>
     <!-- https://github.com/dotnet/source-build/issues/4693 -->
     <BuildArgs Condition="'$(TargetOS)' == 'windows' and '$(UseOfficialBuildVersioning)' != 'true'">$(BuildArgs) /p:SkipBuildingInstallers=true /p:SkipBuildingSdkBundle=true</BuildArgs>
 


### PR DESCRIPTION
Also do some cleanup in the installer logic, removing unused properties and RHEL 6 support (which has been out of our support matrix for years at this point).