### PR TITLE
Support package@version syntax in dotnet new install, partial fix for #45422

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -207,12 +207,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (string installArg in args.TemplatePackages)
             {
-                string[] splitByColons = installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries);
-                string[] splitByAt = installArg.Split('@', StringSplitOptions.RemoveEmptyEntries);
-                string[] split = splitByColons.Length > splitByAt.Length ? splitByColons :
-                                 splitByAt.Length > splitByColons.Length ? splitByAt :
-                                 splitByColons[0].Length < splitByAt[0].Length ? splitByColons :
-                                 splitByAt;
+                string[] split = installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries).SelectMany(arg => arg.Split('@', StringSplitOptions.RemoveEmptyEntries)).ToArray();
                 string identifier = split[0];
                 string? version = split.Length > 1 ? split[1] : null;
                 foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(identifier, _engineEnvironmentSettings))

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -209,7 +209,10 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 string[] splitByColons = installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries);
                 string[] splitByAt = installArg.Split('@', StringSplitOptions.RemoveEmptyEntries);
-                string[] split = splitByColons.Length > splitByAt.Length ? splitByColons : splitByAt;
+                string[] split = splitByColons.Length > splitByAt.Length ? splitByColons :
+                                 splitByAt.Length > splitByColons.Length ? splitByAt :
+                                 splitByColons[0].Length < splitByAt[0].Length ? splitByColons :
+                                 splitByAt;
                 string identifier = split[0];
                 string? version = split.Length > 1 ? split[1] : null;
                 foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(identifier, _engineEnvironmentSettings))

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -207,9 +207,11 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (string installArg in args.TemplatePackages)
             {
-                string[] splitByColons = installArg.Split(new[] { "::" }, StringSplitOptions.RemoveEmptyEntries);
-                string identifier = splitByColons[0];
-                string? version = splitByColons.Length > 1 ? splitByColons[1] : null;
+                string[] splitByColons = installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries);
+                string[] splitByAt = installArg.Split('@', StringSplitOptions.RemoveEmptyEntries);
+                string[] split = splitByColons.Length > splitByAt.Length ? splitByColons : splitByAt;
+                string identifier = split[0];
+                string? version = split.Length > 1 ? split[1] : null;
                 foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(identifier, _engineEnvironmentSettings))
                 {
                     installRequests.Add(new InstallRequest(expandedIdentifier, version, details: details, force: args.Force));

--- a/test/dotnet-new.Tests/DotnetNewInstallTests.cs
+++ b/test/dotnet-new.Tests/DotnetNewInstallTests.cs
@@ -42,21 +42,22 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         }
 
         [Theory]
-        [InlineData("-i")]
-        [InlineData("install")]
-        public void CanInstallRemoteNuGetPackage_LatestVariations(string commandName)
+        [InlineData("::")]
+        [InlineData("@")]
+        public void CanInstallRemoteNuGetPackage_LatestVariations(string separator)
         {
+            var commandName = "install";
             CommandResult command1 = new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Common.ProjectTemplates.5.0")
                 .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                 .WithWorkingDirectory(CreateTemporaryFolder())
                 .Execute();
 
-            CommandResult command2 = new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Common.ProjectTemplates.5.0::")
+            CommandResult command2 = new DotnetNewCommand(_log, commandName, $"Microsoft.DotNet.Common.ProjectTemplates.5.0{separator}")
                 .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                 .WithWorkingDirectory(CreateTemporaryFolder())
                 .Execute();
 
-            CommandResult command3 = new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Common.ProjectTemplates.5.0::*")
+            CommandResult command3 = new DotnetNewCommand(_log, commandName, $"Microsoft.DotNet.Common.ProjectTemplates.5.0{separator}*")
                 .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                 .WithWorkingDirectory(CreateTemporaryFolder())
                 .Execute();


### PR DESCRIPTION
Progress towards #45422

This adds support for package@version syntax without removing support for package::version syntax. I'll add a follow-up PR in main to add a warning, and then we can remove support for package::version syntax in .NET 11.