### PR TITLE
Use latest jdk available in VMR aspnetcore build

### DIFF
--- a/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
+++ b/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
@@ -1,24 +1,24 @@
-From 6f55fd1639e918e3d0ad402d703e76ba8d6c412b Mon Sep 17 00:00:00 2001
+From ae5bdadc2e4fe78690a0ef418b6bbe06acb33b42 Mon Sep 17 00:00:00 2001
 From: Viktor Hofer <viktor.hofer@microsoft.com>
-Date: Thu, 9 Jan 2025 08:54:39 +0100
-Subject: [PATCH] Use the latest available jdk
+Date: Thu, 9 Jan 2025 10:56:16 +0100
+Subject: [PATCH] Specify toolchain in build.gradle files
 
 Backport: https://github.com/dotnet/aspnetcore/pull/59788
 
 ---
- global.json | 2 +-
+ src/SignalR/clients/java/signalr/build.gradle | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/global.json b/global.json
-index c1270224e3..bd7a41270d 100644
---- a/global.json
-+++ b/global.json
-@@ -24,7 +24,7 @@
-     "xcopy-msbuild": "17.8.5"
-   },
-   "native-tools": {
--    "jdk": "11.0.24"
-+    "jdk": "latest"
-   },
-   "msbuild-sdks": {
-     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25056.1",
+diff --git a/src/SignalR/clients/java/signalr/build.gradle b/src/SignalR/clients/java/signalr/build.gradle
+index 895f8c4338..3e192445c9 100644
+--- a/src/SignalR/clients/java/signalr/build.gradle
++++ b/src/SignalR/clients/java/signalr/build.gradle
+@@ -22,7 +22,7 @@ allprojects {
+     version project.findProperty('packageVersion') ?: "99.99.99-dev"
+ 
+     java {
+-        sourceCompatibility = 1.8
++        sourceCompatibility = 1.9
+     }
+ 
+     repositories {

--- a/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
+++ b/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
@@ -1,14 +1,28 @@
-From ae5bdadc2e4fe78690a0ef418b6bbe06acb33b42 Mon Sep 17 00:00:00 2001
+From d04dfb1ab0f13dbe0f15c065d7f127d8747a0832 Mon Sep 17 00:00:00 2001
 From: Viktor Hofer <viktor.hofer@microsoft.com>
-Date: Thu, 9 Jan 2025 10:56:16 +0100
-Subject: [PATCH] Specify toolchain in build.gradle files
+Date: Thu, 9 Jan 2025 08:54:39 +0100
+Subject: [PATCH] Use the latest available jdk
 
 Backport: https://github.com/dotnet/aspnetcore/pull/59788
 
 ---
+ global.json                                   | 2 +-
  src/SignalR/clients/java/signalr/build.gradle | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
+diff --git a/global.json b/global.json
+index c1270224e3..bd7a41270d 100644
+--- a/global.json
++++ b/global.json
+@@ -24,7 +24,7 @@
+     "xcopy-msbuild": "17.8.5"
+   },
+   "native-tools": {
+-    "jdk": "11.0.24"
++    "jdk": "latest"
+   },
+   "msbuild-sdks": {
+     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25056.1",
 diff --git a/src/SignalR/clients/java/signalr/build.gradle b/src/SignalR/clients/java/signalr/build.gradle
 index 895f8c4338..3e192445c9 100644
 --- a/src/SignalR/clients/java/signalr/build.gradle

--- a/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
+++ b/src/SourceBuild/patches/aspnetcore/0001-update-jdk-version.patch
@@ -1,0 +1,24 @@
+From 6f55fd1639e918e3d0ad402d703e76ba8d6c412b Mon Sep 17 00:00:00 2001
+From: Viktor Hofer <viktor.hofer@microsoft.com>
+Date: Thu, 9 Jan 2025 08:54:39 +0100
+Subject: [PATCH] Use the latest available jdk
+
+Backport: https://github.com/dotnet/aspnetcore/pull/59788
+
+---
+ global.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/global.json b/global.json
+index c1270224e3..bd7a41270d 100644
+--- a/global.json
++++ b/global.json
+@@ -24,7 +24,7 @@
+     "xcopy-msbuild": "17.8.5"
+   },
+   "native-tools": {
+-    "jdk": "11.0.24"
++    "jdk": "latest"
+   },
+   "msbuild-sdks": {
+     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25056.1",


### PR DESCRIPTION
**All VMR and aspnetcore repos builds are currently broken**

Our build images got updated yesterday and with that, the installed jdk versions changed significantly (across major versions). This broke aspnetcore's build which asserts on a very specific version.

I reached out to @wtgodbe in https://github.com/dotnet/aspnetcore/pull/58465#discussion_r1908303243 to better understand why they had to change back to a an exact version match instead of just depending on a specific major version.

This patch tries to use whatever latest version is available by using "latest". Let's see if that works.