### PR TITLE
Remove dead code from APICompat

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -58,13 +58,6 @@ namespace Microsoft.DotNet.ApiCompatibility
             {
                 Visit(@namespace);
             }
-
-            // After visiting the assembly, the assembly mapper will contain any assembly load errors that happened
-            // when trying to resolve type forwarded types. If there were any, we add them to the diagnostic bag next.
-            foreach (CompatDifference item in assembly.AssemblyLoadErrors)
-            {
-                _compatDifferences.Add(item);
-            }
         }
 
         /// <inheritdoc />

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblyMapper.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/AssemblyMapper.cs
@@ -21,13 +21,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         IAssemblySetMapper? containingAssemblySet = null) : ElementMapper<ElementContainer<IAssemblySymbol>>(ruleRunner, settings, rightSetSize), IAssemblyMapper
     {
         private Dictionary<INamespaceSymbol, INamespaceMapper>? _namespaces;
-        private readonly List<CompatDifference> _assemblyLoadErrors = [];
 
         /// <inheritdoc />
         public IAssemblySetMapper? ContainingAssemblySet { get; } = containingAssemblySet;
-
-        /// <inheritdoc />
-        public IEnumerable<CompatDifference> AssemblyLoadErrors => _assemblyLoadErrors;
 
         /// <inheritdoc />
         public IEnumerable<INamespaceMapper> GetNamespaces()

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/IAssemblyMapper.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Mapping/IAssemblyMapper.cs
@@ -18,11 +18,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Mapping
         IAssemblySetMapper? ContainingAssemblySet { get; }
 
         /// <summary>
-        /// Gets the assembly load errors that happened when trying to follow type forwards.
-        /// </summary>
-        IEnumerable<CompatDifference> AssemblyLoadErrors { get; }
-
-        /// <summary>
         /// Gets the mappers for the namespaces contained in <see cref="IElementMapper{T}.Left"/> and <see cref="IElementMapper{T}.Right"/>
         /// </summary>
         /// <returns>The list of <see cref="INamespaceMapper"/>.</returns>


### PR DESCRIPTION
This code path isn't needed anymore since https://github.com/dotnet/sdk/commit/3ca2fccb17bf28192c98339be3e4775d8bff993f#diff-8e654ae0b010dc7115de001ba217ab7744931c7540e800d2a8c942c3b87edcfe