### PR TITLE
add pgort140 to the exclusion list

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -55,7 +55,7 @@ jobs:
     templateContext:
       sdl:
         binskim:
-          analyzeTargetGlob: +:f|eng\**\*.props;+:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;-:f|artifacts\bin\**\msdia140.dll;
+          analyzeTargetGlob: +:f|eng\**\*.props;+:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;-:f|artifacts\bin\**\msdia140.dll;-:f|artifacts\bin\**\pgort140.dll;
 
     steps:
     ############## PREP ###############


### PR DESCRIPTION
This component comes from the runtime and so we shouldn't scan it.