### PR TITLE
Rename host key to _EXPERIMENTAL namespace to prevent SDK task failures

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
     {
         public override string Name => "Microsoft.DotNet.MSBuildSdkResolver";
 
-        // Default resolver has priority 10000 and we want to go before it and leave room on either side of us. 
+        // Default resolver has priority 10000 and we want to go before it and leave room on either side of us.
         public override int Priority => 5000;
 
         private readonly Func<string, string?> _getEnvironmentVariable;
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         private readonly Func<string, string, string?> _getMsbuildRuntime;
         private readonly NETCoreSdkResolver _netCoreSdkResolver;
 
-        private const string DotnetHost = "DOTNET_HOST_PATH";
+        private const string DotnetHostExperimentalKey = "DOTNET_EXPERIMENTAL_HOST_PATH";
         private const string MSBuildTaskHostRuntimeVersion = "SdkResolverMSBuildTaskHostRuntimeVersion";
 
         private static CachingWorkloadResolver _staticWorkloadResolver = new();
@@ -201,11 +201,11 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                 if (File.Exists(dotnetExe))
                 {
                     propertiesToAdd ??= new Dictionary<string, string?>();
-                    propertiesToAdd.Add(DotnetHost, dotnetExe);
+                    propertiesToAdd.Add(DotnetHostExperimentalKey, dotnetExe);
                 }
                 else
                 {
-                    logger?.LogMessage($"Could not set '{DotnetHost}' because dotnet executable '{dotnetExe}' does not exist.");
+                    logger?.LogMessage($"Could not set '{DotnetHostExperimentalKey}' because dotnet executable '{dotnetExe}' does not exist.");
                 }
 
                 string? runtimeVersion = dotnetRoot != null ?

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     public class GivenAnMSBuildSdkResolver : SdkTest
     {
-        private const string DotnetHost = "DOTNET_HOST_PATH";
+        private const string DotnetHostExperimentalKey = "DOTNET_EXPERIMENTAL_HOST_PATH";
         private const string MSBuildTaskHostRuntimeVersion = "SdkResolverMSBuildTaskHostRuntimeVersion";
 
         public GivenAnMSBuildSdkResolver(ITestOutputHelper logger) : base(logger)
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             {
                 // DotnetHost is the path to dotnet.exe. Can be only on Windows.
                 result.PropertiesToAdd.Count.Should().Be(2);
-                result.PropertiesToAdd.Should().ContainKey(DotnetHost);          
+                result.PropertiesToAdd.Should().ContainKey(DotnetHostExperimentalKey);
             }
             else
             {
@@ -291,7 +291,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             {
                 // DotnetHost is the path to dotnet.exe. Can be only on Windows.
                 result.PropertiesToAdd.Count.Should().Be(4);
-                result.PropertiesToAdd.Should().ContainKey(DotnetHost);
+                result.PropertiesToAdd.Should().ContainKey(DotnetHostExperimentalKey);
             }
             else
             {


### PR DESCRIPTION
Due to VS testing of 9.0.200 finding several places in the SDK that were doing a combination of:

* checking in MSBuild Targets if DOTNET_HOST_PATH was null and setting some backstop values, then
* inside Task implementations reading the value of DOTNET_HOST_PATH from environment.

Because of this combination tasks would hard-error.

We're going to effectively unset this key by renaming it so that we can continue with progress on https://github.com/dotnet/msbuild/issues/11142 while not impacting Tasks that need to be unified in their detection logic.