### PR TITLE
Allow users to set a specific ContainerImageFormat to force OCI support

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -6,6 +6,12 @@ using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
 
+internal enum KnownImageFormats
+{
+    OCI,
+    Docker
+}
+
 internal static class ContainerBuilder
 {
     internal static async Task<int> ContainerizeAsync(
@@ -34,6 +40,7 @@ internal static class ContainerBuilder
         string? archiveOutputPath,
         bool generateLabels,
         bool generateDigestLabel,
+        KnownImageFormats? imageFormat,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
@@ -98,6 +105,15 @@ internal static class ContainerBuilder
         }
         logger.LogInformation(Strings.ContainerBuilder_StartBuildingImage, imageName, string.Join(",", imageName), sourceImageReference);
         cancellationToken.ThrowIfCancellationRequested();
+
+        // forcibly change the media type if required
+        imageBuilder.ManifestMediaType = imageFormat switch
+        {
+            null => imageBuilder.ManifestMediaType,
+            KnownImageFormats.Docker => SchemaTypes.DockerManifestV2,
+            KnownImageFormats.OCI => SchemaTypes.OciManifestV1,
+            _ => imageBuilder.ManifestMediaType // should be impossible unless we add to the enum
+        };
 
         Layer newLayer = Layer.FromDirectory(publishDirectory.FullName, workingDir, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -19,7 +19,6 @@ internal sealed class ImageBuilder
 
     // the mutable internal manifest that we're building by modifying the base and applying customizations
     private readonly ManifestV2 _manifest;
-    private readonly string _manifestMediaType;
     private readonly ImageConfig _baseImageConfig;
     private readonly ILogger _logger;
 
@@ -32,15 +31,15 @@ internal sealed class ImageBuilder
     public ImageConfig BaseImageConfig => _baseImageConfig;
 
     /// <summary>
-    /// MediaType of the output manifest.
+    /// MediaType of the output manifest. By default, this will be the same as the base images' manifest.
     /// </summary>
-    public string ManifestMediaType => _manifestMediaType; // output the same media type as the base image manifest.
+    public string ManifestMediaType { get; set; }
 
     internal ImageBuilder(ManifestV2 manifest, string manifestMediaType, ImageConfig baseImageConfig, ILogger logger)
     {
         _baseImageManifest = manifest;
         _manifest = new ManifestV2() { SchemaVersion = manifest.SchemaVersion, Config = manifest.Config, Layers = new(manifest.Layers), MediaType = manifest.MediaType };
-        _manifestMediaType = manifestMediaType;
+        ManifestMediaType = manifestMediaType;
         _baseImageConfig = baseImageConfig;
         _logger = logger;
     }
@@ -70,14 +69,20 @@ internal sealed class ImageBuilder
         ManifestConfig newManifestConfig = _manifest.Config with
         {
             digest = imageDigest,
-            size = imageSize
+            size = imageSize,
+            mediaType = ManifestMediaType switch
+            {
+                SchemaTypes.OciManifestV1 => SchemaTypes.OciImageConfigV1,
+                SchemaTypes.DockerManifestV2 => SchemaTypes.DockerContainerV1,
+                _ => SchemaTypes.OciImageConfigV1 // opinion - defaulting to modern here, but really this should never happen
+            }
         };
 
         ManifestV2 newManifest = new ManifestV2()
         {
             Config = newManifestConfig,
             SchemaVersion = _manifest.SchemaVersion,
-            MediaType = _manifest.MediaType,
+            MediaType = ManifestMediaType,
             Layers = _manifest.Layers
         };
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -31,7 +31,7 @@ internal sealed class ImageBuilder
     public ImageConfig BaseImageConfig => _baseImageConfig;
 
     /// <summary>
-    /// MediaType of the output manifest. By default, this will be the same as the base images' manifest.
+    /// MediaType of the output manifest. By default, this will be the same as the base image manifest.
     /// </summary>
     public string ManifestMediaType { get; set; }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -243,6 +243,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> b
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.set -> void
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.set -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -90,6 +90,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> b
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.set -> void
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolName.get -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateCommandLineCommands() -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateFullPathToTool() -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
@@ -9,8 +9,11 @@ internal class SchemaTypes
     internal const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
     internal const string DockerManifestListV2 = "application/vnd.docker.distribution.manifest.list.v2+json";
     internal const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
+
     internal const string OciManifestV1 = "application/vnd.oci.image.manifest.v1+json"; // https://containers.gitbook.io/build-containers-the-hard-way/#registry-format-oci-image-manifest
     internal const string OciImageIndexV1 = "application/vnd.oci.image.index.v1+json";
+    internal const string OciImageConfigV1 = "application/vnd.oci.image.config.v1+json";
+
     internal const string DockerLayerGzip = "application/vnd.docker.image.rootfs.diff.tar.gzip";
     internal const string OciLayerGzipV1 = "application/vnd.oci.image.layer.v1.tar+gzip";
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Microsoft.NET.Build.Containers.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Strings() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER0000: Value for unit test {0}.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("_Test", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1002: Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry..
         /// </summary>
@@ -77,7 +77,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("AmazonRegistryFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2008: Both {0} and {1} were provided, but only one or the other is allowed..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("AmbiguousTags", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2025: ContainerAppCommandArgs are provided without specifying a ContainerAppCommand..
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("AppCommandArgsSetNoAppCommand", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2026: ContainerAppCommand and ContainerAppCommandArgs must be empty when ContainerAppCommandInstruction is &apos;{0}&apos;..
         /// </summary>
@@ -104,7 +104,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("AppCommandSetNotUsed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to local archive at &apos;{0}&apos;.
         /// </summary>
@@ -113,7 +113,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ArchiveRegistry_PushInfo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2022: The base image has an entrypoint that will be overwritten to start the application. Set ContainerAppCommandInstruction to &apos;Entrypoint&apos; if this is desired. To preserve the base image entrypoint, set ContainerAppCommandInstruction to &apos;DefaultArgs&apos;..
         /// </summary>
@@ -122,7 +122,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BaseEntrypointOverwritten", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2009: Could not parse {0}: {1}.
         /// </summary>
@@ -131,7 +131,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BaseImageNameParsingFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2020: {0} does not specify a registry and will be pulled from Docker Hub. Please prefix the name with the image registry, for example: &apos;{1}/&lt;image&gt;&apos;..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BaseImageNameRegistryFallback", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2013: {0} had spaces in it, replacing with dashes..
         /// </summary>
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BaseImageNameWithSpaces", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1011: Couldn&apos;t find matching base image for {0} that matches RuntimeIdentifier {1}..
         /// </summary>
@@ -158,7 +158,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BaseImageNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1001: Failed to upload blob using {0}; received status code &apos;{1}&apos;..
         /// </summary>
@@ -167,7 +167,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BlobUploadFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Building image index &apos;{0}&apos; on top of manifests {1}..
         /// </summary>
@@ -176,7 +176,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("BuildingImageIndex", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to {1}..
         /// </summary>
@@ -185,7 +185,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToLocalDaemon", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pushed image &apos;{0}&apos; to registry &apos;{1}&apos;..
         /// </summary>
@@ -194,7 +194,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ContainerBuilder_ImageUploadedToRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Building image &apos;{0}&apos; with tags &apos;{1}&apos; on top of base image &apos;{2}&apos;..
         /// </summary>
@@ -203,7 +203,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ContainerBuilder_StartBuildingImage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3001: Failed creating {0} process..
         /// </summary>
@@ -212,7 +212,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ContainerRuntimeProcessCreationFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1007: Could not deserialize token from JSON..
         /// </summary>
@@ -221,7 +221,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("CouldntDeserializeJsonToken", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2012: Could not recognize registry &apos;{0}&apos;..
         /// </summary>
@@ -230,7 +230,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("CouldntRecognizeRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to local registry via &apos;{0}&apos;.
         /// </summary>
@@ -239,7 +239,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("DockerCli_PushInfo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info({0})\n{1}\n{2}.
         /// </summary>
@@ -248,7 +248,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("DockerInfoFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER3002: Failed to get docker info: {0}.
         /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("DockerInfoFailed_Ex", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4006: Property &apos;{0}&apos; is empty or contains whitespace and will be ignored..
         /// </summary>
@@ -266,7 +266,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EmptyOrWhitespacePropertyIgnored", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4004: Items &apos;{0}&apos; contain empty item(s) which will be ignored..
         /// </summary>
@@ -275,7 +275,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EmptyValuesIgnored", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2023: A ContainerEntrypoint and ContainerAppCommandArgs are provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
         /// </summary>
@@ -284,7 +284,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EntrypointAndAppCommandArgsSetNoAppCommandInstruction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2024: ContainerEntrypointArgs are provided without specifying a ContainerEntrypoint..
         /// </summary>
@@ -293,7 +293,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EntrypointArgsSetNoEntrypoint", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2029: ContainerEntrypointArgsSet are provided. Change to use ContainerAppCommandArgs for arguments that must always be set, or ContainerDefaultArgs for arguments that can be overridden when the container is created..
         /// </summary>
@@ -302,7 +302,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EntrypointArgsSetPreferAppCommandArgs", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2028: ContainerEntrypoint can not be combined with ContainerAppCommandInstruction &apos;{0}&apos;..
         /// </summary>
@@ -311,7 +311,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EntrypointConflictAppCommand", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2027: A ContainerEntrypoint is provided. ContainerAppInstruction must be set to configure how the application is started. Valid instructions are {0}..
         /// </summary>
@@ -320,7 +320,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("EntrypointSetNoAppCommandInstruction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1008: Failed retrieving credentials for &quot;{0}&quot;: {1}.
         /// </summary>
@@ -329,7 +329,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("FailedRetrievingCredentials", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2030: GenerateLabels was disabled but GenerateDigestLabel was enabled - no digest label will be created..
         /// </summary>
@@ -338,7 +338,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("GenerateDigestLabelWithoutGenerateLabels", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No host object detected..
         /// </summary>
@@ -347,7 +347,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("HostObjectNotDetected", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pushed image index &apos;{0}&apos; to registry &apos;{1}&apos;..
         /// </summary>
@@ -356,7 +356,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ImageIndexUploadedToRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1009: Failed to load image from local registry. stdout: {0}.
         /// </summary>
@@ -365,7 +365,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ImageLoadFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1010: Pulling images from local registry is not supported..
         /// </summary>
@@ -374,7 +374,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ImagePullNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cannot create manifest list (image index) because no images were provided..
         /// </summary>
@@ -383,7 +383,16 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ImagesEmpty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to CONTAINER2031: The container image format &apos;{0}&apos; is not supported. Supported formats are &apos;{1}&apos;..
+        /// </summary>
+        internal static string InvalidContainerImageFormat {
+            get {
+                return ResourceManager.GetString("InvalidContainerImageFormat", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2015: {0}: &apos;{1}&apos; was not a valid Environment Variable. Ignoring..
         /// </summary>
@@ -392,7 +401,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidEnvVar", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cannot create manifest list (image index) because provided images are invalid. Items must have &apos;Config&apos;, &apos;Manifest&apos;, &apos;ManifestMediaType&apos; and &apos;ManifestDigest&apos; metadata..
         /// </summary>
@@ -401,7 +410,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidImageMetadata", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The inferred image name &apos;{0}&apos; contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character..
         /// </summary>
@@ -410,7 +419,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidImageName_EntireNameIsInvalidCharacters", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The first character of the image name &apos;{0}&apos; must be a lowercase letter or a digit and all characters in the name must be an alphanumeric character, -, /, or _..
         /// </summary>
@@ -419,7 +428,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidImageName_NonAlphanumericStartCharacter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
@@ -428,7 +437,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidPort_Number", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port number &apos;{0}&apos; and an invalid port type &apos;{1}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
@@ -437,7 +446,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidPort_NumberAndType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2017: A ContainerPort item was provided with an invalid port type &apos;{0}&apos;. ContainerPort items must have an Include value that is an integer, and a Type value that is either &apos;tcp&apos; or &apos;udp&apos;..
         /// </summary>
@@ -446,7 +455,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidPort_Type", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2018: Invalid SDK prerelease version &apos;{0}&apos; - only &apos;rc&apos; and &apos;preview&apos; are supported..
         /// </summary>
@@ -455,7 +464,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidSdkPrereleaseVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2019: Invalid SDK semantic version &apos;{0}&apos;..
         /// </summary>
@@ -464,7 +473,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidSdkVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2007: Invalid {0} provided: {1}. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
@@ -473,7 +482,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidTag", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2010: Invalid {0} provided: {1}. {0} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period..
         /// </summary>
@@ -482,7 +491,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidTags", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid string[] TargetRuntimeIdentifiers. Either all should be &apos;linux-musl&apos; or none..
         /// </summary>
@@ -491,7 +500,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidTargetRuntimeIdentifiers", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1003: Token response had neither token nor access_token..
         /// </summary>
@@ -500,7 +509,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("InvalidTokenResponse", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4005: Item &apos;{0}&apos; contains items without metadata &apos;Value&apos;, and they will be ignored..
         /// </summary>
@@ -509,7 +518,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("ItemsWithoutMetadata", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error while reading daemon config: {0}.
         /// </summary>
@@ -518,7 +527,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("LocalDocker_FailedToGetConfig", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The daemon server reported errors: {0}.
         /// </summary>
@@ -527,7 +536,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("LocalDocker_LocalDaemonErrors", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1012: The local registry is not available, but pushing to a local registry was requested..
         /// </summary>
@@ -536,7 +545,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("LocalRegistryNotAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2004: Unable to download layer with descriptor &apos;{0}&apos; from registry &apos;{1}&apos; because it does not exist..
         /// </summary>
@@ -545,7 +554,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("MissingLinkToRegistry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2016: ContainerPort item &apos;{0}&apos; does not specify the port number. Please ensure the item&apos;s Include is a port number, for example &apos;&lt;ContainerPort Include=&quot;80&quot; /&gt;&apos;.
         /// </summary>
@@ -554,7 +563,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("MissingPortNumber", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;mediaType&apos; of manifests should be the same in manifest list (image index)..
         /// </summary>
@@ -563,7 +572,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("MixedMediaTypes", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1004: No RequestUri specified..
         /// </summary>
@@ -572,7 +581,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("NoRequestUriSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was not a valid container image name, it was normalized to &apos;{1}&apos;.
         /// </summary>
@@ -581,7 +590,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("NormalizedContainerName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to create tarball for oci image with multiple tags..
         /// </summary>
@@ -590,7 +599,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("OciImageMultipleTagsNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2011: {0} &apos;{1}&apos; does not exist.
         /// </summary>
@@ -599,7 +608,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("PublishDirectoryDoesntExist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded config to registry..
         /// </summary>
@@ -608,7 +617,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_ConfigUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading config to registry at blob &apos;{0}&apos;,.
         /// </summary>
@@ -617,7 +626,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_ConfigUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Layer &apos;{0}&apos; already exists..
         /// </summary>
@@ -626,7 +635,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_LayerExists", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Finished uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
@@ -635,7 +644,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_LayerUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading layer &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
@@ -644,7 +653,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_LayerUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded manifest to &apos;{0}&apos;..
         /// </summary>
@@ -653,7 +662,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_ManifestUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading manifest to registry &apos;{0}&apos; as blob &apos;{1}&apos;..
         /// </summary>
@@ -662,7 +671,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_ManifestUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploaded tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
@@ -671,7 +680,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_TagUploaded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Uploading tag &apos;{0}&apos; to &apos;{1}&apos;..
         /// </summary>
@@ -680,7 +689,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("Registry_TagUploadStarted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1017: Unable to communicate with the registry &apos;{0}&apos;..
         /// </summary>
@@ -689,7 +698,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RegistryOperationFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1013: Failed to push to the output registry: {0}.
         /// </summary>
@@ -698,7 +707,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RegistryOutputPushFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1014: Manifest pull failed..
         /// </summary>
@@ -707,7 +716,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RegistryPullFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1005: Registry push failed; received status code &apos;{0}&apos;..
         /// </summary>
@@ -716,7 +725,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RegistryPushFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1015: Unable to access the repository &apos;{0}&apos; at tag &apos;{1}&apos; in the registry &apos;{2}&apos;. Please confirm that this name and tag are present in the registry..
         /// </summary>
@@ -725,7 +734,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RepositoryNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4003: Required &apos;{0}&apos; items contain empty items..
         /// </summary>
@@ -734,7 +743,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RequiredItemsContainsEmptyItems", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4002: Required &apos;{0}&apos; items were not set..
         /// </summary>
@@ -743,7 +752,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RequiredItemsNotSet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER4001: Required property &apos;{0}&apos; was not set or empty..
         /// </summary>
@@ -752,7 +761,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("RequiredPropertyNotSetOrEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1006: Too many retries, stopping..
         /// </summary>
@@ -761,7 +770,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("TooManyRetries", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER1016: Unable to access the repository &apos;{0}&apos; in the registry &apos;{1}&apos;. Please confirm your credentials are correct and that you have access to this repository and registry..
         /// </summary>
@@ -770,7 +779,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnableToAccessRepository", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2021: Unknown AppCommandInstruction &apos;{0}&apos;. Valid instructions are {1}..
         /// </summary>
@@ -779,7 +788,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnknownAppCommandInstruction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2002: Unknown local registry type &apos;{0}&apos;. Valid local container registry types are {1}..
         /// </summary>
@@ -788,7 +797,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnknownLocalRegistryType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2003: The manifest for {0}:{1} from registry {2} was an unknown type: {3}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message..
         /// </summary>
@@ -797,7 +806,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnknownMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2001: Unrecognized mediaType &apos;{0}&apos;..
         /// </summary>
@@ -806,7 +815,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnrecognizedMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cannot create manifest list (image index) for the provided &apos;mediaType&apos; = &apos;{0}&apos;..
         /// </summary>
@@ -815,7 +824,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("UnsupportedMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to create tarball for mediaType &apos;{0}&apos;..
         /// </summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -456,4 +456,8 @@
     <value>CONTAINER2030: GenerateLabels was disabled but GenerateDigestLabel was enabled - no digest label will be created.</value>
     <comment>{StrBegins="CONTAINER2030: "}</comment>
   </data>
+  <data name="InvalidContainerImageFormat" xml:space="preserve">
+    <value>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</value>
+    <comment>{StrBegins="CONTAINER2031: "}</comment>
+  </data>
 </root>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' は有効な環境変数ではありませんでした。無視しています。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}'은(는) 유효한 환경 변수가 아닙니다. 무시 중.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: "{1}" 不是有效的环境变量。忽略。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -179,6 +179,11 @@
         <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidContainerImageFormat">
+        <source>CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</source>
+        <target state="new">CONTAINER2031: The container image format '{0}' is not supported. Supported formats are '{1}'.</target>
+        <note>{StrBegins="CONTAINER2031: "}</note>
+      </trans-unit>
       <trans-unit id="InvalidEnvVar">
         <source>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</source>
         <target state="needs-review-translation">CONTAINER2015: {0}: '{1}' 不是有效的環境變數。正在忽略。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -166,6 +166,11 @@ partial class CreateNewImage
     [Required]
     public bool GenerateDigestLabel { get; set; }
 
+    /// <summary>
+    /// Set to either 'OCI', 'Docker', or null. If unset, the generated images' mediaType will be that of the base image. If set, the generated image will be given the specified media type.
+    /// </summary>
+    public string? ImageFormat { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -136,6 +136,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                     _ => imageBuilder.ManifestMediaType // should be impossible unless we add to the enum
                 };
             }
+            else
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidContainerImageFormat), ImageFormat, string.Join(",", Enum.GetValues<KnownImageFormats>()));
+            }
         }
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -124,6 +124,20 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, string.Join(",", ImageTags), sourceImageReference);
 
+        // forcibly change the media type if required
+        if (ImageFormat is not null)
+        {
+            if (Enum.TryParse<KnownImageFormats>(ImageFormat, out var imageFormat))
+            {
+                imageBuilder.ManifestMediaType = imageFormat switch
+                {
+                    KnownImageFormats.Docker => SchemaTypes.DockerManifestV2,
+                    KnownImageFormats.OCI => SchemaTypes.OciManifestV1,
+                    _ => imageBuilder.ManifestMediaType // should be impossible unless we add to the enum
+                };
+            }
+        }
+
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(WorkingDirectory);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -123,6 +123,10 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         {
             builder.AppendSwitchIfNotNull("--appcommandinstruction ", AppCommandInstruction);
         }
+        if (!string.IsNullOrWhiteSpace(ImageFormat))
+        {
+            builder.AppendSwitchIfNotNull("--image-format ", ImageFormat);
+        }
 
         AppendSwitchIfNotNullSanitized(builder, "--entrypoint ", nameof(Entrypoint), Entrypoint);
         AppendSwitchIfNotNullSanitized(builder, "--entrypointargs ", nameof(EntrypointArgs), EntrypointArgs);

--- a/src/Containers/containerize/ContainerizeCommand.cs
+++ b/src/Containers/containerize/ContainerizeCommand.cs
@@ -203,6 +203,11 @@ internal class ContainerizeCommand : CliRootCommand
         Arity = ArgumentArity.Zero
     };
 
+    internal CliOption<KnownImageFormats?> ImageFormatOption { get; } = new("--image-format")
+    {
+        Description = "If set to OCI or Docker will force the generated image to be that format. If unset, the base images format will be used."
+    };
+
     internal ContainerizeCommand() : base("Containerize an application without Docker.")
     {
         PublishDirectoryArgument.AcceptLegalFilePathsOnly();
@@ -232,6 +237,7 @@ internal class ContainerizeCommand : CliRootCommand
         Options.Add(ContainerUserOption);
         Options.Add(GenerateLabelsOption);
         Options.Add(GenerateDigestLabelOption);
+        Options.Add(ImageFormatOption);
 
         SetAction(async (parseResult, cancellationToken) =>
         {
@@ -260,6 +266,7 @@ internal class ContainerizeCommand : CliRootCommand
             string? _containerUser = parseResult.GetValue(ContainerUserOption);
             bool _generateLabels = parseResult.GetValue(GenerateLabelsOption);
             bool _generateDigestLabel = parseResult.GetValue(GenerateDigestLabelOption);
+            KnownImageFormats? _imageFormat = parseResult.GetValue(ImageFormatOption);
 
             //setup basic logging
             bool traceEnabled = Env.GetEnvironmentVariableAsBool("CONTAINERIZE_TRACE_LOGGING_ENABLED");
@@ -292,6 +299,7 @@ internal class ContainerizeCommand : CliRootCommand
                 _archiveOutputPath,
                 _generateLabels,
                 _generateDigestLabel,
+                _imageFormat,
                 loggerFactory,
                 cancellationToken).ConfigureAwait(false);
         });

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -256,6 +256,7 @@
                     BaseImageName="$(ContainerBaseName)"
                     BaseImageTag="$(ContainerBaseTag)"
                     BaseImageDigest="$(ContainerBaseDigest)"
+                    ImageFormat="$(ContainerImageFormat)"
                     LocalRegistry="$(LocalRegistry)"
                     OutputRegistry="$(ContainerRegistry)"
                     ArchiveOutputPath="$(ContainerArchiveOutputPath)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/611

This introduces a new MSBuild property, `ContainerImageFormat`, which can be one of `OCI` or `Docker`. If present, this will force single image manifests and configuration to use the format specified. If unset, the formats of the base image will be used.

I was able to test this locally and verify all of the expected media types on a locally-running `registry:2` instance

```terminal
(dogfood) PS E:\Code\sdk-container-demo\src\sdk-container-demo> docker run -d -p 5000:5000 --name registry registry:2
Unable to find image 'registry:2' locally
2: Pulling from library/registry
9959184a302f: Download complete
c8f4e00e7d3c: Download complete
665375f37302: Download complete
b6afea20d55c: Download complete
f54a5150a760: Download complete
Digest: sha256:319881be2ee9e345d5837d15842a04268de6a139e23be42654fc7664fc6eaf52
Status: Downloaded newer image for registry:2
acac5772a8c31fcb36d1cd921701354c88f436cb476522f2bf94669c43475419

> dotnet publish -t:PublishContainer -r linux-x64 -v d -bl -p ContainerRegistry=localhost:5000
Restore complete (0.8s)
    Determining projects to restore...
    Restored E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj (in 240 ms).
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  sdk-container-demo succeeded (1.0s) → E:\Code\sdk-container-demo\artifacts\publish\sdk-container-demo\release_linux-x64\
  sdk-container-demo succeeded (1.7s)
    Building image 'sdk-container-demo' with tags 'latest,v1.1' on top of base image 'mcr.microsoft.com/dotnet/aspnet:8.0'.
    Uploading layer 'sha256:af302e5c37e9dc1dbe2eadc8f5059d82a914066b541b0d1a6daa91d0cc55057d' to 'localhost:5000'.
    Uploading layer 'sha256:91ab5e0aabf0f167bbdba019f1b60b9548e08fdf67363574c6b82e6092103e57' to 'localhost:5000'.
    Uploading layer 'sha256:1c1e4530721eb878290d29bdf34361bf78cc59c7327025c2fe28864a63f3711e' to 'localhost:5000'.
    Uploading layer 'sha256:1f39ca6dcc3a12c21f7199d627b864351ac61c0db49df3a25de0e15450a02f80' to 'localhost:5000'.
    Uploading layer 'sha256:ea20083aa80192d617a64b64459368605749911195831cf824197dddc2a1961c' to 'localhost:5000'.
    Uploading layer 'sha256:64c242a4f5610cb4ad633229aa50fa34290f74842cf6a32ae6dd31d79f827757' to 'localhost:5000'.
    Uploading layer 'sha256:885ece27c2d30d127979e3a15ac05efef79df2998126483a0b1bd03628749972' to 'localhost:5000'.
    Layer 'sha256:af302e5c37e9dc1dbe2eadc8f5059d82a914066b541b0d1a6daa91d0cc55057d' already exists.
    Layer 'sha256:64c242a4f5610cb4ad633229aa50fa34290f74842cf6a32ae6dd31d79f827757' already exists.
    Layer 'sha256:91ab5e0aabf0f167bbdba019f1b60b9548e08fdf67363574c6b82e6092103e57' already exists.
    Layer 'sha256:1f39ca6dcc3a12c21f7199d627b864351ac61c0db49df3a25de0e15450a02f80' already exists.
    Layer 'sha256:ea20083aa80192d617a64b64459368605749911195831cf824197dddc2a1961c' already exists.
    Layer 'sha256:1c1e4530721eb878290d29bdf34361bf78cc59c7327025c2fe28864a63f3711e' already exists.
    Finished uploading layer 'sha256:885ece27c2d30d127979e3a15ac05efef79df2998126483a0b1bd03628749972' to 'localhost:5000'.
    Uploading config to registry at blob 'sha256:9229a63791908fbdac174ef991638983bcf739aa03c5a083e03df5863b8fdafd',
    Uploaded config to registry.
    Uploading tag 'latest' to 'localhost:5000'.
    Uploaded tag 'latest' to 'localhost:5000'.
    Uploading tag 'v1.1' to 'localhost:5000'.
    Uploaded tag 'v1.1' to 'localhost:5000'.
    Pushed image 'sdk-container-demo:latest, v1.1' to registry 'localhost:5000'.

Build succeeded in 3.7s

(dogfood) PS E:\Code\sdk-container-demo\src\sdk-container-demo> curl localhost:5000/v2/sdk-container-demo/manifests/latest
{"errors":[{"code":"MANIFEST_UNKNOWN","message":"OCI manifest found, but accept header does not support OCI manifests"}]}

(dogfood) PS E:\Code\sdk-container-demo\src\sdk-container-demo> curl --header 'Accept: application/vnd.oci.image.manifest.v1+json' localhost:5000/v2/sdk-container-demo/manifests/latest | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1402  100  1402    0     0  44092      0 --:--:-- --:--:-- --:--:-- 45225
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "size": 4169,
    "digest": "sha256:9229a63791908fbdac174ef991638983bcf739aa03c5a083e03df5863b8fdafd"
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 28212417,
      "digest": "sha256:af302e5c37e9dc1dbe2eadc8f5059d82a914066b541b0d1a6daa91d0cc55057d"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 18722950,
      "digest": "sha256:91ab5e0aabf0f167bbdba019f1b60b9548e08fdf67363574c6b82e6092103e57"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 3278,
      "digest": "sha256:1c1e4530721eb878290d29bdf34361bf78cc59c7327025c2fe28864a63f3711e"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 32244715,
      "digest": "sha256:1f39ca6dcc3a12c21f7199d627b864351ac61c0db49df3a25de0e15450a02f80"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 153,
      "digest": "sha256:ea20083aa80192d617a64b64459368605749911195831cf824197dddc2a1961c"
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 11069200,
      "digest": "sha256:64c242a4f5610cb4ad633229aa50fa34290f74842cf6a32ae6dd31d79f827757"
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "size": 9377902,
      "digest": "sha256:885ece27c2d30d127979e3a15ac05efef79df2998126483a0b1bd03628749972"
    }
  ]
}

(dogfood) PS E:\Code\sdk-container-demo\src\sdk-container-demo> curl --header 'Accept: application/vnd.oci.image.config.v1+json' localhost:5000/v2/sdk-container-demo/blobs/sha256:9229a63791908fbdac174ef991638983bcf739aa03c5a083e03df5863b8fdafd | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4169  100  4169    0     0   234k      0 --:--:-- --:--:-- --:--:--  239k
{
  "config": {
    "ExposedPorts": {
      "8080/tcp": {}
    },
    "Labels": {
      "org.opencontainers.image.created": "2025-01-15T21:11:53.7672978Z",
      "org.opencontainers.artifact.created": "2025-01-15T21:11:53.7672978Z",
      "org.opencontainers.artifact.description": "\r\n\t\t\tA project that demonstrates publishing to various container registries using just\r\n\t\t\tthe .NET SDK\r\n\t\t",
      "org.opencontainers.image.description": "\r\n\t\t\tA project that demonstrates publishing to various container registries using just\r\n\t\t\tthe .NET SDK\r\n\t\t",
      "org.opencontainers.image.authors": "Chet Husk",
      "org.opencontainers.image.url": "https://github.com/baronfel/sdk-container-demo",
      "org.opencontainers.image.documentation": "https://github.com/baronfel/sdk-container-demo",
      "org.opencontainers.image.version": "1.0.0",
      "org.opencontainers.image.licenses": "MIT",
      "org.opencontainers.image.title": ".NET SDK 8 Container Demo",
      "org.opencontainers.image.base.name": "mcr.microsoft.com/dotnet/aspnet:8.0",
      "net.dot.runtime.majorminor": "8.0",
      "net.dot.sdk.version": "10.0.100-dev",
      "org.opencontainers.image.source": "https://github.com/baronfel/sdk-container-demo",
      "org.opencontainers.image.revision": "530356ee6891b317b316d1c98199e6fcc50341ef",
      "org.opencontainers.image.base.digest": "sha256:2cd76b1aba9a5ee9013baeed7cb52784cfd8198a8f343f5264daa9db7b73f5de"
    },
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "APP_UID=1654",
      "ASPNETCORE_HTTP_PORTS=8080",
      "DOTNET_RUNNING_IN_CONTAINER=true",
      "DOTNET_VERSION=8.0.12",
      "ASPNET_VERSION=8.0.12"
    ],
    "WorkingDir": "/app/",
    "Entrypoint": [
      "dotnet",
      "/app/sdk-container-demo.dll"
    ],
    "User": "1654"
  },
  "created": "2025-01-15T21:11:55.2438910Z",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:f5fe472da25334617e6e6467c7ebce41e0ae5580e5bd0ecbf0d573bacd560ecb",
      "sha256:b138fdfd1095780b78eb87d172392eaedb62c02443fb29e6955d69894d13667c",
      "sha256:bc198994fabd5cb872694fddb790802e81cfbfc7af240138561ae30308bc93c8",
      "sha256:0fbbfdee9cddbc405d7577d75a38028f9ada2fc968343e0d7eaea6d88d7f1cc4",
      "sha256:9f71735511ce298381e7a7cffbbd340976a328622d0fb5ac01e8c4afd7ba9c1d",
      "sha256:f07c146df8a618e310357dccc538d52ee52bddb1f5f6fff2113e47cb9efbd8cc",
      "sha256:a65e489c8479e8d70167886170579ab6dc0c7b6ba7c0c2fec6dee02ddcbca555"
    ]
  },
  "architecture": "amd64",
  "os": "linux",
  "history": [
    {
      "comment": "debuerreotype 0.15",
      "created": "2025-01-13T00:00:00.0000000Z",
      "created_by": "# debian.sh --arch 'amd64' out/ 'bookworm' '@1736726400'"
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:44.0220201Z",
      "created_by": "ENV APP_UID=1654 ASPNETCORE_HTTP_PORTS=8080 DOTNET_RUNNING_IN_CONTAINER=true",
      "empty_layer": true
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:44.0220201Z",
      "created_by": "RUN /bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         ca-certificates                 libc6         libgcc-s1         libicu72         libssl3         libstdc++6         tzdata         zlib1g     && rm -rf /var/lib/apt/lists/* # buildkit"
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:45.9027407Z",
      "created_by": "RUN /bin/sh -c groupadd         --gid=$APP_UID         app     && useradd -l         --uid=$APP_UID         --gid=$APP_UID         --create-home         app # buildkit"
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:52.9595288Z",
      "created_by": "ENV DOTNET_VERSION=8.0.12",
      "empty_layer": true
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:52.9595288Z",
      "created_by": "COPY /dotnet /usr/share/dotnet # buildkit"
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:00:54.4897837Z",
      "created_by": "RUN /bin/sh -c ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet # buildkit"
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:01:00.3575580Z",
      "created_by": "ENV ASPNET_VERSION=8.0.12",
      "empty_layer": true
    },
    {
      "comment": "buildkit.dockerfile.v0",
      "created": "2025-01-14T19:01:00.3575580Z",
      "created_by": "COPY /shared/Microsoft.AspNetCore.App /usr/share/dotnet/shared/Microsoft.AspNetCore.App # buildkit"
    },
    {
      "author": ".NET SDK",
      "created": "2025-01-15T21:11:55.2438835Z",
      "created_by": ".NET SDK Container Tooling, version 10.0.100-dev"
    }
  ]
}
```
Todo:
* [ ] tests