### PR TITLE
Append `_Attempt$(System.JobAttempt)` to artifact name on failure

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -627,7 +627,7 @@ jobs:
 
     - publish: $(artifactsStagingDir)
       artifact: $(failedJobArtifactName)
-      displayName: Publish Artifacts
+      displayName: Publish Artifacts (On Failure)
       condition: failed()
       continueOnError: true
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -621,7 +621,7 @@ jobs:
     # This prevents overwrite conflicts in the event of a failed build followed by a rerun and a successful build.
     - publish: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
-      displayName: Publish Artifacts
+      displayName: Publish Artifacts (On Success)
       condition: succeeded()
       continueOnError: true
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -214,7 +214,7 @@ jobs:
     - output: pipelineArtifact
       path: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
-      displayName: Publish Artifacts
+      displayName: Publish Artifacts (On Success)
       condition: succeeded()
       sbomEnabled: true
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -209,6 +209,8 @@ jobs:
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
       sbomEnabled: false
 
+    # Both publishing steps are necessary to ensure artifacts are published on both success and failure.
+    # This prevents overwrite conflicts in the event of a failed build followed by a rerun and a successful build.
     - output: pipelineArtifact
       path: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
@@ -615,6 +617,8 @@ jobs:
         testRunTitle: ScenarioTests_$(Agent.JobName)
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+    # Both publishing steps are necessary to ensure artifacts are published on both success and failure.
+    # This prevents overwrite conflicts in the event of a failed build followed by a rerun and a successful build.
     - publish: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
       displayName: Publish Artifacts

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -210,7 +210,8 @@ jobs:
       sbomEnabled: false
 
     # Both publishing steps are necessary to ensure artifacts are published on both success and failure.
-    # This prevents overwrite conflicts in the event of a failed build followed by a rerun and a successful build.
+    # This prevents overwrite conflicts in the event of a failed build followed by a rerun.
+    # Additionally, the 'Download Previous Build *' steps depend on a fixed name to acquire specific assets in multi-stage builds.
     - output: pipelineArtifact
       path: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
@@ -619,6 +620,7 @@ jobs:
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     # Both publishing steps are necessary to ensure artifacts are published on both success and failure.
     # This prevents overwrite conflicts in the event of a failed build followed by a rerun.
+    # Additionally, the 'Download Previous Build *' steps depend on a fixed name to acquire specific assets in multi-stage builds.
     - publish: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
       displayName: Publish Artifacts (On Success)

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -221,7 +221,7 @@ jobs:
     - output: pipelineArtifact
       path: $(artifactsStagingDir)
       artifact: $(failedJobArtifactName)
-      displayName: Publish Artifacts
+      displayName: Publish Artifacts (On Failure)
       condition: failed()
       sbomEnabled: true
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -191,7 +191,7 @@ jobs:
     value: $(Agent.JobName)_Artifacts
 
   - name: failedJobArtifactName
-    value: $(Agent.JobName)_Artifacts_Attempt$(System.JobAttempt)
+    value: $(successfulJobArtifactName)_Attempt$(System.JobAttempt)
 
   # manually disable CodeQL until https://dev.azure.com/mseng/1ES/_workitems/edit/2211548 is implemented
   # CodeQL doesn't work on arm64 macOS, see https://portal.microsofticm.com/imp/v5/incidents/details/532165079/summary

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -618,7 +618,7 @@ jobs:
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     # Both publishing steps are necessary to ensure artifacts are published on both success and failure.
-    # This prevents overwrite conflicts in the event of a failed build followed by a rerun and a successful build.
+    # This prevents overwrite conflicts in the event of a failed build followed by a rerun.
     - publish: $(artifactsStagingDir)
       artifact: $(successfulJobArtifactName)
       displayName: Publish Artifacts (On Success)

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -187,6 +187,12 @@ jobs:
   - name: artifactsStagingDir
     value: $(Build.ArtifactStagingDirectory)/artifacts
 
+  - name: successfulJobArtifactName
+    value: $(Agent.JobName)_Artifacts
+
+  - name: failedJobArtifactName
+    value: $(Agent.JobName)_Artifacts_Attempt$(System.JobAttempt)
+
   # manually disable CodeQL until https://dev.azure.com/mseng/1ES/_workitems/edit/2211548 is implemented
   # CodeQL doesn't work on arm64 macOS, see https://portal.microsofticm.com/imp/v5/incidents/details/532165079/summary
   - ${{ if eq(parameters.pool.os, 'macOS') }}:
@@ -205,9 +211,16 @@ jobs:
 
     - output: pipelineArtifact
       path: $(artifactsStagingDir)
-      artifact: $(Agent.JobName)_Artifacts
+      artifact: $(successfulJobArtifactName)
       displayName: Publish Artifacts
-      condition: succeededOrFailed()
+      condition: succeeded()
+      sbomEnabled: true
+
+    - output: pipelineArtifact
+      path: $(artifactsStagingDir)
+      artifact: $(failedJobArtifactName)
+      displayName: Publish Artifacts
+      condition: failed()
       sbomEnabled: true
 
     # Using build artifacts to enable publishing the vertical manifests to a single artifact from different jobs
@@ -603,9 +616,15 @@ jobs:
 
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(artifactsStagingDir)
-      artifact: $(Agent.JobName)_Artifacts
+      artifact: $(successfulJobArtifactName)
       displayName: Publish Artifacts
-      condition: succeededOrFailed()
+      condition: succeeded()
+      continueOnError: true
+
+    - publish: $(artifactsStagingDir)
+      artifact: $(failedJobArtifactName)
+      displayName: Publish Artifacts
+      condition: failed()
       continueOnError: true
 
     # Using build artifacts to enable publishing the vertical manifests to a single artifact from different jobs


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4829

This PR breaks the `Publish Artifacts` step into two separate steps:
- One step is conditioned to run on a successful build and publishes the artifacts to `$(Agent.JobName)_Artifacts`.
- The other step is conditioned to run on a failed build and publishes the artifacts to `$(Agent.JobName)_Artifacts_Attempt$(System.JobAttempt)`.

These changes allow for the artifacts to still be published on success or failure, and these changes prevent the failure described in https://github.com/dotnet/source-build/issues/4829

