### PR TITLE
Temporarily downgrade assembly reference load warnings to messages

### DIFF
--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
@@ -420,8 +420,10 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
 
                     if (!found)
                     {
-                        _log.LogWarning(AssemblyReferenceNotFoundErrorCode,
-                            string.Format(Resources.CouldNotResolveReference, assemblyReferenceName, rootAssemblyDisplayString));
+                        // Temporarily downgrade assembly reference load warnings to messages: https://github.com/dotnet/sdk/issues/46236
+                        // _log.LogWarning(AssemblyReferenceNotFoundErrorCode,
+                        //     string.Format(Resources.CouldNotResolveReference, assemblyReferenceName, rootAssemblyDisplayString));
+                        _log.LogMessage(MessageImportance.High, string.Format(Resources.CouldNotResolveReference, assemblyReferenceName, rootAssemblyDisplayString));
                     }
                 }
             }

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
@@ -270,17 +270,21 @@ namespace MyNamespace
 
             if (resolveReferences)
             {
-                Assert.True(log.HasLoggedWarnings);
+                // Temporarily downgrade assembly reference load warnings to messages: https://github.com/dotnet/sdk/issues/46236
 
-                string expectedReference = "System.Runtime.dll";
+                // Assert.True(log.HasLoggedWarnings);
 
-                if (TargetFrameworks.StartsWith("net4", StringComparison.OrdinalIgnoreCase))
-                {
-                    expectedReference = "mscorlib.dll";
-                }
+                // string expectedReference = "System.Runtime.dll";
 
-                Assert.Single(log.Warnings);
-                Assert.Matches($"CP1002.*?'{Regex.Escape(expectedReference)}'.*?'{Regex.Escape(assemblyPath)}'.*", log.Warnings.Single());
+                // if (TargetFrameworks.StartsWith("net4", StringComparison.OrdinalIgnoreCase))
+                // {
+                //     expectedReference = "mscorlib.dll";
+                // }
+
+                // Assert.Single(log.Warnings);
+                // Assert.Matches($"CP1002.*?'{Regex.Escape(expectedReference)}'.*?'{Regex.Escape(assemblyPath)}'.*", log.Warnings.Single());
+
+                Assert.Empty(log.Warnings);
             }
             else
             {


### PR DESCRIPTION
See https://github.com/dotnet/sdk/issues/46236
This is necessary to unblock dependency flow into runtime.