### PR TITLE
Parallelize workload pack downloads Fixes #43870

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools;
@@ -35,7 +36,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         private readonly IReporter _reporter;
         private readonly IFirstPartyNuGetPackageSigningVerifier _firstPartyNuGetPackageSigningVerifier;
         private bool _validationMessagesDisplayed = false;
-        private readonly Dictionary<PackageSource, SourceRepository> _sourceRepositories;
+        private readonly ConcurrentDictionary<PackageSource, SourceRepository> _sourceRepositories;
         private readonly bool _shouldUsePackageSourceMapping;
 
         private readonly bool _verifySignatures;
@@ -818,7 +819,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             if (!_sourceRepositories.TryGetValue(source, out SourceRepository value))
             {
                 value = Repository.Factory.GetCoreV3(source);
-                _sourceRepositories.Add(source, value);
+                _sourceRepositories.AddOrUpdate(source, _ => value, (_, _) => value);
             }
 
             return value;

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -289,9 +289,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         RemoveManifestInstallationRecord(manifestUpdate.ManifestId, manifestUpdate.NewVersion, new SdkFeatureBand(manifestUpdate.NewFeatureBand), _sdkFeatureBand);
                     });
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
+                throw; // new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -140,74 +141,81 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
         public void InstallWorkloads(IEnumerable<WorkloadId> workloadIds, SdkFeatureBand sdkFeatureBand, ITransactionContext transactionContext, bool overwriteExistingPacks, DirectoryPath? offlineCache = null)
         {
             var packInfos = GetPacksInWorkloads(workloadIds);
-
+            List<PackInfo> packsToInstall = [];
             foreach (var packInfo in packInfos)
+            {
+                if (PackIsInstalled(packInfo) && !overwriteExistingPacks)
+                {
+                    _reporter.WriteLine(string.Format(LocalizableStrings.WorkloadPackAlreadyInstalledMessage, packInfo.ResolvedPackageId, packInfo.Version));
+                }
+                else
+                {
+                    packsToInstall.Add(packInfo);
+                }
+            }
+
+            var tempFilesToDelete = new ConcurrentBag<string>();
+            var packagePaths = packsToInstall.AsParallel().Select(packInfo =>
+            {
+                if (offlineCache == null || !offlineCache.HasValue)
+                {
+                    var packagePath = _nugetPackageDownloader
+                        .DownloadPackageAsync(new PackageId(packInfo.ResolvedPackageId),
+                            new NuGetVersion(packInfo.Version),
+                            _packageSourceLocation).GetAwaiter().GetResult();
+                    tempFilesToDelete.Add(packagePath);
+                    return (packagePath, packInfo);
+                }
+                else
+                {
+                    _reporter.WriteLine(string.Format(LocalizableStrings.UsingCacheForPackInstall, packInfo.ResolvedPackageId, packInfo.Version, offlineCache));
+                    var packagePath = Path.Combine(offlineCache.Value.Value, $"{packInfo.ResolvedPackageId}.{packInfo.Version}.nupkg");
+                    if (!File.Exists(packagePath))
+                    {
+                        throw new Exception(string.Format(LocalizableStrings.CacheMissingPackage, packInfo.ResolvedPackageId, packInfo.Version, offlineCache));
+                    }
+                    return (packagePath, packInfo);
+                }
+            });
+
+            foreach (var (packagePath, packInfo) in packagePaths)
             {
                 _reporter.WriteLine(string.Format(LocalizableStrings.InstallingPackVersionMessage, packInfo.ResolvedPackageId, packInfo.Version));
                 var tempDirsToDelete = new List<string>();
-                var tempFilesToDelete = new List<string>();
-                bool shouldRollBackPack = false;
 
                 transactionContext.Run(
                     action: () =>
                     {
-                        if (PackIsInstalled(packInfo) && !overwriteExistingPacks)
+                        if (!Directory.Exists(Path.GetDirectoryName(packInfo.Path)))
                         {
-                            _reporter.WriteLine(string.Format(LocalizableStrings.WorkloadPackAlreadyInstalledMessage, packInfo.ResolvedPackageId, packInfo.Version));
+                            Directory.CreateDirectory(Path.GetDirectoryName(packInfo.Path));
+                        }
+
+                        if (IsSingleFilePack(packInfo))
+                        {
+                            File.Copy(packagePath, packInfo.Path, overwrite: overwriteExistingPacks);
                         }
                         else
                         {
-                            shouldRollBackPack = true;
-                            string packagePath;
-                            if (offlineCache == null || !offlineCache.HasValue)
+                            var tempExtractionDir = Path.Combine(_tempPackagesDir.Value, $"{packInfo.ResolvedPackageId}-{packInfo.Version}-extracted");
+                            tempDirsToDelete.Add(tempExtractionDir);
+
+                            // This directory should have been deleted, but remove it just in case
+                            if (overwriteExistingPacks && Directory.Exists(tempExtractionDir))
                             {
-                                packagePath = _nugetPackageDownloader
-                                    .DownloadPackageAsync(new PackageId(packInfo.ResolvedPackageId),
-                                        new NuGetVersion(packInfo.Version),
-                                        _packageSourceLocation).GetAwaiter().GetResult();
-                                tempFilesToDelete.Add(packagePath);
-                            }
-                            else
-                            {
-                                _reporter.WriteLine(string.Format(LocalizableStrings.UsingCacheForPackInstall, packInfo.ResolvedPackageId, packInfo.Version, offlineCache));
-                                packagePath = Path.Combine(offlineCache.Value.Value, $"{packInfo.ResolvedPackageId}.{packInfo.Version}.nupkg");
-                                if (!File.Exists(packagePath))
-                                {
-                                    throw new Exception(string.Format(LocalizableStrings.CacheMissingPackage, packInfo.ResolvedPackageId, packInfo.Version, offlineCache));
-                                }
+                                Directory.Delete(tempExtractionDir, recursive: true);
                             }
 
-                            if (!Directory.Exists(Path.GetDirectoryName(packInfo.Path)))
+                            Directory.CreateDirectory(tempExtractionDir);
+                            var packFiles = _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(tempExtractionDir)).GetAwaiter().GetResult();
+
+                            if (overwriteExistingPacks && Directory.Exists(packInfo.Path))
                             {
-                                Directory.CreateDirectory(Path.GetDirectoryName(packInfo.Path));
+                                Directory.Delete(packInfo.Path, recursive: true);
                             }
 
-                            if (IsSingleFilePack(packInfo))
-                            {
-                                File.Copy(packagePath, packInfo.Path, overwrite: overwriteExistingPacks);
-                            }
-                            else
-                            {
-                                var tempExtractionDir = Path.Combine(_tempPackagesDir.Value, $"{packInfo.ResolvedPackageId}-{packInfo.Version}-extracted");
-                                tempDirsToDelete.Add(tempExtractionDir);
-
-                                // This directory should have been deleted, but remove it just in case
-                                if (overwriteExistingPacks && Directory.Exists(tempExtractionDir))
-                                {
-                                    Directory.Delete(tempExtractionDir, recursive: true);
-                                }
-
-                                Directory.CreateDirectory(tempExtractionDir);
-                                var packFiles = _nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(tempExtractionDir)).GetAwaiter().GetResult();
-
-                                if (overwriteExistingPacks && Directory.Exists(packInfo.Path))
-                                {
-                                    Directory.Delete(packInfo.Path, recursive: true);
-                                }
-
-                                FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(tempExtractionDir, packInfo.Path));
-                            }
-                        }                        
+                            FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(tempExtractionDir, packInfo.Path));
+                        }
 
                         WritePackInstallationRecord(packInfo, sdkFeatureBand);
                     },
@@ -215,14 +223,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                     {
                         try
                         {
-                            if (shouldRollBackPack)
+                            _reporter.WriteLine(string.Format(LocalizableStrings.RollingBackPackInstall, packInfo.ResolvedPackageId));
+                            DeletePackInstallationRecord(packInfo, sdkFeatureBand);
+                            if (!PackHasInstallRecords(packInfo))
                             {
-                                _reporter.WriteLine(string.Format(LocalizableStrings.RollingBackPackInstall, packInfo.ResolvedPackageId));
-                                DeletePackInstallationRecord(packInfo, sdkFeatureBand);
-                                if (!PackHasInstallRecords(packInfo))
-                                {
-                                    DeletePack(packInfo);
-                                }
+                                DeletePack(packInfo);
                             }
                         }
                         catch (Exception e)

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -289,9 +289,9 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                         RemoveManifestInstallationRecord(manifestUpdate.ManifestId, manifestUpdate.NewVersion, new SdkFeatureBand(manifestUpdate.NewFeatureBand), _sdkFeatureBand);
                     });
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                throw; // new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
+                throw new Exception(string.Format(LocalizableStrings.FailedToInstallWorkloadManifest, manifestUpdate.ManifestId, manifestUpdate.NewVersion, e.Message), e);
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -147,6 +147,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
                 if (PackIsInstalled(packInfo) && !overwriteExistingPacks)
                 {
                     _reporter.WriteLine(string.Format(LocalizableStrings.WorkloadPackAlreadyInstalledMessage, packInfo.ResolvedPackageId, packInfo.Version));
+                    WritePackInstallationRecord(packInfo, sdkFeatureBand);
                 }
                 else
                 {

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                 catch (Exception)
                 {
                     // Don't show entire stack trace
-                    throw; // new GracefulException(string.Format(LocalizableStrings.WorkloadUpdateFailed, e.Message), e, isUserError: false);
+                    throw new GracefulException(string.Format(LocalizableStrings.WorkloadUpdateFailed, e.Message), e, isUserError: false);
                 }
             }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -129,10 +129,10 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                         UpdateWorkloads();
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // Don't show entire stack trace
-                    throw new GracefulException(string.Format(LocalizableStrings.WorkloadUpdateFailed, e.Message), e, isUserError: false);
+                    throw; // new GracefulException(string.Format(LocalizableStrings.WorkloadUpdateFailed, e.Message), e, isUserError: false);
                 }
             }
 

--- a/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/update/WorkloadUpdateCommand.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Update
                         UpdateWorkloads();
                     }
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     // Don't show entire stack trace
                     throw new GracefulException(string.Format(LocalizableStrings.WorkloadUpdateFailed, e.Message), e, isUserError: false);

--- a/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
+++ b/test/dotnet-workload-install.Tests/GivenFileBasedWorkloadInstall.cs
@@ -410,11 +410,11 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var version = "6.0.100";
             var cachePath = Path.Combine(dotnetRoot, "MockCache");
 
-            var exceptionThrown = Assert.Throws<Exception>(() =>
+            var exceptionThrown = Assert.Throws<AggregateException>(() =>
                 CliTransaction.RunNew(context => installer.InstallWorkloads(new[] { new WorkloadId("android-sdk-workload") }, new SdkFeatureBand(version), context, new DirectoryPath(cachePath))));
-            exceptionThrown.Message.Should().Contain(packId);
-            exceptionThrown.Message.Should().Contain(packVersion);
-            exceptionThrown.Message.Should().Contain(cachePath);
+            exceptionThrown.InnerException.Message.Should().Contain(packId);
+            exceptionThrown.InnerException.Message.Should().Contain(packVersion);
+            exceptionThrown.InnerException.Message.Should().Contain(cachePath);
         }
 
         private (string, FileBasedInstaller, INuGetPackageDownloader, Func<string, IWorkloadResolver>) GetTestInstaller([CallerMemberName] string testName = "", bool failingInstaller = false, string identifier = "", bool manifestDownload = false,

--- a/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
+++ b/test/dotnet-workload-install.Tests/MockNuGetPackageInstaller.cs
@@ -54,7 +54,14 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             DownloadCallResult.Add(path);
             if (_downloadPath != string.Empty)
             {
-                File.WriteAllText(path, string.Empty);
+                try
+                {
+                    File.WriteAllText(path, string.Empty);
+                }
+                catch (IOException)
+                {
+                    // Do not write this file twice in parallel
+                }
             }
             _lastPackageVersion = packageVersion ?? new NuGetVersion("1.0.42");
             return Task.FromResult(path);


### PR DESCRIPTION
Fixes #43870

There are multiple possible reasons AzDO might be much slower than nuget.org. My untested hypothesis is that it may be some authentication work, which would be substantially mitigated by parallelizing the workload pack downloads (not the installs). That's what I tried to do here.

@AArnott, any chance you could try this out and let me know if it helps?