### PR TITLE
[darc] add ASP.NET dependency for use in dotnet/maui

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -307,7 +307,52 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
     </Dependency>
+    <!-- Authentication and Components needed for dotnet/maui CoherentParentDependency -->
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Components.SdkAnalyzers" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-alpha.2.25062.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-alpha.2.25064.2">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="10.0.0-alpha.2.25064.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -356,10 +356,6 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Mvc.Analyzers" Version="10.0.0-alpha.2.25064.2">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="10.0.0-alpha.2.25064.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>d4880ed4160b476346850ac653ce4b829ab09c94</Sha>


### PR DESCRIPTION
In .NET 10, we are facing some errors due to MSBuild files containing mismatched versions:

    packages\microsoft.aspnetcore.app.internal.assets\10.0.0-alpha.2.25061.1\build\Microsoft.AspNetCore.App.Internal.Assets.targets
    packages\microsoft.aspnetcore.components.webview\10.0.0-alpha.2.25062.2\build\Microsoft.AspNetCore.Components.WebView.props

The version of the first is controlled by the .NET SDK, while the second by the version of the `Microsoft.AspNetCore.Components.WebView` package.

To align this, we could add `CoherentParentDependency`:

    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-alpha.2.25062.2" CoherentParentDependency="Microsoft.NET.Sdk">
      <Uri>https://github.com/dotnet/aspnetcore</Uri>
      <Sha>a869e316fd72bd8b94dfee3704266260b9c547ab</Sha>
    </Dependency>

However, this results in an error such as:

    > darc update-dependencies --coherency-only
    Checking for coherency updates...
    fail: Coherency updates failed for the following dependencies:  Unable to update Microsoft.AspNetCore.Components.WebView to have coherency with Microsoft.NET.Sdk: https://github.com/dotnet/sdk @ 60e9a46917ff91cc570272ecc83249497c99a79f does not contain dependency Microsoft.AspNetCore.Components.WebView
            - Add the dependency to https://github.com/dotnet/sdk.

To solve this, we can add dependency to dotnet/sdk and dotnet/maui can align these version numbers going forward. It should also make it so for dotnet/maui gets the proper ASP.NET versions for release branches.

I added several packages that are used by dotnet/maui.