### PR TITLE
Enable package source mapping

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,13 +8,8 @@
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
-    <add key="dotnet8-workloads" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-workloads/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
@@ -22,13 +17,95 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet-tools-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-transport/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <!-- Used for Rich Navigation indexing task -->
-    <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+  <clear />
+  <packageSource key="dotnet8">
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet8-transport">
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet9">
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet9-transport">
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet10">
+    <package pattern="microsoft.*" />
+    <package pattern="system.*" />
+  </packageSource>
+  <packageSource key="dotnet10-transport">
+    <package pattern="dotnet-dev-certs" />
+    <package pattern="dotnet-user-jwts" />
+    <package pattern="dotnet-user-secrets" />
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet-public">
+    <package pattern="Argon" />
+    <package pattern="Castle.Core" />
+    <package pattern="DiffEngine" />
+    <package pattern="DiffPlex" />
+    <package pattern="EmptyFiles" />
+    <package pattern="FakeItEasy" />
+    <package pattern="FluentAssertions" />
+    <package pattern="FluentAssertions.Json" />
+    <package pattern="FSharp.NET.Sdk" />
+    <package pattern="Humanizer.Core" />
+    <package pattern="MicroBuild.Core" />
+    <package pattern="microsoft.*" />
+    <package pattern="Moq" />
+    <package pattern="NETStandard.Library" />
+    <package pattern="NETStandard.Library.NETFramework" />
+    <package pattern="NETStandard.Library.Ref" />
+    <package pattern="Newtonsoft.Json" />
+    <package pattern="NuGet.Credentials" />
+    <package pattern="NuGet.Resolver" />
+    <package pattern="runtime.*" />
+    <package pattern="SimpleInfoName" />
+    <package pattern="StyleCop.Analyzers" />
+    <package pattern="StyleCop.Analyzers.Unstable" />
+    <package pattern="system.*" />
+    <package pattern="Valleysoft.DockerCredsProvider" />
+    <package pattern="Verify" />
+    <package pattern="Verify.DiffPlex" />
+    <package pattern="Verify.Xunit" />
+    <package pattern="vswhere" />
+    <package pattern="Wcwidth.Sources" />
+    <package pattern="xunit" />
+    <package pattern="xunit.*" />
+  </packageSource>
+  <packageSource key="dotnet-eng">
+    <package pattern="microsoft.*" />
+  </packageSource>
+  <packageSource key="dotnet-tools">
+    <package pattern="MicroBuild.Core.Sentinel" />
+    <package pattern="microsoft.*" />
+    <package pattern="NuGet.Build.Tasks" />
+    <package pattern="NuGet.Build.Tasks.Console" />
+    <package pattern="NuGet.Build.Tasks.Pack" />
+    <package pattern="NuGet.CommandLine.XPlat" />
+    <package pattern="NuGet.Commands" />
+    <package pattern="NuGet.Common" />
+    <package pattern="NuGet.Configuration" />
+    <package pattern="NuGet.Credentials" />
+    <package pattern="NuGet.DependencyResolver.Core" />
+    <package pattern="NuGet.Frameworks" />
+    <package pattern="NuGet.LibraryModel" />
+    <package pattern="NuGet.Localization" />
+    <package pattern="NuGet.Packaging" />
+    <package pattern="NuGet.ProjectModel" />
+    <package pattern="NuGet.Protocol" />
+    <package pattern="NuGet.Versioning" />
+    <package pattern="sn" />
+  </packageSource>
+  <packageSource key="dotnet-libraries">
+    <package pattern="system.*" />
+  </packageSource>
+</packageSourceMapping>
   <disabledPackageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->

--- a/NuGet.config
+++ b/NuGet.config
@@ -55,6 +55,7 @@
     <package pattern="FluentAssertions.Json" />
     <package pattern="FSharp.NET.Sdk" />
     <package pattern="Humanizer.Core" />
+    <package pattern="Libuv" />
     <package pattern="MicroBuild.Core" />
     <package pattern="microsoft.*" />
     <package pattern="Moq" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -22,6 +22,12 @@
   </packageSources>
   <packageSourceMapping>
   <clear />
+  <packageSource key="nugetcache">
+    <package pattern="*" />
+  </packageSource>
+  <packageSource key="testpackages">
+    <package pattern="*" />
+  </packageSource>
   <packageSource key="dotnet8">
     <package pattern="microsoft.*" />
   </packageSource>
@@ -38,6 +44,7 @@
     <package pattern="microsoft.*" />
     <package pattern="runtime.*" />
     <package pattern="system.*" />
+    <package pattern="FSharp.*" />
   </packageSource>
   <packageSource key="dotnet10-transport">
     <package pattern="dotnet-dev-certs" />
@@ -91,6 +98,7 @@
   <packageSource key="dotnet-tools">
     <package pattern="MicroBuild.Core.Sentinel" />
     <package pattern="microsoft.*" />
+    <package pattern="MSTest.*" />
     <package pattern="NuGet.Build.Tasks" />
     <package pattern="NuGet.Build.Tasks.Console" />
     <package pattern="NuGet.Build.Tasks.Pack" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -36,6 +36,7 @@
   </packageSource>
   <packageSource key="dotnet10">
     <package pattern="microsoft.*" />
+    <package pattern="runtime.*" />
     <package pattern="system.*" />
   </packageSource>
   <packageSource key="dotnet10-transport">
@@ -45,6 +46,7 @@
     <package pattern="microsoft.*" />
   </packageSource>
   <packageSource key="dotnet-public">
+    <package pattern="*" />
     <package pattern="Argon" />
     <package pattern="Castle.Core" />
     <package pattern="DiffEngine" />
@@ -53,12 +55,16 @@
     <package pattern="FakeItEasy" />
     <package pattern="FluentAssertions" />
     <package pattern="FluentAssertions.Json" />
+    <package pattern="FSharp.Core" />
     <package pattern="FSharp.NET.Sdk" />
     <package pattern="Humanizer.Core" />
+    <package pattern="Humanizer" />
     <package pattern="Libuv" />
     <package pattern="MicroBuild.Core" />
     <package pattern="microsoft.*" />
     <package pattern="Moq" />
+    <package pattern="MSTest.TestAdapter" />
+    <package pattern="MSTest.TestFramework" />
     <package pattern="NETStandard.Library" />
     <package pattern="NETStandard.Library.NETFramework" />
     <package pattern="NETStandard.Library.Ref" />

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -33,7 +33,7 @@ dotnet new --debug:ephemeral-hive
 REM We downloaded a special zip of files to the .nuget folder so add that as a source
 dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
 PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure"
-dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile %TestExecutionDirectory%\nuget.config --name nugetcache
 if exist %TestExecutionDirectory%\Testpackages dotnet nuget add source %TestExecutionDirectory%\Testpackages --name testpackages --configfile %TestExecutionDirectory%\nuget.config
 
 dotnet nuget remove source dotnet6-transport --configfile %TestExecutionDirectory%\nuget.config

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -22,8 +22,8 @@ dotnet new --debug:ephemeral-hive
 
 # We downloaded a special zip of files to the .nuget folder so add that as a source
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
-dotnet nuget add source $DOTNET_ROOT/.nuget --configfile $TestExecutionDirectory/NuGet.config
-dotnet nuget add source $TestExecutionDirectory/Testpackages --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget add source $DOTNET_ROOT/.nuget --configfile $TestExecutionDirectory/NuGet.config --name nugetcache
+dotnet nuget add source $TestExecutionDirectory/Testpackages --configfile $TestExecutionDirectory/NuGet.config --name testpackages
 #Remove feeds not needed for tests
 dotnet nuget remove source dotnet6-transport --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet6-internal-transport --configfile $TestExecutionDirectory/NuGet.config

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.tmp</DefaultItemExcludes>
+    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <Import Project="..\Directory.Build.props" />


### PR DESCRIPTION
Ran a build and all tests locally with a fresh nuget package cache and then ran https://github.com/NuGet/PackageSourceMapper?tab=readme-ov-file#nuget-package-source-mapper-tool to generate a package source mapping configuration

TODO

- Investigate any broken tests as I likely didn't run all tests and not all passed locally (ie dotnet-format)
- Figure out how this will work with stable feeds come GA time