### PR TITLE
[VMR] Disable CG/CodeQL on public builds

### DIFF
--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -39,6 +39,13 @@ parameters:
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: skipComponentGovernanceDetection  # we run CG on internal builds only
+    value: true
+
+  - name: Codeql.Enabled  # we run CodeQL on internal builds only
+    value: false
+
 - ${{ if ne(parameters.vmrBranch, ' ') }}:
   - name: VmrBranch
     value: ${{ replace(parameters.vmrBranch, ' ', '') }}

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -43,6 +43,13 @@ variables:
 - name: isPRTrigger
   value: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
 
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: skipComponentGovernanceDetection  # we run CG on internal builds only
+    value: true
+
+  - name: Codeql.Enabled  # we run CodeQL on internal builds only
+    value: false
+
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - template: /src/sdk/eng/pipelines/templates/variables/vmr-build.yml@self
 

--- a/src/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/pr.yml
@@ -28,8 +28,12 @@ variables:
 - name: isPRTrigger
   value: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
 
-- name: Codeql.Enabled  # we run CodeQL on internal builds only
-  value: false
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: skipComponentGovernanceDetection  # we run CG on internal builds only
+    value: true
+
+  - name: Codeql.Enabled  # we run CodeQL on internal builds only
+    value: false
 
 - template: /eng/common/templates/variables/pool-providers.yml@self
 


### PR DESCRIPTION
We only want to run these on internal/official builds. This is the same logic as we have in arcade but we're not using their job templates.