### PR TITLE
Disable asset comparison tests

### DIFF
--- a/src/SourceBuild/content/test/tests.proj
+++ b/src/SourceBuild/content/test/tests.proj
@@ -24,8 +24,11 @@
     <ProjectReference Include="Microsoft.DotNet.SourceBuild.Tests\Microsoft.DotNet.SourceBuild.Tests.csproj"
                       Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <!-- Unified-build specific tests. -->
-    <ProjectReference Include="Microsoft.DotNet.UnifiedBuild.Tests\Microsoft.DotNet.UnifiedBuild.Tests.csproj"
-                      Condition="'$(ShortStack)' != 'true' and '$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" />
+    <!-- TODO: Re-enable the asset comparison tests when building in the final stage build with the final merged manifest as an input.
+               Disabling the tests meanwhile as the current mechanism doesn't work with unique official build ids for which there is no
+               corresponding msft build. https://github.com/dotnet/source-build/issues/4763 -->
+    <!-- <ProjectReference Include="Microsoft.DotNet.UnifiedBuild.Tests\Microsoft.DotNet.UnifiedBuild.Tests.csproj"
+                      Condition="'$(ShortStack)' != 'true' and '$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" /> -->
   </ItemGroup>
 
   <!-- Make sure that the sdk archive is extracted before running the scenario-tests. Need to do this here as it's hard


### PR DESCRIPTION
The UnifiedBuild.Tests tests are the comparison tests.

Disabling the asset comparison tests as the current mechanism doesn't work with unique official build ids for which there is no corresponding msft build. https://github.com/dotnet/source-build/issues/4763