### PR TITLE
Use Windows scouting image in VMR to unblock builds

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -150,8 +150,9 @@ variables:
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
     value: macos-13
+  # TODO: Change back to preview image when it has a recent enough version of VS installed.
   - name: poolImage_Windows
-    value: windows.vs2022preview.amd64.open
+    value: windows.vs2022preview.scout.amd64.open
 - ${{ else }}:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: defaultPoolName


### PR DESCRIPTION
Dnceng rolled back the machine image updates, so we are back on a too old version of VS and the VMR is again broken. All sdk PRs are failing since the rollback.

I'm not sure if this will work because of wpf's strong dependency on wpf-int because of LTCG compilation. Let's see...