### PR TITLE
Don't restore baseline package when project isn't packable

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ApiCompat.targets
@@ -16,6 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnablePackageValidation)' == 'true' and
+                        '$(IsPackable)' == 'true' and
                         '$(DisablePackageBaselineValidation)' != 'true' and
                         '$(PackageValidationBaselinePath)' == '' and
                         '$(PackageValidationBaselineVersion)' != ''">


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/46039

cc @bitbonk