### PR TITLE
Remove the spacing from the table header of the templating new tests 

### DIFF
--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
@@ -2,7 +2,7 @@
 For more information, run: 
    dotnet new list -h
 These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                              
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
@@ -2,7 +2,7 @@
 For more information, run: 
    dotnet new list -h
 These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                          
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
@@ -2,7 +2,7 @@
 For more information, run: 
    dotnet new list -h
 These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                              
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
@@ -1,5 +1,5 @@
 ﻿These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                              
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
@@ -1,5 +1,5 @@
 ﻿These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                          
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
+++ b/test/dotnet-new.Tests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
@@ -1,5 +1,5 @@
 These templates matched your input: 
-Template Name                                 Short Name                  Language    Tags                              
+Template
 API
 ASP.NET
 Blazor

--- a/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
+++ b/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             foreach (var line in lines)
             {
-                if (line.StartsWith("-----"))
+                if (line.StartsWith("Template Name", StringComparison.Ordinal))
                 {
                     isTable = true;
                     continue;

--- a/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
+++ b/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Utils;
@@ -57,7 +57,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             foreach (var line in lines)
             {
-
                 // start trimming whitespace and anything but the first word with the start of the table
                 if (line.StartsWith("Template Name", StringComparison.Ordinal))
                 {

--- a/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
+++ b/test/dotnet-new.Tests/DotnetNewListTests.Approval.cs
@@ -57,9 +57,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             foreach (var line in lines)
             {
+
+                // start trimming whitespace and anything but the first word with the start of the table
                 if (line.StartsWith("Template Name", StringComparison.Ordinal))
                 {
                     isTable = true;
+                }
+
+                // We don't want to have to count how many dashes are in the table separator as this can change based on the width of the column
+                if (line.StartsWith("-----", StringComparison.Ordinal))
+                {
                     continue;
                 }
 


### PR DESCRIPTION
Figuring out the spaces required in the table header is really hard without running the test on every platform. It's completely impossible from test results. So let's just remove that entirely. That'll simplify maintenance of these tests even further as I'm seeing them fail in other PRs into 2xx and 3xx already with spacing issues.