### PR TITLE
Implement workaround for Aspire dashboard launching

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
+++ b/src/BuiltInTools/dotnet-watch/Browser/BrowserConnector.cs
@@ -14,10 +14,14 @@ namespace Microsoft.DotNet.Watch
         // This needs to be in sync with the version BrowserRefreshMiddleware is compiled against.
         private static readonly Version s_minimumSupportedVersion = Versions.Version6_0;
 
-        private static readonly Regex s_nowListeningRegex = s_nowListeningOnRegex();
+        private static readonly Regex s_nowListeningRegex = GetNowListeningOnRegex();
+        private static readonly Regex s_aspireDashboardUrlRegex = GetAspireDashboardUrlRegex();
 
         [GeneratedRegex(@"Now listening on: (?<url>.*)\s*$", RegexOptions.Compiled)]
-        private static partial Regex s_nowListeningOnRegex();
+        private static partial Regex GetNowListeningOnRegex();
+
+        [GeneratedRegex(@"Login to the dashboard at (?<url>.*)\s*$", RegexOptions.Compiled)]
+        private static partial Regex GetAspireDashboardUrlRegex();
 
         private readonly object _serversGuard = new();
         private readonly Dictionary<ProjectGraphNode, BrowserRefreshServer?> _servers = [];
@@ -117,6 +121,10 @@ namespace Microsoft.DotNet.Watch
 
             bool matchFound = false;
 
+            // Workaround for Aspire dashboard launching: scan for "Login to the dashboard at " prefix in the output and use the URL.
+            // TODO: Share launch profile processing logic as implemented in VS with dotnet-run and implement browser launching there.
+            var isAspireHost = projectNode.GetCapabilities().Contains(AspireServiceFactory.AppHostProjectCapability);
+
             return handler;
 
             void handler(OutputLine line)
@@ -129,7 +137,7 @@ namespace Microsoft.DotNet.Watch
                     return;
                 }
 
-                var match = s_nowListeningRegex.Match(line.Content);
+                var match = (isAspireHost ? s_aspireDashboardUrlRegex : s_nowListeningRegex).Match(line.Content);
                 if (!match.Success)
                 {
                     return;
@@ -141,7 +149,8 @@ namespace Microsoft.DotNet.Watch
                 if (projectAddedToAttemptedSet)
                 {
                     // first iteration:
-                    LaunchBrowser(launchProfile, match.Groups["url"].Value, server);
+                    var launchUrl = GetLaunchUrl(launchProfile.LaunchUrl, match.Groups["url"].Value);
+                    LaunchBrowser(launchUrl, server);
                 }
                 else if (server != null)
                 {
@@ -153,10 +162,15 @@ namespace Microsoft.DotNet.Watch
             }
         }
 
-        private void LaunchBrowser(LaunchSettingsProfile launchProfile, string launchUrl, BrowserRefreshServer? server)
+        public static string GetLaunchUrl(string? profileLaunchUrl, string outputLaunchUrl)
+            => string.IsNullOrWhiteSpace(profileLaunchUrl) ? outputLaunchUrl :
+                Uri.TryCreate(profileLaunchUrl, UriKind.Absolute, out _) ? profileLaunchUrl :
+                Uri.TryCreate(outputLaunchUrl, UriKind.Absolute, out var launchUri) ? new Uri(launchUri, profileLaunchUrl).ToString() :
+                outputLaunchUrl;
+
+        private void LaunchBrowser(string launchUrl, BrowserRefreshServer? server)
         {
-            var launchPath = launchProfile.LaunchUrl;
-            var fileName = Uri.TryCreate(launchPath, UriKind.Absolute, out _) ? launchPath : launchUrl + "/" + launchPath;
+            var fileName = launchUrl;
 
             var args = string.Empty;
             if (EnvironmentVariables.BrowserPath is { } browserPath)

--- a/test/dotnet-watch.Tests/Browser/BrowserConnectorTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserConnectorTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class BrowserConnectorTests
+{
+    [Theory]
+    [InlineData(null, "https://localhost:1234", "https://localhost:1234")]
+    [InlineData("", "https://localhost:1234", "https://localhost:1234")]
+    [InlineData("   ", "https://localhost:1234", "https://localhost:1234")]
+    [InlineData("", "a/b", "a/b")]
+    [InlineData("x/y", "a/b", "a/b")]
+    [InlineData("a/b?X=1", "https://localhost:1234", "https://localhost:1234/a/b?X=1")]
+    [InlineData("https://localhost:1000/a/b", "https://localhost:1234", "https://localhost:1000/a/b")]
+    [InlineData("https://localhost:1000/x/y?z=u", "https://localhost:1234/a?b=c", "https://localhost:1000/x/y?z=u")]
+    public void GetLaunchUrl(string? profileLaunchUrl, string outputLaunchUrl, string expected)
+    {
+        Assert.Equal(expected, BrowserConnector.GetLaunchUrl(profileLaunchUrl, outputLaunchUrl));
+    }
+}

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             App.AssertOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
 
             // Browser is launched based on blazor-devserver output "Now listening on: ...".
-            await App.WaitUntilOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}/");
+            await App.WaitUntilOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}");
 
             // Middleware should have been loaded to blazor-devserver before the browser is launched:
             App.AssertOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]");
@@ -395,7 +395,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             App.AssertOutputContains(MessageDescriptor.ConfiguredToUseBrowserRefresh);
             App.AssertOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
-            App.AssertOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}/");
+            App.AssertOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}");
             App.Process.ClearOutput();
 
             var scopedCssPath = Path.Combine(testAsset.Path, "RazorClassLibrary", "Components", "Example.razor.css");

--- a/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.AssertOutputLineStartsWith(MessageDescriptor.ConfiguredToLaunchBrowser);
 
             // Verify we launched the browser.
-            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Launching browser: mycustombrowser.bat https://localhost:5001/");
+            await App.AssertOutputLineStartsWith("dotnet watch ⌚ Launching browser: mycustombrowser.bat https://localhost:5001");
         }
     }
 }

--- a/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BrowserLaunchTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Contains(App.Process.Output, line => line.Contains("Hosting environment: Development"));
 
             // Verify we launched the browser.
-            Assert.Contains(App.Process.Output, line => line.Contains("dotnet watch ⌚ Launching browser: https://localhost:5001/"));
+            Assert.Contains(App.Process.Output, line => line.Contains("dotnet watch ⌚ Launching browser: https://localhost:5001"));
         }
 
         [Fact]


### PR DESCRIPTION
Workaround for https://github.com/dotnet/sdk/issues/44262.

### Context

The change fixes browser launching for Aspire projects in dotnet watch. Aspire application is expected to launch browser on dashboard URL that contains auth token, but the standard dotnet-watch browser launching implementation launches browser without the token. 

### Customer impact

Aspire application run via dotnet-watch doesn't open dashboard page in the browser.

### Details

The fix implements a simple workaround: it scans the output of the app host for the full dashboard URL.
The proper fix would be to add DCP protocol request that instructs IDE to launch browser at specified URL. This approach would avoid adding Aspire specific logic to launch profile processing. See https://github.com/dotnet/aspire/issues/7197.

We should also 
a) Move VS implementation of profile processing to a shared library/source package in SDK, so that we can share the logic between VS, VS Code and dotnet-run
b) Implement browser launching in dotnet run (https://github.com/dotnet/sdk/issues/9038) and use [a] to process launch profile

### Changes made

Special cases Aspire project in existing URL scanning code.

### Testing

Manual testing to confirm that the changes correctly open the dashboard in the browser.

### Risks

Small potential risk of breaking URL scanning, although this has been mitigated by added tests.

