### PR TITLE
Look up the target OS for crossgen2 using the full target RID

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -181,42 +181,19 @@ namespace Microsoft.NET.Build.Tasks
 
             // Determine targetOS based on target rid.
             // Use the runtime graph to support non-portable target rids.
+            // Use the full target rid instead of just the target OS as the runtime graph
+            // may only have the full target rid and not an OS-only rid for non-portable target rids
+            // added by our source-build partners.
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
             string portablePlatform = NuGetUtils.GetBestMatchingRid(
                     runtimeGraph,
-                    _targetPlatform,
-                    new[] { "linux", "linux-musl", "osx", "win", "freebsd", "illumos" },
+                    _targetRuntimeIdentifier,
+                    new[] { "linux", "osx", "win", "freebsd", "illumos" },
                     out _);
-
-            // For source-build, allow the bootstrap SDK rid to be unknown to the runtime repo graph.
-            if (portablePlatform == null && _targetRuntimeIdentifier == _hostRuntimeIdentifier)
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    portablePlatform = "win";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    portablePlatform = "linux";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")))
-                {
-                    portablePlatform = "freebsd";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ILLUMOS")))
-                {
-                    portablePlatform = "illumos";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    portablePlatform = "osx";
-                }
-            }
 
             targetOS = portablePlatform switch
             {
                 "linux" => "linux",
-                "linux-musl" => "linux",
                 "osx" => "osx",
                 "win" => "windows",
                 "freebsd" => "freebsd",


### PR DESCRIPTION
Lookup the target OS for crossgen2 invocation based on the full RID instead of an OS-only portion of the RID. In source-build scenarios, we will likely only have a full `os-arch` RID in the RID graph. If we use only the `os` RID, we won't find a matching OS RID in the graph for the target OS. If we use the full `os-arch` RID, we'll be able to find our target in the graph.

This work allows us to remove the `portablePlatform == null && _hostRuntimeIdentifier == _targetRuntimeIdentifier` special case, as we'll now find the portable platform based on `_targetRuntimeIdentifier`.

Also remove the special checks for `linux-musl` as the `linux-musl` RID imports the `linux` RID, so we can just look for `linux` and get the right behavior.