### PR TITLE
Update owner of artifacts staging directory for offline builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -432,6 +432,13 @@ jobs:
       displayName: Build
       workingDirectory: $(sourcesPath)
 
+    - ${{ if ne(parameters.runOnline, 'True' )}}:
+      - script: |
+          set -ex
+          # Update the owner of the staging directory to the current user
+          sudo chown -R $(whoami) $(artifactsStagingDir)
+        displayName: Update owner of artifacts staging directory
+
     # Only run tests if enabled
     - ${{ if eq(parameters.runTests, 'True') }}:
       # Setup the NuGet sources used by the tests to use private feeds. This is necessary when testing internal-only product


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4801

Example pipeline run with successful SBOM generation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2602750&view=logs&j=982236b9-d2f5-5520-9b78-6920a163a85d&t=843e9abf-9579-5f0e-2feb-5c0e36bc45d7 (internal Microsoft link)