### PR TITLE
Fix to support iterative source builds

### DIFF
--- a/src/SourceBuild/content/eng/init-source-only.proj
+++ b/src/SourceBuild/content/eng/init-source-only.proj
@@ -56,6 +56,9 @@
       <UnpackedSourceBuildReferencePackage Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*" />
     </ItemGroup>
 
+    <!-- When building iteratively (e.g. making infra changes), the directory may already exist and needs to be cleaned up. -->
+    <RemoveDir Directories="$(ReferencePackagesDir)" />
+
     <!-- Either move or copy the unpacked SBRP packages.
          Don't move when the packages directory is externally provided. -->
     <Move SourceFiles="@(UnpackedSourceBuildReferencePackage)"


### PR DESCRIPTION
When building iteratively while making certain types of infra changes, source builds may fail with numerous error like the following:

```
/vmr/dotnet/eng/init-source-only.proj(61,5): error MSB3677: Unable to move file "/vmr/dotnet/prereqs/packages/previously-source-built/SourceBuildReferencePackages/System.Windows.Extensions.6.0.0.nupkg" to "/vmr/dotnet/prereqs/packages/reference/System.Windows.Extensions.6.0.0.nupkg". Moving target is read-only
```

This is caused from the logic to move/copy the SBRP reference packages to the reference package location.  Updating the move task to specify `OverwriteReadOnlyFiles` will not fix the problem therefore a RemoveDir call was added to address the problem.
