### PR TITLE
Use the "live" NuGet.config file from sdk in VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -6,6 +6,7 @@
 
     <ScenarioTestsArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'scenario-tests'))</ScenarioTestsArtifactsDir>
     <ScenarioTestsResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)', 'scenario-tests'))</ScenarioTestsResultsDir>
+    <!-- Use the updated NuGet.config file from the intermediate folder which contains the live local feeds. -->
     <NuGetConfigInputForScenarioTests>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
     <NuGetConfigOutputForScenarioTests>$(ScenarioTestsArtifactsDir)NuGet.config</NuGetConfigOutputForScenarioTests>
   </PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -6,7 +6,7 @@
 
     <ScenarioTestsArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'scenario-tests'))</ScenarioTestsArtifactsDir>
     <ScenarioTestsResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)', 'scenario-tests'))</ScenarioTestsResultsDir>
-    <NuGetConfigInputForScenarioTests>$([MSBuild]::NormalizePath('$(SrcDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
+    <NuGetConfigInputForScenarioTests>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
     <NuGetConfigOutputForScenarioTests>$(ScenarioTestsArtifactsDir)NuGet.config</NuGetConfigOutputForScenarioTests>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -8,6 +8,8 @@
     <ScenarioTestsResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)', 'scenario-tests'))</ScenarioTestsResultsDir>
     <!-- Use the updated NuGet.config file from the intermediate folder which contains the live local feeds. -->
     <NuGetConfigInputForScenarioTests>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
+    <!-- TODO: Consolidate with the above line when building source-only: https://github.com/dotnet/source-build/issues/4841 -->
+    <NuGetConfigInputForScenarioTests Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizePath('$(SrcDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
     <NuGetConfigOutputForScenarioTests>$(ScenarioTestsArtifactsDir)NuGet.config</NuGetConfigOutputForScenarioTests>
   </PropertyGroup>
 


### PR DESCRIPTION
The checked-in NuGet.config file under src/sdk is missing the live feeds which are necessary when restoring packages in scenario-tests.