### PR TITLE
Add 100 to version patch number for Unified Build 

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -96,7 +96,9 @@
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
-    <BuildArgs Condition="'$(OfficialBuildId)' != ''">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
+    <BuildArgs Condition="'$(OfficialBuildId)' != '' and '$(DotNetBuildSourceOnly)' == 'true'">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
+    <!-- Add 100 to patch version for Unified Build -->
+    <BuildArgs Condition="'$(OfficialBuildId)' != '' and '$(DotNetBuildSourceOnly)' != 'true'">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId.Split('.')[0]).$([MSBuild]::Add($(OfficialBuildId.Split('.')[1]), 100))</BuildArgs>
     <BuildArgs Condition="'$(ForceDryRunSigning)' != ''">$(BuildArgs) /p:ForceDryRunSigning=$(ForceDryRunSigning)</BuildArgs>
   </PropertyGroup>
 


### PR DESCRIPTION
We want Unified Build artifact not to clash with MS build ones when published to one channel. 
For that reason, 100 added to patch numbers should make them unique and distinguishable from regular MS build artifacts.