### PR TITLE
Take two on copying dmp properly on posix

### DIFF
--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -122,7 +122,7 @@
       <HelixPreCommands Condition="$(IsPosixShell)">. $HELIX_CORRELATION_PAYLOAD/t/RunTestsOnHelix.sh;$(HelixPreCommands)</HelixPreCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure";$(HelixPostCommands)</HelixPostCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "Get-ChildItem -Recurse -File -Filter '*hangdump.dmp' | Copy-Item -Destination $env:HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
-      <HelixPostCommands Condition="$(IsPosixShell)">find . -name '*hangdump.dmp' -exec cp {} "$HELIX_WORKITEM_UPLOAD_ROOT" \%3B;$(HelixPostCommands)</HelixPostCommands>
+      <HelixPostCommands Condition="$(IsPosixShell)">find "$HELIX_WORKITEM_UPLOAD_ROOT/.." -name '*hangdump.dmp' -exec cp {} "$HELIX_WORKITEM_UPLOAD_ROOT" \%3B;$(HelixPostCommands)</HelixPostCommands>
       <TestDotnetRoot>$(RepoRoot)artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
       <TestDotnetVersion>$(Version)</TestDotnetVersion>
       <MSBuildSdkResolverDir>$(RepoRoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>


### PR DESCRIPTION
The previous version apparently extended to:
find . -name *hangdump.dmp -exec cp {} /datadisks/disk1/work/A990088E/w/A95709AA/uploads /

The dmp was at:
/datadisks/disk1/work/A990088E/w/A95709AA/e/c6594614-4208-4b0b-b54d-967fbddc3173/dotnet_26747_20250118T001243_hangdump.dmp

So taking the env var and appending '..' should do the trick.

I'd be interested in seeing where '.' currently is, but I'd rather have this work now than add a pwd call then wait for it to fail again.

Helix file I inspected:
https://[helixr1107v0xd1eu3ibi6ka.blob.core.windows.net/dotnet-sdk-refs-pull-45880-merge-90fdd365f73d4e9694/dotnet-watch.Tests.dll.1/1/console.9e9600b2.log?helixlogtype=result](https://helixr1107v0xd1eu3ibi6ka.blob.core.windows.net/dotnet-sdk-refs-pull-45880-merge-90fdd365f73d4e9694/dotnet-watch.Tests.dll.1/1/console.9e9600b2.log?helixlogtype=result)