### PR TITLE
Fix browser refresh after project restart

### DIFF
--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Watch
                 };
 
                 var browserRefreshServer = (projectRootNode != null)
-                    ? await browserConnector.LaunchOrRefreshBrowserAsync(projectRootNode, processSpec, environmentBuilder, Context.RootProjectOptions, shutdownCancellationToken)
+                    ? await browserConnector.GetOrCreateBrowserRefreshServerAsync(projectRootNode, processSpec, environmentBuilder, Context.RootProjectOptions, shutdownCancellationToken)
                     : null;
 
                 environmentBuilder.SetProcessEnvironmentVariables(processSpec);

--- a/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ProjectLauncher.cs
@@ -94,7 +94,7 @@ internal sealed class ProjectLauncher(
             }
         }
 
-        var browserRefreshServer = await browserConnector.LaunchOrRefreshBrowserAsync(projectNode, processSpec, environmentBuilder, projectOptions, cancellationToken);
+        var browserRefreshServer = await browserConnector.GetOrCreateBrowserRefreshServerAsync(projectNode, processSpec, environmentBuilder, projectOptions, cancellationToken);
 
         var arguments = new List<string>()
         {


### PR DESCRIPTION
Ports https://github.com/dotnet/sdk/pull/46112 to 2xx.

### Context

dotnet-watch does not set environment variables correctly causing browser refresh to stop working after restarting a web project due to rude edit. The issue only occurs in Aspire orchestrated web projects, not in standalone web projects.

### Customer impact

Web pages are not refreshed when further changes are made to the web project, after restarting due to rude edit, which greatly diminishes the value of Hot Reload.

### Changes made

Apply the necessary environment variables to the restarted process.

### Testing

Manual testing to confirm that the changes fix the issue.

### Risks

Negligible. The fix is simple.


