### PR TITLE
[release/9.0.1xx] Add missing net8 workload manifest entries

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.InstallRecords.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.InstallRecords.cs
@@ -69,9 +69,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 "Microsoft.NET.Workload.Emscripten.Current",
                 "Microsoft.NET.Workload.Emscripten.net6",
                 "Microsoft.NET.Workload.Emscripten.net7",
+                "Microsoft.NET.Workload.Emscripten.net8",
                 "Microsoft.NET.Workload.Mono.ToolChain.Current",
                 "Microsoft.NET.Workload.Mono.ToolChain.net6",
                 "Microsoft.NET.Workload.Mono.ToolChain.net7",
+                "Microsoft.NET.Workload.Mono.ToolChain.net8",
             ];
 
         private static readonly IReadOnlyDictionary<string, string> ManifestIdCasing = CasedManifestIds.ToDictionary(id => id.ToLowerInvariant()).AsReadOnly();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks
             { "android", "android-aot", "ios", "maccatalyst", "macos", "maui", "maui-android",
             "maui-desktop", "maui-ios", "maui-maccatalyst", "maui-mobile", "maui-windows", "tvos" };
         private static readonly HashSet<string> WasmWorkloadIds = new(StringComparer.OrdinalIgnoreCase)
-            { "wasm-tools", "wasm-tools-net6", "wasm-tools-net7" };
+            { "wasm-tools", "wasm-tools-net6", "wasm-tools-net7", "wasm-tools-net8" };
 
         public ITaskItem[] MissingWorkloadPacks { get; set; }
 


### PR DESCRIPTION
I noticed these while working on https://github.com/dotnet/sdk/pull/45500