### PR TITLE
Fix regression in SBRP usage report

### DIFF
--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -25,8 +25,13 @@
   <Target Name="ReportSbrpUsage"
           BeforeTargets="Build"
           Condition="'$(ReportSbrpUsage)' == 'true'">
+    <ItemGroup>
+      <ProjectAssetsJsonFile Include="$(ArtifactsDir)**/project.assets.json" />
+      <ProjectAssetsJsonFile Include="$(SrcDir)**/project.assets.json" />
+    </ItemGroup>
+
     <WriteSbrpUsageReport SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
-                          SrcPath="$(SrcDir)"
+                          ProjectAssetsJsons="@(ProjectAssetsJsonFile)"
                           OutputPath="$(ArtifactsLogDir)" />
   </Target>
 


### PR DESCRIPTION
The WriteSbrpUsageReport task was failing to find any project.assets.jsons files due to the changes made in https://github.com/dotnet/sdk/pull/46208.  This resulted in a report that listed all SBRP packages as unreferenced.  As part of the fix, additional error checks were added to help prevent regressions like this in the future.