### PR TITLE
[dotnet-watch] Microsoft.DotNet.HotReload.Agent.PipeRpc source package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,6 +91,9 @@
     <PackageVersion Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersPackageVersion)" />
+    <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageVersion Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -282,6 +282,20 @@
     <MicrosoftSourceLinkGitLabVersion>9.0.0-beta.24617.1</MicrosoftSourceLinkGitLabVersion>
     <MicrosoftSourceLinkBitbucketGitVersion>9.0.0-beta.24617.1</MicrosoftSourceLinkBitbucketGitVersion>
   </PropertyGroup>
+  <!--
+    Dependencies to support netstandard2.0 targets.
+    Versions need to be conditionally selected: due to https://github.com/dotnet/sdk/issues/45155
+  -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <SystemBuffersVersion>4.6.0</SystemBuffersVersion>
+    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
+    <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
+  </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/sdk.sln
+++ b/sdk.sln
@@ -516,6 +516,10 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.HotReload.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.HotReload.Agent.Package", "src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.Package.csproj", "{2FF79F82-60C1-349A-4726-7783D5A6D5DF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.HotReload.Agent.PipeRpc.Package", "src\BuiltInTools\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.Package.csproj", "{692B71D8-9C31-D1EE-6C1B-570A12B18E39}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.HotReload.Agent.PipeRpc", "src\BuiltInTools\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.shproj", "{FA3C7F91-42A2-45AD-897C-F646B081016C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -982,6 +986,10 @@ Global
 		{2FF79F82-60C1-349A-4726-7783D5A6D5DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FF79F82-60C1-349A-4726-7783D5A6D5DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FF79F82-60C1-349A-4726-7783D5A6D5DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{692B71D8-9C31-D1EE-6C1B-570A12B18E39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{692B71D8-9C31-D1EE-6C1B-570A12B18E39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{692B71D8-9C31-D1EE-6C1B-570A12B18E39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{692B71D8-9C31-D1EE-6C1B-570A12B18E39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1163,6 +1171,8 @@ Global
 		{1F0B4B3C-DC88-4740-B04F-1707102E9930} = {580D1AE7-AA8F-4912-8B76-105594E00B3B}
 		{418B10BD-CA42-49F3-8F4A-D8CC90C8A17D} = {71A9F549-0EB6-41F9-BC16-4A6C5007FC91}
 		{2FF79F82-60C1-349A-4726-7783D5A6D5DF} = {71A9F549-0EB6-41F9-BC16-4A6C5007FC91}
+		{692B71D8-9C31-D1EE-6C1B-570A12B18E39} = {71A9F549-0EB6-41F9-BC16-4A6C5007FC91}
+		{FA3C7F91-42A2-45AD-897C-F646B081016C} = {71A9F549-0EB6-41F9-BC16-4A6C5007FC91}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB8F26CE-4DE6-433F-B32A-79183020BBD6}
@@ -1170,12 +1180,15 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems*{03c5a84a-982b-4f38-ac73-ab832c645c4a}*SharedItemsImports = 5
 		src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems*{0a3c9afd-f6e6-4a5d-83fb-93bf66732696}*SharedItemsImports = 5
+		src\BuiltInTools\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems*{1bbfa19c-03f0-4d27-9d0d-0f8172642107}*SharedItemsImports = 5
 		src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems*{1bbfa19c-03f0-4d27-9d0d-0f8172642107}*SharedItemsImports = 5
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{1f0b4b3c-dc88-4740-b04f-1707102e9930}*SharedItemsImports = 5
 		src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems*{418b10bd-ca42-49f3-8f4a-d8cc90c8a17d}*SharedItemsImports = 13
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{445efbd5-6730-4f09-943d-278e77501ffd}*SharedItemsImports = 5
+		src\BuiltInTools\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems*{445efbd5-6730-4f09-943d-278e77501ffd}*SharedItemsImports = 5
 		src\BuiltInTools\AspireService\Microsoft.WebTools.AspireService.projitems*{94c8526e-dcc2-442f-9868-3dd0ba2688be}*SharedItemsImports = 13
 		src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems*{9d36039f-d0a1-462f-85b4-81763c6b02cb}*SharedItemsImports = 13
 		src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems*{a9103b98-d888-4260-8a05-fa36f640698a}*SharedItemsImports = 5
+		src\BuiltInTools\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems*{fa3c7f91-42a2-45ad-897c-f646b081016c}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="..\dotnet-watch\EnvironmentVariables_StartupHook.cs" Link="EnvironmentVariables_StartupHook.cs" />
     <Compile Include="..\dotnet-watch\HotReload\NamedPipeContract.cs" />
+    <Compile Include="..\dotnet-watch\HotReload\StreamExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.projitems" Label="Shared" />
+  <Import Project="..\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
   <PropertyGroup>
     <!--
       dotnet-watch may inject this assembly to .NET 6.0+ app, so we can't target a newer version.
@@ -14,12 +15,10 @@
 
   <ItemGroup>
     <Compile Include="..\dotnet-watch\EnvironmentVariables_StartupHook.cs" Link="EnvironmentVariables_StartupHook.cs" />
-    <Compile Include="..\dotnet-watch\HotReload\NamedPipeContract.cs" />
-    <Compile Include="..\dotnet-watch\HotReload\StreamExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Extensions.DotNetDeltaApplier.Tests"/>
+    <InternalsVisibleTo Include="Microsoft.Extensions.DotNetDeltaApplier.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -58,26 +58,36 @@ internal sealed class StartupHook
             {
                 agent.Reporter.Report("Writing capabilities: " + agent.Capabilities, AgentMessageSeverity.Verbose);
 
-                var initPayload = new ClientInitializationPayload(agent.Capabilities);
+                var initPayload = new ClientInitializationRequest(agent.Capabilities);
                 await initPayload.WriteAsync(pipeClient, CancellationToken.None);
 
                 while (pipeClient.IsConnected)
                 {
-                    var update = await UpdatePayload.ReadAsync(pipeClient, CancellationToken.None);
-
+                    var update = await ManagedCodeUpdateRequest.ReadAsync(pipeClient, CancellationToken.None);
                     Log($"ResponseLoggingLevel = {update.ResponseLoggingLevel}");
 
-                    agent.ApplyDeltas(update.Deltas);
+                    bool success;
+                    try
+                    {
+                        agent.ApplyDeltas(update.Deltas);
+                        success = true;
+                    }
+                    catch (Exception e)
+                    {
+                        agent.Reporter.Report($"The runtime failed to applying the change: {e.Message}", AgentMessageSeverity.Error);
+                        agent.Reporter.Report("Further changes won't be applied to this process.", AgentMessageSeverity.Warning);
+                        success = false;
+                    }
+
                     var logEntries = agent.GetAndClearLogEntries(update.ResponseLoggingLevel);
 
-                    // response:
-                    await pipeClient.WriteAsync((byte)UpdatePayload.ApplySuccessValue, CancellationToken.None);
-                    await UpdatePayload.WriteLogAsync(pipeClient, logEntries, CancellationToken.None);
+                    var response = new UpdateResponse(logEntries, success);
+                    await response.WriteAsync(pipeClient, CancellationToken.None);
                 }
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                Log(ex.Message);
+                Log(e.ToString());
             }
 
             Log("Stopped received delta updates. Server is no longer connected.");

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.Package.csproj
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.Package.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      Intentionally pinned. Supports Visual Studio in-proc agent client.
+    -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <DebugType>none</DebugType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+    <IsSourcePackage>true</IsSourcePackage>
+    <PackageId>Microsoft.DotNet.HotReload.Agent.PipeRpc</PackageId>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageDescription>
+      Package containing sources of Hot Reload agent pipe RPC.
+    </PackageDescription>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- netstandard2.0 polyfills -->
+    <PackageReference Include="System.Buffers" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+
+  <!-- Make sure the shared source files do not require any global usings -->
+  <ItemGroup>
+    <Using Remove="@(Using)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\HotReloadAgent\AgentMessageSeverity.cs" Link="AgentContracts\AgentMessageSeverity.cs" />
+    <Compile Include="..\HotReloadAgent\ResponseLoggingLevel.cs" Link="AgentContracts\ResponseLoggingLevel.cs" />
+    <Compile Include="..\HotReloadAgent\UpdateDelta.cs" Link="AgentContracts\UpdateDelta.cs" />
+  </ItemGroup>
+</Project>

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{FA3C7F91-42A2-45AD-897C-F646B081016C}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.DotNet.HotReload</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)**\*.cs" />
+  </ItemGroup>
+</Project>

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.shproj
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/Microsoft.DotNet.HotReload.Agent.PipeRpc.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>FA3C7F91-42A2-45AD-897C-F646B081016C</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/NamedPipeContract.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/NamedPipeContract.cs
@@ -7,9 +7,8 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.HotReload;
 
-namespace Microsoft.DotNet.Watch;
+namespace Microsoft.DotNet.HotReload;
 
 internal interface IRequest
 {

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.Watch;
+namespace Microsoft.DotNet.HotReload;
 
 /// <summary>
 /// Implements async read/write helpers that provide functionality of <see cref="BinaryReader"/> and <see cref="BinaryWriter"/>.

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
@@ -258,7 +258,7 @@ internal static class StreamExtesions
     private static async ValueTask<int> ReadExactlyAsync(this Stream stream, byte[] buffer, int size, CancellationToken cancellationToken)
     {
         int totalRead = 0;
-        while (totalRead < buffer.Length)
+        while (totalRead < size)
         {
             int read = await stream.ReadAsync(buffer, offset: totalRead, count: size - totalRead, cancellationToken).ConfigureAwait(false);
             if (read == 0)

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
-using Microsoft.DotNet.Watch;
 
 namespace Microsoft.DotNet.HotReload;
 

--- a/src/BuiltInTools/HotReloadAgent/UpdateDelta.cs
+++ b/src/BuiltInTools/HotReloadAgent/UpdateDelta.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.DotNet.Watch;
+namespace Microsoft.DotNet.HotReload;
 
 internal readonly struct UpdateDelta(Guid moduleId, byte[] metadataDelta, byte[] ilDelta, byte[] pdbDelta, int[] updatedTypes)
 {

--- a/src/BuiltInTools/dotnet-watch.slnf
+++ b/src/BuiltInTools/dotnet-watch.slnf
@@ -9,6 +9,8 @@
       "src\\BuiltInTools\\DotNetWatchTasks\\DotNetWatchTasks.csproj",
       "src\\BuiltInTools\\HotReloadAgent\\Microsoft.DotNet.HotReload.Agent.Package.csproj",
       "src\\BuiltInTools\\HotReloadAgent\\Microsoft.DotNet.HotReload.Agent.shproj",
+      "src\\BuiltInTools\\HotReloadAgent.PipeRpc\\Microsoft.DotNet.HotReload.Agent.PipeRpc.Package.csproj",
+      "src\\BuiltInTools\\HotReloadAgent.PipeRpc\\Microsoft.DotNet.HotReload.Agent.PipeRpc.shproj",
       "src\\BuiltInTools\\dotnet-watch\\dotnet-watch.csproj",
       "test\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests\\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj",
       "test\\Microsoft.Extensions.DotNetDeltaApplier.Tests\\Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj",

--- a/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/NamedPipeContract.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -11,446 +9,182 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.HotReload;
 
-namespace Microsoft.DotNet.Watch
+namespace Microsoft.DotNet.Watch;
+
+internal interface IRequest
 {
-    internal interface IRequest
+    ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken);
+}
+
+internal enum RequestType
+{
+    ManagedCodeUpdate = 1,
+    StaticAssetUpdate = 2,
+    InitialUpdatesCompleted = 3,
+}
+
+internal readonly struct ManagedCodeUpdateRequest(IReadOnlyList<UpdateDelta> deltas, ResponseLoggingLevel responseLoggingLevel) : IRequest
+{
+    private const byte Version = 4;
+
+    public IReadOnlyList<UpdateDelta> Deltas { get; } = deltas;
+    public ResponseLoggingLevel ResponseLoggingLevel { get; } = responseLoggingLevel;
+
+    /// <summary>
+    /// Called by the dotnet-watch.
+    /// </summary>
+    public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
     {
-        ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken);
-    }
+        await stream.WriteAsync(Version, cancellationToken);
+        await stream.WriteAsync(Deltas.Count, cancellationToken);
 
-    internal enum RequestType
-    {
-        ManagedCodeUpdate = 1,
-        StaticAssetUpdate = 2,
-        InitialUpdatesCompleted = 3,
-    }
-
-    internal readonly struct ManagedCodeUpdateRequest(IReadOnlyList<UpdateDelta> deltas, ResponseLoggingLevel responseLoggingLevel) : IRequest
-    {
-        private const byte Version = 4;
-
-        public IReadOnlyList<UpdateDelta> Deltas { get; } = deltas;
-        public ResponseLoggingLevel ResponseLoggingLevel { get; } = responseLoggingLevel;
-
-        /// <summary>
-        /// Called by the dotnet-watch.
-        /// </summary>
-        public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
+        foreach (var delta in Deltas)
         {
-            await stream.WriteAsync(Version, cancellationToken);
-            await stream.WriteAsync(Deltas.Count, cancellationToken);
-
-            foreach (var delta in Deltas)
-            {
-                await stream.WriteAsync(delta.ModuleId, cancellationToken);
-                await stream.WriteByteArrayAsync(delta.MetadataDelta, cancellationToken);
-                await stream.WriteByteArrayAsync(delta.ILDelta, cancellationToken);
-                await stream.WriteByteArrayAsync(delta.PdbDelta, cancellationToken);
-                await stream.WriteAsync(delta.UpdatedTypes, cancellationToken);
-            }
-
-            await stream.WriteAsync((byte)ResponseLoggingLevel, cancellationToken);
+            await stream.WriteAsync(delta.ModuleId, cancellationToken);
+            await stream.WriteByteArrayAsync(delta.MetadataDelta, cancellationToken);
+            await stream.WriteByteArrayAsync(delta.ILDelta, cancellationToken);
+            await stream.WriteByteArrayAsync(delta.PdbDelta, cancellationToken);
+            await stream.WriteAsync(delta.UpdatedTypes, cancellationToken);
         }
 
-        /// <summary>
-        /// Called by delta applier.
-        /// </summary>
-        public static async ValueTask<ManagedCodeUpdateRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            var version = await stream.ReadByteAsync(cancellationToken);
-            if (version != Version)
-            {
-                throw new NotSupportedException($"Unsupported version {version}.");
-            }
-
-            var count = await stream.ReadInt32Async(cancellationToken);
-
-            var deltas = new UpdateDelta[count];
-            for (var i = 0; i < count; i++)
-            {
-                var moduleId = await stream.ReadGuidAsync(cancellationToken);
-                var metadataDelta = await stream.ReadByteArrayAsync(cancellationToken);
-                var ilDelta = await stream.ReadByteArrayAsync(cancellationToken);
-                var pdbDelta = await stream.ReadByteArrayAsync(cancellationToken);
-                var updatedTypes = await stream.ReadIntArrayAsync(cancellationToken);
-
-                deltas[i] = new UpdateDelta(moduleId, metadataDelta: metadataDelta, ilDelta: ilDelta, pdbDelta: pdbDelta, updatedTypes);
-            }
-
-            var responseLoggingLevel = (ResponseLoggingLevel)await stream.ReadByteAsync(cancellationToken);
-            return new ManagedCodeUpdateRequest(deltas, responseLoggingLevel: responseLoggingLevel);
-        }
-    }
-
-    internal readonly struct UpdateResponse(IReadOnlyCollection<(string message, AgentMessageSeverity severity)> log, bool success)
-    {
-        public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            await stream.WriteAsync(success, cancellationToken);
-            await stream.WriteAsync(log.Count, cancellationToken);
-
-            foreach (var (message, severity) in log)
-            {
-                await stream.WriteAsync(message, cancellationToken);
-                await stream.WriteAsync((byte)severity, cancellationToken);
-            }
-        }
-
-        public static async ValueTask<(bool success, IAsyncEnumerable<(string message, AgentMessageSeverity severity)>)> ReadAsync(
-            Stream stream, CancellationToken cancellationToken)
-        {
-            var success = await stream.ReadBooleanAsync(cancellationToken);
-            var log = ReadLogAsync(cancellationToken);
-            return (success, log);
-
-            async IAsyncEnumerable<(string message, AgentMessageSeverity severity)> ReadLogAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-            {
-                var entryCount = await stream.ReadInt32Async(cancellationToken);
-
-                for (var i = 0; i < entryCount; i++)
-                {
-                    var message = await stream.ReadStringAsync(cancellationToken);
-                    var severity = (AgentMessageSeverity)await stream.ReadByteAsync(cancellationToken);
-                    yield return (message, severity);
-                }
-            }
-        }
-    }
-
-    internal readonly struct ClientInitializationRequest(string capabilities) : IRequest
-    {
-        private const byte Version = 0;
-
-        public string Capabilities { get; } = capabilities;
-
-        /// <summary>
-        /// Called by delta applier.
-        /// </summary>
-        public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            await stream.WriteAsync(Version, cancellationToken);
-            await stream.WriteAsync(Capabilities, cancellationToken);
-        }
-
-        /// <summary>
-        /// Called by dotnet-watch.
-        /// </summary>
-        public static async ValueTask<ClientInitializationRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            var version = await stream.ReadByteAsync(cancellationToken);
-            if (version != Version)
-            {
-                throw new NotSupportedException($"Unsupported version {version}.");
-            }
-
-            var capabilities = await stream.ReadStringAsync(cancellationToken);
-            return new ClientInitializationRequest(capabilities);
-        }
-    }
-
-    internal readonly struct StaticAssetUpdateRequest(
-        string assemblyName,
-        string relativePath,
-        byte[] contents,
-        bool isApplicationProject) : IRequest
-    {
-        private const byte Version = 1;
-
-        public string AssemblyName { get; } = assemblyName;
-        public bool IsApplicationProject { get; } = isApplicationProject;
-        public string RelativePath { get; } = relativePath;
-        public byte[] Contents { get; } = contents;
-
-        public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            await stream.WriteAsync(Version, cancellationToken);
-            await stream.WriteAsync(AssemblyName, cancellationToken);
-            await stream.WriteAsync(IsApplicationProject, cancellationToken);
-            await stream.WriteAsync(RelativePath, cancellationToken);
-            await stream.WriteByteArrayAsync(Contents, cancellationToken);
-        }
-
-        public static async ValueTask<StaticAssetUpdateRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
-        {
-            var version = await stream.ReadByteAsync(cancellationToken);
-            if (version != Version)
-            {
-                throw new NotSupportedException($"Unsupported version {version}.");
-            }
-
-            var assemblyName = await stream.ReadStringAsync(cancellationToken);
-            var isAppProject = await stream.ReadBooleanAsync(cancellationToken);
-            var relativePath = await stream.ReadStringAsync(cancellationToken);
-            var contents = await stream.ReadByteArrayAsync(cancellationToken);
-
-            return new StaticAssetUpdateRequest(
-                assemblyName: assemblyName,
-                relativePath: relativePath,
-                contents: contents,
-                isApplicationProject: isAppProject);
-        }
+        await stream.WriteAsync((byte)ResponseLoggingLevel, cancellationToken);
     }
 
     /// <summary>
-    /// Implements async read/write helpers that provide functionality of <see cref="BinaryReader"/> and <see cref="BinaryWriter"/>.
-    /// See https://github.com/dotnet/runtime/issues/17229
+    /// Called by delta applier.
     /// </summary>
-    internal static class StreamExtesions
+    public static async ValueTask<ManagedCodeUpdateRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
     {
-        public static ValueTask WriteAsync(this Stream stream, bool value, CancellationToken cancellationToken)
-            => WriteAsync(stream, (byte)(value ? 1 : 0), cancellationToken);
-
-        public static async ValueTask WriteAsync(this Stream stream, byte value, CancellationToken cancellationToken)
+        var version = await stream.ReadByteAsync(cancellationToken);
+        if (version != Version)
         {
-            var size = sizeof(byte);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                buffer[0] = value;
-                await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+            throw new NotSupportedException($"Unsupported version {version}.");
         }
 
-        public static async ValueTask WriteAsync(this Stream stream, int value, CancellationToken cancellationToken)
+        var count = await stream.ReadInt32Async(cancellationToken);
+
+        var deltas = new UpdateDelta[count];
+        for (var i = 0; i < count; i++)
         {
-            var size = sizeof(int);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
-                await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+            var moduleId = await stream.ReadGuidAsync(cancellationToken);
+            var metadataDelta = await stream.ReadByteArrayAsync(cancellationToken);
+            var ilDelta = await stream.ReadByteArrayAsync(cancellationToken);
+            var pdbDelta = await stream.ReadByteArrayAsync(cancellationToken);
+            var updatedTypes = await stream.ReadIntArrayAsync(cancellationToken);
+
+            deltas[i] = new UpdateDelta(moduleId, metadataDelta: metadataDelta, ilDelta: ilDelta, pdbDelta: pdbDelta, updatedTypes);
         }
 
-        public static ValueTask WriteAsync(this Stream stream, Guid value, CancellationToken cancellationToken)
-            => stream.WriteAsync(value.ToByteArray(), cancellationToken);
+        var responseLoggingLevel = (ResponseLoggingLevel)await stream.ReadByteAsync(cancellationToken);
+        return new ManagedCodeUpdateRequest(deltas, responseLoggingLevel: responseLoggingLevel);
+    }
+}
 
-        public static async ValueTask WriteByteArrayAsync(this Stream stream, byte[] value, CancellationToken cancellationToken)
+internal readonly struct UpdateResponse(IReadOnlyCollection<(string message, AgentMessageSeverity severity)> log, bool success)
+{
+    public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await stream.WriteAsync(success, cancellationToken);
+        await stream.WriteAsync(log.Count, cancellationToken);
+
+        foreach (var (message, severity) in log)
         {
-            await stream.WriteAsync(value.Length, cancellationToken);
-            await stream.WriteAsync(value, cancellationToken);
+            await stream.WriteAsync(message, cancellationToken);
+            await stream.WriteAsync((byte)severity, cancellationToken);
         }
+    }
 
-        public static async ValueTask WriteAsync(this Stream stream, int[] value, CancellationToken cancellationToken)
+    public static async ValueTask<(bool success, IAsyncEnumerable<(string message, AgentMessageSeverity severity)>)> ReadAsync(
+        Stream stream, CancellationToken cancellationToken)
+    {
+        var success = await stream.ReadBooleanAsync(cancellationToken);
+        var log = ReadLogAsync(cancellationToken);
+        return (success, log);
+
+        async IAsyncEnumerable<(string message, AgentMessageSeverity severity)> ReadLogAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var size = sizeof(int) * (value.Length + 1);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
+            var entryCount = await stream.ReadInt32Async(cancellationToken);
+
+            for (var i = 0; i < entryCount; i++)
             {
-                BinaryPrimitives.WriteInt32LittleEndian(buffer, value.Length);
-                for (int i = 0; i < value.Length; i++)
-                {
-                    BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan((i + 1) * sizeof(int), sizeof(int)), value[i]);
-                }
-
-                await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-
-        public static async ValueTask WriteAsync(this Stream stream, string value, CancellationToken cancellationToken)
-        {
-            var bytes = Encoding.UTF8.GetBytes(value);
-            await stream.Write7BitEncodedIntAsync(bytes.Length, cancellationToken);
-            await stream.WriteAsync(bytes, cancellationToken);
-        }
-
-    #if !NET
-        public static async ValueTask WriteAsync(this Stream stream, byte[] value, CancellationToken cancellationToken)
-            => await stream.WriteAsync(value, offset: 0, count: value.Length, cancellationToken);
-    #endif
-        public static async ValueTask Write7BitEncodedIntAsync(this Stream stream, int value, CancellationToken cancellationToken)
-        {
-            uint uValue = (uint)value;
-
-            while (uValue > 0x7Fu)
-            {
-                await stream.WriteAsync((byte)(uValue | ~0x7Fu), cancellationToken);
-                uValue >>= 7;
-            }
-
-            await stream.WriteAsync((byte)uValue, cancellationToken);
-        }
-
-        public static async ValueTask<bool> ReadBooleanAsync(this Stream stream, CancellationToken cancellationToken)
-            => await stream.ReadByteAsync(cancellationToken) != 0;
-
-        public static async ValueTask<byte> ReadByteAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            int size = sizeof(byte);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-                return buffer[0];
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
+                var message = await stream.ReadStringAsync(cancellationToken);
+                var severity = (AgentMessageSeverity)await stream.ReadByteAsync(cancellationToken);
+                yield return (message, severity);
             }
         }
+    }
+}
 
-        public static async ValueTask<int> ReadInt32Async(this Stream stream, CancellationToken cancellationToken)
+internal readonly struct ClientInitializationRequest(string capabilities) : IRequest
+{
+    private const byte Version = 0;
+
+    public string Capabilities { get; } = capabilities;
+
+    /// <summary>
+    /// Called by delta applier.
+    /// </summary>
+    public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await stream.WriteAsync(Version, cancellationToken);
+        await stream.WriteAsync(Capabilities, cancellationToken);
+    }
+
+    /// <summary>
+    /// Called by dotnet-watch.
+    /// </summary>
+    public static async ValueTask<ClientInitializationRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var version = await stream.ReadByteAsync(cancellationToken);
+        if (version != Version)
         {
-            int size = sizeof(int);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-                return BinaryPrimitives.ReadInt32LittleEndian(buffer);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+            throw new NotSupportedException($"Unsupported version {version}.");
         }
 
-        public static async ValueTask<Guid> ReadGuidAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            const int size = 16;
-    #if NET
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        var capabilities = await stream.ReadStringAsync(cancellationToken);
+        return new ClientInitializationRequest(capabilities);
+    }
+}
 
-            try
-            {
-                await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-                return new Guid(buffer.AsSpan(0, size));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-    #else
-            var buffer = new byte[size];
-            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-            return new Guid(buffer);
-    #endif
+internal readonly struct StaticAssetUpdateRequest(
+    string assemblyName,
+    string relativePath,
+    byte[] contents,
+    bool isApplicationProject) : IRequest
+{
+    private const byte Version = 1;
+
+    public string AssemblyName { get; } = assemblyName;
+    public bool IsApplicationProject { get; } = isApplicationProject;
+    public string RelativePath { get; } = relativePath;
+    public byte[] Contents { get; } = contents;
+
+    public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await stream.WriteAsync(Version, cancellationToken);
+        await stream.WriteAsync(AssemblyName, cancellationToken);
+        await stream.WriteAsync(IsApplicationProject, cancellationToken);
+        await stream.WriteAsync(RelativePath, cancellationToken);
+        await stream.WriteByteArrayAsync(Contents, cancellationToken);
+    }
+
+    public static async ValueTask<StaticAssetUpdateRequest> ReadAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var version = await stream.ReadByteAsync(cancellationToken);
+        if (version != Version)
+        {
+            throw new NotSupportedException($"Unsupported version {version}.");
         }
 
-        public static async ValueTask<byte[]> ReadByteArrayAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            var count = await stream.ReadInt32Async(cancellationToken);
-            if (count == 0)
-            {
-                return [];
-            }
+        var assemblyName = await stream.ReadStringAsync(cancellationToken);
+        var isAppProject = await stream.ReadBooleanAsync(cancellationToken);
+        var relativePath = await stream.ReadStringAsync(cancellationToken);
+        var contents = await stream.ReadByteArrayAsync(cancellationToken);
 
-            var bytes = new byte[count];
-            await ReadExactlyAsync(stream, bytes, count, cancellationToken);
-            return bytes;
-        }
-
-        public static async ValueTask<int[]> ReadIntArrayAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            var count = await stream.ReadInt32Async(cancellationToken);
-            if (count == 0)
-            {
-                return [];
-            }
-
-            var result = new int[count];
-            int size = count * sizeof(int);
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-
-                for (var i = 0; i < count; i++)
-                {
-                    result[i] = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(i * sizeof(int)));
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-
-            return result;
-        }
-
-        public static async ValueTask<string> ReadStringAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            int size = await stream.Read7BitEncodedIntAsync(cancellationToken);
-            if (size < 0)
-            {
-                throw new InvalidDataException();
-            }
-
-            if (size == 0)
-            {
-                return string.Empty;
-            }
-
-            var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
-            try
-            {
-                await ReadExactlyAsync(stream, buffer, size, cancellationToken);
-                return Encoding.UTF8.GetString(buffer, 0, size);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-
-        public static async ValueTask<int> Read7BitEncodedIntAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            const int MaxBytesWithoutOverflow = 4;
-
-            uint result = 0;
-            byte b;
-
-            for (int shift = 0; shift < MaxBytesWithoutOverflow * 7; shift += 7)
-            {
-                b = await stream.ReadByteAsync(cancellationToken);
-                result |= (b & 0x7Fu) << shift;
-
-                if (b <= 0x7Fu)
-                {
-                    return (int)result;
-                }
-            }
-
-            // Read the 5th byte. Since we already read 28 bits,
-            // the value of this byte must fit within 4 bits (32 - 28),
-            // and it must not have the high bit set.
-
-            b = await stream.ReadByteAsync(cancellationToken);
-            if (b > 0b_1111u)
-            {
-                throw new InvalidDataException();
-            }
-
-            result |= (uint)b << (MaxBytesWithoutOverflow * 7);
-            return (int)result;
-        }
-
-        private static async ValueTask<int> ReadExactlyAsync(this Stream stream, byte[] buffer, int size, CancellationToken cancellationToken)
-        {
-            int totalRead = 0;
-            while (totalRead < buffer.Length)
-            {
-                int read = await stream.ReadAsync(buffer, offset: totalRead, count: size - totalRead, cancellationToken).ConfigureAwait(false);
-                if (read == 0)
-                {
-                    throw new EndOfStreamException();
-                }
-
-                totalRead += read;
-            }
-
-            return totalRead;
-        }
+        return new StaticAssetUpdateRequest(
+            assemblyName: assemblyName,
+            relativePath: relativePath,
+            contents: contents,
+            isApplicationProject: isAppProject);
     }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/StreamExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StreamExtensions.cs
@@ -10,4 +10,265 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Watch;
 
+/// <summary>
+/// Implements async read/write helpers that provide functionality of <see cref="BinaryReader"/> and <see cref="BinaryWriter"/>.
+/// See https://github.com/dotnet/runtime/issues/17229
+/// </summary>
+internal static class StreamExtesions
+{
+    public static ValueTask WriteAsync(this Stream stream, bool value, CancellationToken cancellationToken)
+        => WriteAsync(stream, (byte)(value ? 1 : 0), cancellationToken);
 
+    public static async ValueTask WriteAsync(this Stream stream, byte value, CancellationToken cancellationToken)
+    {
+        var size = sizeof(byte);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            buffer[0] = value;
+            await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static async ValueTask WriteAsync(this Stream stream, int value, CancellationToken cancellationToken)
+    {
+        var size = sizeof(int);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+            await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static ValueTask WriteAsync(this Stream stream, Guid value, CancellationToken cancellationToken)
+        => stream.WriteAsync(value.ToByteArray(), cancellationToken);
+
+    public static async ValueTask WriteByteArrayAsync(this Stream stream, byte[] value, CancellationToken cancellationToken)
+    {
+        await stream.WriteAsync(value.Length, cancellationToken);
+        await stream.WriteAsync(value, cancellationToken);
+    }
+
+    public static async ValueTask WriteAsync(this Stream stream, int[] value, CancellationToken cancellationToken)
+    {
+        var size = sizeof(int) * (value.Length + 1);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, value.Length);
+            for (int i = 0; i < value.Length; i++)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan((i + 1) * sizeof(int), sizeof(int)), value[i]);
+            }
+
+            await stream.WriteAsync(buffer, offset: 0, count: size, cancellationToken);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static async ValueTask WriteAsync(this Stream stream, string value, CancellationToken cancellationToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        await stream.Write7BitEncodedIntAsync(bytes.Length, cancellationToken);
+        await stream.WriteAsync(bytes, cancellationToken);
+    }
+
+#if !NET
+        public static async ValueTask WriteAsync(this Stream stream, byte[] value, CancellationToken cancellationToken)
+            => await stream.WriteAsync(value, offset: 0, count: value.Length, cancellationToken);
+#endif
+    public static async ValueTask Write7BitEncodedIntAsync(this Stream stream, int value, CancellationToken cancellationToken)
+    {
+        uint uValue = (uint)value;
+
+        while (uValue > 0x7Fu)
+        {
+            await stream.WriteAsync((byte)(uValue | ~0x7Fu), cancellationToken);
+            uValue >>= 7;
+        }
+
+        await stream.WriteAsync((byte)uValue, cancellationToken);
+    }
+
+    public static async ValueTask<bool> ReadBooleanAsync(this Stream stream, CancellationToken cancellationToken)
+        => await stream.ReadByteAsync(cancellationToken) != 0;
+
+    public static async ValueTask<byte> ReadByteAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        int size = sizeof(byte);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+            return buffer[0];
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static async ValueTask<int> ReadInt32Async(this Stream stream, CancellationToken cancellationToken)
+    {
+        int size = sizeof(int);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static async ValueTask<Guid> ReadGuidAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        const int size = 16;
+#if NET
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+
+        try
+        {
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+            return new Guid(buffer.AsSpan(0, size));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+#else
+            var buffer = new byte[size];
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+            return new Guid(buffer);
+#endif
+    }
+
+    public static async ValueTask<byte[]> ReadByteArrayAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        var count = await stream.ReadInt32Async(cancellationToken);
+        if (count == 0)
+        {
+            return [];
+        }
+
+        var bytes = new byte[count];
+        await ReadExactlyAsync(stream, bytes, count, cancellationToken);
+        return bytes;
+    }
+
+    public static async ValueTask<int[]> ReadIntArrayAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        var count = await stream.ReadInt32Async(cancellationToken);
+        if (count == 0)
+        {
+            return [];
+        }
+
+        var result = new int[count];
+        int size = count * sizeof(int);
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+
+            for (var i = 0; i < count; i++)
+            {
+                result[i] = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(i * sizeof(int)));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        return result;
+    }
+
+    public static async ValueTask<string> ReadStringAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        int size = await stream.Read7BitEncodedIntAsync(cancellationToken);
+        if (size < 0)
+        {
+            throw new InvalidDataException();
+        }
+
+        if (size == 0)
+        {
+            return string.Empty;
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(minimumLength: size);
+        try
+        {
+            await ReadExactlyAsync(stream, buffer, size, cancellationToken);
+            return Encoding.UTF8.GetString(buffer, 0, size);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public static async ValueTask<int> Read7BitEncodedIntAsync(this Stream stream, CancellationToken cancellationToken)
+    {
+        const int MaxBytesWithoutOverflow = 4;
+
+        uint result = 0;
+        byte b;
+
+        for (int shift = 0; shift < MaxBytesWithoutOverflow * 7; shift += 7)
+        {
+            b = await stream.ReadByteAsync(cancellationToken);
+            result |= (b & 0x7Fu) << shift;
+
+            if (b <= 0x7Fu)
+            {
+                return (int)result;
+            }
+        }
+
+        // Read the 5th byte. Since we already read 28 bits,
+        // the value of this byte must fit within 4 bits (32 - 28),
+        // and it must not have the high bit set.
+
+        b = await stream.ReadByteAsync(cancellationToken);
+        if (b > 0b_1111u)
+        {
+            throw new InvalidDataException();
+        }
+
+        result |= (uint)b << (MaxBytesWithoutOverflow * 7);
+        return (int)result;
+    }
+
+    private static async ValueTask<int> ReadExactlyAsync(this Stream stream, byte[] buffer, int size, CancellationToken cancellationToken)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer, offset: totalRead, count: size - totalRead, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += read;
+        }
+
+        return totalRead;
+    }
+}

--- a/src/BuiltInTools/dotnet-watch/HotReload/StreamExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/StreamExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Watch;
+
+

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\AspireService\Microsoft.WebTools.AspireService.projitems" Label="Shared" />
+  <Import Project="..\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
   <Import Project="$(RepoRoot)\src\Layout\redist\targets\PublishDotnetWatch.targets" />
 
   <PropertyGroup>
@@ -45,33 +46,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\Cli\dotnet\dotnet.csproj"/>
+    <ProjectReference Include="$(RepoRoot)\src\Cli\dotnet\dotnet.csproj" />
 
-    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\BrowserRefresh\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="middleware\Microsoft.AspNetCore.Watch.BrowserRefresh.dll" CopyToOutputDirectory="PreserveNewest" />
 
-    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll" CopyToOutputDirectory="PreserveNewest" />
 
-    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj"
-                      PrivateAssets="All"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework;TargetFrameworks"
-                      OutputItemType="Content"
-                      CopyToOutputDirectory="PreserveNewest"/>
+    <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!--
@@ -79,7 +60,5 @@
     These files are used for layout generation in redist project.
     Tests are also running dotnet.exe from redist artifacts.
   -->
-  <Target Name="PublishToRedist"
-          DependsOnTargets="PublishDotnetWatchToRedist"
-          BeforeTargets="AfterBuild" />
+  <Target Name="PublishToRedist" DependsOnTargets="PublishDotnetWatchToRedist" BeforeTargets="AfterBuild" />
 </Project>

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/ManagedCodeUpdateRequestTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/ManagedCodeUpdateRequestTests.cs
@@ -5,12 +5,12 @@ using Microsoft.DotNet.HotReload;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class UpdatePayloadTests
+public class ManagedCodeUpdateRequestTests
 {
     [Fact]
     public async Task Roundtrip()
     {
-        var initial = new UpdatePayload(
+        var initial = new ManagedCodeUpdateRequest(
             [
                 new UpdateDelta(
                     moduleId: Guid.NewGuid(),
@@ -31,7 +31,7 @@ public class UpdatePayloadTests
         await initial.WriteAsync(stream, CancellationToken.None);
 
         stream.Position = 0;
-        var read = await UpdatePayload.ReadAsync(stream, CancellationToken.None);
+        var read = await ManagedCodeUpdateRequest.ReadAsync(stream, CancellationToken.None);
 
         AssertEqual(initial, read);
     }
@@ -39,7 +39,7 @@ public class UpdatePayloadTests
     [Fact]
     public async Task WithLargeDeltas()
     {
-        var initial = new UpdatePayload(
+        var initial = new ManagedCodeUpdateRequest(
             [
                 new UpdateDelta(
                     moduleId: Guid.NewGuid(),
@@ -54,12 +54,12 @@ public class UpdatePayloadTests
         await initial.WriteAsync(stream, CancellationToken.None);
 
         stream.Position = 0;
-        var read = await UpdatePayload.ReadAsync(stream, CancellationToken.None);
+        var read = await ManagedCodeUpdateRequest.ReadAsync(stream, CancellationToken.None);
 
         AssertEqual(initial, read);
     }
 
-    private static void AssertEqual(UpdatePayload initial, UpdatePayload read)
+    private static void AssertEqual(ManagedCodeUpdateRequest initial, ManagedCodeUpdateRequest read)
     {
         Assert.Equal(initial.Deltas.Count, read.Deltas.Count);
 

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
@@ -1,16 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.HotReload;
-
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class StaticAssetPayloadTests
+public class StaticAssetUpdateRequestTests
 {
     [Fact]
     public async Task Roundtrip()
     {
-        var initial = new StaticAssetPayload(
+        var initial = new StaticAssetUpdateRequest(
             assemblyName: "assembly name",
             relativePath: "some path",
             [1, 2, 3],
@@ -20,12 +18,12 @@ public class StaticAssetPayloadTests
         await initial.WriteAsync(stream, CancellationToken.None);
 
         stream.Position = 0;
-        var read = await StaticAssetPayload.ReadAsync(stream, CancellationToken.None);
+        var read = await StaticAssetUpdateRequest.ReadAsync(stream, CancellationToken.None);
 
         AssertEqual(initial, read);
     }
 
-    private static void AssertEqual(StaticAssetPayload initial, StaticAssetPayload read)
+    private static void AssertEqual(StaticAssetUpdateRequest initial, StaticAssetUpdateRequest read)
     {
         Assert.Equal(initial.AssemblyName, read.AssemblyName);
         Assert.Equal(initial.RelativePath, read.RelativePath);

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.HotReload;
+
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class StaticAssetUpdateRequestTests

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.HotReload;
+
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 public class StreamExtensionsTests


### PR DESCRIPTION
Factors named pipe RPC code to a source package sharable across dotnet-watch, Microsoft.Extensions.DotNetDeltaApplier and WebTool VS client.

The package targets netstandard2.0 to support VS in-proc client.