### PR TITLE
[ApiDiff] Update symbol filtering code to be able to load a list of strings or a list of files

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -27,21 +27,12 @@ namespace Microsoft.DotNet.ApiCompat
             _compatibilityLogger = new Lazy<ISuppressibleLog>(() => logFactory(SuppressionEngine));
             _apiCompatRunner = new Lazy<IApiCompatRunner>(() =>
             {
-                AccessibilitySymbolFilter accessibilitySymbolFilter = new(respectInternals);
                 SymbolEqualityComparer symbolEqualityComparer = new();
 
-                // The attribute data symbol filter is a composite that contains both the accessibility
-                // symbol filter and the doc id symbol filter.
-                CompositeSymbolFilter attributeDataSymbolFilter = new(accessibilitySymbolFilter);
-                if (excludeAttributesFiles is not null)
-                {
-                    attributeDataSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
-                }
-
                 ApiComparerSettings apiComparerSettings = new(
-                    accessibilitySymbolFilter,
+                    symbolFilter: null, // Gets a default value inside the constructor
                     symbolEqualityComparer,
-                    attributeDataSymbolFilter,
+                    SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals),
                     new AttributeDataEqualityComparer(symbolEqualityComparer,
                         new TypedConstantEqualityComparer(symbolEqualityComparer)),
                     respectInternals);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -29,13 +29,15 @@ namespace Microsoft.DotNet.ApiCompat
             {
                 SymbolEqualityComparer symbolEqualityComparer = new();
 
+                ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals);
+                AttributeDataEqualityComparer attributeDataEqualityComparer = new(symbolEqualityComparer,
+                        new TypedConstantEqualityComparer(symbolEqualityComparer));
+
                 ApiComparerSettings apiComparerSettings = new(
-                    symbolFilter: null, // Gets a default value inside the constructor
-                    symbolEqualityComparer,
-                    SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals),
-                    new AttributeDataEqualityComparer(symbolEqualityComparer,
-                        new TypedConstantEqualityComparer(symbolEqualityComparer)),
-                    respectInternals);
+                    symbolEqualityComparer: symbolEqualityComparer,
+                    attributeDataSymbolFilter: attributeDataSymbolFilter,
+                    attributeDataEqualityComparer: attributeDataEqualityComparer,
+                    includeInternalSymbols: respectInternals);
 
                 return new ApiCompatRunner(SuppressibleLog,
                     SuppressionEngine,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Shared/ApiCompatServiceProvider.cs
@@ -27,13 +27,19 @@ namespace Microsoft.DotNet.ApiCompat
             _compatibilityLogger = new Lazy<ISuppressibleLog>(() => logFactory(SuppressionEngine));
             _apiCompatRunner = new Lazy<IApiCompatRunner>(() =>
             {
+                AccessibilitySymbolFilter accessibilitySymbolFilter = new(respectInternals);
                 SymbolEqualityComparer symbolEqualityComparer = new();
 
-                ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals);
+                ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles(
+                    apiExclusionFilePaths: excludeAttributesFiles,
+                    accessibilitySymbolFilter: accessibilitySymbolFilter,
+                    respectInternals: respectInternals);
+
                 AttributeDataEqualityComparer attributeDataEqualityComparer = new(symbolEqualityComparer,
                         new TypedConstantEqualityComparer(symbolEqualityComparer));
 
                 ApiComparerSettings apiComparerSettings = new(
+                    symbolFilter: accessibilitySymbolFilter,
                     symbolEqualityComparer: symbolEqualityComparer,
                     attributeDataSymbolFilter: attributeDataSymbolFilter,
                     attributeDataEqualityComparer: attributeDataEqualityComparer,

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -48,22 +48,6 @@ namespace Microsoft.DotNet.GenAPI
                 includeEffectivelyPrivateSymbols: true,
                 includeExplicitInterfaceImplementationSymbols: true);
 
-            // Configure the symbol filter
-            CompositeSymbolFilter symbolFilter = new();
-            if (excludeApiFiles is not null)
-            {
-                symbolFilter.Add(new DocIdSymbolFilter(excludeApiFiles));
-            }
-            symbolFilter.Add(new ImplicitSymbolFilter());
-            symbolFilter.Add(accessibilitySymbolFilter);
-
-            // Configure the attribute data symbol filter
-            CompositeSymbolFilter attributeDataSymbolFilter = new();
-            if (excludeAttributesFiles is not null)
-            {
-                attributeDataSymbolFilter.Add(new DocIdSymbolFilter(excludeAttributesFiles));
-            }
-            attributeDataSymbolFilter.Add(accessibilitySymbolFilter);
 
             // Invoke the CSharpFileBuilder for each directly loaded assembly.
             foreach (IAssemblySymbol? assemblySymbol in assemblySymbols)
@@ -75,8 +59,8 @@ namespace Microsoft.DotNet.GenAPI
                 textWriter.Write(headerFileText);
 
                 using CSharpFileBuilder fileBuilder = new(log,
-                    symbolFilter,
-                    attributeDataSymbolFilter,
+                    SymbolFilterFactory.GetFilterFromFiles(excludeApiFiles, respectInternals),
+                    SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals),
                     textWriter,
                     exceptionMessage,
                     includeAssemblyAttributes,

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -59,8 +59,8 @@ namespace Microsoft.DotNet.GenAPI
                 textWriter.Write(headerFileText);
 
                 using CSharpFileBuilder fileBuilder = new(log,
-                    SymbolFilterFactory.GetFilterFromFiles(excludeApiFiles, respectInternals),
-                    SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals),
+                    SymbolFilterFactory.GetFilterFromFiles(excludeApiFiles, respectInternals: respectInternals),
+                    SymbolFilterFactory.GetFilterFromFiles(excludeAttributesFiles, respectInternals: respectInternals),
                     textWriter,
                     exceptionMessage,
                     includeAssemblyAttributes,

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -80,6 +80,5 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
                 }
             }
         }
-
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -13,12 +13,40 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     {
         private readonly HashSet<string> _docIdsToExclude;
 
+        /// <summary>
+        /// Creates a filter to exclude APIs using the DocIDs provided in the specified files.
+        /// </summary>
+        /// <param name="filesWithDocIdsToExclude">A collection of files each containing multiple DocIDs to exclude.</param>
+        /// <returns>An instance of the symbol filter.</returns>
         public static DocIdSymbolFilter CreateFromFiles(params string[] filesWithDocIdsToExclude)
-            => new DocIdSymbolFilter(ReadDocIdsFromFiles(filesWithDocIdsToExclude));
+        {
+            List<string> docIds = new();
 
+            foreach (string docIdsToExcludeFile in filesWithDocIdsToExclude)
+            {
+                if (string.IsNullOrWhiteSpace(docIdsToExcludeFile))
+                {
+                    continue;
+                }
+
+                foreach (string docId in ReadDocIdsFromList(File.ReadAllLines(docIdsToExcludeFile)))
+                {
+                    docIds.Add(docId);
+                }
+            }
+
+            return new DocIdSymbolFilter(docIds);
+        }
+
+        /// <summary>
+        /// Creates a filter to exclude APIs using the DocIDs provided in the specified list.
+        /// </summary>
+        /// <param name="docIdsToExclude">A collection of DocIDs to exclude.</param>
+        /// <returns>An instance of the symbol filter.</returns>
         public static DocIdSymbolFilter CreateFromLists(params string[] docIdsToExclude)
             => new DocIdSymbolFilter(ReadDocIdsFromList(docIdsToExclude));
 
+        // Private constructor to avoid creating an instance with an empty list.
         private DocIdSymbolFilter(IEnumerable<string> docIdsToExclude)
             => _docIdsToExclude = [.. docIdsToExclude];
 
@@ -53,20 +81,5 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
             }
         }
 
-        private static IEnumerable<string> ReadDocIdsFromFiles(params string[] docIdsToExcludeFiles)
-        {
-            foreach (string docIdsToExcludeFile in docIdsToExcludeFiles)
-            {
-                if (string.IsNullOrWhiteSpace(docIdsToExcludeFile))
-                {
-                    continue;
-                }
-
-                foreach (string docId in ReadDocIdsFromList(File.ReadAllLines(docIdsToExcludeFile)))
-                {
-                    yield return docId;
-                }
-            }
-        }
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
@@ -14,49 +14,58 @@ public static class SymbolFilterFactory
     /// Creates a composite filter to exclude APIs using the DocIDs provided in the specifed file paths.
     /// </summary>
     /// <param name="apiExclusionFilePaths">A collection of paths where the exclusion files should be searched.</param>
+    /// <param name="accessibilitySymbolFilter">An optional custom accessibility symbol filter to use.</param>
     /// <param name="respectInternals">Whether to include internal symbols or not.</param>
     /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
     /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
+    /// <param name="includeImplicitSymbolFilter">Whether to include implicit symbols or not.</param>
     /// <returns>An instance of the symbol filter.</returns>
     public static ISymbolFilter GetFilterFromFiles(string[]? apiExclusionFilePaths,
-                                                                 bool respectInternals = false,
-                                                                 bool includeEffectivelyPrivateSymbols = true,
-                                                                 bool includeExplicitInterfaceImplementationSymbols = true)
+                                                   AccessibilitySymbolFilter? accessibilitySymbolFilter = null,
+                                                   bool respectInternals = false,
+                                                   bool includeEffectivelyPrivateSymbols = true,
+                                                   bool includeExplicitInterfaceImplementationSymbols = true,
+                                                   bool includeImplicitSymbolFilter = true)
     {
         DocIdSymbolFilter? docIdSymbolFilter =
             apiExclusionFilePaths?.Length > 0 ?
             DocIdSymbolFilter.CreateFromFiles(apiExclusionFilePaths) : null;
 
-        return GetCompositeSymbolFilter(docIdSymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, withImplicitSymbolFilter: true);
+        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter);
     }
 
     /// <summary>
     /// Creates a composite filter to exclude APIs using the DocIDs provided in the specifed list.
     /// </summary>
     /// <param name="apiExclusionList">A collection of exclusion list.</param>
+    /// <param name="accessibilitySymbolFilter">An optional custom accessibility symbol filter to use.</param>
     /// <param name="respectInternals">Whether to include internal symbols or not.</param>
     /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
     /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
+    /// <param name="includeImplicitSymbolFilter">Whether to include implicit symbols or not.</param>
     /// <returns>An instance of the symbol filter.</returns>
     public static ISymbolFilter GetFilterFromList(string[]? apiExclusionList,
-                                                                bool respectInternals = false,
-                                                                bool includeEffectivelyPrivateSymbols = true,
-                                                                bool includeExplicitInterfaceImplementationSymbols = true)
+                                                  AccessibilitySymbolFilter? accessibilitySymbolFilter = null,
+                                                  bool respectInternals = false,
+                                                  bool includeEffectivelyPrivateSymbols = true,
+                                                  bool includeExplicitInterfaceImplementationSymbols = true,
+                                                  bool includeImplicitSymbolFilter = true)
     {
         DocIdSymbolFilter? docIdSymbolFilter =
             apiExclusionList?.Count() > 0 ?
             DocIdSymbolFilter.CreateFromLists(apiExclusionList) : null;
 
-        return GetCompositeSymbolFilter(docIdSymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, withImplicitSymbolFilter: true);
+        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter);
     }
 
     private static ISymbolFilter GetCompositeSymbolFilter(DocIdSymbolFilter? customFilter,
-                                                                  bool respectInternals,
-                                                                  bool includeEffectivelyPrivateSymbols,
-                                                                  bool includeExplicitInterfaceImplementationSymbols,
-                                                                  bool withImplicitSymbolFilter)
+                                                          AccessibilitySymbolFilter? accessibilitySymbolFilter,
+                                                          bool respectInternals,
+                                                          bool includeEffectivelyPrivateSymbols,
+                                                          bool includeExplicitInterfaceImplementationSymbols,
+                                                          bool includeImplicitSymbolFilter)
     {
-        AccessibilitySymbolFilter accessibilitySymbolFilter = new(
+        accessibilitySymbolFilter ??= new(
                 respectInternals,
                 includeEffectivelyPrivateSymbols,
                 includeExplicitInterfaceImplementationSymbols);
@@ -67,7 +76,7 @@ public static class SymbolFilterFactory
         {
             filter.Add(customFilter);
         }
-        if (withImplicitSymbolFilter)
+        if (includeImplicitSymbolFilter)
         {
             filter.Add(new ImplicitSymbolFilter());
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering;
+
+public static class SymbolFilterFactory
+{
+    /// <summary>
+    /// Creates a composite filter to exclude APIs using the DocIDs provided in the specifed file paths.
+    /// </summary>
+    /// <param name="apiExclusionFilePaths">A collection of paths where the exclusion files should be searched.</param>
+    /// <param name="respectInternals">Whether to include internal symbols or not.</param>
+    /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
+    /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
+    /// <returns>An instance of the symbol filter.</returns>
+    public static ISymbolFilter GetFilterFromFiles(string[]? apiExclusionFilePaths,
+                                                                 bool respectInternals = false,
+                                                                 bool includeEffectivelyPrivateSymbols = true,
+                                                                 bool includeExplicitInterfaceImplementationSymbols = true)
+    {
+        DocIdSymbolFilter? docIdSymbolFilter =
+            apiExclusionFilePaths?.Count() > 0 ?
+            DocIdSymbolFilter.CreateFromFiles(apiExclusionFilePaths) : null;
+
+        return GetCompositeSymbolFilter(docIdSymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, withImplicitSymbolFilter: true);
+    }
+
+    /// <summary>
+    /// Creates a composite filter to exclude APIs using the DocIDs provided in the specifed list.
+    /// </summary>
+    /// <param name="apiExclusionList">A collection of exclusion list.</param>
+    /// <param name="respectInternals">Whether to include internal symbols or not.</param>
+    /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
+    /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
+    /// <returns>An instance of the symbol filter.</returns>
+    public static ISymbolFilter GetFilterFromList(string[]? apiExclusionList,
+                                                                bool respectInternals = false,
+                                                                bool includeEffectivelyPrivateSymbols = true,
+                                                                bool includeExplicitInterfaceImplementationSymbols = true)
+    {
+        DocIdSymbolFilter? docIdSymbolFilter =
+            apiExclusionList?.Count() > 0 ?
+            DocIdSymbolFilter.CreateFromLists(apiExclusionList) : null;
+
+        return GetCompositeSymbolFilter(docIdSymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, withImplicitSymbolFilter: true);
+    }
+
+    private static ISymbolFilter GetCompositeSymbolFilter(DocIdSymbolFilter? customFilter,
+                                                                  bool respectInternals,
+                                                                  bool includeEffectivelyPrivateSymbols,
+                                                                  bool includeExplicitInterfaceImplementationSymbols,
+                                                                  bool withImplicitSymbolFilter)
+    {
+        AccessibilitySymbolFilter accessibilitySymbolFilter = new(
+                respectInternals,
+                includeEffectivelyPrivateSymbols,
+                includeExplicitInterfaceImplementationSymbols);
+
+        CompositeSymbolFilter filter = new();
+
+        if (customFilter != null)
+        {
+            filter.Add(customFilter);
+        }
+        if (withImplicitSymbolFilter)
+        {
+            filter.Add(new ImplicitSymbolFilter());
+        }
+
+        filter.Add(accessibilitySymbolFilter);
+
+        return filter;
+    }
+}

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
@@ -5,6 +5,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 
+/// <summary>
+/// A factory class to create symbol filters.
+/// </summary>
 public static class SymbolFilterFactory
 {
     /// <summary>

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
@@ -24,7 +24,7 @@ public static class SymbolFilterFactory
                                                                  bool includeExplicitInterfaceImplementationSymbols = true)
     {
         DocIdSymbolFilter? docIdSymbolFilter =
-            apiExclusionFilePaths?.Count() > 0 ?
+            apiExclusionFilePaths?.Length > 0 ?
             DocIdSymbolFilter.CreateFromFiles(apiExclusionFilePaths) : null;
 
         return GetCompositeSymbolFilter(docIdSymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, withImplicitSymbolFilter: true);

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\Compatibility\Microsoft.DotNet.ApiSymbolExtensions\Microsoft.DotNet.ApiSymbolExtensions.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Compatibility\Microsoft.DotNet.ApiSymbolExtensions\Microsoft.DotNet.ApiSymbolExtensions.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -20,16 +20,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
          * - ReturnValues
          * - Constructors
          * - Generic Parameters
-         * 
+         *
          * Grouped into:
          * - Type
          * - Member
          */
 
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
-
-        private static ISymbolFilter GetAccessibilityAndAttributeSymbolFiltersAsComposite(params string[] excludeAttributeFiles) =>
-            new CompositeSymbolFilter().Add(new AccessibilitySymbolFilter(false)).Add(new DocIdSymbolFilter(excludeAttributeFiles));
 
         public static TheoryData<string, string, CompatDifference[]> TypesCases => new()
         {
@@ -39,7 +36,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -56,7 +53,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -77,7 +74,7 @@ new CompatDifference[] {}
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -94,7 +91,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -116,7 +113,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -133,7 +130,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -156,7 +153,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -173,7 +170,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -196,7 +193,7 @@ new CompatDifference[] {}
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -212,7 +209,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -311,7 +308,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -337,7 +334,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -370,7 +367,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -396,7 +393,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -429,7 +426,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -457,7 +454,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -492,7 +489,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -518,7 +515,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -551,7 +548,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -577,7 +574,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -610,7 +607,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -634,7 +631,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -666,7 +663,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -687,7 +684,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -716,7 +713,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -740,7 +737,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -792,7 +789,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -815,7 +812,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -832,7 +829,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -1332,7 +1329,7 @@ new CompatDifference[] {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles([filePath], respectInternals: false);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1349,7 +1346,7 @@ new CompatDifference[] {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles([filePath], respectInternals: false);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1366,7 +1363,7 @@ new CompatDifference[] {
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -1382,7 +1379,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -1398,7 +1395,7 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
-            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles([filePath], respectInternals: false);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
@@ -1418,7 +1415,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -1433,7 +1430,7 @@ namespace CompatTests
 namespace CompatTests
 {
   using System;
-  
+
   [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
   public class FooAttribute : Attribute {
     public FooAttribute(String s) {}
@@ -1448,7 +1445,7 @@ namespace CompatTests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(ruleFactory, new ApiComparerSettings(strictMode: true));
-            differ.Settings.AttributeDataSymbolFilter = GetAccessibilityAndAttributeSymbolFiltersAsComposite(filePath);
+            differ.Settings.AttributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles([filePath], respectInternals: false);
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right).ToArray();
 

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Xunit;
+using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiSymbolExtensions.Tests;
+
+public class SymbolFilterFactoryTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Test_FilterFromFiles(bool includeCustomType)
+    {
+        using TempDirectory root = new();
+        string filePath = Path.Combine(root.DirPath, "exclusions.txt");
+        using (FileStream fileStream = File.Create(filePath))
+        {
+            using StreamWriter writer = new(fileStream);
+            writer.WriteLine("T:System.Int32");
+            writer.WriteLine("T:System.String");
+            if (!includeCustomType)
+            {
+                writer.WriteLine("T:MyNamespace.MyClass");
+            }
+        }
+
+        CompositeSymbolFilter filter = SymbolFilterFactory.GetFilterFromFiles(
+            apiExclusionFilePaths: [filePath],
+            respectInternals: true,
+            includeEffectivelyPrivateSymbols: true,
+            includeExplicitInterfaceImplementationSymbols: true) as CompositeSymbolFilter;
+
+        Test_GetFilter_Internal(filter, includeCustomType);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Test_FilterFromList(bool includeCustomType)
+    {
+        List<string> exclusions = ["T:System.Int32", "T:System.String"];
+        if (!includeCustomType)
+        {
+            exclusions.Add("T:MyNamespace.MyClass");
+        }
+
+        CompositeSymbolFilter filter = SymbolFilterFactory.GetFilterFromList(
+            apiExclusionList: exclusions.ToArray(),
+            respectInternals: true,
+            includeEffectivelyPrivateSymbols: true,
+            includeExplicitInterfaceImplementationSymbols: true) as CompositeSymbolFilter;
+
+        Test_GetFilter_Internal(filter, includeCustomType);
+    }
+
+    private void Test_GetFilter_Internal(CompositeSymbolFilter filter, bool includeCustomType)
+    {
+        Assert.NotNull(filter);
+
+        Assert.Equal(3, filter.Filters.Count);
+
+        DocIdSymbolFilter docIdFilter = filter.Filters[0] as DocIdSymbolFilter;
+        Assert.NotNull(docIdFilter);
+
+        ImplicitSymbolFilter implicitFilter = filter.Filters[1] as ImplicitSymbolFilter;
+        Assert.NotNull(implicitFilter);
+
+        AccessibilitySymbolFilter accessibilityFilter = filter.Filters[2] as AccessibilitySymbolFilter;
+        Assert.NotNull(accessibilityFilter);
+
+        IAssemblySymbol assemblySymbol = SymbolFactory.GetAssemblyFromSyntax(@"
+namespace MyNamespace
+{
+    public class MyClass { }
+}");
+        Assert.NotNull(assemblySymbol);
+        INamedTypeSymbol myClass = assemblySymbol.GetTypeByMetadataName("MyNamespace.MyClass");
+        Assert.NotNull(myClass);
+        Assert.Equal(includeCustomType, docIdFilter.Include(myClass));
+    }
+}

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -41,8 +41,17 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
             IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(
                 log.Object,
-                SymbolFilterFactory.GetFilterFromList([], includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols),
-                SymbolFilterFactory.GetFilterFromList(excludedAttributeList ?? [], includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols),
+                SymbolFilterFactory.GetFilterFromList(
+                    apiExclusionList: [],
+                    accessibilitySymbolFilter: null,
+                    includeInternalSymbols,
+                    includeEffectivelyPrivateSymbols,
+                    includeExplicitInterfaceImplementationSymbols),
+                SymbolFilterFactory.GetFilterFromList(
+                    apiExclusionList: excludedAttributeList ?? [],  accessibilitySymbolFilter: null,
+                    includeInternalSymbols,
+                    includeEffectivelyPrivateSymbols,
+                    includeExplicitInterfaceImplementationSymbols),
                 stringWriter,
                 null,
                 false,


### PR DESCRIPTION
This PR is part of the work needed to create an ApiDiff tool that reuses some of the code from Microsoft.DotNet.GenAPI. The idea is to make the larger PR smaller and make it easier to review: https://github.com/dotnet/sdk/pull/45389

This change adds the ability to load DocIDs for consumption in API or Attribute symbol filtering and simplifies the code. It also updates the locations where this was being used.

This code will be reused by ApiDiff in a very similar way as in GenAPI, and the methods that generate filters from files or from lists needed to be clearly separated.

Please review ignoring whitespace as VS Code keeps insisting on removing it automatically in files I modify.