### PR TITLE
Make the SkipPrepareSdkArchive more useful for local dev innerloop

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -2,7 +2,10 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
 
-  <Target Name="DetermineSourceBuiltSdkVersion">
+  <!-- The SkipPrepareSdkArchive switch exists so that outside components like the license scan test pipeline
+       can run a subset of tests that don't need the SDK archive without building the VMR.
+       The switch is also useful for the local dev innerloop to build the test projects without needing to run them. -->
+  <Target Name="DetermineSourceBuiltSdkVersion" Condition="'$(SkipPrepareSdkArchive)' != 'true'">
     <PropertyGroup>
       <SdkFilenamePrefix>dotnet-sdk-</SdkFilenamePrefix>
     </PropertyGroup>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
@@ -10,10 +10,7 @@
     <!-- Multiple loggers are specified so that results are captured in trx and pipelines can fail with AzDO pipeline warnings
          Workaround https://github.com/dotnet/source-build/issues/4003 by disabling VSTestUseMSBuildOutput -->
     <VSTestUseMSBuildOutput>false</VSTestUseMSBuildOutput>
-    <!-- The license scan test pipeline invokes this project directly and only runs the license scan tests.
-         They don't require the SDK archive and therefore don't build the VMR. The DetermineSourceBuiltSdkVersion
-         target would fail as the SDK archive doesn't exist. This hook disables invoking the target and the P2P below. -->
-    <SetRuntimeConfigOptionsDependsOn Condition="'$(SkipPrepareSdkArchive)' != 'true'">DetermineSourceBuiltSdkVersion</SetRuntimeConfigOptionsDependsOn>
+    <SetRuntimeConfigOptionsDependsOn Condition="'$(SkipPrepareSdkArchive)' != 'true'"></SetRuntimeConfigOptionsDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +33,7 @@
   </ItemGroup>
 
   <Target Name="SetRuntimeConfigOptions"
-          DependsOnTargets="$(SetRuntimeConfigOptionsDependsOn)"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion"
           BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
     <ItemGroup Condition="'$(SourceBuiltArtifactsPath)' == ''">
       <SourceBuiltArtifactsItem Include="$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="NuGet.Protocol" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)merge-asset-manifests.proj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" ReferenceOutputAssembly="false" Condition="'$(SkipPrepareSdkArchive)' != 'true'" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)merge-asset-manifests.proj" ReferenceOutputAssembly="false" Condition="'$(SkipPrepareSdkArchive)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/test/tests.proj
+++ b/src/SourceBuild/content/test/tests.proj
@@ -31,7 +31,7 @@
   <!-- Make sure that the sdk archive is extracted before running the scenario-tests. Need to do this here as it's hard
        to define the dependency directly in scenario-tests.proj. -->
   <ItemGroup>
-    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" BuildInParallel="false" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" BuildInParallel="false" Condition="'$(SkipPrepareSdkArchive)' != 'true'" />
     <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" Condition="'$(_RunScenarioTests)' == 'true'" BuildInParallel="false" />
   </ItemGroup>
 


### PR DESCRIPTION
The SkipPrepareSdkArchive switch exists so that outside components like the license scan test pipeline can run a subset of tests that don't need the SDK archive without building the VMR. The switch is also useful for the local dev innerloop to build the test projects without needing to run them.