### PR TITLE
Do not set RestoreConfigFile in environment

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -154,9 +154,6 @@
 
     <!-- Need to be passed in as an env var so that custom Exec tasks in the repo's DotNetBuild.props receive this setting. -->
     <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
-
-    <!-- Needed for miscellanous projects in various repos - see https://github.com/dotnet/source-build/issues/4081-->
-    <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -13,6 +13,8 @@
     <!-- Enable building installers on Windows and Linux. ASP.NET Core doesn't produce installers on Mac -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)BuildInstallers</BuildActions>
     <BuildActions Condition="'$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-installers</BuildActions>
+    <BuildActions Condition="'$(NuGetConfigFile)' != '' and '$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)RestoreConfigFile "$(NuGetConfigFile)"</BuildActions>
+    <BuildActions Condition="'$(NuGetConfigFile)' != '' and '$(BuildOS)' != 'windows'">$(BuildActions) $(FlagParameterPrefix)restore-config-file "$(NuGetConfigFile)"</BuildActions>
     <!-- In a source-only build, we don't pass -all, so we need to explicitly opt-in to managed components here. -->
     <BuildActions Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(BuildOS)' == 'linux'">$(BuildActions) $(FlagParameterPrefix)build-managed</BuildActions>
 

--- a/src/SourceBuild/patches/aspnetcore/0002-Add-restore-config-file-param.patch
+++ b/src/SourceBuild/patches/aspnetcore/0002-Add-restore-config-file-param.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Matt Mitchell (.NET) (from Dev Box)" <mmitche@microsoft.com>
+Date: Wed, 22 Jan 2025 14:58:12 -0800
+Subject: [PATCH] Add restore config file param
+
+Backport: https://github.com/dotnet/aspnetcore/pull/60004
+
+---
+ eng/DotNetBuild.props |  2 +-
+ eng/build.ps1         | 11 +++++++++++
+ eng/build.sh          | 14 ++++++++++++++
+ 3 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/eng/DotNetBuild.props b/eng/DotNetBuild.props
+index 9c4eb173ed..c4827cbcb4 100644
+--- a/eng/DotNetBuild.props
++++ b/eng/DotNetBuild.props
+@@ -32,7 +32,7 @@
+       <_AdditionalRepoTaskBuildArgs />
+       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeed)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeed $(DotNetRuntimeSourceFeed)</_AdditionalRepoTaskBuildArgs>
+       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeedKey)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeedkey $(DotNetRuntimeSourceFeedKey)</_AdditionalRepoTaskBuildArgs>
+-      <_AdditionalRepoTaskBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</_AdditionalRepoTaskBuildArgs>
++      <_AdditionalRepoTaskBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) --restore-config-file $(RestoreConfigFile)</_AdditionalRepoTaskBuildArgs>
+     </PropertyGroup>
+ 
+     <ItemGroup>
+diff --git a/eng/build.ps1 b/eng/build.ps1
+index 15fe87ac6f..9b34eec7f4 100644
+--- a/eng/build.ps1
++++ b/eng/build.ps1
+@@ -99,6 +99,9 @@ Additional feed that can be used when downloading .NET runtimes and SDKs
+ .PARAMETER RuntimeSourceFeedKey
+ Key for feed that can be used when downloading .NET runtimes and SDKs
+ 
++.PARAMETER RestoreConfigFile
++NuGet.config that should be passed to build commands (via /p:RestoreConfigFile)
++
+ .EXAMPLE
+ Building both native and managed projects.
+ 
+@@ -196,6 +199,8 @@ param(
+     [Alias('DotNetRuntimeSourceFeedKey')]
+     [string]$RuntimeSourceFeedKey,
+ 
++    [string]$RestoreConfigFile
++
+     # Capture the rest
+     [Parameter(ValueFromRemainingArguments = $true)]
+     [string[]]$MSBuildArguments
+@@ -288,6 +293,12 @@ if ($RuntimeSourceFeed -or $RuntimeSourceFeedKey) {
+     $ToolsetBuildArguments += $runtimeFeedKeyArg
+ }
+ 
++if ($RestoreConfigFile) {
++    $restoreConfigFileArg = "/p:RestoreConfigFile=$RestoreConfigFile"
++    $MSBuildArguments += $restoreConfigFileArg
++    $ToolsetBuildArguments += $restoreConfigFileArg
++}
++
+ # Split build categories between dotnet msbuild and desktop msbuild. Use desktop msbuild as little as possible.
+ [string[]]$dotnetBuildArguments = ''
+ [string[]]$MSBuildOnlyArguments = ''
+diff --git a/eng/build.sh b/eng/build.sh
+index a27eaad468..0ffb000c57 100755
+--- a/eng/build.sh
++++ b/eng/build.sh
+@@ -35,6 +35,7 @@ target_arch='x64'
+ configuration=''
+ runtime_source_feed=''
+ runtime_source_feed_key=''
++restore_config_file=''
+ 
+ if [ "$(uname)" = "Darwin" ]; then
+     target_os_name='osx'
+@@ -88,6 +89,8 @@ Options:
+     --runtime-source-feed             Additional feed that can be used when downloading .NET runtimes and SDKs
+     --runtime-source-feed-key         Key for feed that can be used when downloading .NET runtimes and SDKs
+ 
++    --restore-config-file             NuGet.config file to use when building the repository
++
+ Description:
+     This build script installs required tools and runs an MSBuild command on this repository
+     This script can be used to invoke various targets, such as targets to produce packages
+@@ -242,6 +245,11 @@ while [[ $# -gt 0 ]]; do
+             [ -z "${1:-}" ] && __error "Missing value for parameter --runtime-source-feed-key" && __usage
+             runtime_source_feed_key="${1:-}"
+             ;;
++        -restore-config-file|-restoreconfigfile)
++            shift
++            [ -z "${1:-}" ] && __error "Missing value for parameter --restore-config-file" && __usage
++            restore_config_file="${1:-}"
++            ;;
+         *)
+             msbuild_args[${#msbuild_args[*]}]="$1"
+             ;;
+@@ -330,6 +338,12 @@ if [ ! -z "$runtime_source_feed$runtime_source_feed_key" ]; then
+     toolset_build_args[${#toolset_build_args[*]}]=$runtimeFeedKeyArg
+ fi
+ 
++if [ ! -z "$restore_config_file" ]; then
++    restoreConfigFileArg="/p:RestoreConfigFile=$restore_config_file"
++    msbuild_args[${#msbuild_args[*]}]=$restoreConfigFileArg
++    toolset_build_args[${#toolset_build_args[*]}]=$restoreConfigFileArg
++fi
++
+ # Initialize global variables need to be set before the import of Arcade is imported
+ restore=$run_restore
+ 

--- a/src/SourceBuild/patches/aspnetcore/0002-Add-restore-config-file-param.patch
+++ b/src/SourceBuild/patches/aspnetcore/0002-Add-restore-config-file-param.patch
@@ -42,7 +42,7 @@ index 15fe87ac6f..9b34eec7f4 100644
      [Alias('DotNetRuntimeSourceFeedKey')]
      [string]$RuntimeSourceFeedKey,
  
-+    [string]$RestoreConfigFile
++    [string]$RestoreConfigFile,
 +
      # Capture the rest
      [Parameter(ValueFromRemainingArguments = $true)]

--- a/src/SourceBuild/patches/fsharp/0001-Pass-restore-config-file-arg-to-bootstrap-build.patch
+++ b/src/SourceBuild/patches/fsharp/0001-Pass-restore-config-file-arg-to-bootstrap-build.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Matt Mitchell (.NET) (from Dev Box)" <mmitche@microsoft.com>
+Date: Wed, 22 Jan 2025 15:31:13 -0800
+Subject: [PATCH] Pass restore config file arg to bootstrap build
+
+Backport PR: https://github.com/dotnet/fsharp/pull/18260
+
+---
+ eng/DotNetBuild.props | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/eng/DotNetBuild.props b/eng/DotNetBuild.props
+index d16818033..b44b8bae3 100644
+--- a/eng/DotNetBuild.props
++++ b/eng/DotNetBuild.props
+@@ -31,6 +31,7 @@
+     <PropertyGroup>
+       <SourceBuildBootstrapTfmArg Condition="$(SourceBuildBootstrapTfm) != ''">--tfm $(SourceBuildBootstrapTfm)</SourceBuildBootstrapTfmArg>
+       <DotNetBuildUseMonoRuntime Condition="'$(DotNetBuildUseMonoRuntime)' == ''">false</DotNetBuildUseMonoRuntime>
++      <SourceBuildBootstrapRestoreConfigFileArg Condition="'$(RestoreConfigFile)' != ''" >/p:RestoreConfigFile=$(RestoreConfigFile)</SourceBuildBootstrapRestoreConfigFileArg>
+     </PropertyGroup>
+ 
+     <!-- this runs the source-build bootstrap path as described in https://github.com/dotnet/fsharp/blob/95df49e380ea8dbf33653fa4209f89dba29413f5/eng/build.sh#L247
+@@ -41,7 +42,7 @@
+          -bl enables the binlogs for the tools and Proto builds, which make debugging failures here easier
+     -->
+     <Exec
+-      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg) /p:DotNetBuildUseMonoRuntime=$(DotNetBuildUseMonoRuntime) /p:DotNetBuildSourceOnly=true /p:DotNetBuildInnerRepo=true /p:DotNetBuildRepo=true /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator)"
++      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg) $(SourceBuildBootstrapRestoreConfigFileArg) /p:DotNetBuildUseMonoRuntime=$(DotNetBuildUseMonoRuntime) /p:DotNetBuildSourceOnly=true /p:DotNetBuildInnerRepo=true /p:DotNetBuildRepo=true /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator)"
+       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+       EnvironmentVariables="@(InnerBuildEnv)" />
+   </Target>


### PR DESCRIPTION
Internal tool restore requires use a separate nuget.config. Setting this globally causes issues.