### PR TITLE
Use emojis for stage and job display names

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -84,17 +84,18 @@ extends:
           ignoreDirectories: artifacts, .packages
 
     stages:
-    ############### BUILD STAGE ###############
+    ############### 🛠️ BUILD STAGE ###############
     - stage: build
-      displayName: Build
+      displayName: 🛠️
       jobs:
-      ############### WINDOWS ###############
+      ############### 🪟 WINDOWS ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:
           pool:
             name: $(DncEngInternalBuildPool)
             image: windows.vs2022.amd64
             os: windows
+            emoji: 🪟
           helixTargetQueue: windows.amd64.vs2022.pre
           oneESCompat:
             templateFolderName: templates-official
@@ -104,8 +105,9 @@ extends:
           ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
             timeoutInMinutes: 90
             windowsJobParameterSets:
-            ### OFFICIAL ###
+            ### ⭐ OFFICIAL ###
             - categoryName: Official
+              categoryEmoji: ⭐
               publishArgument: $(_publishArgument)
               signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties)
@@ -115,6 +117,7 @@ extends:
               variables:
                 _SignType: real
             - categoryName: Official
+              categoryEmoji: ⭐
               buildArchitecture: x86
               publishArgument: $(_publishArgument)
               signArgument: $(_signArgument)
@@ -123,6 +126,7 @@ extends:
               variables:
                 _SignType: real
             - categoryName: Official
+              categoryEmoji: ⭐
               buildArchitecture: arm64
               publishArgument: $(_publishArgument)
               signArgument: $(_signArgument)
@@ -130,8 +134,9 @@ extends:
               runTests: false
               variables:
                 _SignType: real
-            ### PGO ###
+            ### 🧭 PGO ###
             - categoryName: PGO
+              categoryEmoji: 🧭
               pgoInstrument: true
               publishArgument: $(_publishArgument)
               signArgument: $(_signArgument)
@@ -140,6 +145,7 @@ extends:
               variables:
                 _SignType: real
             - categoryName: PGO
+              categoryEmoji: 🧭
               pgoInstrument: true
               buildArchitecture: x86
               publishArgument: $(_publishArgument)
@@ -149,6 +155,7 @@ extends:
               variables:
                 _SignType: real
             - categoryName: PGO
+              categoryEmoji: 🧭
               pgoInstrument: true
               buildArchitecture: arm64
               publishArgument: $(_publishArgument)
@@ -158,13 +165,14 @@ extends:
               variables:
                 _SignType: real
 
-      ############### LINUX ###############
+      ############### 🐧 LINUX ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:
           pool:
             name: $(DncEngInternalBuildPool)
             image: 1es-ubuntu-2204
             os: linux
+            emoji: 🐧
           helixTargetQueue: ubuntu.2204.amd64
           oneESCompat:
             templateFolderName: templates-official
@@ -173,14 +181,16 @@ extends:
           ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
             timeoutInMinutes: 90
             linuxJobParameterSets:
-            ### OFFICIAL ###
+            ### ⭐ OFFICIAL ###
             # Note: These builds are also portable like the Portable category, but that category uses containers, and doesn't publish zips and tarballs.
             - categoryName: Official
+              categoryEmoji: ⭐
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties)
               runTests: false
             - categoryName: Official
+              categoryEmoji: ⭐
               buildArchitecture: arm
               runtimeIdentifier: linux-arm
               publishArgument: $(_publishArgument)
@@ -188,20 +198,23 @@ extends:
               osProperties: $(linuxOsPortableProperties)
               runTests: false
             - categoryName: Official
+              categoryEmoji: ⭐
               buildArchitecture: arm64
               runtimeIdentifier: linux-arm64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties)
               runTests: false
-            ### PORTABLE ###
+            ### 💼 PORTABLE ###
             - categoryName: Portable
+              categoryEmoji: 💼
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties) /p:BuildSdkDeb=true
               runTests: false
             - categoryName: Portable
+              categoryEmoji: 💼
               container: centosStream9
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
@@ -209,6 +222,7 @@ extends:
               osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
               runTests: false
             - categoryName: Portable
+              categoryEmoji: 💼
               container: centosStream9
               buildArchitecture: arm64
               runtimeIdentifier: linux-arm64
@@ -217,8 +231,9 @@ extends:
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
               runTests: false
-            ### MUSL ###
+            ### 💪 MUSL ###
             - categoryName: Musl
+              categoryEmoji: 💪
               container: alpine319WithNode
               runtimeIdentifier: linux-musl-x64
               publishArgument: $(_publishArgument)
@@ -229,6 +244,7 @@ extends:
               enableSbom: false
               runTests: false
             - categoryName: Musl
+              categoryEmoji: 💪
               container: mariner20CrossArm
               buildArchitecture: arm
               runtimeIdentifier: linux-musl-arm
@@ -237,20 +253,23 @@ extends:
               osProperties: /p:OSName=linux-musl
               runTests: false
             - categoryName: Musl
+              categoryEmoji: 💪
               buildArchitecture: arm64
               runtimeIdentifier: linux-musl-arm64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: /p:OSName=linux-musl
               runTests: false
-            ### PGO ###
+            ### 🧭 PGO ###
             - categoryName: PGO
+              categoryEmoji: 🧭
               pgoInstrument: true
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties)
               runTests: false
             - categoryName: PGO
+              categoryEmoji: 🧭
               pgoInstrument: true
               buildArchitecture: arm64
               runtimeIdentifier: linux-arm64
@@ -259,13 +278,14 @@ extends:
               osProperties: $(linuxOsPortableProperties)
               runTests: false
 
-      ############### MACOS ###############
+      ############### 🍎 MACOS ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:
           pool:
             name: Azure Pipelines
             image: macOS-latest
             os: macOS
+            emoji: 🍎
           helixTargetQueue: osx.13.amd64
           oneESCompat:
             templateFolderName: templates-official
@@ -274,19 +294,21 @@ extends:
           ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
             timeoutInMinutes: 90
             macOSJobParameterSets:
-            ### OFFICIAL ###
+            ### ⭐ OFFICIAL ###
             - categoryName: Official
+              categoryEmoji: ⭐
               runtimeIdentifier: osx-x64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               runTests: false
             - categoryName: Official
+              categoryEmoji: ⭐
               buildArchitecture: arm64
               runtimeIdentifier: osx-arm64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               runTests: false
-      ### ARM64 TESTBUILD ###
+      ### ARM64 🧪 TESTBUILD ###
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
           parameters:
@@ -294,9 +316,11 @@ extends:
               name: Azure Pipelines
               vmImage: macOS-latest
               os: macOS
+              emoji: 🍎
             helixTargetQueue: osx.13.arm64
             macOSJobParameterSets:
             - categoryName: TestBuild
+              categoryEmoji: 🧪
               buildArchitecture: arm64
               runtimeIdentifier: osx-arm64
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -33,46 +33,51 @@ resources:
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
 
 stages:
-############### BUILD STAGE ###############
+############### 🛠️ BUILD STAGE ###############
 - stage: build
-  displayName: Build
+  displayName: 🛠️
   jobs:
-  ############### WINDOWS ###############
+  ############### 🪟 WINDOWS ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
         demands: ImageOverride -equals windows.vs2022.amd64.open
         os: windows
+        emoji: 🪟
       helixTargetQueue: windows.amd64.vs2022.pre.open
 
-  ############### LINUX ###############
+  ############### 🐧 LINUX ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
         demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         os: linux
+        emoji: 🐧
       helixTargetQueue: ubuntu.2204.amd64.open
 
-  ############### MACOS ###############
+  ############### 🍎 MACOS ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
       pool:
         name: Azure Pipelines
         vmImage: macOS-latest
         os: macOS
+        emoji: 🍎
       helixTargetQueue: osx.13.amd64.open
-  ### ARM64 ###
+  ### ARM64 🧪 TESTBUILD ###
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
       pool:
         name: Azure Pipelines
         vmImage: macOS-latest
         os: macOS
+        emoji: 🍎
       helixTargetQueue: osx.13.arm64.open
       macOSJobParameterSets:
       - categoryName: TestBuild
+        categoryEmoji: 🧪
         buildArchitecture: arm64
         runtimeIdentifier: osx-arm64
 

--- a/eng/dotnet-format/dotnet-format-integration.yml
+++ b/eng/dotnet-format/dotnet-format-integration.yml
@@ -64,9 +64,10 @@ parameters:
   type: string
   default: ''
 
+### 📰 DOTNET-FORMAT ###
 jobs:
-- job: Formatting_Check
-  displayName: Run Formatting Check
+- job: dotnet_format_formatting_check
+  displayName: 📰 ✔️
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: $(DncEngPublicBuildPool)
@@ -95,7 +96,7 @@ jobs:
 
 - ${{ each testArgs in parameters.TestArguments }}:
   - job: dotnet_format_integration_tests_${{ testArgs.Name }}
-    displayName: 'Dotnet-Format Integration Tests: ${{ testArgs.Name }}'
+    displayName: 📰 🧪 ${{ testArgs.Name }}
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -7,6 +7,7 @@ parameters:
   container: ''
   helixTargetContainer: ''
   categoryName: Build
+  categoryEmoji: 🛠️
   runTests: true
   testProjects: $(Build.SourcesDirectory)/test/UnitTests.proj
   publishRetryConfig: false
@@ -32,11 +33,11 @@ jobs:
 - template: /eng/common/${{ parameters.oneESCompat.templateFolderName }}/job/job.yml
   parameters:
     ${{ if eq(parameters.container, '') }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.buildArchitecture }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.buildArchitecture }})'
+      name: ${{ parameters.pool.os }}_${{ parameters.categoryName }}_${{ parameters.buildArchitecture }}
+      displayName: ${{ parameters.pool.emoji }} ${{ parameters.categoryEmoji }} ${{ parameters.buildArchitecture }}
     ${{ else }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.buildArchitecture }}_${{ parameters.container }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.buildArchitecture }}) [${{ parameters.container }}]'
+      name: ${{ parameters.pool.os }}_${{ parameters.categoryName }}_${{ parameters.buildArchitecture }}_${{ parameters.container }}
+      displayName: ${{ parameters.pool.emoji }} ${{ parameters.categoryEmoji }} ${{ parameters.buildArchitecture }} ${{ parameters.container }}
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
     strategy: ${{ parameters.strategy }}
@@ -125,7 +126,7 @@ jobs:
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: Run ${{ parameters.categoryName }} Tests
+          displayName: Run ${{ parameters.categoryEmoji }} Tests
           condition: succeeded()
           env:
             # Required by Arcade for running in Helix.
@@ -147,7 +148,7 @@ jobs:
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: Run ${{ parameters.categoryName }} Tests
+          displayName: Run ${{ parameters.categoryEmoji }} Tests
           condition: succeeded()
           env:
             # Required by Arcade for running in Helix.

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -82,7 +82,7 @@ jobs:
           ${{ parameters.runtimeSourceProperties }}
           ${{ parameters.officialBuildProperties }}
           /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        displayName: Build
+        displayName: Build ${{ parameters.categoryName }}
         env:
           BuildConfig: $(buildConfiguration)
           TestFullMSBuild: ${{ parameters.testFullMSBuild }}
@@ -106,7 +106,7 @@ jobs:
           ${{ parameters.runtimeSourceProperties }} \
           ${{ parameters.officialBuildProperties }} \
           /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        displayName: Build
+        displayName: Build ${{ parameters.categoryName }}
         env:
           BuildConfig: $(buildConfiguration)
 
@@ -126,7 +126,7 @@ jobs:
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: Run ${{ parameters.categoryEmoji }} Tests
+          displayName: Run ${{ parameters.categoryName }} Tests
           condition: succeeded()
           env:
             # Required by Arcade for running in Helix.
@@ -148,7 +148,7 @@ jobs:
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: Run ${{ parameters.categoryEmoji }} Tests
+          displayName: Run ${{ parameters.categoryName }} Tests
           condition: succeeded()
           env:
             # Required by Arcade for running in Helix.

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -2,33 +2,47 @@ parameters:
   oneESCompat:
     templateFolderName: templates
   locBranch: ''
-  ### WINDOWS ###
+  ### LEGEND ###
+  # 🧪 TestBuild
+  # 🖼️ FullFramework
+  # 🪛 TestAsTools
+  # 📦 ContainerBased
+  # 🧩 TemplateEngine
+  # ⏰ AoT
+  ### 🪟 WINDOWS ###
   windowsJobParameterSets:
   - categoryName: TestBuild
+    categoryEmoji: 🧪
     publishRetryConfig: true
   - categoryName: FullFramework
+    categoryEmoji: 🖼️
     testFullMSBuild: true
   - categoryName: TestAsTools
+    categoryEmoji: 🪛
     runTestsAsTool: true
     # This job uses the build step for testing, so the extra test step is not necessary.
     runTests: false
-  # Turn off template engine runs on Windows temporarily until agent images are updated
-  #- categoryName: TemplateEngine
-  #  testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
-  #  publishXunitResults: true
+  - categoryName: TemplateEngine
+    categoryEmoji: 🧩
+    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
+    publishXunitResults: true
   - categoryName: AoT
+    categoryEmoji: ⏰
     runAoTTests: true
-  ### LINUX ###
+  ### 🐧 LINUX ###
   linuxJobParameterSets:
   - categoryName: TestBuild
+    categoryEmoji: 🧪
     osProperties: $(linuxOsPortableProperties)
   - categoryName: TestBuild
+    categoryEmoji: 🧪
     buildArchitecture: arm64
     runtimeIdentifier: linux-arm64
     osProperties: $(linuxOsPortableProperties)
     # Don't run the tests on arm64. Only perform the build itself.
     runTests: false
   - categoryName: ContainerBased
+    categoryEmoji: 📦
     container: ubuntu2204DebPkg
     helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
     osProperties: $(linuxOsPortableProperties)
@@ -36,6 +50,7 @@ parameters:
     # See: https://github.com/dotnet/sdk/issues/40935
     runTests: false
   - categoryName: ContainerBased
+    categoryEmoji: 📦
     container: fedora39
     # No fedora Helix container is available, so use the ubuntu one instead.
     helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
@@ -44,6 +59,7 @@ parameters:
     # See: https://github.com/dotnet/sdk/issues/40935
     runTests: false
   - categoryName: ContainerBased
+    categoryEmoji: 📦
     container: centosStream9
     helixTargetContainer: $(helixTargetContainerPrefix)centos-stream9-helix
     osProperties: /p:OSName=linux
@@ -51,6 +67,7 @@ parameters:
     # See: https://github.com/dotnet/sdk/issues/40935
     runTests: false
   - categoryName: ContainerBased
+    categoryEmoji: 📦
     container: debian12Amd64
     helixTargetContainer: $(helixTargetContainerPrefix)debian-11-helix-amd64
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
@@ -58,6 +75,7 @@ parameters:
     # See: https://github.com/dotnet/sdk/issues/40935
     runTests: false
   - categoryName: ContainerBased
+    categoryEmoji: 📦
     container: alpine319WithNode
     helixTargetContainer: $(helixTargetContainerPrefix)alpine-3.18-helix-amd64
     runtimeIdentifier: linux-musl-x64
@@ -69,16 +87,20 @@ parameters:
     # See: https://github.com/dotnet/sdk/issues/40935
     runTests: false
   - categoryName: TemplateEngine
+    categoryEmoji: 🧩
     osProperties: $(linuxOsPortableProperties)
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
-  ### MACOS ###
+  ### 🍎 MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild
+    categoryEmoji: 🧪
   - categoryName: TemplateEngine
+    categoryEmoji: 🧩
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
   - categoryName: AoT
+    categoryEmoji: ⏰
     runAoTTests: true
 
 jobs:


### PR DESCRIPTION
## Summary

Currently, the names of the jobs in the GitHub checks are quite long and have a lot of different parts to them. Similarly, viewing the jobs in Azure Pipelines has a similar problem when the job names are wider than the list panel width. I wanted to solve this with replacing some of the information with a fixed-width emoji.


## Design
The GitHub checks are a string in this format (***cannot be changed***, defined by GitHub):

- `pipeline_name` (`stage_name` `job_name`)

This PR doesn't change our job name. It only updates the display name of the stage and jobs. The jobs have multiple parts to their names:

- Category
- OS
- Architecture
- Container

Category is a concept I created because the builds have different aspects of how they run. A category represents the same/similar group of settings. This came about when merging the SDK and Installer builds together. Here's the list of categories and the emoji legend for them:

- ⭐ Official
- 💼 Portable
- 💪 Musl
- 🧭 PGO
- 🧪 TestBuild
- 🖼️ FullFramework
- 🪛 TestAsTools
- 📦 ContainerBased
- 🧩 TemplateEngine
- ⏰ AoT

OS is for the operating system of the job. Here's the emoji legend:

- 🪟 Windows
- 🐧 Linux
- 🍎 macOS

Architecture and Container remain as text. They're quite specific and don't really have an easy way to map emojis to them.

For the dotnet-format jobs, I've used this format:

- 📰 represents `dotnet-format`
- ✔️ for the `Formatting Check` job
- 🧪 `repo` for the `Integration Tests` job

#### GitHub Concept Sampling

This isn't a full list but just a random selection showing how they'd look in the GitHub checks.

- dotnet-sdk-public-ci (🛠️ 🪟 🧪 x64)
- dotnet-sdk-public-ci (🛠️ 🪟 🖼️ x64)
- dotnet-sdk-public-ci (🛠️ 🪟 ⏰ x64)
- dotnet-sdk-public-ci (🛠️ 🪟 🪛 x64)
- dotnet-sdk-public-ci (🛠️ 🐧 📦 x64 alpine319WithNode)
- dotnet-sdk-public-ci (🛠️ 🐧 📦 x64 debian12Amd64)
- dotnet-sdk-public-ci (🛠️ 🍎 🧪 x64)
- dotnet-sdk-public-ci (🛠️ 🍎 🧪 arm64)
- dotnet-sdk-public-ci (🛠️ 🍎 ⏰ x64)

### Other Change

For the `Build` and `Test` steps, I've added the category name since it can be more difficult to make the emoji association. So, you'll see the text name of the category emoji in those steps.

#### Example
![image](https://github.com/user-attachments/assets/af508c07-e7a4-4d25-afbb-e5720689fdf5)

## GitHub PR Example

### Current
![image](https://github.com/user-attachments/assets/dc63248f-0d32-4dcb-a552-4a069b717dfe)

### Emoji
![image](https://github.com/user-attachments/assets/e883a502-084d-4a52-9126-0b381a5c9e9f)

## AzDO PR Example

### Current
![image](https://github.com/user-attachments/assets/9653f0e7-ccf3-48e1-a55e-c942bd3ca173)

### Emoji
![image](https://github.com/user-attachments/assets/9262b99e-ba47-4d9e-b9b9-23606c0a99ed)

## AzDO CI (Official) Example

### Current
![image](https://github.com/user-attachments/assets/8ea1556b-78a2-4f2b-8f09-9d7129b26a7e)

### Emoji
![image](https://github.com/user-attachments/assets/a13424c8-e222-425a-b36b-855e0d1f9a68)