### PR TITLE
Add exit code to the compatibility tool.

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidateAssemblies.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.ApiCompat
 {
     internal static class ValidateAssemblies
     {
-        public static void Run(Func<ISuppressionEngine, ISuppressibleLog> logFactory,
+        public static int Run(Func<ISuppressionEngine, ISuppressibleLog> logFactory,
             bool generateSuppressionFile,
             bool preserveUnnecessarySuppressions,
             bool permitUnnecessarySuppressions,
@@ -100,6 +100,8 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.ValidateUnnecessarySuppressions(serviceProvider.SuppressionEngine, serviceProvider.SuppressibleLog);
             }
+
+            return serviceProvider.SuppressibleLog.HasLoggedErrorSuppressions ? 1 : 0;
         }
 
         private static string[]? GetAssemblyReferences(string[][]? assemblyReferences, int counter)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ValidatePackage.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.ApiCompat
 {
     internal static class ValidatePackage
     {
-        public static void Run(Func<ISuppressionEngine, ISuppressibleLog> logFactory,
+        public static int Run(Func<ISuppressionEngine, ISuppressibleLog> logFactory,
             bool generateSuppressionFile,
             bool preserveUnnecessarySuppressions,
             bool permitUnnecessarySuppressions,
@@ -96,6 +96,8 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SuppressionFileHelper.ValidateUnnecessarySuppressions(serviceProvider.SuppressionEngine, serviceProvider.SuppressibleLog);
             }
+
+            return serviceProvider.SuppressibleLog.HasLoggedErrorSuppressions ? 1 : 0;
         }
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tool/Program.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 (string, string)[]? rightAssembliesTransformationPattern = parseResult.GetValue(rightAssembliesTransformationPatternOption);
 
                 SuppressibleConsoleLog logFactory(ISuppressionEngine suppressionEngine) => new(suppressionEngine, verbosity);
-                ValidateAssemblies.Run(logFactory,
+                int exitCode = ValidateAssemblies.Run(logFactory,
                     generateSuppressionFile,
                     preserveUnnecessarySuppressions,
                     permitUnnecessarySuppressions,
@@ -218,6 +218,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                     rightAssembliesTransformationPattern);
 
                 roslynResolver.Unregister();
+
+                return exitCode;
             });
 
             // Package command
@@ -319,7 +321,7 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                 string[]? baselinePackageFrameworksToIgnore = parseResult.GetValue(baselinePackageFrameworksToIgnoreOption);
 
                 SuppressibleConsoleLog logFactory(ISuppressionEngine suppressionEngine) => new(suppressionEngine, verbosity);
-                ValidatePackage.Run(logFactory,
+                int exitCode = ValidatePackage.Run(logFactory,
                     generateSuppressionFile,
                     preserveUnnecessarySuppressions,
                     permitUnnecessarySuppressions,
@@ -342,6 +344,8 @@ namespace Microsoft.DotNet.ApiCompat.Tool
                     baselinePackageFrameworksToIgnore);
 
                 roslynResolver.Unregister();
+
+                return exitCode;
             });
 
             rootCommand.Subcommands.Add(packageCommand);


### PR DESCRIPTION
`Microsoft.DotNet.ApiCompat.Tool` always returns a `0` exit code, which means users are unable to determine if the compatibility check was successful or not without reading the output. Mainly contribute this change because I don't want to determine it based on the output via grep or other tool as a workaround.