### PR TITLE
Remove 'NETSDK1219' warning

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -957,10 +957,7 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1218: This project has a transitive dependency on the full Windows SDK projections (including Windows.UI.Xaml.* types), but does not specify the UseUwp property. That must be enabled to ensure that .NET types are projected and marshalled correctly for interop scenarios with these XAML types.</value>
     <comment>{StrBegin="NETSDK1218: "}</comment>
   </data>
-  <data name="UsingPreviewUseUwpFeature" xml:space="preserve">
-    <value>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</value>
-    <comment>{StrBegin="NETSDK1219: "}</comment>
-  </data>
+  <!-- Skipping NETSDK1219 on purpose, as that is "UsingPreviewUseUwpFeature" on .NET < 9.0.2xx, and has been removed on new SDK versions -->
   <data name="WindowsSDKXamlInvalidTfm" xml:space="preserve">
     <value>NETSDK1220: UseUwp and all associated functionality require using a TFM of 'net8.0-windows' or greater.</value>
     <comment>{StrBegin="NETSDK1220: "}</comment>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Používáte verzi Preview rozhraní .NET. Viz: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp a všechny související funkce jsou v současné době experimentální a nejsou oficiálně podporovány.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: Vytvoření spravované komponenty Metadata Windows s WinMDExp se při cílení na {0} nepodporuje.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Sie verwenden eine Vorschauversion von .NET. Weitere Informationen: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp und alle zugehörigen Funktionen sind derzeit experimentell und werden nicht offiziell unterstützt.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: Das Erstellen einer verwalteten Windows-Metadatenkomponente mit WinMDExp wird mit dem Ziel "{0}" nicht unterstützt.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Está usando una versión preliminar de .NET. Visite: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp y toda la funcionalidad asociada son experimentales actualmente y no se admiten oficialmente.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: No se admite la generación de un componente administrado de metadatos de Windows con WinMDExp cuando el destino es {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: vous utilisez une version d'aperçu de .NET. Voir : https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp et toutes les fonctionnalités associées sont actuellement expérimentales et ne sont pas officiellement prises en charge.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: la production d'un composant de métadonnées Windows managé avec WinMDExp n'est pas prise en charge pour le ciblage de {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: si sta usando una versione in anteprima di .NET. Vedere https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp e tutte le funzionalità associate sono attualmente sperimentali e non sono ufficialmente supportate.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: la produzione di un componente Metadati Windows gestito con WinMDExp non è supportata quando la destinazione è {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: プレビュー版の .NET を使用しています。https://aka.ms/dotnet-support-policy をご覧ください</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp および関連するすべての機能は現在試験段階であり、正式にはサポートされていません。</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: {0} をターゲットにする場合、WinMDExp を使用したマネージド Windows メタデータ コンポーネント生成はサポートされていません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: .NET의 미리 보기 버전을 사용하고 있습니다. 참조: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp와 관련된 모든 기능은 현재 실험 상태이며 공식적으로 지원되지 않습니다.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: {0}을(를) 대상으로 지정하는 경우 WinMDExp로 관리형 Windows 메타데이터 구성 요소를 생성하는 것은 지원되지 않습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Korzystasz z wersji zapoznawczej platformy .NET. Zobacz: ttps://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: protokół UseUwp i wszystkie skojarzone funkcje są obecnie eksperymentalne i nie są oficjalnie obsługiwane.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: Generowanie zarządzanego składnika metadanych systemu Windows za pomocą narzędzia WinMDExp nie jest obsługiwane, gdy używany jest element docelowy {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Você está usando uma versão de visualização do .NET. Veja: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp e todas as funcionalidades associadas atualmente são experimentais e não têm suporte oficial.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: não há suporte para a produção de um componente de Metadados do Windows gerenciado com o WinMDExp ao direcionar ao {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Вы используете предварительную версию .NET. Дополнительные сведения см. на странице https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp и все связанные функции на данный момент являются экспериментальными и официально не поддерживаются.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: создание управляемого компонента метаданных Windows с WinMDExp не поддерживается при нацеливании на {0}.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: Bir .NET önizleme sürümü kullanıyorsunuz. Bkz. https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp ve ilişkili tüm işlevler şu anda deneyseldir ve resmi olarak desteklenmez.</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: {0} hedeflenirken, WinMDExp ile yönetilen bir Windows Meta Veri bileşeninin üretilmesi desteklenmiyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 你正在使用 .NET 的预览版。请参阅 https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp 和所有关联的功能目前都是试验性的，并且不受官方支持。</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: 当目标为 {0} 时，不支持使用 WinMDExp 生成托管 Windows 元数据组件。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -1023,11 +1023,6 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1057: 您目前使用的是 .NET 預覽版。請參閱: https://aka.ms/dotnet-support-policy</target>
         <note>{StrBegin="NETSDK1057: "}</note>
       </trans-unit>
-      <trans-unit id="UsingPreviewUseUwpFeature">
-        <source>NETSDK1219: UseUwp and all associated functionality are currently experimental and not officially supported.</source>
-        <target state="translated">NETSDK1219: UseUwp 和所有相關聯的功能目前為實驗性功能，並未正式支援。</target>
-        <note>{StrBegin="NETSDK1219: "}</note>
-      </trans-unit>
       <trans-unit id="WinMDObjNotSupportedOnTargetFramework">
         <source>NETSDK1131: Producing a managed Windows Metadata component with WinMDExp is not supported when targeting {0}.</source>
         <target state="translated">NETSDK1131: 當目標為 {0} 時，無法使用 WinMDExp 產生受控 Windows 中繼資料元件。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -37,7 +37,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             1190,
             1192,
             1213,
-            1214
+            1214,
+            1219
         };
 
         //ILLink lives in other repos and violated the _info requirement for no error code

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Windows.targets
@@ -167,16 +167,4 @@ Copyright (c) .NET Foundation. All rights reserved.
                       and '$(UseUwp)' == 'true' ">
     <NetSdkError ResourceName="WindowsSDKXamlInvalidTfm" />
   </Target>
-
-  <!--
-    Emit a warning if 'UseUwp' is set.
-
-    NOTE: remove this target when 'UseUwp' becomes officially supported.
-  -->
-  <Target Name="_WarnForUseUwpPreviewFeatureEnabled"
-          AfterTargets="ResolvePackageAssets"
-          Condition=" '$(IncludeWindowsSDKRefFrameworkReferences)' == 'true'
-                      and '$(UseUwp)' == 'true'">
-    <NETSdkWarning ResourceName="UsingPreviewUseUwpFeature" />
-  </Target>
 </Project>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -453,8 +453,9 @@ namespace Microsoft.NET.Build.Tests
 
         }
 
+        // We used to emit NETSDK1219 while UWP support on .NET 9 was not GA yet, make sure it's gone now
         [WindowsOnlyFact]
-        public void ItWarnsWhenBuildingAProjectWithUseUwpProperty()
+        public void ItDoesNotWarnAnymoreWhenBuildingAProjectWithUseUwpProperty()
         {
             TestProject testProject = new()
             {
@@ -472,7 +473,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("NETSDK1219");
+                .NotHaveStdOutContaining("NETSDK1219");
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
### Follow up to #41936

### Summary

This PR removes the 'NETSDK1219' warning, effectively making UWP .NET 9 support GA. This warning has been added to signal that UWP support for .NET 9 was in preview, as all other components and tooling was also still work in progress (eg. Windows SDK changes for the XAML compiler, Visual Studio support, etc.). Now that all that tooling has shipped in stable (or, will have shipped in stable by the time this PR is published), we can remove this warning and officially mark the feature as GA.

Doing so is also needed to ensure customers on .NET Native can confidently start the migration away from .NET Native.

### Customer Impact

No customer impact, this PR is only removing a warning.

### Regression?

No.

### Testing

Updated unit tests to ensure the new warning is gone.

### Risk

Low. This is just removing a target whose sole purpose was to emit a warning.