### PR TITLE
Allow wpf test binary in VMR

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -152,3 +152,4 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict
 src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.BIN
 src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.bin
+src/wpf/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/Resources/Invalid_1.xps


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4831

Allows wpf test binary into the VMR.