### PR TITLE
ApiDiff: Allow deciding whether to include partial modifier in TypeDeclarationCSharpSyntaxRewriter output

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.GenAPI
         private readonly AdhocWorkspace _adhocWorkspace;
         private readonly SyntaxGenerator _syntaxGenerator;
         private readonly IEnumerable<MetadataReference> _metadataReferences;
+        private readonly bool _addPartialModifier;
 
         public CSharpFileBuilder(ILog logger,
             ISymbolFilter symbolFilter,
@@ -41,7 +42,8 @@ namespace Microsoft.DotNet.GenAPI
             TextWriter textWriter,
             string? exceptionMessage,
             bool includeAssemblyAttributes,
-            IEnumerable<MetadataReference> metadataReferences)
+            IEnumerable<MetadataReference> metadataReferences,
+            bool addPartialModifier)
         {
             _logger = logger;
             _textWriter = textWriter;
@@ -52,6 +54,7 @@ namespace Microsoft.DotNet.GenAPI
             _adhocWorkspace = new AdhocWorkspace();
             _syntaxGenerator = SyntaxGenerator.GetGenerator(_adhocWorkspace, LanguageNames.CSharp);
             _metadataReferences = metadataReferences;
+            _addPartialModifier = addPartialModifier;
         }
 
         /// <inheritdoc />
@@ -79,7 +82,7 @@ namespace Microsoft.DotNet.GenAPI
 
             SyntaxNode compilationUnit = _syntaxGenerator.CompilationUnit(namespaceSyntaxNodes)
                 .WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation)
-                .Rewrite(new TypeDeclarationCSharpSyntaxRewriter())
+                .Rewrite(new TypeDeclarationCSharpSyntaxRewriter(addPartialModifier: true))
                 .Rewrite(new BodyBlockCSharpSyntaxRewriter(_exceptionMessage));
 
             if (_includeAssemblyAttributes)

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -81,7 +81,8 @@ namespace Microsoft.DotNet.GenAPI
                     textWriter,
                     exceptionMessage,
                     includeAssemblyAttributes,
-                    loader.MetadataReferences);
+                    loader.MetadataReferences,
+                    addPartialModifier: true);
 
                 fileBuilder.WriteAssembly(assemblySymbol);
             }

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriter.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriter.cs
@@ -15,13 +15,15 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
     /// - adds partial keyword
     /// - remove Object from a list of base types.
     /// </summary>
-    /// <remarks>
-    /// Initializes a new instance of the <see cref="TypeDeclarationCSharpSyntaxRewriter"/> class, and optionally allows deciding whether to insert the partial modifier for types or not.
-    /// </remarks>
-    /// <param name="addPartialModifier">Determines whether to insert the partial modifier for types or not.</param>
-    public class TypeDeclarationCSharpSyntaxRewriter(bool addPartialModifier) : CSharpSyntaxRewriter
+    public class TypeDeclarationCSharpSyntaxRewriter : CSharpSyntaxRewriter
     {
-        private readonly bool _addPartialModifier = addPartialModifier;
+        private readonly bool _addPartialModifier;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeDeclarationCSharpSyntaxRewriter"/> class, and allows deciding whether to insert the partial modifier for types or not.
+        /// </summary>
+        /// <param name="addPartialModifier">Determines whether to insert the partial modifier for types or not.</param>
+        public TypeDeclarationCSharpSyntaxRewriter(bool addPartialModifier) => _addPartialModifier = addPartialModifier;
 
         /// <inheritdoc />
         public override SyntaxNode? VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriter.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriter.cs
@@ -15,8 +15,14 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
     /// - adds partial keyword
     /// - remove Object from a list of base types.
     /// </summary>
-    public class TypeDeclarationCSharpSyntaxRewriter : CSharpSyntaxRewriter
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="TypeDeclarationCSharpSyntaxRewriter"/> class, and optionally allows deciding whether to insert the partial modifier for types or not.
+    /// </remarks>
+    /// <param name="addPartialModifier">Determines whether to insert the partial modifier for types or not.</param>
+    public class TypeDeclarationCSharpSyntaxRewriter(bool addPartialModifier) : CSharpSyntaxRewriter
     {
+        private readonly bool _addPartialModifier = addPartialModifier;
+
         /// <inheritdoc />
         public override SyntaxNode? VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
         {
@@ -83,7 +89,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             }
         }
 
-        private static T? VisitCommonTypeDeclaration<T>(T? node) where T : TypeDeclarationSyntax
+        private T? VisitCommonTypeDeclaration<T>(T? node) where T : TypeDeclarationSyntax
         {
             if (node == null)
             {
@@ -91,7 +97,7 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
             }
 
             node = RemoveBaseType(node, "global::System.Object");
-            return AddPartialModifier(node);
+            return _addPartialModifier ? AddPartialModifier(node) : node;
         }
 
         private static T? AddPartialModifier<T>(T? node) where T : TypeDeclarationSyntax =>

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -61,7 +61,8 @@ namespace Microsoft.DotNet.GenAPI.Tests
                 stringWriter,
                 null,
                 false,
-                MetadataReferences);
+                MetadataReferences,
+                addPartialModifier: true);
 
             using Stream assemblyStream = SymbolFactory.EmitAssemblyStreamFromSyntax(original, enableNullable: true, allowUnsafe: allowUnsafe, assemblyName: assemblyName);
             AssemblySymbolLoader assemblySymbolLoader = new(resolveAssemblyReferences: true, includeInternalSymbols: includeInternalSymbols);
@@ -231,7 +232,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
         {
             RunTest(original: """
                 namespace Foo
-                {   
+                {
                     public record RecordClass;
                     public record RecordClass1(int i);
                     public record RecordClass2(string s, int i);
@@ -240,7 +241,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     public record DerivedRecord3(string x, int i, double d) : RecordClass2(default(string)!, i);
                     public record DerivedRecord4(double d) : RecordClass2(default(string)!, default);
                     public record DerivedRecord5() : RecordClass2(default(string)!, default);
-                
+
                     public record RecordClassWithMethods(int i)
                     {
                         public void DoSomething() { }
@@ -345,11 +346,11 @@ namespace Microsoft.DotNet.GenAPI.Tests
             RunTest(original: """
                 namespace Foo
                 {
-                    
-                    public record struct RecordStruct;                    
+
+                    public record struct RecordStruct;
                     public record struct RecordStruct1(int i);
                     public record struct RecordStruct2(string s, int i);
-                
+
                     public record struct RecordStructWithMethods(int i)
                     {
                         public void DoSomething() { }
@@ -367,10 +368,10 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         public RecordStructWithConstructors() : this(1) { }
                         public RecordStructWithConstructors(string s) : this(int.Parse(s)) { }
                     }
-                
+
                 }
                 """,
-                expected: """                
+                expected: """
                 namespace Foo
                 {
                     public partial struct RecordStruct : System.IEquatable<RecordStruct>
@@ -1644,12 +1645,12 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         {
                             public B(int i) {}
                         }
-                    
+
                         public class C : B
                         {
                             internal C() : base(0) {}
                         }
-                    
+
                         public class D : B
                         {
                             internal D(int i) : base(i) {}
@@ -1672,7 +1673,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         {
                             public B(int i) {}
                         }
-                    
+
                         public partial class C : B
                         {
                             internal C() : base(default) {}
@@ -1702,12 +1703,12 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         {
                             public B(int i) {}
                         }
-                    
+
                         public class C : B
                         {
                             internal C() : base(0) {}
                         }
-                    
+
                         public class D : B
                         {
                             internal D(int i) : base(i) {}
@@ -1781,8 +1782,8 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         public partial class B
                         {
                             protected B() {}
-                        }                    
-                    
+                        }
+
                         public partial class C : B
                         {
                             internal C() {}
@@ -1935,7 +1936,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         public class D { }
 
                         public class Id { }
-                    
+
                         public class V { }
                     }
                     """,
@@ -2828,7 +2829,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
                         }
                     }
-                    
+
                     """,
                 // https://github.com/dotnet/sdk/issues/32195 tracks interface expansion
                 expected: """
@@ -2909,7 +2910,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     public ref struct C<T>
                         where T : unmanaged
                     {
-                        public required (string? k, dynamic v, nint n) X { get; init; }    
+                        public required (string? k, dynamic v, nint n) X { get; init; }
                     }
 
                     public static class E
@@ -2918,7 +2919,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     }
                 }
                 """,
-                expected: """                
+                expected: """
                 namespace N
                 {
                     public ref partial struct C<T>
@@ -2982,7 +2983,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                     namespace a
                     {
                         #pragma warning disable CS8597
-                        
+
                         public partial class MyStringCollection : ICollection, IEnumerable, IList
                         {
                             public int Count { get { throw null; } }
@@ -3006,7 +3007,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                             void ICollection.CopyTo(Array array, int index) { }
                             IEnumerator IEnumerable.GetEnumerator() { throw null; }
                             int IList.Add(object? value) { throw null; }
-                            bool IList.Contains(object? value) { throw null; }                            
+                            bool IList.Contains(object? value) { throw null; }
                             int IList.IndexOf(object? value) { throw null; }
                             void IList.Insert(int index, object? value) { }
                             void IList.Remove(object? value) { }
@@ -3015,7 +3016,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
                         #pragma warning restore CS8597
                     }
                     """,
-                expected: """                    
+                expected: """
                     namespace a
                     {
                         public partial class MyStringCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList

--- a/test/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriterTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/SyntaxRewriter/TypeDeclarationCSharpSyntaxRewriterTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.GenAPI.Tests.SyntaxRewriter
         [Fact]
         public void TestRemoveSystemObjectAsBaseClass()
         {
-            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(),
+            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(addPartialModifier: true),
                 original: """
                 namespace A
                 {
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.GenAPI.Tests.SyntaxRewriter
         [Fact]
         public void TestAddPartialKeyword()
         {
-            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(),
+            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(addPartialModifier: true),
                 original: """
                 namespace A
                 {
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.GenAPI.Tests.SyntaxRewriter
         [Fact]
         public void TestPartialTypeDeclaration()
         {
-            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(),
+            CompareSyntaxTree(new TypeDeclarationCSharpSyntaxRewriter(addPartialModifier: true),
                 original: """
                 namespace A
                 {


### PR DESCRIPTION
This PR is part of the work needed to create an ApiDiff tool that reuses some of the code from Microsoft.DotNet.GenAPI. The idea is to make the larger PR smaller and make it easier to review: https://github.com/dotnet/sdk/pull/45389

This change adds a boolean parameter to the TypeDeclarationCSharpSyntaxRewriter to allow callers to decide whether to include the partial modifier in the output or not.