### PR TITLE
Update scancode to latest

### DIFF
--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-SCANCODE_VERSION="32.2.1"
+SCANCODE_VERSION="32.3.1"
 
 pyEnvPath="/tmp/scancode-env"
 python3 -m venv $pyEnvPath

--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-SCANCODE_VERSION="32.3.1"
+SCANCODE_VERSION="32.3.2"
 
 pyEnvPath="/tmp/scancode-env"
 python3 -m venv $pyEnvPath

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -56,6 +56,7 @@ public class LicenseScanTests : TestBase
         "bsd-original", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-original.LICENSE
         "bsd-original-uc", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-original-uc.LICENSE
         "bsd-simplified", // https://opensource.org/license/bsd-2-clause/
+        "bsd-zero", // https://opensource.org/license/0bsd/
         "bytemark", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bytemark.LICENSE
         "bzip2-libbzip-2010", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bzip2-libbzip-2010.LICENSE
         "cc0-1.0", // https://creativecommons.org/publicdomain/zero/1.0/legalcode
@@ -102,6 +103,7 @@ public class LicenseScanTests : TestBase
         "sax-pd", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/sax-pd.LICENSE
         "unicode", // https://opensource.org/license/unicode-inc-license-agreement-data-files-and-software/
         "unicode-mappings", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/unicode-mappings.LICENSE
+        "unlicense", // https://opensource.org/license/unlicense/
         "uoi-ncsa", // https://opensource.org/license/uoi-ncsa-php/
         "w3c-software-19980720", // https://opensource.org/license/w3c/
         "w3c-software-doc-20150513", // https://opensource.org/license/w3c/

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -239,11 +239,10 @@ src/vstest/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Lice
 
 # Not applicable to source
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingRights.cs|proprietary-license
-src/wpf/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs|proprietary-license
 src/wpf/eng/WpfArcadeSdk/tools/AvTrace/GenTraceSources.pl|proprietary-license
 src/wpf/eng/WpfArcadeSdk/tools/GenXmlStringTable.pl|proprietary-license
 
-# False positive - https://github.com/dotnet/source-build/issues/4373
+# False positive
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs|unknown-license-reference
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/WindowBackdropType.cs|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/*.xaml|bsd-2-clause-views
@@ -251,6 +250,7 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resourc
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|mpl-2.0
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/*.xaml|bsd-2-clause-views
+src/wpf/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs|proprietary-license
 
 # Test data
 src/wpf/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Security/RightsManagement/PublishLicenseTests.cs|unknown-license-reference

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -68,7 +68,9 @@ src/diagnostics/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
 
 # False positive
 src/efcore/test/EfCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs|proprietary-license
+src/efcore/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs|proprietary-license
 src/efcore/test/EfCore.Tests/ChangeTracking/MemberEntryTest.cs|proprietary-license
+src/efcore/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs|proprietary-license
 
 #
 # fsharp
@@ -76,6 +78,7 @@ src/efcore/test/EfCore.Tests/ChangeTracking/MemberEntryTest.cs|proprietary-licen
 
 # Applies to installer, not source
 src/fsharp/setup/resources/eula/*.rtf
+src/fsharp/tests/fsharp/core/members/ops/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
 
 #
 # msbuild
@@ -108,6 +111,7 @@ src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValue
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/LicenseExpressionTokenizerTests.cs
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseExpressionParserTests.cs
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseTests.cs
+src/nuget-client/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs|389-exception
 src/nuget-client/test/TestUtilities/Test.Utility/JsonData.cs
 
 #
@@ -235,6 +239,7 @@ src/vstest/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Lice
 
 # Not applicable to source
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontEmbeddingRights.cs|proprietary-license
+src/wpf/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs|proprietary-license
 src/wpf/eng/WpfArcadeSdk/tools/AvTrace/GenTraceSources.pl|proprietary-license
 src/wpf/eng/WpfArcadeSdk/tools/GenXmlStringTable.pl|proprietary-license
 
@@ -246,3 +251,6 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resourc
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|mpl-2.0
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/*.xaml|bsd-2-clause-views
+
+# Test data
+src/wpf/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/System/Security/RightsManagement/PublishLicenseTests.cs|unknown-license-reference


### PR DESCRIPTION
[Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2625350&view=results) (wpf failure was the result of a typo. That typo was addressed after the test run)