### PR TITLE
[release/8.0.4xx] Fix regression - single arch scenario with no rid specified

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -110,8 +110,8 @@
 
     <ItemGroup Label="AppCommand Assignment" Condition="'$(ContainerAppCommandInstruction)' != 'None'">
       <!-- For self-contained, invoke the native executable as a single arg -->
-      <ContainerAppCommand Condition="@(ContainerAppCommand->Count()) == 0 and '$(UseAppHost)' == 'true' and !$(_ContainerIsTargetingWindows)" Include="$(ContainerWorkingDirectory)/$(AssemblyName)" />
-      <ContainerAppCommand Condition="@(ContainerAppCommand->Count()) == 0 and '$(UseAppHost)' == 'true' and $(_ContainerIsTargetingWindows)" Include="$(AssemblyName)$(_NativeExecutableExtension)" />
+      <ContainerAppCommand Condition="@(ContainerAppCommand->Count()) == 0 and '$(_ContainerIsSelfContained)' == 'true' and !$(_ContainerIsTargetingWindows)" Include="$(ContainerWorkingDirectory)/$(AssemblyName)" />
+      <ContainerAppCommand Condition="@(ContainerAppCommand->Count()) == 0 and '$(_ContainerIsSelfContained)' == 'true' and $(_ContainerIsTargetingWindows)" Include="$(AssemblyName)$(_NativeExecutableExtension)" />
       <!-- For non self-contained, invoke `dotnet` `app.dll` as separate args -->
       <ContainerAppCommand Condition="@(ContainerAppCommand->Count()) == 0" Include="dotnet;$(TargetFileName)" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -688,6 +688,39 @@ public class EndToEndTests : IDisposable
         privateNuGetAssets.Delete(true);
     }
 
+    [DockerAvailableFact]
+    public void EndToEnd_SingleArch_NoRid()
+    {
+        // Create a new console project
+        DirectoryInfo newProjectDir = CreateNewProject("console");
+
+        string imageName = NewImageName();
+        string imageTag = "1.0";
+
+        // Run PublishContainer for multi-arch
+        CommandResult commandResult = new DotnetCommand(
+            _testOutput,
+            "publish",
+            "/t:PublishContainer",
+            $"/p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageAspNet}",
+            $"/p:ContainerRepository={imageName}",
+            $"/p:ContainerImageTag={imageTag}",
+            "/p:EnableSdkContainerSupport=true")
+            .WithWorkingDirectory(newProjectDir.FullName)
+            .Execute();
+        commandResult.Should().Pass();
+
+        // Check that the containers can be run
+        CommandResult processResultX64 = ContainerCli.RunCommand(
+            _testOutput,
+            "--rm",
+            "--name",
+            $"test-container-singlearch-norid",
+            $"{imageName}:{imageTag}")
+        .Execute();
+        processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
+    }
+
     [DockerSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_LocalRegistry()
     {


### PR DESCRIPTION
### Context
Fixes https://github.com/dotnet/sdk-container-builds/issues/610
In a single arch scenario when no `RuntimeIdentifier` is specified, the produced container cannot be run. This is a very common scenario for single arch.

This is a regression that was caused by https://github.com/dotnet/sdk/pull/43085 PR. 

### Customer impact
Without this fix, customers will not be able to run the published containers in single arch scenario when no `RuntimeIdentifier` is specified. They were able to do this before the regression.

### Details
 The problem is that the `ContainerAppCommand` item is missing `dotnet`. In the PR above `ContainerAppCommand` setting was changed to check `UseAppHost` property instead of  `_ContainerIsSelfContained` https://github.com/dotnet/sdk/pull/43085/files#diff-a5f4ada40b043c8a36b7a1d56148dcfd0abcfe13fa82dbfb456f7c43bebedff7L103
 This works for the cases when `RuntimeIdentfier` is specified, but not for the cases when it is not.

The tests did not catch this because there is no test covering this specific scenario with no `RuntimeIdentifier` specified - all single arch tests specify a `RuntimeIdentifier`.

### Changes made
Fixed by setting `ContainerAppCommand` correctly.

### Testing
Added a test to cover this scenario. Also tested manually.

### Risks
Low - new test ensures the scenario is now covered, the existing tests ensure that other scenarios were not affected.




