### PR TITLE
[VMR] Disable codeql on arm64 mac builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -181,6 +181,12 @@ jobs:
     value: $(Build.ArtifactStagingDirectory)/artifacts
 
   templateContext:
+    ${{ if eq(parameters.pool.os, 'macOS') }}:
+      sdl:
+        codeql:
+          compiled:
+            enabled: false
+            justificationForDisabling: "CodeQL doesn't work on arm64 macOS, see https://portal.microsofticm.com/imp/v5/incidents/details/532165079/summary"
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
     - output: pipelineArtifact


### PR DESCRIPTION
We can now disable SDL tools at the job level, let's do that for codeql which doesn't work on arm64 macOS right now.