### PR TITLE
Deduplicate results from dotnet workload search version

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -549,7 +549,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
 
             IEnumerable<(PackageSource source, IPackageSearchMetadata package)> accumulativeSearchResults =
                 foundPackagesBySource
-                    .SelectMany(result => result.foundPackages.Select(package => (result.source, package)));
+                    .SelectMany(result => result.foundPackages.Select(package => (result.source, package)))
+                    .Distinct();
 
             if (!accumulativeSearchResults.Any())
             {


### PR DESCRIPTION
These results were reported:
```
dotnet workload search version
9.0.102
9.0.102
9.0.101.2
9.0.101.2
9.0.101.1
```

This should deduplicate the returned list.