### PR TITLE
Synchronize watched process and reporter output printing

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/BrowserSpecificReporter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Graph;
-
 namespace Microsoft.DotNet.Watch;
 
 internal sealed class BrowserSpecificReporter(int browserId, IReporter underlyingReporter) : IReporter
@@ -12,14 +10,8 @@ internal sealed class BrowserSpecificReporter(int browserId, IReporter underlyin
     public bool IsVerbose
         => underlyingReporter.IsVerbose;
 
-    public bool EnableProcessOutputReporting
-        => false;
-
-    public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-        => throw new InvalidOperationException();
-
     public void ReportProcessOutput(OutputLine line)
-        => throw new InvalidOperationException();
+        => underlyingReporter.ReportProcessOutput(line);
 
     public void Report(MessageDescriptor descriptor, string prefix, object?[] args)
         => underlyingReporter.Report(descriptor, _prefix + prefix, args);

--- a/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ConsoleReporter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Graph;
-
 namespace Microsoft.DotNet.Watch
 {
     /// <summary>
@@ -15,16 +13,15 @@ namespace Microsoft.DotNet.Watch
         public bool IsQuiet { get; } = quiet;
         public bool SuppressEmojis { get; } = suppressEmojis;
 
-        private readonly object _writeLock = new();
-
-        public bool EnableProcessOutputReporting
-            => false;
+        private readonly Lock _writeLock = new();
 
         public void ReportProcessOutput(OutputLine line)
-            => throw new InvalidOperationException();
-
-        public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-            => throw new InvalidOperationException();
+        {
+            lock (_writeLock)
+            {
+                (line.IsError ? console.Error : console.Out).WriteLine(line.Content);
+            }
+        }
 
         private void WriteLine(TextWriter writer, string message, ConsoleColor? color, string emoji)
         {

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -86,13 +86,19 @@ namespace Microsoft.DotNet.Watch
             => false;
 
         /// <summary>
-        /// True to call <see cref="ReportProcessOutput"/> when launched process writes to standard output.
+        /// If true, the output of the process will be prefixed with the project display name.
         /// Used for testing.
         /// </summary>
-        bool EnableProcessOutputReporting { get; }
+        public bool PrefixProcessOutput
+            => false;
 
+        /// <summary>
+        /// Reports the output of a process that is being watched.
+        /// </summary>
+        /// <remarks>
+        /// Not used to report output of dotnet-build processed launched by dotnet-watch to build or evaluate projects.
+        /// </remarks>
         void ReportProcessOutput(OutputLine line);
-        void ReportProcessOutput(ProjectGraphNode project, OutputLine line);
 
         void Report(MessageDescriptor descriptor, params object?[] args)
             => Report(descriptor, prefix: "", args);

--- a/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/NullReporter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Graph;
-
 namespace Microsoft.DotNet.Watch
 {
     /// <summary>
@@ -11,20 +9,15 @@ namespace Microsoft.DotNet.Watch
     /// </summary>
     internal sealed class NullReporter : IReporter
     {
-        private NullReporter()
-        { }
-
         public static IReporter Singleton { get; } = new NullReporter();
 
-        public bool EnableProcessOutputReporting
-            => false;
+        private NullReporter()
+        {
+        }
 
         public void ReportProcessOutput(OutputLine line)
-            => throw new InvalidOperationException();
-
-        public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-            => throw new InvalidOperationException();
-
+        {
+        }
 
         public void Report(MessageDescriptor descriptor, string prefix, object?[] args)
         {

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -31,11 +31,10 @@ namespace Microsoft.DotNet.Watch
 
             var onOutput = processSpec.OnOutput;
 
-            // allow tests to watch for application output:
-            if (reporter.EnableProcessOutputReporting)
-            {
-                onOutput += line => reporter.ReportProcessOutput(line);
-            }
+            // If output isn't already redirected (build invocation) we redirect it to the reporter.
+            // The reporter synchronizes the output of the process with the reporter output,
+            // so that the printed lines don't interleave.
+            onOutput ??= line => reporter.ReportProcessOutput(line);
 
             using var process = CreateProcess(processSpec, onOutput, state, reporter);
 
@@ -186,7 +185,7 @@ namespace Microsoft.DotNet.Watch
                     FileName = processSpec.Executable,
                     UseShellExecute = false,
                     WorkingDirectory = processSpec.WorkingDirectory,
-                    RedirectStandardOutput =  onOutput != null,
+                    RedirectStandardOutput = onOutput != null,
                     RedirectStandardError = onOutput != null,
                 }
             };

--- a/src/BuiltInTools/dotnet-watch/Internal/ProjectSpecificReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProjectSpecificReporter.cs
@@ -12,14 +12,9 @@ internal sealed class ProjectSpecificReporter(ProjectGraphNode node, IReporter u
     public bool IsVerbose
         => underlyingReporter.IsVerbose;
 
-    public bool EnableProcessOutputReporting
-        => underlyingReporter.EnableProcessOutputReporting;
-
-    public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-        => underlyingReporter.ReportProcessOutput(project, line);
-
     public void ReportProcessOutput(OutputLine line)
-        => ReportProcessOutput(node, line);
+        => underlyingReporter.ReportProcessOutput(
+            underlyingReporter.PrefixProcessOutput ? line with { Content = $"[{_projectDisplayName}] {line.Content}" } : line);
 
     public void Report(MessageDescriptor descriptor, string prefix, object?[] args)
         => underlyingReporter.Report(descriptor, $"[{_projectDisplayName}] {prefix}", args);

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -273,7 +273,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             var hasUpdateSource = w.CreateCompletionSource();
             w.Reporter.OnProcessOutput += line =>
             {
-                if (line.Content.StartsWith($"[ServiceA ({tfm})]") && line.Content.Contains("Started A: 2"))
+                if (line.Content.StartsWith($"[A ({tfm})]") && line.Content.Contains("Started A: 2"))
                 {
                     hasUpdateSource.SetResult();
                 }

--- a/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/dotnet-watch.Tests/MsBuildFileSetFactoryTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         private readonly TestReporter _reporter = new(output);
         private readonly TestAssetsManager _testAssets = new(output);
 
-        private string MuxerPath
+        private static string MuxerPath
             => TestContext.Current.ToolsetUnderTest.DotNetHostPath;
 
         private static string InspectPath(string path, string rootDir)
@@ -329,9 +329,6 @@ $@"<ItemGroup>
                 MuxerPath: MuxerPath,
                 WorkingDirectory: testDirectory);
 
-            var output = new List<string>();
-            _reporter.OnProcessOutput += line => output.Add(line.Content);
-
             var filesetFactory = new MSBuildFileSetFactory(projectA, buildArguments: ["/p:_DotNetWatchTraceOutput=true"], options, _reporter);
 
             var result = await filesetFactory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
@@ -367,7 +364,7 @@ $@"<ItemGroup>
                     "Collecting watch items from 'F'",
                     "Collecting watch items from 'G'",
                 ],
-                output.Where(l => l.Contains("Collecting watch items from")).Select(l => l.Trim()).Order());
+                _reporter.Messages.Where(l => l.text.Contains("Collecting watch items from")).Select(l => l.text.Trim()).Order());
         }
 
         [Fact]
@@ -390,17 +387,14 @@ $@"<ItemGroup>
                 MuxerPath: MuxerPath,
                 WorkingDirectory: Path.GetDirectoryName(project1Path)!);
 
-            var output = new List<string>();
-            _reporter.OnProcessOutput += line => output.Add($"{(line.IsError ? "[stderr]" : "[stdout]")} {line.Content}");
-
             var factory = new MSBuildFileSetFactory(project1Path, buildArguments: [], options, _reporter);
             var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
             Assert.Null(result);
 
-            // note: msbuild prints errors to stdout:
+            // note: msbuild prints errors to stdout, we match the pattern and report as error:
             AssertEx.Equal(
-                $"[stdout] {project1Path} : error NU1201: Project Project2 is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Project2 supports: netstandard2.1 (.NETStandard,Version=v2.1)",
-                output.Single(l => l.Contains("error NU1201")));
+                (MessageSeverity.Error, $"{project1Path} : error NU1201: Project Project2 is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Project2 supports: netstandard2.1 (.NETStandard,Version=v2.1)"),
+                _reporter.Messages.Single(l => l.text.Contains("error NU1201")));
         }
 
         private Task<EvaluationResult> Evaluate(TestAsset projectPath)

--- a/test/dotnet-watch.Tests/Utilities/MockReporter.cs
+++ b/test/dotnet-watch.Tests/Utilities/MockReporter.cs
@@ -3,21 +3,15 @@
 
 #nullable enable
 
-using Microsoft.Build.Graph;
-
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal class MockReporter : IReporter
 {
     public readonly List<string> Messages = [];
 
-    public bool EnableProcessOutputReporting => false;
-
     public void ReportProcessOutput(OutputLine line)
-    => throw new InvalidOperationException();
-
-    public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-        => throw new InvalidOperationException();
+    {
+    }
 
     public void Report(MessageDescriptor descriptor, string prefix, object?[] args)
     {

--- a/test/dotnet-watch.Tests/Utilities/TestReporter.cs
+++ b/test/dotnet-watch.Tests/Utilities/TestReporter.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System.Diagnostics;
-using Microsoft.Build.Graph;
 
 namespace Microsoft.DotNet.Watch.UnitTests
 {
@@ -12,14 +11,14 @@ namespace Microsoft.DotNet.Watch.UnitTests
     {
         private readonly Dictionary<int, Action> _actions = [];
         public readonly List<string> ProcessOutput = [];
-
-        public bool EnableProcessOutputReporting
-            => true;
+        public readonly List<(MessageSeverity severity, string text)> Messages = [];
 
         public bool IsVerbose
             => true;
 
-        public event Action<string, OutputLine>? OnProjectProcessOutput;
+        public bool PrefixProcessOutput
+            => true;
+
         public event Action<OutputLine>? OnProcessOutput;
 
         public void ReportProcessOutput(OutputLine line)
@@ -28,16 +27,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
             ProcessOutput.Add(line.Content);
 
             OnProcessOutput?.Invoke(line);
-        }
-
-        public void ReportProcessOutput(ProjectGraphNode project, OutputLine line)
-        {
-            var content = $"[{project.GetDisplayName()}]: {line.Content}";
-
-            WriteTestOutput(content);
-            ProcessOutput.Add(content);
-
-            OnProjectProcessOutput?.Invoke(project.ProjectInstance.FullPath, line);
         }
 
         public SemaphoreSlim RegisterSemaphore(MessageDescriptor descriptor)
@@ -67,6 +56,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
         {
             if (descriptor.TryGetMessage(prefix, args, out var message))
             {
+                Messages.Add((descriptor.Severity, message));
+
                 WriteTestOutput($"{ToString(descriptor.Severity)} {descriptor.Emoji} {message}");
             }
 
@@ -76,11 +67,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
             }
         }
 
-        private void WriteTestOutput(string message)
+        private void WriteTestOutput(string line)
         {
             try
             {
-                output.WriteLine(message);
+                output.WriteLine(line);
             }
             catch (InvalidOperationException)
             {


### PR DESCRIPTION
Prevents output lines of the watched process and dotnet-watch from interleaving.

Fixes intermittent test failures.

Simplify testing of project-specific output.