### PR TITLE
Skip experimental in recommending workloads

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSuggestionFinder.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSuggestionFinder.cs
@@ -187,6 +187,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         internal static WorkloadSuggestion GetBestSuggestion(ICollection<WorkloadSuggestion> suggestions) => FindBest(
                 suggestions,
+                (x, y) => ContainsExperimental(y.Workloads) - ContainsExperimental(x.Workloads),
                 (x, y) => y.ExtraPacks - x.ExtraPacks,
                 (x, y) => y.Workloads.Count - x.Workloads.Count);
 
@@ -194,6 +195,8 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         /// Gets the suggestion with the lowest number of extra packs and lowest number of workload IDs.
         /// </summary>
         public WorkloadSuggestion GetBestSuggestion() => GetBestSuggestion(UnsortedSuggestions);
+
+        private static int ContainsExperimental(HashSet<WorkloadId> set) => set.Any(w => w.ToString().Contains("experimental")) ? 1 : 0;
 
         /// <summary>
         /// A partial or complete suggestion for workloads to install, annotated with which requested packs it does not satisfy

--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -315,7 +315,7 @@ namespace Microsoft.NET.Build.Tests
                 // Conditionally check the OS and modify the expected workloads on Linux
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    expected = "android;wasi-experimental";
+                    expected = "android;wasm-tools";
                 }
                 
                 getValuesCommand.GetValues()


### PR DESCRIPTION
We've had issues around (heuristically) finding the appropriate workloads to recommend that the user install if they're missing packs. This should help in that it will avoid recommending experimental workloads if there are any other options.

I don't feel too attached to this PR.

I did test this PR, but I neglected to save screenshots.