### PR TITLE
Update Helix queues to osx.15.amd64|arm64

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -271,7 +271,7 @@ extends:
             name: Azure Pipelines
             image: macOS-latest
             os: macOS
-          helixTargetQueue: osx.13.amd64
+          helixTargetQueue: osx.15.amd64
           oneESCompat:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
@@ -299,7 +299,7 @@ extends:
               name: Azure Pipelines
               vmImage: macOS-latest
               os: macOS
-            helixTargetQueue: osx.13.arm64
+            helixTargetQueue: osx.15.arm64
             macOSJobParameterSets:
             - categoryName: TestBuild
               buildArchitecture: arm64

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -57,7 +57,7 @@ stages:
         name: Azure Pipelines
         vmImage: macOS-latest
         os: macOS
-      helixTargetQueue: osx.13.amd64.open
+      helixTargetQueue: osx.15.amd64.open
   ### ARM64 ###
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
@@ -65,7 +65,7 @@ stages:
         name: Azure Pipelines
         vmImage: macOS-latest
         os: macOS
-      helixTargetQueue: osx.13.arm64.open
+      helixTargetQueue: osx.15.arm64.open
       macOSJobParameterSets:
       - categoryName: TestBuild
         buildArchitecture: arm64


### PR DESCRIPTION
This will allow us to run MAUI tests that require XCode 16.

Contributes to https://github.com/dotnet/sdk/issues/45521.