### PR TITLE
Split tests by method rather than class

### DIFF
--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -94,7 +94,11 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var typeInfo in typeInfoList)
                 {
                     _currentTypeInfoList.Add(typeInfo);
-                    _builder.Append($@"-class ""{typeInfo.FullName}"" ");
+                    if(_builder.Length > 0)
+                    {
+                        var separator = "|";
+                    }
+                    _builder.Append($@"{separator}{typeInfo.FullName}");
                     CheckForPartitionLimit(done: false);
                 }
 

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             var typeInfoList = GetTypeInfoList(assemblyPath);
             var assemblyInfoList = new List<AssemblyPartitionInfo>();
             var partitionList = new List<Partition>();
-            AssemblyInfoBuilder.Build(assemblyPath, _methodLimit, typeInfoList, out partitionList, out assemblyInfoList;
+            AssemblyInfoBuilder.Build(assemblyPath, _methodLimit, typeInfoList, out partitionList, out assemblyInfoList);
 
             // If the scheduling didn't actually produce multiple partition then send back an unpartitioned
             // representation.

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text;
 
 namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 {
@@ -93,13 +94,19 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var typeInfo in typeInfoList)
                 {
                     _currentTypeInfoList.Add(typeInfo);
-
-                    if (_builder.Length > 0)
+                    if (_netFramework)
                     {
-                        _builder.Append("|");
-                    }
-                    _builder.Append($@"{typeInfo.FullName}");
+                        if (_builder.Length > 0)
+                        {
+                            _builder.Append("|");
+                        }
+                        _builder.Append($@"{typeInfo.FullName}");
 
+                    }
+                    else
+                    {
+                        _builder.Append($@"-class ""{typeInfo.FullName}"" ");
+                    }
                     CheckForPartitionLimit(done: false);
                 }
 
@@ -211,22 +218,25 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         private static List<TypeInfo> GetTypeInfoList(MetadataReader reader)
         {
             var list = new List<TypeInfo>();
-            foreach (var handle in reader.TypeDefinitions)
+            foreach (var handle in reader.MethodDefinitions)
             {
-                var type = reader.GetTypeDefinition(handle);
-                if (!IsValidIdentifier(reader, type.Name))
+                var method = reader.GetMethodDefinition(handle);
+
+                var name = reader.GetString(method.Name);
+                if (!IsValidIdentifier(reader, name))
                 {
                     continue;
                 }
 
-                var methodCount = GetMethodCount(reader, type);
-                if (!ShouldIncludeType(reader, type, methodCount))
+                if (!ShouldIncludeMethod(reader, method))
                 {
                     continue;
                 }
 
-                var fullName = GetFullName(reader, type);
-                list.Add(new TypeInfo(fullName, methodCount));
+                var type = reader.GetTypeDefinition(method.GetDeclaringType());
+                var fullName = GetFullName(reader, type) + "." + name;
+                list.Add(new TypeInfo(fullName, 1));
+
             }
 
             // Ensure we get classes back in a deterministic order.
@@ -235,69 +245,47 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         }
 
         /// <summary>
-        /// Determine if this type should be one of the <c>class</c> values passed to xunit.  This
-        /// code doesn't actually resolve base types or trace through inherrited Fact attributes
-        /// hence we have to error on the side of including types with no tests vs. excluding them.
+        /// Determine if this method method values passed to xunit. This doesn't check for skipping
+        /// Include any tests with the known theory and fact attributes
         /// </summary>
-        private static bool ShouldIncludeType(MetadataReader reader, TypeDefinition type, int testMethodCount)
+        private static bool ShouldIncludeMethod(MetadataReader reader, MethodDefinition method)
         {
-            // xunit only handles public, non-abstract, non-generic classes
-            var isPublic =
-                TypeAttributes.Public == (type.Attributes & TypeAttributes.VisibilityMask) ||
-                TypeAttributes.NestedPublic == (type.Attributes & TypeAttributes.VisibilityMask);
-            if (!isPublic ||
-                TypeAttributes.Abstract == (type.Attributes & TypeAttributes.Abstract) ||
-                type.GetGenericParameters().Count != 0 ||
-                TypeAttributes.Class != (type.Attributes & TypeAttributes.ClassSemanticsMask))
-            {
-                return false;
-            }
+                var methodAttributes = method.GetCustomAttributes();
+                bool isTestMethod = false;
 
-            // Compiler generated types / methods have the shape of the heuristic that we are looking
-            // at here.  Filter them out as well.
-            if (!IsValidIdentifier(reader, type.Name))
-            {
-                return false;
-            }
+                foreach (var attributeHandle in methodAttributes)
+                {
+                    var attribute = reader.GetCustomAttribute(attributeHandle);
+                    var attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                    var attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
+                    var attributeTypeName = reader.GetString(attributeType.Name);
 
-            if (testMethodCount > 0)
-            {
-                return true;
-            }
-
-            // The case we still have to consider at this point is a class with 0 defined methods, 
-            // inheritting from a class with > 0 defined test methods.  That is a completely valid
-            // xunit scenario.  For now we're just going to exclude types that inherit from object
-            // because they clearly don't fit that category.
-            return !(InheritsFromObject(reader, type) ?? false);
+                    if (attributeTypeName == "FactAttribute" ||
+                        attributeTypeName == "TheoryAttribute" ||
+                        attributeTypeName == "CoreMSBuildAndWindowsOnlyFactAttribute" ||
+                        attributeTypeName == "CoreMSBuildAndWindowsOnlyTheoryAttribute" ||
+                        attributeTypeName == "CoreMSBuildOnlyFactAttribute" ||
+                        attributeTypeName == "CoreMSBuildOnlyTheoryAttribute" ||
+                        attributeTypeName == "FullMSBuildOnlyFactAttribute" ||
+                        attributeTypeName == "FullMSBuildOnlyTheoryAttribute" ||
+                        attributeTypeName == "PlatformSpecificFact" ||
+                        attributeTypeName == "PlatformSpecificTheory" ||
+                        attributeTypeName == "RequiresMSBuildVersionFactAttribute" ||
+                        attributeTypeName == "RequiresMSBuildVersionTheoryAttribute" ||
+                        attributeTypeName == "RequiresSpecificFrameworkFactAttribute" ||
+                        attributeTypeName == "RequiresSpecificFrameworkTheoryAttribute" ||
+                        attributeTypeName == "WindowsOnlyRequiresMSBuildVersionFactAttribute" ||
+                        attributeTypeName == "WindowsOnlyRequiresMSBuildVersionTheoryAttribute")
+                    {
+                        isTestMethod = true;
+                        break;
+                    }
+                }
+                return isTestMethod;
         }
 
-        private static int GetMethodCount(MetadataReader reader, TypeDefinition type)
+        private static bool IsValidIdentifier(MetadataReader reader, String name)
         {
-            var count = 0;
-            foreach (var handle in type.GetMethods())
-            {
-                var methodDefinition = reader.GetMethodDefinition(handle);
-                if (methodDefinition.GetCustomAttributes().Count == 0 ||
-                    !IsValidIdentifier(reader, methodDefinition.Name))
-                {
-                    continue;
-                }
-
-                if (MethodAttributes.Public != (methodDefinition.Attributes & MethodAttributes.Public))
-                {
-                    continue;
-                }
-
-                count++;
-            }
-
-            return count;
-        }
-
-        private static bool IsValidIdentifier(MetadataReader reader, StringHandle handle)
-        {
-            var name = reader.GetString(handle);
             for (int i = 0; i < name.Length; i++)
             {
                 switch (name[i])
@@ -310,19 +298,6 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             }
 
             return true;
-        }
-
-        private static bool? InheritsFromObject(MetadataReader reader, TypeDefinition type)
-        {
-            if (type.BaseType.Kind != HandleKind.TypeReference)
-            {
-                return null;
-            }
-
-            var typeRef = reader.GetTypeReference((TypeReferenceHandle)type.BaseType);
-            return
-                reader.GetString(typeRef.Namespace) == "System" &&
-                reader.GetString(typeRef.Name) == "Object";
         }
 
         private static string GetFullName(MetadataReader reader, TypeDefinition type)

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 _methodLimit = methodLimit;
             }
 
-            internal static void Build(string assemblyPath, int methodLimit, List<TypeInfo> typeInfoList, out List<Partition> partitionList, out List<AssemblyPartitionInfo> assemblyInfoList, bool netFramework = false)
+            internal static void Build(string assemblyPath, int methodLimit, List<TypeInfo> typeInfoList, out List<Partition> partitionList, out List<AssemblyPartitionInfo> assemblyInfoList)
             {
                 var builder = new AssemblyInfoBuilder(assemblyPath, methodLimit);
                 builder.Build(typeInfoList);
@@ -94,19 +94,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var typeInfo in typeInfoList)
                 {
                     _currentTypeInfoList.Add(typeInfo);
-                    if (_netFramework)
-                    {
-                        if (_builder.Length > 0)
-                        {
-                            _builder.Append("|");
-                        }
-                        _builder.Append($@"{typeInfo.FullName}");
-
-                    }
-                    else
-                    {
-                        _builder.Append($@"-class ""{typeInfo.FullName}"" ");
-                    }
+                    _builder.Append($@"-class ""{typeInfo.FullName}"" ");
                     CheckForPartitionLimit(done: false);
                 }
 
@@ -182,12 +170,12 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             return list;
         }
 
-        public IEnumerable<AssemblyPartitionInfo> Schedule(string assemblyPath, bool force = false, bool netFramework = false)
+        public IEnumerable<AssemblyPartitionInfo> Schedule(string assemblyPath, bool force = false)
         {
             var typeInfoList = GetTypeInfoList(assemblyPath);
             var assemblyInfoList = new List<AssemblyPartitionInfo>();
             var partitionList = new List<Partition>();
-            AssemblyInfoBuilder.Build(assemblyPath, _methodLimit, typeInfoList, out partitionList, out assemblyInfoList, netFramework);
+            AssemblyInfoBuilder.Build(assemblyPath, _methodLimit, typeInfoList, out partitionList, out assemblyInfoList;
 
             // If the scheduling didn't actually produce multiple partition then send back an unpartitioned
             // representation.

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -94,9 +94,10 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var typeInfo in typeInfoList)
                 {
                     _currentTypeInfoList.Add(typeInfo);
+                    var separator = "";
                     if(_builder.Length > 0)
                     {
-                        var separator = "|";
+                        separator = "|";
                     }
                     _builder.Append($@"{separator}{typeInfo.FullName}");
                     CheckForPartitionLimit(done: false);

--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -256,7 +256,16 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 foreach (var attributeHandle in methodAttributes)
                 {
                     var attribute = reader.GetCustomAttribute(attributeHandle);
-                    var attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                    var attributeConstructorHandle = attribute.Constructor;
+                    MemberReference attributeConstructor;
+                    if (attributeConstructorHandle.Kind == HandleKind.MemberReference)
+                    {
+                        attributeConstructor = reader.GetMemberReference((MemberReferenceHandle)attributeConstructorHandle);
+                    }
+                    else
+                    {
+                        continue;
+                    }
                     var attributeType = reader.GetTypeReference((TypeReferenceHandle)attributeConstructor.Parent);
                     var attributeTypeName = reader.GetString(attributeType.Name);
 


### PR DESCRIPTION
I'm still not sure if we want this. It solves the problem of classes having too many tests and timing out but this split may be too much or run the risk of hitting some sort of character limit.

I ported this manually as I wanted to see how the arm64 leg faired with this change and if it could help us track down the issue causing the timeouts as it would be far fewer tests running per leg.