### PR TITLE
sln-add: Remove default values

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -82,15 +82,15 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 {
                     Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)
                 });
-            }
-            // Set default configurations and platforms for sln file
-            foreach (var platform in _defaultPlatforms)
-            {
-                solution.AddPlatform(platform);
-            }
-            foreach (var buildType in _defaultBuildTypes)
-            {
-                solution.AddBuildType(buildType);
+                // Set default configurations and platforms for sln file
+                foreach (var platform in _defaultPlatforms)
+                {
+                    solution.AddPlatform(platform);
+                }
+                foreach (var buildType in _defaultBuildTypes)
+                {
+                    solution.AddBuildType(buildType);
+                }
             }
 
             SolutionFolderModel? solutionFolder = (!_inRoot && !string.IsNullOrEmpty(_solutionFolderPath))

--- a/test/TestAssets/TestProjects/SolutionFilesTemplates/ExpectedSlnFileAfterAddingLibProjToEmptySln.slnx
+++ b/test/TestAssets/TestProjects/SolutionFilesTemplates/ExpectedSlnFileAfterAddingLibProjToEmptySln.slnx
@@ -1,8 +1,3 @@
 <Solution>
-  <Configurations>
-    <Platform Name="Any CPU" />
-    <Platform Name="x64" />
-    <Platform Name="x86" />
-  </Configurations>
   <Project Path="Lib/Lib.csproj" />
 </Solution>


### PR DESCRIPTION
For compatibility and to avoid breaking changes, default configurations and platforms were kept when moving to vs-solutionpersistence. This is irrelevant to add by default to .slnx files (i.e., doesn't break anything and might be redundant)