### PR TITLE
Use -e to set env variables 

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -12,7 +12,6 @@ internal sealed class StartupHook
 {
     private static readonly bool s_logToStandardOutput = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages) == "1";
     private static readonly string s_namedPipeName = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName);
-    private static readonly string s_targetProcessPath = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.DotnetWatchHotReloadTargetProcessPath);
 
     /// <summary>
     /// Invoked by the runtime when the containing assembly is listed in DOTNET_STARTUP_HOOKS.
@@ -20,16 +19,6 @@ internal sealed class StartupHook
     public static void Initialize()
     {
         var processPath = Environment.GetCommandLineArgs().FirstOrDefault();
-
-        // Workaround for https://github.com/dotnet/sdk/issues/40484
-        // When launching the application process dotnet-watch sets Hot Reload environment variables via CLI environment directives (dotnet [env:X=Y] run).
-        // Currently, the CLI parser sets the env variables to the dotnet.exe process itself, rather then to the target process.
-        // This may cause the dotnet.exe process to connect to the named pipe and break it for the target process.
-        if (!IsMatchingProcess(processPath, s_targetProcessPath))
-        {
-            Log($"Ignoring process '{processPath}', expecting '{s_targetProcessPath}'");
-            return;
-        }
 
         Log($"Loaded into process: {processPath}");
 

--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -215,7 +215,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                 BuildArguments = _hostProjectOptions.BuildArguments,
                 Command = "run",
                 CommandArguments = GetRunCommandArguments(projectLaunchInfo, hostLaunchProfile),
-                LaunchEnvironmentVariables = [],
+                LaunchEnvironmentVariables = projectLaunchInfo.Environment?.Select(e => (e.Key, e.Value))?.ToArray() ?? [],
                 LaunchProfileName = projectLaunchInfo.LaunchProfile,
                 NoLaunchProfile = projectLaunchInfo.DisableLaunchProfile,
                 TargetFramework = _hostProjectOptions.TargetFramework,
@@ -259,12 +259,6 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                     // indicate that no arguments should be used even if launch profile specifies some:
                     arguments.Add("--no-launch-profile-arguments");
                 }
-            }
-
-            foreach (var (name, value) in projectLaunchInfo.Environment ?? [])
-            {
-                arguments.Add("-e");
-                arguments.Add($"{name}={value}");
             }
 
             return arguments;

--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Watch
                     ? await browserConnector.LaunchOrRefreshBrowserAsync(projectRootNode, processSpec, environmentBuilder, Context.RootProjectOptions, shutdownCancellationToken)
                     : null;
 
-                environmentBuilder.ConfigureProcess(processSpec);
+                environmentBuilder.SetProcessEnvironmentVariables(processSpec);
 
                 // Reset for next run
                 buildEvaluator.RequiresRevaluation = false;

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariablesBuilder.cs
@@ -18,13 +18,6 @@ namespace Microsoft.DotNet.Watch
         /// </summary>
         private readonly Dictionary<string, string> _variables = [];
 
-        /// <summary>
-        /// Environment variables passed as directives on command line (dotnet [env:name=value] run).
-        /// Currently, the effect is the same as setting <see cref="_variables"/> due to
-        /// https://github.com/dotnet/sdk/issues/40484
-        /// </summary>
-        private readonly Dictionary<string, string> _directives = [];
-
         public static EnvironmentVariablesBuilder FromCurrentEnvironment()
         {
             var builder = new EnvironmentVariablesBuilder();
@@ -42,57 +35,39 @@ namespace Microsoft.DotNet.Watch
             return builder;
         }
 
-        public void SetDirective(string name, string value)
-        {
-            // should use DotNetStartupHookDirective
-            Debug.Assert(!name.Equals(EnvironmentVariables.Names.DotnetStartupHooks, StringComparison.OrdinalIgnoreCase));
-
-            _directives[name] = value;
-        }
-
         public void SetVariable(string name, string value)
         {
-            // should use AspNetCoreHostingStartupAssembliesVariable
+            // should use AspNetCoreHostingStartupAssembliesVariable/DotNetStartupHookDirective
             Debug.Assert(!name.Equals(EnvironmentVariables.Names.AspNetCoreHostingStartupAssemblies, StringComparison.OrdinalIgnoreCase));
+            Debug.Assert(!name.Equals(EnvironmentVariables.Names.DotnetStartupHooks, StringComparison.OrdinalIgnoreCase));
 
             _variables[name] = value;
         }
 
-        public void ConfigureProcess(ProcessSpec processSpec)
+        public void SetProcessEnvironmentVariables(ProcessSpec processSpec)
         {
-            processSpec.Arguments = [.. GetCommandLineDirectives(), .. processSpec.Arguments ?? []];
-            AddToEnvironment(processSpec.EnvironmentVariables);
+            foreach (var (name, value) in GetEnvironment())
+            {
+                processSpec.EnvironmentVariables.Add(name, value);
+            }
         }
 
-        // for testing
-        internal void AddToEnvironment(Dictionary<string, string> variables)
+        public IEnumerable<(string name, string value)> GetEnvironment()
         {
             foreach (var (name, value) in _variables)
             {
-                variables.Add(name, value);
-            }
-
-            if (AspNetCoreHostingStartupAssembliesVariable is not [])
-            {
-                variables.Add(EnvironmentVariables.Names.AspNetCoreHostingStartupAssemblies, string.Join(AssembliesSeparator, AspNetCoreHostingStartupAssembliesVariable));
-            }
-        }
-
-        // for testing
-        internal IEnumerable<string> GetCommandLineDirectives()
-        {
-            foreach (var (name, value) in _directives)
-            {
-                yield return MakeDirective(name, value);
+                yield return (name, value);
             }
 
             if (DotNetStartupHookDirective is not [])
             {
-                yield return MakeDirective(EnvironmentVariables.Names.DotnetStartupHooks, string.Join(s_startupHooksSeparator, DotNetStartupHookDirective));
+                yield return (EnvironmentVariables.Names.DotnetStartupHooks, string.Join(s_startupHooksSeparator, DotNetStartupHookDirective));
             }
 
-            static string MakeDirective(string name, string value)
-                => $"[env:{name}={value}]";
+            if (AspNetCoreHostingStartupAssembliesVariable is not [])
+            {
+                yield return (EnvironmentVariables.Names.AspNetCoreHostingStartupAssemblies, string.Join(AssembliesSeparator, AspNetCoreHostingStartupAssembliesVariable));
+            }
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariables_StartupHook.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariables_StartupHook.cs
@@ -14,12 +14,6 @@ internal static partial class EnvironmentVariables
         public const string DotnetWatchHotReloadNamedPipeName = "DOTNET_WATCH_HOTRELOAD_NAMEDPIPE_NAME";
 
         /// <summary>
-        /// The full path to the process being launched by dotnet run.
-        /// Workaround for https://github.com/dotnet/sdk/issues/40484
-        /// </summary>
-        public const string DotnetWatchHotReloadTargetProcessPath = "DOTNET_WATCH_HOTRELOAD_TARGET_PROCESS_PATH";
-
-        /// <summary>
         /// Enables logging from the client delta applier agent.
         /// </summary>
         public const string HotReloadDeltaClientLogMessages = "HOTRELOAD_DELTA_CLIENT_LOG_MESSAGES";

--- a/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IRuntimeProcessLauncherFactory.cs
@@ -12,5 +12,5 @@ namespace Microsoft.DotNet.Watch;
 /// </summary>
 internal interface IRuntimeProcessLauncherFactory
 {
-    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments);
+    public IRuntimeProcessLauncher? TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, ProjectOptions hostProjectOptions);
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Build.Graph;
 
@@ -53,16 +54,11 @@ internal sealed class ProjectLauncher(
         {
             Executable = EnvironmentOptions.MuxerPath,
             WorkingDirectory = projectOptions.WorkingDirectory,
-            OnOutput = onOutput,
-            Arguments = [projectOptions.Command, "--no-build", .. projectOptions.CommandArguments]
+            OnOutput = onOutput
         };
 
         var environmentBuilder = EnvironmentVariablesBuilder.FromCurrentEnvironment();
         var namedPipeName = Guid.NewGuid().ToString();
-
-        // Directives:
-
-        // Variables:
 
         foreach (var (name, value) in projectOptions.LaunchEnvironmentVariables)
         {
@@ -85,30 +81,36 @@ internal sealed class ProjectLauncher(
         // expect DOTNET_MODIFIABLE_ASSEMBLIES to be set in the blazor-devserver process, even though we are not performing Hot Reload in this process.
         // The value is converted to DOTNET-MODIFIABLE-ASSEMBLIES header, which is in turn converted back to environment variable in Mono browser runtime loader:
         // https://github.com/dotnet/runtime/blob/342936c5a88653f0f622e9d6cb727a0e59279b31/src/mono/browser/runtime/loader/config.ts#L330
-        environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
+        environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetModifiableAssemblies, "debug");
 
         if (injectDeltaApplier)
         {
             environmentBuilder.DotNetStartupHookDirective.Add(DeltaApplier.StartupHookPath);
-            environmentBuilder.SetDirective(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName, namedPipeName);
+            environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchHotReloadNamedPipeName, namedPipeName);
 
-            // Do not ask agent to log to stdout until https://github.com/dotnet/sdk/issues/40484 is fixed.
-            // For now we need to set the env variable explicitly when we need to diagnose issue with the agent.
-            // Build targets might launch a process and read it's stdout. If the agent is loaded into such process and starts logging
-            // to stdout it might interfere with the expected output.
-            //if (context.Options.Verbose)
-            //{
-            //    environmentBuilder.SetVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages, "1");
-            //}
-
-            // TODO: workaround for https://github.com/dotnet/sdk/issues/40484
-            var targetPath = projectNode.ProjectInstance.GetPropertyValue("RunCommand");
-            environmentBuilder.SetVariable(EnvironmentVariables.Names.DotnetWatchHotReloadTargetProcessPath, targetPath);
-            Reporter.Verbose($"Target process is '{targetPath}'");
+            if (context.Options.Verbose)
+            {
+                environmentBuilder.SetVariable(EnvironmentVariables.Names.HotReloadDeltaClientLogMessages, "1");
+            }
         }
 
         var browserRefreshServer = await browserConnector.LaunchOrRefreshBrowserAsync(projectNode, processSpec, environmentBuilder, projectOptions, cancellationToken);
-        environmentBuilder.ConfigureProcess(processSpec);
+
+        var arguments = new List<string>()
+        {
+            projectOptions.Command,
+            "--no-build"
+        };
+
+        foreach (var (name, value) in environmentBuilder.GetEnvironment())
+        {
+            arguments.Add("-e");
+            arguments.Add($"{name}={value}");
+        }
+
+        arguments.AddRange(projectOptions.CommandArguments);
+
+        processSpec.Arguments = arguments;
 
         var processReporter = new ProjectSpecificReporter(projectNode, Reporter);
 

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Watch
 
                     var rootProjectNode = evaluationResult.ProjectGraph.GraphRoots.Single();
 
-                    runtimeProcessLauncher = runtimeProcessLauncherFactory?.TryCreate(rootProjectNode, projectLauncher, rootProjectOptions.BuildArguments);
+                    runtimeProcessLauncher = runtimeProcessLauncherFactory?.TryCreate(rootProjectNode, projectLauncher, rootProjectOptions);
                     if (runtimeProcessLauncher != null)
                     {
                         var launcherEnvironment = runtimeProcessLauncher.GetEnvironmentVariables();

--- a/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
@@ -149,21 +149,4 @@ public class AspireServiceFactoryTests
 
         AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P", "a", "b"], args);
     }
-
-    [Fact]
-    public void GetRunCommandArguments_EnvironmentVariables()
-    {
-        var request = new ProjectLaunchRequest()
-        {
-            Arguments = null,
-            DisableLaunchProfile = false,
-            LaunchProfile = null,
-            Environment = [KeyValuePair.Create("X", "1"), KeyValuePair.Create("Y", ""), KeyValuePair.Create("Z", "=")],
-            ProjectPath = "a.csproj"
-        };
-
-        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: null);
-
-        AssertEx.SequenceEqual(["--project", "a.csproj", "-e", "X=1", "-e", "Y=", "-e", "Z=="], args);
-    }
 }

--- a/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Aspire.Tools.Service;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class AspireServiceFactoryTests
+{
+    [Fact]
+    public void GetRunCommandArguments_Empty()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = false,
+            LaunchProfile = null,
+            Environment = null,
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: null);
+
+        AssertEx.SequenceEqual(["--project", "a.csproj"], args);
+    }
+
+    [Fact]
+    public void GetRunCommandArguments_DisableLaunchProfile()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = true,
+            LaunchProfile = "P",
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--no-launch-profile" ], args);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GetRunCommandArguments_NoLaunchProfile_HostProfile(string? launchProfile)
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = false,
+            LaunchProfile = launchProfile,
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "H"], args);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GetRunCommandArguments_DisableLaunchProfile_HostProfile(string? launchProfile)
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = true,
+            LaunchProfile = launchProfile,
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--no-launch-profile"], args);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GetRunCommandArguments_NoLaunchProfile_NoHostProfile(string? launchProfile)
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = false,
+            LaunchProfile = launchProfile,
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: null);
+
+        AssertEx.SequenceEqual(["--project", "a.csproj"], args);
+    }
+    [Fact]
+    public void GetRunCommandArguments_LaunchProfile_NoArgs()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = false,
+            LaunchProfile = "P",
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P"], args);
+    }
+
+    [Fact]
+    public void GetRunCommandArguments_LaunchProfile_EmptyArgs()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = [],
+            DisableLaunchProfile = false,
+            LaunchProfile = "P",
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P", "--no-launch-profile-arguments"], args);
+    }
+
+    [Fact]
+    public void GetRunCommandArguments_LaunchProfile_NonEmptyArgs()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = ["a", "b"],
+            DisableLaunchProfile = false,
+            LaunchProfile = "P",
+            Environment = [],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: "H");
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P", "a", "b"], args);
+    }
+
+    [Fact]
+    public void GetRunCommandArguments_EnvironmentVariables()
+    {
+        var request = new ProjectLaunchRequest()
+        {
+            Arguments = null,
+            DisableLaunchProfile = false,
+            LaunchProfile = null,
+            Environment = [KeyValuePair.Create("X", "1"), KeyValuePair.Create("Y", ""), KeyValuePair.Create("Z", "=")],
+            ProjectPath = "a.csproj"
+        };
+
+        var args = AspireServiceFactory.SessionManager.GetRunCommandArguments(request, hostLaunchProfile: null);
+
+        AssertEx.SequenceEqual(["--project", "a.csproj", "-e", "X=1", "-e", "Y=", "-e", "Z=="], args);
+    }
+}

--- a/test/dotnet-watch.Tests/Internal/EnvironmentVariablesBuilderTests.cs
+++ b/test/dotnet-watch.Tests/Internal/EnvironmentVariablesBuilderTests.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests
 {
-    public class EnvironmentVariablesBuilderTest
+    public class EnvironmentVariablesBuilderTests
     {
         [Fact]
         public void Value()
@@ -12,10 +12,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             builder.DotNetStartupHookDirective.Add("a");
             builder.AspNetCoreHostingStartupAssembliesVariable.Add("b");
 
-            var values = new Dictionary<string, string>();
-            builder.AddToEnvironment(values);
-            AssertEx.SequenceEqual(["[env:DOTNET_STARTUP_HOOKS=a]"], builder.GetCommandLineDirectives());
-            AssertEx.SequenceEqual([("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", "b")], values.Select(e => (e.Key, e.Value)));
+            var env = builder.GetEnvironment();
+            AssertEx.SequenceEqual(
+            [
+                ("DOTNET_STARTUP_HOOKS", "a"),
+                ("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", "b")
+            ], env);
         }
 
         [Fact]
@@ -27,10 +29,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             builder.AspNetCoreHostingStartupAssembliesVariable.Add("b1");
             builder.AspNetCoreHostingStartupAssembliesVariable.Add("b2");
 
-            var values = new Dictionary<string, string>();
-            builder.AddToEnvironment(values);
-            AssertEx.SequenceEqual([$"[env:DOTNET_STARTUP_HOOKS=a1{Path.PathSeparator}a2]"], builder.GetCommandLineDirectives());
-            AssertEx.SequenceEqual([("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", "b1;b2")], values.Select(e => (e.Key, e.Value)));
+            var env = builder.GetEnvironment();
+            AssertEx.SequenceEqual(
+            [
+                ("DOTNET_STARTUP_HOOKS", $"a1{Path.PathSeparator}a2"),
+                ("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", "b1;b2")
+            ], env);
         }
     }
 }

--- a/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestRuntimeProcessLauncher.cs
@@ -11,7 +11,7 @@ internal class TestRuntimeProcessLauncher(ProjectLauncher projectLauncher) : IRu
 {
     public class Factory(Action<TestRuntimeProcessLauncher>? initialize = null) : IRuntimeProcessLauncherFactory
     {
-        public IRuntimeProcessLauncher TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, IReadOnlyList<string> buildArguments)
+        public IRuntimeProcessLauncher TryCreate(ProjectGraphNode projectNode, ProjectLauncher projectLauncher, ProjectOptions hostProjectOptions)
         {
             var service = new TestRuntimeProcessLauncher(projectLauncher);
             initialize?.Invoke(service);


### PR DESCRIPTION
Use new `-e` dotnet-run option instead of env directives. Allows to remove workarounds for https://github.com/dotnet/sdk/issues/40484 and override env variables set by launch profile as required by Aspire spec.

Also use new option `--no-launch-profile-arguments` to ignore launch profile command line arguments when requested by DCP.

Implements https://github.com/dotnet/sdk/issues/43946
