### PR TITLE
Change Aspire RunSessionRequest definition

### DIFF
--- a/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
+++ b/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
@@ -58,7 +58,7 @@ internal class RunSessionRequest
     public EnvVar[] Environment { get; set; } = Array.Empty<EnvVar>();
 
     [JsonPropertyName("args")]
-    public string[] Arguments { get; set; } = Array.Empty<string>();
+    public string[]? Arguments { get; set; }
 
     public ProjectLaunchRequest? ToProjectLaunchInformation()
     {

--- a/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
@@ -25,6 +25,12 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         env = new List<EnvVar> { new EnvVar { Name = "var1", Value = "value1" } }
     };
 
+    private static readonly TestRunSessionRequest Project2SessionRequest = new TestRunSessionRequest(Project1Path, debugging: false, launchProfile: null, disableLaunchProfile: false)
+    {
+        args = null,
+        env = new List<EnvVar> { new EnvVar { Name = "var1", Value = "value1" } }
+    };
+
     [Fact]
     public async Task SessionStarted_Test()
     {
@@ -102,6 +108,30 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         HttpResponseMessage response;
         response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
+
+        await server.DisposeAsync();
+
+        mocks.Verify();
+    }
+
+    [Fact]
+    public async Task LaunchProject_WithNullArgs_PassesThroughNullArgs()
+    {
+        var mocks = new Mocks();
+
+        mocks.GetOrCreate<IAspireServerEventsMock>()
+             .ImplementStartProjectAsync(DcpId, "2", requireNullArguments: true);
+
+        var server = await GetAspireServer(mocks);
+        var tokens = server.GetServerVariables();
+
+        using HttpClient client = GetHttpClient(tokens);
+
+        HttpResponseMessage response;
+        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project2SessionRequest);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using Moq;
+using Moq.Language.Flow;
 
 namespace Aspire.Tools.Service.UnitTests;
 
@@ -11,19 +12,28 @@ internal class IAspireServerEventsMock : MockFactory<IAspireServerEvents>
     {
     }
 
-    public IAspireServerEventsMock ImplementStartProjectAsync(string dcpId, string sessionId, Exception? ex = null)
+    public IAspireServerEventsMock ImplementStartProjectAsync(string dcpId, string sessionId, Exception? ex = null, bool requireNullArguments = false)
     {
-        MockObject.Setup(x => x.StartProjectAsync(dcpId, It.IsAny<ProjectLaunchRequest>(), It.IsAny<CancellationToken>()))
-                  .Returns(() =>
-                  {
-                        if (ex is not null)
-                        {
-                            throw ex;
-                        }
+        ISetup<IAspireServerEvents, ValueTask<string>> setup;
+        if (requireNullArguments)
+        {
+            setup = MockObject.Setup(x => x.StartProjectAsync(dcpId, It.Is<ProjectLaunchRequest>(plr => plr.Arguments == null), It.IsAny<CancellationToken>()));
+        }
+        else
+        {
+            setup = MockObject.Setup(x => x.StartProjectAsync(dcpId, It.IsAny<ProjectLaunchRequest>(), It.IsAny<CancellationToken>()));
+        }
 
-                        return new ValueTask<string>(sessionId);
-                  })
-                  .Verifiable();
+        setup.Returns(() =>
+        {
+            if (ex is not null)
+            {
+                throw ex;
+            }
+             
+            return new ValueTask<string>(sessionId);
+        }).Verifiable();
+
         return this;
     }
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/6120

Whether or not `args` is null is an important piece of information to the IDE when the json gets deserialized. A value of null would indicate that a user-specified set of command line arguments can be used to launch the project. A non-null value (empty or not) would indicate that the user-specified set of command line arguments should be replaced with those in the array. 

The current model has a default value of `Array.Empty<string>()` which means the IDE will always receive an array of strings regardless of whether the orchestrator passed null.

This issue has been present for a while but was hidden because VS was not properly overriding user-specified command line arguments until 17.12.