### PR TITLE
Shorten the sdk layout path folder

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RedistLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet\</RedistLayoutPath>
-    <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\internal\</SdkInternalLayoutPath>
+    <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\int\</SdkInternalLayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>
   </PropertyGroup>
 


### PR DESCRIPTION
We are hitting MAX_PATH limits in the VMR when building the sdk repository with an OfficialBuildId that has three digits.

```
      Creating dotnet MSI at D:\a\_work\1\s\src\sdk\artifacts\packages\Release\NonShipping\dotnet-sdk-internal-10.0.100-alpha.1.25074.101-win-arm64.msi
      Running heat..
      Heat output: Windows Installer XML Toolset Toolset Harvester version 3.14.1.9323 Copyright (c) .NET Foundation and contributors. All rights reserved.  heat.exe : error HEAT5059 : The file 'D:\a\_work\1\s\src\sdk\artifacts\bin\redist-installer\Release\internal\sdk\10.0.100-alpha.1.25074.101\DotnetTools\dotnet-watch\10.0.100-alpha.1.25074.101\tools\net10.0\any\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.runtimeconfig.json' cannot be found.
      Heat failed with exit code 5059.
      RunHeat result: False
      Heat failed
```

Shortening the "internal" name to "int" was the best immediate solution. We will eventually switch to Wix v5/6 which will avoid these issues alltogether as it won't have MAX_PATH restrictions.