### PR TITLE
Fix not failing when build fails

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -134,23 +134,21 @@ namespace Microsoft.DotNet.Cli
         {
             foreach (Module module in modules)
             {
-                if (module.IsTestProject)
-                {
-                    if (module.IsTestingPlatformApplication)
-                    {
-                        var testApp = new TestApplication(module, _args);
-                        _testApplications.Add(testApp);
-                    }
-                    else // If one test app has IsTestingPlatformApplication set to false, then we will not run any of the test apps
-                    {
-                        _areTestingPlatformApplications = false;
-                        return;
-                    }
-                }
-                else
+                if (!module.IsTestProject)
                 {
                     // Non test projects, like the projects that include production code are skipped over, we won't run them.
+                    return;
                 }
+
+                if (!module.IsTestingPlatformApplication)
+                {
+                    // If one test app has IsTestingPlatformApplication set to false, then we will not run any of the test apps
+                    _areTestingPlatformApplications = false;
+                    return;
+                }
+
+                var testApp = new TestApplication(module, _args);
+                _testApplications.Add(testApp);
             }
         }
 
@@ -212,7 +210,7 @@ namespace Microsoft.DotNet.Cli
                 () => true,
                 (project, state, localRestored) =>
                 {
-                    var (relatedProjects, isRestored) = GetProjectPropertiesInternal(project, allowBinLog, $"msbuild_{Guid.NewGuid().ToString()}.binlog");
+                    var (relatedProjects, isRestored) = GetProjectPropertiesInternal(project, allowBinLog, binLogFileName);
                     foreach (var relatedProject in relatedProjects)
                     {
                         allProjects.Add(relatedProject);
@@ -342,7 +340,7 @@ namespace Microsoft.DotNet.Cli
                 }
                 else
                 {
-                    binLogFileName = $"msbuild_{Guid.NewGuid().ToString()}.binlog";
+                    binLogFileName = CliConstants.BinLogFileName;
                 }
 
                 return true;

--- a/src/Cli/dotnet/commands/dotnet-test/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Terminal/TerminalTestReporter.cs
@@ -306,7 +306,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         string skippedText = $"{SingleIndentation}skipped: {skipped}";
         string durationText = $"{SingleIndentation}duration: ";
 
-        if(error > 0)
+        if (error > 0)
         {
             terminal.SetColor(TerminalColor.Red);
             terminal.AppendLine(errorText);

--- a/src/Cli/dotnet/commands/dotnet-test/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Terminal/TestProgressState.cs
@@ -48,6 +48,8 @@ internal sealed class TestProgressState
     public long Version { get; internal set; }
 
     public List<(string? DisplayName, string? UID)> DiscoveredTests { get; internal set; } = new();
+    public int? ExitCode { get; internal set; }
+    public bool Success { get; internal set; }
 
     internal void AddError(string text)
         => Messages.Add(new ErrorMessage(text));

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -387,6 +387,10 @@ namespace Microsoft.DotNet.Cli
             {
                 _output.AssemblyRunCompleted(appInfo.ModulePath, appInfo.TargetFramework, appInfo.Architecture, appInfo.ExecutionId, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
             }
+            else
+            {
+                _output.AssemblyRunCompleted(testApplication.Module.DllOrExePath ?? testApplication.Module.ProjectPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
+            }
 
             if (!VSTestTrace.TraceEnabled) return;
 


### PR DESCRIPTION
When build fails to finish, add error count and fail the run.

This problem is caused by build being "additional" work that is not a test, so we did not report it as failure.

Fix https://github.com/microsoft/testfx/issues/4683

![image](https://github.com/user-attachments/assets/ee30efc0-a9c7-4cf6-bbea-986c7f29e607)

Working towards https://github.com/dotnet/sdk/issues/45927
