### PR TITLE
Update MSB3825 warning presence

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -103,7 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PredefinedCulturesOnly Condition="'$(PredefinedCulturesOnly)' == '' and '$(InvariantGlobalization)' == 'true'">true</PredefinedCulturesOnly>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(GenerateResourceWarnOnBinaryFormatterUse)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))">
+  <PropertyGroup Condition="'$(GenerateResourceWarnOnBinaryFormatterUse)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))">
     <GenerateResourceWarnOnBinaryFormatterUse>true</GenerateResourceWarnOnBinaryFormatterUse>
   </PropertyGroup>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/msbuild/issues/11185

### Context

https://github.com/dotnet/msbuild/issues/11185#issuecomment-2557717163

It was decided that MSB3825 should not be applicalbe to NET9+ - as BinaryFormatter is being used only in a very limited number of subcases, where it needs to be explicitly opted in via `System.Resources.Extensions.UseBinaryFormatter` switch. 