### PR TITLE
Add error for incorrect PublishSelfContained

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -981,9 +981,13 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1224: ASP.NET Core framework assets are not supported for the target framework.</value>
     <comment>{StrBegins="NETSDK1224: "}</comment>
   </data>
-  <!-- The latest message added is NativeCompilationRequiresPublishing. Please update this value with each PR to catch parallel PRs both adding a new message -->
   <data name="NativeCompilationRequiresPublishing" xml:space="preserve">
     <value>NETSDK1225: Native compilation is not supported when invoking the Publish target directly. Try running dotnet publish.</value>
     <comment>{StrBegins="NETSDK1225: "}</comment>
+  </data>
+  <!-- The latest message added is PublishSelfContainedRequiresPublishing. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="PublishSelfContainedRequiresPublishing" xml:space="preserve">
+    <value>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</value>
+    <comment>{StrBegins="NETSDK1126: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -987,7 +987,7 @@ You may need to build the project on another operating system or architecture, o
   </data>
   <!-- The latest message added is PublishSelfContainedRequiresPublishing. Please update this value with each PR to catch parallel PRs both adding a new message -->
   <data name="PublishSelfContainedRequiresPublishing" xml:space="preserve">
-    <value>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</value>
-    <comment>{StrBegins="NETSDK1126: "}</comment>
+    <value>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</value>
+    <comment>{StrBegins="NETSDK1226: "}</comment>
   </data>
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: Pokud je nastavená hodnota PublishSelfContained, musí být buď true, nebo false. Zadaná hodnota byla {0}.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: Publikování aplikace do jednoho souboru vyžaduje architekturu .NET Core 3.0 nebo vyšší.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: Wenn PublishSelfContained festgelegt ist, muss es entweder "true" oder "false" sein. Der angegebene Wert war "{0}".</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: Zum Veröffentlichen einer Anwendung in einer einzelnen Datei ist .NET Core 3.0 oder höher erforderlich.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: si se establece PublishSelfContained, debe ser true o false. El valor dado era “{0}”.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: La publicación de una aplicación en un único archivo requiere .NET Core 3.0 o versiones posteriores.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: Si PublishSelfContained est défini, il doit avoir la valeur true ou false. La valeur donnée a été '{0}'.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: la publication d'une application sur un seul fichier nécessite .NET Core 3.0 ou une version ultérieure.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: se PublishSelfContained è impostato, deve essere true o false. Il valore specificato è '{0}'.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: per la pubblicazione di un'applicazione in un file singolo è richiesto .NET Core 3.0 o versioni successive.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: PublishSelfContained が設定されている場合、true または false のいずれかにする必要があります。指定された値は '{0}' でした。</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: アプリケーションを 1 つのファイルに発行するには、.NET Core 3.0 以降が必要です。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: PublishSelfContained가 설정된 경우 true 또는 false여야 합니다. 지정된 값은 '{0}'입니다.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: 애플리케이션을 단일 파일에 게시하려면 .NET Core 3.0 이상이 필요합니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: Jeśli właściwość PublishSelfContained jest ustawiona, musi mieć wartość true lub false. Podana wartość to „{0}”.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: Publikowanie aplikacji do pojedynczego pliku wymaga platformy .NET Core 3.0 lub nowszej.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: se PublishSelfContained estiver definido, ele deverá ser true ou false. O valor fornecido foi '{0} '.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: a publicação de um aplicativo em um único arquivo exige o .NET Core 3.0 ou superior.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="new">NETSDK1193: If PublishSelfContained is set, it must be either true or false. The value given was '{0}'.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="new">NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: PublishSelfContained ayarlanmışsa değeri true veya false olmalıdır. Verilen değer '{0}'.</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: Bir uygulamayı tek bir dosyada yayımlamak için .NET Core 3.0 veya üzeri gerekir.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: 如果已设置 PublishSelfContained，则它必须为 true 或 false。给定的值为“{0}”。</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: 将应用程序发布到单个文件需要 .NET Core 3.0 或更高版本。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -806,6 +806,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="needs-review-translation">NETSDK1193: 如果已設定 PublishSelfContained，它必須是 True 或 False。提供的值是 '{0}'。</target>
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
+      <trans-unit id="PublishSelfContainedRequiresPublishing">
+        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1126: "}</note>
+      </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>
         <target state="needs-review-translation">NETSDK1123: 將應用程式發行至單一檔案需使用 .NET Core 3.0 或更高版本。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -807,9 +807,9 @@ The following are names of parameters or literal values and should not be transl
         <note>{StrBegins="NETSDK1193: "}</note>
       </trans-unit>
       <trans-unit id="PublishSelfContainedRequiresPublishing">
-        <source>NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
-        <target state="new">NETSDK1126: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
-        <note>{StrBegins="NETSDK1126: "}</note>
+        <source>NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</source>
+        <target state="new">NETSDK1226: PublishSelfContained is not supported when invoking the Publish target directly. Try running dotnet publish, or set SelfContained to true.</target>
+        <note>{StrBegins="NETSDK1226: "}</note>
       </trans-unit>
       <trans-unit id="PublishSingleFileRequiresVersion30">
         <source>NETSDK1123: Publishing an application to a single-file requires .NET Core 3.0 or higher.</source>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -219,6 +219,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="SolutionProjectConfigurationsConflict"
                  FormatArguments="PublishRelease;$(ProjectName)"/>
 
+    <NETSdkError Condition="'$(PublishSelfContained)' == 'true' and
+                            '$(_IsPublishing)' != 'true' and
+                            '$(SelfContained)' != 'true' and
+                            '$(_TargetFrameworkVersionWithoutV)' >= '10.0'"
+                 ResourceName="PublishSelfContainedRequiresPublishing" />
+
     <NETSdkError Condition="'$(PublishAot)' == 'true' and
                             '$(_IsPublishing)' != 'true' and
                             '$(PublishAotUsingRuntimePack)' == 'true' and

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -292,6 +292,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "SingleFileTest",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
+                SelfContained = "true"
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -325,6 +326,7 @@ namespace Microsoft.NET.Publish.Tests
                 Name = projName,
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
+                SelfContained = "true"
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -769,7 +771,8 @@ namespace Microsoft.NET.Publish.Tests
             {
                 Name = projectName,
                 TargetFrameworks = targetFramework,
-                IsExe = isExecutable
+                IsExe = isExecutable,
+                SelfContained = "true"
             };
 
             testProject.SourceFiles[$"{projectName}.cs"] = @"
@@ -850,6 +853,7 @@ class C
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 RuntimeIdentifier = rid,
                 IsExe = true,
+                SelfContained = "true"
             };
             if (cetCompat.HasValue)
             {
@@ -981,6 +985,7 @@ class C
                 Name = "SingleFileTest",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
+                SelfContained = "true"
             };
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileLibrary.cs
@@ -24,7 +24,8 @@ namespace Microsoft.NET.Publish.Tests
             TestProject testProject = new("MainProject")
             {
                 TargetFrameworks = targetFramework,
-                IsExe = true
+                IsExe = true,
+                SelfContained = "true"
             };
             testProject.ReferencedProjects.Add(referencedProject);
             testProject.RecordProperties("RuntimeIdentifier");

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -19,7 +19,8 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "RegularPublishToSingleExe",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "win-x86"
+                RuntimeIdentifier = "win-x86",
+                SelfContained = "true"
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
@@ -58,7 +59,8 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "PublishSingleFile1",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "win-x86"
+                RuntimeIdentifier = "win-x86",
+                SelfContained = "true"
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
@@ -100,7 +102,8 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "PublishSingleExe",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "win-x86"
+                RuntimeIdentifier = "win-x86",
+                SelfContained = "true"
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
@@ -199,7 +202,7 @@ namespace Microsoft.NET.Publish.Tests
 
             // Publish as a single file
             new PublishCommand(Log, Path.Combine(testDir.Path, assetName))
-                .Execute(@"/p:RuntimeIdentifier=win-x86;PublishSingleFile=true")
+                .Execute(@"/p:RuntimeIdentifier=win-x86;PublishSingleFile=true;SelfContained=true")
                 .Should()
                 .Pass();
             CheckPublishOutput(publishDir, expectedSingleFiles.Append("UserData.txt"), expectedRegularFiles);
@@ -214,7 +217,8 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "PublishToCustomDir",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "win-x86"
+                RuntimeIdentifier = "win-x86",
+                SelfContained = "true"
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 
@@ -249,7 +253,8 @@ namespace Microsoft.NET.Publish.Tests
                 Name = "PublishToMultipleDirs",
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
-                RuntimeIdentifier = "win-x86"
+                RuntimeIdentifier = "win-x86",
+                SelfContained = "true"
             };
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testProject.Name);
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1575,8 +1575,9 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
-        public void ILLink_error_on_portable_app(string targetFramework)
+        [InlineData("net5.0")]
+        [InlineData("net9.0")]
+        public void ILLink_not_supported_error_on_portable_app(string targetFramework)
         {
             var projectName = "HelloWorld";
             var referenceProjectName = "ClassLibForILLink";
@@ -1588,6 +1589,22 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute("/p:PublishTrimmed=true")
                 .Should().Fail()
                 .And.HaveStdOutContaining(Strings.ILLinkNotSupportedError);
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [MemberData(nameof(Net10Plus), MemberType = typeof(PublishTestUtils))]
+        public void ILLink_error_on_portable_app(string targetFramework)
+        {
+            var projectName = "HelloWorld";
+            var referenceProjectName = "ClassLibForILLink";
+
+            var testProject = CreateTestProjectForILLinkTesting(_testAssetsManager, targetFramework, projectName, referenceProjectName, setSelfContained: false);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute("/p:PublishTrimmed=true")
+                .Should().Fail()
+                .And.HaveStdOutContaining(Strings.PublishSelfContainedRequiresPublishing);
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsIntegrationTest.cs
@@ -258,7 +258,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
 
             var publish = CreatePublishCommand(ProjectDirectory);
-            ExecuteCommand(publish, "/p:PublishSingleFile=true", $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}").Should().Pass();
+            ExecuteCommand(publish, "/p:PublishSingleFile=true", "/p:SelfContained=true", $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}").Should().Pass();
 
             var intermediateOutputPath = publish.GetIntermediateDirectory(DefaultTfm, "Debug", RuntimeInformation.RuntimeIdentifier).ToString();
             var publishPath = publish.GetOutputDirectory(DefaultTfm, "Debug").ToString();
@@ -776,7 +776,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             ExecuteCommand(restore).Should().Pass();
 
             var publish = CreatePublishCommand(ProjectDirectory, "AppWithPackageAndP2PReference");
-            ExecuteCommand(publish, "/p:PublishSingleFile=true", $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}").Should().Pass();
+            ExecuteCommand(publish, "/p:PublishSingleFile=true", "/p:SelfContained=true", $"/p:RuntimeIdentifier={RuntimeInformation.RuntimeIdentifier}").Should().Pass();
 
             var intermediateOutputPath = publish.GetIntermediateDirectory(DefaultTfm, "Debug", RuntimeInformation.RuntimeIdentifier).ToString();
             var publishPath = publish.GetOutputDirectory(DefaultTfm, "Debug").ToString();

--- a/test/TestAssets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
+++ b/test/TestAssets/TestProjects/HelloWorldWithSubDirs/HelloWorldWithSubDirs.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For the following project (note it sets PublishSelfContained):

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <PublishSelfContained>true</PublishSelfContained>
  </PropertyGroup>

</Project>
```

This command doesn't produce a self-contained publish output:

```
> dotnet build /t:Publish
Restore complete (0.4s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  selfc succeeded (0.3s) → bin/Debug/net10.0/publish/

Build succeeded in 1.1s
> ls bin/Debug/net10.0/
publish  selfc  selfc.deps.json  selfc.dll  selfc.pdb  selfc.runtimeconfig.json
> ls bin/Debug/net10.0/publish/
selfc  selfc.deps.json  selfc.dll  selfc.pdb  selfc.runtimeconfig.json
```

This adds an error message for this unsupported scenario.

Related: https://github.com/dotnet/sdk/issues/32272 (discusses the PublishSelfContained behavior with /t:Publish)
Related: https://github.com/dotnet/runtime/pull/95496
Related: https://github.com/dotnet/sdk/pull/46070