### PR TITLE
Improve AssemblySymbolLoader logging

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Resources.resx
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Resources.resx
@@ -117,8 +117,26 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AssemblyLoaded" xml:space="preserve">
+    <value>Assembly '{0}' loaded.</value>
+  </data>
+  <data name="AssemblyReferenceLoaded" xml:space="preserve">
+    <value>Assembly '{0}' referenced by '{1}' loaded.</value>
+  </data>
   <data name="CouldNotResolveReference" xml:space="preserve">
-    <value>Could not resolve reference '{0}' in any of the provided search directories.</value>
+    <value>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</value>
+  </data>
+  <data name="LoadingAssemblies" xml:space="preserve">
+    <value>Loading assemblies '{0}'.</value>
+  </data>
+  <data name="LoadingAssembliesFromArchive" xml:space="preserve">
+    <value>Loading assemblies '{0}' ({1}).</value>
+  </data>
+  <data name="LoadingAssembly" xml:space="preserve">
+    <value>Loading assembly '{0}'.</value>
+  </data>
+  <data name="LoadingAssemblyFromStream" xml:space="preserve">
+    <value>Loading assembly '{0}' from stream.</value>
   </data>
   <data name="MatchingAssemblyNotFound" xml:space="preserve">
     <value>Could not find matching assembly: '{0}' in any of the search directories.</value>
@@ -128,6 +146,12 @@
   </data>
   <data name="ProvidedStreamDoesNotHaveMetadata" xml:space="preserve">
     <value>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</value>
+  </data>
+  <data name="RootAssemblyDisplayString" xml:space="preserve">
+    <value>'{0}'</value>
+  </data>
+  <data name="RootAssemblyFromPackageDisplayString" xml:space="preserve">
+    <value>'{0}' ({1})</value>
   </data>
   <data name="ShouldNotBeNullAndContainAtLeastOneElement" xml:space="preserve">
     <value>Should not be null and contain at least one element.</value>

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.cs.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.cs.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">V žádném z uvedených adresářů vyhledávání se nepovedlo přeložit odkaz {0}.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Poskytnutý datový proud pro sestavení {0} nemá žádná metadata pro čtení.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.de.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.de.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Der Verweis "{0}" konnte in keinem der angegebenen Suchverzeichnisse aufgelöst werden.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Der angegebene Datenstrom für die Assembly "{0}" enthält keine Metadaten, aus denen gelesen werden kann.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.es.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.es.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">No se pudo resolver la referencia "{0}" en ninguno de los directorios de búsqueda proporcionados.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">La secuencia proporcionada para el ensamblado "{0}" no tiene metadatos que leer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.fr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.fr.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Impossible de résoudre la référence «{0}» dans l’un des répertoires de recherche fournis.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Le flux fourni pour l’assembly '{0}' n’a aucune métadonnée à lire. De.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.it.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.it.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Non è stato possibile risolvere il riferimento '{0}' in nessuna delle directory di ricerca specificate.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Il flusso specificato per l'assembly '{0}' non contiene metadati da leggere.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ja.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ja.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">指定された検索ディレクトリ内の参照 '{0}' を解決できませんでした。</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">アセンブリ '{0}' に指定されたストリームに読み取るメタデータがありません。送信者。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ko.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ko.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">제공된 검색 디렉터리에서 참조 '{0}'(을)를 확인할 수 없습니다.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">어셈블리 '{0}'에 대해 제공된 스트림에 읽을 메타데이터가 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.pl.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.pl.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Nie można rozpoznać odwołania "{0}" w żadnym z podanych katalogów wyszukiwania.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Podany strumień dla zestawu "{0}" nie ma metadanych, z których można odczytywać.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.pt-BR.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Não foi possível resolver a referência '{0}' em nenhum dos diretórios de pesquisa fornecidos.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">O fluxo fornecido para o assembly '{0}' não tem metadados para ler. desde.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ru.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.ru.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Не удалось разрешить ссылку "{0}" ни в одном из указанных каталогов поиска.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">Указанный поток для сборки "{0}" не имеет метаданных для чтения. От.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.tr.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.tr.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">Sağlanan arama dizinlerinin hiçbirinde '{0}' başvurusu çözümlenemedi.</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">'{0}' bütünleştirilmiş kodu için sağlanan akış, okunacak herhangi bir meta veriye sahip değil.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.zh-Hans.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">无法在任何提供的搜索目录中解析引用“{0}”。</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">为程序集“{0}”提供的流没有任何可供读取的元数据。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/xlf/Resources.zh-Hant.xlf
@@ -2,9 +2,39 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="AssemblyLoaded">
+        <source>Assembly '{0}' loaded.</source>
+        <target state="new">Assembly '{0}' loaded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyReferenceLoaded">
+        <source>Assembly '{0}' referenced by '{1}' loaded.</source>
+        <target state="new">Assembly '{0}' referenced by '{1}' loaded.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldNotResolveReference">
-        <source>Could not resolve reference '{0}' in any of the provided search directories.</source>
-        <target state="translated">無法在任何提供的搜尋目錄中解析參考 '{0}'。</target>
+        <source>Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</source>
+        <target state="new">Could not resolve reference '{0}' directly or transitively referenced by {1} in any of the provided search directories.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblies">
+        <source>Loading assemblies '{0}'.</source>
+        <target state="new">Loading assemblies '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembliesFromArchive">
+        <source>Loading assemblies '{0}' ({1}).</source>
+        <target state="new">Loading assemblies '{0}' ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssembly">
+        <source>Loading assembly '{0}'.</source>
+        <target state="new">Loading assembly '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoadingAssemblyFromStream">
+        <source>Loading assembly '{0}' from stream.</source>
+        <target state="new">Loading assembly '{0}' from stream.</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingAssemblyNotFound">
@@ -20,6 +50,16 @@
       <trans-unit id="ProvidedStreamDoesNotHaveMetadata">
         <source>Provided stream for assembly '{0}' doesn't have any metadata to read. from.</source>
         <target state="translated">為元件 '{0}' 提供的資料流程沒有任何可從中讀取的中繼資料。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyDisplayString">
+        <source>'{0}'</source>
+        <target state="new">'{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RootAssemblyFromPackageDisplayString">
+        <source>'{0}' ({1})</source>
+        <target state="new">'{0}' ({1})</target>
         <note />
       </trans-unit>
       <trans-unit id="ShouldNotBeNullAndContainAtLeastOneElement">

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -264,7 +265,8 @@ namespace MyNamespace
             var assetInfo = GetSimpleTestAsset();
             TestLog log = new();
             AssemblySymbolLoader loader = new(log, resolveAssemblyReferences: resolveReferences);
-            loader.LoadAssembly(Path.Combine(assetInfo.OutputDirectory, assetInfo.TestAsset.TestProject.Name + ".dll"));
+            string assemblyPath = Path.Combine(assetInfo.OutputDirectory, assetInfo.TestAsset.TestProject.Name + ".dll");
+            loader.LoadAssembly(assemblyPath);
 
             if (resolveReferences)
             {
@@ -277,8 +279,8 @@ namespace MyNamespace
                     expectedReference = "mscorlib.dll";
                 }
 
-                List<string> expected = [$"{AssemblySymbolLoader.AssemblyReferenceNotFoundErrorCode} Could not resolve reference '{expectedReference}' in any of the provided search directories."];
-                Assert.Equal(expected, log.Warnings, StringComparer.CurrentCultureIgnoreCase);
+                Assert.Single(log.Warnings);
+                Assert.Matches($"CP1002.*?'{Regex.Escape(expectedReference)}'.*?'{Regex.Escape(assemblyPath)}'.*", log.Warnings.Single());
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/46093

Also update the test to not assert on a an English string. Example loggings with these changes:

> error CP1002: Could not resolve reference 'Microsoft.NET.StringTools.dll' directly or transitively referenced by 'lib/net462/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll' (C:\git\aspnetcore\artifacts\packages\Debug\Shipping\Microsoft.AspNetCore.SignalR.Protocols.MessagePack.10.0.0-dev.nupkg) in any of the provided search directories.

> Loading assemblies 'lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll' from archive 'C:\git\aspnetcore\artifacts\packages\Debug\Shipping\Microsoft.AspNetCore.SignalR.Protocols.MessagePack.10.0.0-dev.nupkg'.

> Assembly 'System.Reflection.Emit.ILGeneration.dll' loaded.

> Assembly 'System.Reflection.Emit.ILGeneration.dll' referenced by 'System.Reflection.Emit.dll' loaded.