### PR TITLE
Remove _OverrideArcadeInitializeBuildToolFramework env var in VMR rep…

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -137,8 +137,6 @@
     <EnvironmentVariables Include="_DotNetInstallDir=$(DotNetRoot)" />
     <EnvironmentVariables Include="_InitializeToolset=$(SourceBuiltSdksDir)Microsoft.DotNet.Arcade.Sdk/tools/Build.proj"
                           Condition="'$(UseBootstrapArcade)' != 'true'" />
-    <!-- TODO: Remove when all repos use a consistent set of eng/common files: https://github.com/dotnet/source-build/issues/3710. -->
-    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=$(NetCurrent)" />
 
     <!-- We pass '-ci', but also apply ci mode via env var for edge cases. (E.g. misbehaving inner builds.) -->
     <!-- TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior changes to dev -->


### PR DESCRIPTION
…o builds


The env var got obsolete with https://github.com/dotnet/arcade/commit/e0270d6e8cf548a62aa70ae7d6b0fab8d3c1dc42.

Now that the VMR uses a re-bootstrapped SDK we can get rid of the env var.