### PR TITLE
Make assembly version logic more robust Fixes #44042

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -530,8 +530,8 @@ namespace Microsoft.NET.Build.Tasks
             {
                 var fileName = Path.GetFileNameWithoutExtension(library.Path);
                 var assemblyPath = userRuntimeAssemblies?.FirstOrDefault(p => Path.GetFileNameWithoutExtension(p).Equals(fileName));
-                var runtimeFile = !string.IsNullOrWhiteSpace(assemblyPath) ? CreateRuntimeFile(referenceProjectInfo.OutputName, Path.GetFullPath(assemblyPath)) :
-                                  !string.IsNullOrWhiteSpace(library.Path) ? CreateRuntimeFile(referenceProjectInfo.OutputName, Path.GetFullPath(library.Path)) :
+                var runtimeFile = !string.IsNullOrWhiteSpace(assemblyPath) && File.Exists(assemblyPath) ? CreateRuntimeFile(referenceProjectInfo.OutputName, assemblyPath) :
+                                  !string.IsNullOrWhiteSpace(library.Path) && File.Exists(library.Path) ? CreateRuntimeFile(referenceProjectInfo.OutputName, library.Path) :
                                   new RuntimeFile(referenceProjectInfo.OutputName, string.Empty, string.Empty);
                 runtimeAssemblyGroups.Add(new RuntimeAssetGroup(string.Empty, [runtimeFile]));
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -530,12 +530,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 var fileName = Path.GetFileNameWithoutExtension(library.Path);
                 var assemblyPath = userRuntimeAssemblies?.FirstOrDefault(p => Path.GetFileNameWithoutExtension(p).Equals(fileName));
-                runtimeAssemblyGroups.Add(new RuntimeAssetGroup(string.Empty,
-                    [ new RuntimeFile(
-                        referenceProjectInfo.OutputName,
-                        library.Version.ToString(),
-                        assemblyPath is null || !File.Exists(assemblyPath) ? string.Empty : FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion)
-                    ]));
+                var runtimeFile = !string.IsNullOrWhiteSpace(assemblyPath) ? CreateRuntimeFile(referenceProjectInfo.OutputName, Path.GetFullPath(assemblyPath)) :
+                                  !string.IsNullOrWhiteSpace(library.Path) ? CreateRuntimeFile(referenceProjectInfo.OutputName, Path.GetFullPath(library.Path)) :
+                                  new RuntimeFile(referenceProjectInfo.OutputName, string.Empty, string.Empty);
+                runtimeAssemblyGroups.Add(new RuntimeAssetGroup(string.Empty, [runtimeFile]));
 
                 resourceAssemblies.AddRange(referenceProjectInfo.ResourceAssemblies
                                 .Select(r => new ResourceAssembly(r.RelativePath, r.Culture)));


### PR DESCRIPTION
Fixes #44042

Replaces the way we look for assembly version.

Without change:
![image](https://github.com/user-attachments/assets/22af9701-79c0-4998-ba50-a07b38a3a2fb)

With change:
![image](https://github.com/user-attachments/assets/4a59b022-948f-41db-96fd-da6904955904)
