### PR TITLE
Revert "Remove repo level SB legs in CI and PR validation (#45765)"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -310,6 +310,15 @@ extends:
               buildArchitecture: arm64
               runtimeIdentifier: osx-arm64
 
+      ############### SOURCE BUILD ###############
+      - template: /eng/common/templates-official/job/source-build.yml@self
+        parameters:
+          platform:
+            name: Managed
+            container: centosStream9
+            jobProperties:
+              timeoutInMinutes: 30
+
       ############### DOTNET-FORMAT ###############
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/dotnet-format/dotnet-format-integration.yml@self

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -76,5 +76,14 @@ stages:
         buildArchitecture: arm64
         runtimeIdentifier: osx-arm64
 
+  ############### SOURCE BUILD ###############
+  - template: /eng/common/templates/job/source-build.yml@self
+    parameters:
+      platform:
+        name: Managed
+        container: centosStream9
+        jobProperties:
+          timeoutInMinutes: 30
+
   ############### DOTNET-FORMAT ###############
   - template: /eng/dotnet-format/dotnet-format-integration.yml

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,59 @@
+<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
+<UsageData>
+  <IgnorePatterns>
+    <!-- TODO: Ignore needed until https://github.com/NuGet/Home/issues/11059 is addressed. -->
+    <UsagePattern IdentityGlob="Nuget.*/*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.NuGetSdkResolver/*" />
+
+    <!-- These are coming in transitively from verious repos (aspnetcore & format). Needs evaluation.
+         https://github.com/dotnet/source-build/issues/3358. -->
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
+    <UsagePattern IdentityGlob="System.Text.Json/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Text.Encodings.Web/*8.0.0*" />
+
+    <!-- These are upgraded to latest versions in product build and can be baselined for repo build -->
+    <UsagePattern IdentityGlob="Microsoft.Build/*16.11.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Framework/*16.11.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Core/*16.11.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Utilities.Core/*16.11.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.FileProviders.Abstractions/*6.0.0*" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.FileSystemGlobbing/*6.0.0*" />
+    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.7.2" />
+    <UsagePattern IdentityGlob="Microsoft.VisualStudio.Setup.Configuration.Interop/3.2.2146" />
+    <UsagePattern IdentityGlob="System.Collections.Immutable/8.0.0" />
+    <UsagePattern IdentityGlob="System.CommandLine.Rendering/0.4.0-alpha.24112.1" />
+    <UsagePattern IdentityGlob="System.Composition/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Composition.AttributedModel/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Composition.Convention/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Composition.Hosting/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Composition.Runtime/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Composition.TypedParts/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
+    <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*7.0.0*" />
+    <UsagePattern IdentityGlob="System.Reflection.Metadata/8.0.0" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*7.0.0*" />
+
+    <!-- Transitive dependencies from MSBuild -->
+	  <UsagePattern IdentityGlob="Microsoft.VisualStudio.SolutionPersistence/1.0.9" />
+
+    <!-- Transitive dependencies from roslyn -->
+    <UsagePattern IdentityGlob="System.Diagnostics.EventLog/8.0.0" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.DependencyInjection/8.0.0" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.Options/8.0.0" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.Primitives/8.0.0" />
+
+    <!-- Used only for publishing -->
+    <UsagePattern IdentityGlob="Microsoft.Net.Compilers.Toolset.Framework/*" />
+
+    <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*10.0.*" />
+
+    <UsagePattern IdentityGlob="System.IO.Pipelines/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
+  </IgnorePatterns>
+
+</UsageData>


### PR DESCRIPTION
This reverts commit cc260aa9a3fd51e20d66f0186a3da9fcf864b208.

By not having a SB leg, it causes the sdk CI to no longer publish SB intermediates. This is a problem for repos that consume sdk's SB intermediates: https://github.com/dotnet/runtime/pull/111328#issuecomment-2611060788.