### PR TITLE
Remove non-OSS licenses and source from source-build

### DIFF
--- a/src/SourceBuild/content/eng/disallowed-sb-license-paths.txt
+++ b/src/SourceBuild/content/eng/disallowed-sb-license-paths.txt
@@ -1,0 +1,44 @@
+# Contains the paths to files that contains non-OSS licenses and should be removed from source-build
+
+# This file is used by the FileRemover tool to remove files from the VMR
+# If importing a file, include the relative path to the file
+
+#
+# arcade
+#
+
+# Applies to installer
+src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/eula.rtf
+
+#
+# aspnetcore
+#
+
+# Windows-only installer components
+src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/license/license.rtf
+
+# Windows installer files that have a reference to a URL for license
+src/aspnetcore/src/Installers/Windows/**/*.wxl
+src/aspnetcore/src/Installers/Windows/**/*.wxs
+
+#
+# fsharp
+#
+
+# Applies to installer
+src/fsharp/setup/resources/eula/*.rtf
+
+#
+# roslyn
+#
+
+# Applies to installer
+src/roslyn/src/Setup/Roslyn.ThirdPartyNotices/ThirdPartyNotices.rtf
+src/roslyn/src/Setup/Roslyn.VsixLicense/EULA.rtf
+
+#
+# runtime
+#
+
+# Installer asset
+src/runtime/src/installer/pkg/LICENSE-MSFT.TXT

--- a/src/SourceBuild/content/eng/remove-license-files.sh
+++ b/src/SourceBuild/content/eng/remove-license-files.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+### Usage: $0
+###
+###   Prepares and runs the file remover tooling to remove files containing non-OSS licenses from the VMR.
+###   Default behavior is to removal licenses specifed in the disallowed-sb-license-paths file.
+###
+### Options:
+###   --removal-file        Path to the file containing the list of paths to be removed.
+###                         Defaults to eng/disallowed-sb-license-paths.txt.
+###   --with-packages       Use the specified directory as the packages source feed.
+###                         Defaults to online dotnet-public and dotnet-libraries feeds.
+###   --with-sdk            Use the specified directory as the dotnet SDK.
+###                         Defaults to .dotnet.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source="${BASH_SOURCE[0]}"
+REPO_ROOT="$( cd -P "$( dirname "$0" )/../" && pwd )"
+REMOVAL_TOOL="$REPO_ROOT/eng/tools/FileRemover"
+
+function print_help () {
+    sed -n '/^### /,/^$/p' "$source" | cut -b 5-
+}
+
+defaultDotnetSdk="$REPO_ROOT/.dotnet"
+defaultRemovalFile="$REPO_ROOT/eng/disallowed-sb-license-paths.txt"
+
+# Set default values
+removalFile=$defaultRemovalFile
+propsDir=''
+packagesDir=''
+restoreSources=''
+dotnetSdk=$defaultDotnetSdk
+
+positional_args=()
+while :; do
+  if [ $# -le 0 ]; then
+    break
+  fi
+  lowerI="$(echo "$1" | awk '{print tolower($0)}')"
+  case $lowerI in
+    "-?"|-h|--help)
+      print_help
+      exit 0
+      ;;
+    --clean)
+      mode="clean"
+      ;;
+    --removal-file)
+      allowedBinariesFile=$2
+      shift
+      ;;
+    --with-packages)
+        packagesDir=$2
+        if [ ! -d "$packagesDir" ]; then
+            echo "ERROR: The specified packages directory does not exist."
+            exit 1
+        elif [ ! -f "$packagesDir/PackageVersions.props" ]; then
+            echo "ERROR: The specified packages directory does not contain PackageVersions.props."
+            exit 1
+        fi
+        shift
+        ;;
+    --with-sdk)
+        dotnetSdk=$2
+        if [ ! -d "$dotnetSdk" ]; then
+            echo "Custom SDK directory '$dotnetSdk' does not exist"
+            exit 1
+        fi
+        if [ ! -x "$dotnetSdk/dotnet" ]; then
+            echo "Custom SDK '$dotnetSdk/dotnet' does not exist or is not executable"
+            exit 1
+        fi
+        shift
+        ;;
+    *)
+      positional_args+=("$1")
+      ;;
+  esac
+
+  shift
+done
+
+function ParseRemovalArgs
+{
+    # Check removal file
+    if [ ! -f "$removalFile" ]; then
+      echo "ERROR: The specified removal file does not exist."
+      exit 1
+    fi
+
+    # Check dotnet sdk
+    if [ "$dotnetSdk" == "$defaultDotnetSdk" ]; then
+        if [ ! -d "$dotnetSdk" ]; then
+            . "$REPO_ROOT/eng/common/tools.sh"
+            InitializeDotNetCli true
+        fi
+        else if [ ! -x "$dotnetSdk/dotnet" ]; then
+            echo "'$dotnetSdk/dotnet' does not exist or is not executable"
+            exit 1
+        fi
+    fi
+
+    # Check the packages directory
+    if [ -z "$packagesDir" ]; then
+        # Use dotnet-public and dotnet-libraries feeds as the default packages source feeds
+        restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+    else
+        restoreSources=$(realpath ${packagesDir})
+    fi
+}
+
+function RunRemovalTool
+{
+  targetDir="$REPO_ROOT"
+  RemovalToolCommand=""$dotnetSdk/dotnet" run --project "$REMOVAL_TOOL" -c Release --property:RestoreSources="$restoreSources" "$targetDir" -rf "$removalFile""
+
+  if [ -n "$packagesDir" ]; then
+    RemovalToolCommand=""$RemovalToolCommand" -p CustomPackageVersionsProps="$packagesDir/PackageVersions.props""
+  fi
+
+  # Run the Removal Tool
+  eval "$RemovalToolCommand"
+}
+
+ParseRemovalArgs
+RunRemovalTool

--- a/src/SourceBuild/content/eng/remove-license-files.sh
+++ b/src/SourceBuild/content/eng/remove-license-files.sh
@@ -3,7 +3,7 @@
 ### Usage: $0
 ###
 ###   Prepares and runs the file remover tooling to remove files containing non-OSS licenses from the VMR.
-###   Default behavior is to removal licenses specifed in the disallowed-sb-license-paths file.
+###   Default behavior is to remove licenses specified in the disallowed-sb-license-paths.txt file.
 ###
 ### Options:
 ###   --removal-file        Path to the file containing the list of paths to be removed.

--- a/src/SourceBuild/content/eng/tools/FileRemover/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/FileRemover/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    Do not import the Arcade SDK as this would introduce a prebuilt as this project builds
+    before the custom sdk resolver is available in source-only mode.
+  -->
+  <PropertyGroup>
+    <SkipArcadeSdkImport>true</SkipArcadeSdkImport>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+</Project>

--- a/src/SourceBuild/content/eng/tools/FileRemover/FileRemover.csproj
+++ b/src/SourceBuild/content/eng/tools/FileRemover/FileRemover.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="CheckCustomPackageVersionsProps">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <CustomPackageVersionsProps></CustomPackageVersionsProps>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <Target Name="CheckCustomPackageVersionsProps">
+    <Error Condition="'$(CustomPackageVersionsProps)' != '' And !Exists('$(CustomPackageVersionsProps)')" Text="CustomPackageVersionsProps file '$(CustomPackageVersionsProps)' does not exist." />
+  </Target>
+
+  <!-- Need to condition this import because msbuild will complain about the project not being valid otherwise. -->
+  <!-- With the condition, the CheckCustomPackageVersionsProps will run as expected and show the respective errors. -->
+  <Import Project="$(CustomPackageVersionsProps)" Condition="'$(CustomPackageVersionsProps)' != ''" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+</Project>

--- a/src/SourceBuild/content/eng/tools/FileRemover/Program.cs
+++ b/src/SourceBuild/content/eng/tools/FileRemover/Program.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+
+namespace FileRemover;
+
+public class Program
+{
+    public static int ExitCode = 0;
+
+    public static async Task<int> Main(string[] args)
+    {
+        var targetDirectoryArgument = new CliArgument<string>("target-directory")
+        {
+            Description = "The directory to run the removal on.",
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        var removalFileOption = new CliOption<string>("--removal-file", "-rf")
+        {
+            Description = "The file containing the list of path to remove from the target directory.\n",
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        var rootCommand = new CliRootCommand("Tool for removing specified files from the target directory.")
+        {
+            targetDirectoryArgument,
+            removalFileOption
+        };
+
+        rootCommand.SetAction((parseResult, cancellationToken) =>
+        {
+            var targetDirectory = parseResult.GetValue(targetDirectoryArgument) ?? throw new ArgumentNullException("target-directory");
+            var removalFile = parseResult.GetValue(removalFileOption) ?? throw new ArgumentNullException("removal-file");
+
+            Remover.RemoveFiles(targetDirectory, removalFile);
+
+            return Task.CompletedTask;
+        });
+
+        await rootCommand.Parse(args).InvokeAsync();
+
+        return ExitCode;
+    }
+}

--- a/src/SourceBuild/content/eng/tools/FileRemover/Remover.cs
+++ b/src/SourceBuild/content/eng/tools/FileRemover/Remover.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace FileRemover
+
+{
+    public static class Remover
+    {
+        public static void RemoveFiles(string targetDirectory, string removalFile)
+        {
+            var filesToRemove = new List<string>();
+
+            if (!string.IsNullOrEmpty(removalFile))
+            {
+                var filePatterns = File.ReadAllLines(removalFile).ToList();
+                filesToRemove.AddRange(ParseFileGlobPatterns(filePatterns, targetDirectory));
+            }
+            else
+            {
+                throw new ArgumentException("No removal file specified.");
+            }
+
+            foreach (var file in filesToRemove.Where(File.Exists))
+            {
+                File.Delete(file);
+            }
+        }
+
+        private static IEnumerable<string> ParseFileGlobPatterns(List<string> filePatterns, string targetDirectory)
+        {
+            var matcher = new Matcher(StringComparison.Ordinal);
+            foreach (var pattern in filePatterns)
+            {
+                matcher.AddInclude(pattern);
+            }
+
+            return matcher.GetResultsInFullPath(targetDirectory);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4736

This PR introduces tooling and functionality to remove non-OSS licenses and associated source in prep-source-build.sh. As is, the tooling removes the following files from the VMR:

```
        deleted:    src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/eula.rtf
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/wix/iisca.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/wix3/iisca.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/license/license.rtf
        deleted:    src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/setupstrings.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/HostOptions/Product.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
        deleted:    src/aspnetcore/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.CHS.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.CHT.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.CSY.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.DEU.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.ENU.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.ESN.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.FRA.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.ITA.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.JPN.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.KOR.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.PLK.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.PTB.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.RUS.rtf
        deleted:    src/fsharp/setup/resources/eula/VF_EULA.TRK.rtf
        deleted:    src/roslyn/src/Setup/Roslyn.ThirdPartyNotices/ThirdPartyNotices.rtf
        deleted:    src/roslyn/src/Setup/Roslyn.VsixLicense/EULA.rtf
        deleted:    src/runtime/src/installer/pkg/LICENSE-MSFT.TXT
```

Some things to consider when reviewing the PR:
- The name of the files containing the paths to remove: `disallowed-sb-licenses-paths.txt`. I had a hard time coming up with a name and am open to suggestions on a different one.
- Combining `detect-binaries.sh` and `remove-licenses.sh`? It might be helpful to have a script that shares the common behavior between these two scripts since the two scripts are very similar.
- Adding logging to `FileRemover` tool. If this is done, I'd like to explore sharing the logging infra from `BinaryToolKit` rather than duplicate it in `FileRemover`. This is a potential item to open an issue about and address at a later time.