### PR TITLE
Merge branch 'release/9.0.1xx' => 'release/9.0.2xx'

### DIFF
--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -337,7 +337,7 @@ namespace Microsoft.DotNet.CommandFactory
                 LocalizableStrings.GeneratingDepsJson,
                 depsPath));
 
-            var tempDepsFile = Path.GetTempFileName();
+            var tempDepsFile = Path.Combine(PathUtilities.CreateTempSubdirectory(), Path.GetRandomFileName());
 
             var args = new List<string>();
 


### PR DESCRIPTION
Porting this internal code flow now, so it's in for a timely manner for the build.

Description/Summary/Customer Impact:
This is a merge of an internal fix, which was documented in our email thread, 'Tactics Approval Request - Jan .NET SDK' sent by me. Please go there for further information.

Regression:
No

Risk:
Low, this is already released in the below branches:

Approval was already granted for:
6.0.4xx
8.0.1xx
8.0.2xx
8.0.3xx
8.0.4xx
9.0.1xx
main