### PR TITLE
Fix unwanted transitive updates to compile only references

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <!-- Disable transitive pinning, we can't upgrade dependencies that are excluded from shipping  -->
+    <!-- Disable transitive pinning, we shouldn't upgrade dependencies that are excluded for runtime and provided externally. -->
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <!-- Disable transitive pinning, we can't upgrade dependencies that are excluded from shipping  -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <IsPackable>true</IsPackable>
     <IsShippingPackage>true</IsShippingPackage>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <!-- Disable transitive pinning, we can't upgrade Roslyn dependencies that are excluded  -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>$(NoWarn);RS1024</NoWarn>
   </PropertyGroup>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Microsoft.DotNet.ApiCompatibility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <!-- Disable transitive pinning, we can't upgrade Roslyn dependencies that are excluded  -->
+    <!-- Disable transitive pinning, we shouldn't upgrade dependencies that are excluded for runtime and provided externally. -->
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- We need to compare ISymbols in a special way (by name) and roslyn symbol comparers take more heuristics into consideration.-->
     <NoWarn>$(NoWarn);RS1024</NoWarn>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation/Microsoft.DotNet.PackageValidation.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <!-- Disable transitive pinning, we shouldn't upgrade dependencies that are excluded for runtime and provided externally. -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <!-- Disable transitive pinning, we can't upgrade Roslyn dependencies that are excluded  -->
+    <!-- Disable transitive pinning, we shouldn't upgrade dependencies that are excluded for runtime and provided externally. -->
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Microsoft.DotNet.ApiSymbolExtensions.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolMinimum);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <!-- Disable transitive pinning, we can't upgrade Roslyn dependencies that are excluded  -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Exclude files that depend on Microsoft.Build.Framework and Microsoft.Build.Utilities.Core. These should be manually included by other projects. -->


### PR DESCRIPTION
Fix https://github.com/dotnet/sdk/issues/45004

What's happening is the CPM+TransitivePinning is updating Roslyn's transitive dependencies.  Some of these are not used, but some are.

In the case of APICompat, it was using `System.Memory` which wasn't directly updated, but was updated as a result of updating System.Text.Encoding.Codepages:
```
  [net472]
   │
   └─ Microsoft.DotNet.ApiSymbolExtensions (v10.0.100-dev)
      └─ Microsoft.CodeAnalysis.CSharp (v4.4.0)
         └─ Microsoft.CodeAnalysis.Common (v4.4.0)
            ├─ System.Collections.Immutable (v6.0.0)
            │  └─ System.Memory (v4.6.0)
            ├─ System.Memory (v4.6.0)
            ├─ System.Reflection.Metadata (v5.0.0)
            │  └─ System.Collections.Immutable (v6.0.0)
            │     └─ System.Memory (v4.6.0)
            └─ System.Text.Encoding.CodePages (v10.0.0-alpha.1.25063.12)
               └─ System.Memory (v4.6.0)

  [net8.0]
   │
   └─ Microsoft.DotNet.ApiSymbolExtensions (v10.0.100-dev)
      └─ Microsoft.CodeAnalysis.CSharp (v4.4.0)
         └─ Microsoft.CodeAnalysis.Common (v4.4.0)
            └─ System.Memory (v4.5.5)
```

What we really need here is a way to tell NuGet not to update transitive references from compile-only packages, in addition to excluding those from audit.  cc @nkolev92 @zivkan this is what we've been discussing around plugin handling.