### PR TITLE
Microsoft.NET.Publish.targets GetCopyToPublishDirectoryItems depends on AssignProjectConfiguration

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -792,6 +792,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                             DefaultCopyToPublishDirectoryMetadata;
                             _CreateSingleFileHost;
                             _CreateAppHostForPublish;
+                            AssignProjectConfiguration;
                             _SplitProjectReferencesByFileExistence;
                             _GetProjectReferenceTargetFrameworkProperties">
 


### PR DESCRIPTION
When GetCopyToPublishDirectoryItems is called on its own, the depends tree terminates at _SplitProjectReferencesByFileExistence
![image](https://github.com/user-attachments/assets/4643ef89-6628-44eb-af7d-17ee4131cd0d)
[_SplitProjectReferencesByFileExistence tries to use @(ProjectReferenceWithConfiguration) ](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1642), which is empty, because it is emitted by AssignProjectConfiguration, which isn't actually called.
Add the target to the dependson list to ensure all projectreferences are considered