### PR TITLE
Fix identity of MSTest item templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-CSharp-TestClass/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-CSharp-TestClass/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "Creates a new MSTest test class",
   "groupIdentity": "Microsoft.Test.MSTest.TestClass",
   "precedence": "12000",
-  "identity": "Microsoft.Test.MSTest.TestClass.CSharp.9.0",
+  "identity": "Microsoft.Test.MSTest.TestClass.CSharp.10.0",
   "shortName": "mstest-class",
   "tags": {
     "language": "C#",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-FSharp-TestClass/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-FSharp-TestClass/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "Creates a new MSTest test class",
   "groupIdentity": "Microsoft.Test.MSTest.TestClass",
   "precedence": "10000",
-  "identity": "Microsoft.Test.MSTest.TestClass.FSharp.8.0",
+  "identity": "Microsoft.Test.MSTest.TestClass.FSharp.10.0",
   "shortName": "mstest-class",
   "tags": {
     "language": "F#",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-VisualBasic-TestClass/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/MSTest-VisualBasic-TestClass/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "Creates a new MSTest test class",
   "groupIdentity": "Microsoft.Test.MSTest.TestClass",
   "precedence": "10000",
-  "identity": "Microsoft.Test.MSTest.TestClass.VisualBasic.8.0",
+  "identity": "Microsoft.Test.MSTest.TestClass.VisualBasic.10.0",
   "shortName": "mstest-class",
   "tags": {
     "language": "VB",


### PR DESCRIPTION
It seems that the other item templates don't have the identity, is it something we could simplify here @dotnet/templating-engine-maintainers ?