### PR TITLE
Fix MonoEnableLLVM & MonoAOTEnableLLVM properties

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -32,7 +32,7 @@
     <ShortStack Condition="'$(TargetOS)' == 'android'">true</ShortStack>
     <ShortStack Condition="'$(TargetOS)' == 'linux-bionic'">true</ShortStack>
     <!-- Mono LLVM builds are short -->
-    <ShortStack Condition="'$(MonoEnableLLVM)' == 'true' or '$(MonoAOTEnableLLVM)' == 'true'">true</ShortStack>
+    <ShortStack Condition="'$(DotNetBuildMonoEnableLLVM)' == 'true' or '$(DotNetBuildMonoAOTEnableLLVM)' == 'true'">true</ShortStack>
     <!-- Short stack builds stop at runtime, not the whole SDK -->
     <RootRepo Condition="'$(ShortStack)' == 'true'">runtime</RootRepo>
   </PropertyGroup>

--- a/src/SourceBuild/patches/runtime/0001-Fix-MonoEnableLLVM-properties.patch
+++ b/src/SourceBuild/patches/runtime/0001-Fix-MonoEnableLLVM-properties.patch
@@ -1,0 +1,23 @@
+From 4bdc827fc7144d9a331fab0c5f65e4e57f41a72f Mon Sep 17 00:00:00 2001
+From: Viktor Hofer <viktor.hofer@microsoft.com>
+Date: Thu, 23 Jan 2025 12:34:20 +0100
+Subject: [PATCH] Fix MonoEnableLLVM* properties
+
+Backport: https://github.com/dotnet/runtime/pull/111746
+---
+ eng/DotNetBuild.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/DotNetBuild.props b/eng/DotNetBuild.props
+index 435c5497b34..223eae78ef3 100644
+--- a/eng/DotNetBuild.props
++++ b/eng/DotNetBuild.props
+@@ -37,7 +37,7 @@
+     <!-- NativeAOT builds are short -->
+     <ShortStack Condition="'$(DotNetBuildRuntimeNativeAOTRuntimePack)' == 'true'">true</ShortStack>
+     <!-- Mono LLVM builds are short -->
+-    <ShortStack Condition="'$(MonoEnableLLVM)' == 'true' or '$(MonoAOTEnableLLVM)' == 'true'">true</ShortStack>
++    <ShortStack Condition="'$(DotNetBuildMonoEnableLLVM)' == 'true' or '$(DotNetBuildMonoAOTEnableLLVM)' == 'true'">true</ShortStack>
+     <!-- Mono AOT cross compiler builds are short -->
+     <ShortStack Condition="'$(DotNetBuildMonoCrossAOT)' == 'true'">true</ShortStack>
+   </PropertyGroup>


### PR DESCRIPTION
The MonoEnableLLVM & MonoAOTEnableLLVM properties were never defined. The YML passes those with the `DotNetBuild` prefix in and runtime.proj conditions on that as well.