### PR TITLE
Use stdout for error messages

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
@@ -58,7 +58,8 @@ namespace Microsoft.DotNet.Watch
             switch (descriptor.Severity)
             {
                 case MessageSeverity.Error:
-                    WriteLine(console.Error, message, ConsoleColor.Red, descriptor.Emoji);
+                    // Use stdout for error messages to preserve ordering with respect to other output.
+                    WriteLine(console.Out, message, ConsoleColor.Red, descriptor.Emoji);
                     break;
 
                 case MessageSeverity.Warning:

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
             IReporter reporter = new ConsoleReporter(testConsole, verbose: true, quiet: false, suppressEmojis: suppressEmojis);
             var dotnetWatchDefaultPrefix = $"dotnet watch {(suppressEmojis ? ":" : "⌚")} ";
 
-            // stdout
             reporter.Verbose("verbose {0}");
             Assert.Equal($"{dotnetWatchDefaultPrefix}verbose {{0}}" + EOL, testConsole.GetOutput());
             testConsole.Clear();
@@ -29,9 +28,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Equal($"{dotnetWatchDefaultPrefix}warn" + EOL, testConsole.GetOutput());
             testConsole.Clear();
 
-            // stderr
             reporter.Error("error");
-            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetError());
+            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetOutput());
             testConsole.Clear();
         }
 
@@ -44,7 +42,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
             IReporter reporter = new ConsoleReporter(testConsole, verbose: true, quiet: false, suppressEmojis: suppressEmojis);
             var dotnetWatchDefaultPrefix = $"dotnet watch {(suppressEmojis ? ":" : "😄")}";
 
-            // stdout
             reporter.Verbose("verbose", emoji: "😄");
             Assert.Equal($"{dotnetWatchDefaultPrefix} verbose" + EOL, testConsole.GetOutput());
             testConsole.Clear();

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -57,9 +57,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Equal($"{dotnetWatchDefaultPrefix} warn" + EOL, testConsole.GetOutput());
             testConsole.Clear();
 
-            // stderr
             reporter.Error("error", emoji: "😄");
-            Assert.Equal($"{dotnetWatchDefaultPrefix} error" + EOL, testConsole.GetError());
+            Assert.Equal($"{dotnetWatchDefaultPrefix} error" + EOL, testConsole.GetOutput());
             testConsole.Clear();
         }
 


### PR DESCRIPTION
Messages written to stdout and stderr are not guaranteed to be displayed in the order they were written. This might cause confusion as an error might not be shown before we prompt the user for action, etc. It also causes intermittent failures of tests that verify error messages.