### PR TITLE
Use Agent.TempDirectory when building from archive in source-build

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -172,7 +172,7 @@ jobs:
   # We either build the repo directly, or we extract them outside (which is what partners do)
   - ${{ if parameters.buildFromArchive }}:
     - name: sourcesPath
-      value: $(Build.ArtifactStagingDirectory)/dotnet-sources/
+      value: $(Agent.TempDirectory)/dotnet-sources/
   - ${{ else }}:
     - name: sourcesPath
       value: $(vmrPath)


### PR DESCRIPTION
This avoids 1ES scanners finding secrets in Build.ArtifactStagingDirectory that we already suppressed via CredScanSuppressions.json

Fixes https://github.com/dotnet/source-build/issues/4773