### PR TITLE
Introduce ExclusionsLibrary to Replace Current Baseline Exclusions Infra

### DIFF
--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace ExclusionsLibrary;
+
+internal class Exclusion : IEquatable<Exclusion>
+{
+    /// <summary>
+    /// The pattern to match.
+    /// </summary>
+    public string Pattern { get; init; }
+
+    /// <summary>
+    /// The suffixes to match.
+    /// </summary>
+    public HashSet<string?> Suffixes { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Exclusion"/> class.
+    /// <param name="line"/>>The line to parse.</param>
+    /// </summary>
+    public Exclusion(string line)
+    {
+        string parsedLine = line.Split('#')[0].Trim();
+        string[] splitLine = parsedLine.Split('|', 2); // Split on the first occurrence of '|'
+        Pattern = splitLine[0].Trim();
+
+        Suffixes = splitLine.Length > 1
+            ? new HashSet<string?>(splitLine[1].Split(',').Select(s => s.Trim()))
+            : new HashSet<string?> { null };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Exclusion"/> class.
+    /// <param name="other">The exclusion to copy.</param>
+    /// </summary>
+    public Exclusion(Exclusion other)
+    {
+        Pattern = other.Pattern;
+        Suffixes = new HashSet<string?>(other.Suffixes);
+    }
+
+        /// <summary>
+    /// Checks if the exclusion matches the path and suffix.
+    /// <param name="path">The path to check.</param>
+    /// <param name="suffix">The suffix to check.</param>
+    /// </summary>
+    public bool HasMatch(string path, string? suffix)
+    {
+        if (Suffixes.Contains(suffix))
+        {
+            Matcher matcher = new(StringComparison.Ordinal);
+            matcher.AddInclude(Pattern);
+            if (matcher.Match(path).HasMatches)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public override bool Equals(object? obj) => obj is Exclusion exclusion && Equals(exclusion);
+
+    public bool Equals(Exclusion? other) =>
+        other is not null && Pattern == other.Pattern && Suffixes.SetEquals(other.Suffixes);
+
+    public override int GetHashCode() => HashCode.Combine(Pattern, Suffixes);
+}

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
@@ -19,6 +19,11 @@ internal class Exclusion : IEquatable<Exclusion>
     public HashSet<string?> Suffixes { get; init; }
 
     /// <summary>
+    /// The matcher for the pattern.
+    /// </summary>
+    private Matcher PatternMatcher = new(StringComparison.Ordinal);
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Exclusion"/> class.
     /// <param name="line"/>>The line to parse.</param>
     /// </summary>
@@ -27,6 +32,8 @@ internal class Exclusion : IEquatable<Exclusion>
         string parsedLine = line.Split('#')[0].Trim();
         string[] splitLine = parsedLine.Split('|', 2); // Split on the first occurrence of '|'
         Pattern = splitLine[0].Trim();
+
+        PatternMatcher.AddInclude(Pattern);
 
         Suffixes = splitLine.Length > 1
             ? new HashSet<string?>(splitLine[1].Split(',').Select(s => s.Trim()))
@@ -52,9 +59,7 @@ internal class Exclusion : IEquatable<Exclusion>
     {
         if (Suffixes.Contains(suffix))
         {
-            Matcher matcher = new(StringComparison.Ordinal);
-            matcher.AddInclude(Pattern);
-            if (matcher.Match(path).HasMatches)
+            if (PatternMatcher.Match(path).HasMatches)
             {
                 return true;
             }

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/Exclusion.cs
@@ -50,7 +50,7 @@ internal class Exclusion : IEquatable<Exclusion>
         Suffixes = new HashSet<string?>(other.Suffixes);
     }
 
-        /// <summary>
+    /// <summary>
     /// Checks if the exclusion matches the path and suffix.
     /// <param name="path">The path to check.</param>
     /// <param name="suffix">The suffix to check.</param>

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsHelper.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsHelper.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ExclusionsLibrary;
+
+public class ExclusionsHelper
+{
+    /// <summary>
+    /// Prefix for lines that import other exclusion files.
+    /// </summary>
+    private const string FileImportPrefix = "import:";
+
+    /// <summary>
+    /// Regex to narrow down the scope of exclusions. If null, all exclusions will be used.
+    /// For instance, setting this to "vstest" will consider 
+    /// "src/vstest/file.txt" but not "src/arcade/file.txt".
+    /// </summary>
+    private readonly Regex? _exclusionRegex;
+
+    /// <summary>
+    /// Storage for exclusions that were used during the test run.
+    /// Used to check if a file matches an exclusion.
+    /// </summary>
+    private readonly ExclusionsStorage _storage = new();
+
+    /// <summary>
+    /// Storage for exclusions that were not used during the test run.
+    /// Used to generate a new baseline file with the exclusions that were used.
+    /// </summary>
+    private readonly ExclusionsStorage _unusedStorage;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExclusionsHelper"/> class.
+    /// <param name="exclusionsFilePath">Path to the exclusions file.</param>
+    /// <param name="exclusionRegexString">Optional regex to narrow down the scope of exclusions.</param>
+    /// </summary>
+    public ExclusionsHelper(string exclusionsFilePath, string? exclusionRegexString = null)
+    {
+        _exclusionRegex = string.IsNullOrWhiteSpace(exclusionRegexString) ? null : new Regex(exclusionRegexString);
+        ParseExclusionsFile(exclusionsFilePath);
+        _unusedStorage = new ExclusionsStorage(_storage);
+    }
+
+    /// <summary>
+    /// Checks if a file is excluded.
+    /// <param name="filePath">Path to the file to check.</param>
+    /// <param name="suffix">
+    ///     Suffix to narrow down the scope of exclusions.
+    ///     Patterns without any suffixes (suffix == null) will also
+    ///     be checked if the file is not excluded with the provided suffix.
+    /// </param>
+    /// </summary>
+    public bool IsFileExcluded(string filePath, string? suffix = null) =>
+        CheckAndRemoveIfExcluded(filePath, suffix) || (suffix != null && CheckAndRemoveIfExcluded(filePath, null));
+
+    /// <summary>
+    /// Generates a new baseline file with the exclusions that were used.
+    /// <param name="updatedFileTag">Optional tag to append to the updated file name.</param>
+    /// <param name="additionalLines">Optional additional lines to append to the updated file.</param>
+    /// <param name="targetDirectory">
+    ///     Optional target directory for the updated file.
+    ///     If not provided, files will be written to the
+    ///     same directory as the original files.
+    /// </param>
+    /// </summary>
+    public void GenerateNewBaselineFile(string? updatedFileTag = null, List<string>? additionalLines = null, string? targetDirectory = null)
+    {
+        foreach (string file in _unusedStorage.GetFiles())
+        {
+            IEnumerable<string> newLines = File.ReadLines(file)
+                .Select(line =>
+                {
+                    if (IsIgnorableLine(line) || line.StartsWith(FileImportPrefix))
+                    {
+                        return line;
+                    }
+
+                    Exclusion exclusion = new(line);
+                    Exclusion? unusedExclusion = _unusedStorage.GetExclusion(file, exclusion.Pattern);
+                    if (unusedExclusion is not null)
+                    {
+                        HashSet<string?> unusedSuffixes = unusedExclusion.Suffixes;
+
+                        // If all suffixes are unused, we can remove the exclusion
+                        if (unusedSuffixes.Count == exclusion.Suffixes.Count)
+                        {
+                            return null;
+                        }
+
+                        // Remove the unused suffixes from the line
+                        foreach (string? suffix in unusedSuffixes)
+                        {
+                            string suffixPattern = $@"\s*,?\s*{suffix}\s*";
+                            line = Regex.Replace(line, suffixPattern.ToString(), string.Empty);
+                        }
+                    }
+                    return line;
+                })
+                .Where(line => line is not null)
+                .Select(line => line!);
+
+             if (additionalLines is not null)
+            {
+                newLines = newLines.Concat(additionalLines);
+            }
+
+            string targetDir = targetDirectory ?? Path.GetDirectoryName(file) ?? throw new InvalidOperationException($"Could not get directory for file: {file}");
+            string fileName = Path.GetFileName(file);
+            string updatedFileName = updatedFileTag is null
+                ? $"Updated{fileName}"
+                : $"Updated{Path.GetFileNameWithoutExtension(fileName)}.{updatedFileTag}{Path.GetExtension(fileName)}";
+
+            File.WriteAllLines(Path.Combine(targetDir, updatedFileName), newLines, Encoding.UTF8);
+        }
+    }
+
+    /// <summary>
+    /// Checks if a file is excluded and removes it from the unused storage if it is.
+    /// <param name="filePath">Path to the file to check.</param>
+    /// <param name="suffix">Suffix to narrow down the scope of exclusions.</param>
+    /// </summary>
+    private bool CheckAndRemoveIfExcluded(string filePath, string? suffix)
+    {
+        if (_storage.HasMatch(filePath, suffix, out (string file, string pattern) match))
+        {
+            _unusedStorage.Remove(match.file, match.pattern, suffix);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses the exclusions file and adds the exclusions to the storage.
+    /// <param name="file">Path to the exclusions file.</param>
+    /// </summary>
+    private void ParseExclusionsFile(string file)
+    {
+        if (_storage.ContainsFile(file))
+        {
+            return;
+        }
+
+        if (!Path.IsPathFullyQualified(file))
+        {
+            throw new ArgumentException($"File path must be fully qualified: {file}");
+        }
+
+        if (!File.Exists(file))
+        {
+            throw new FileNotFoundException($"Exclusions file not found: {file}");
+        }
+
+
+        foreach (string line in File.ReadLines(file))
+        {
+            string trimmedLine = line.Trim();
+            if (IsIgnorableLine(trimmedLine))
+            {
+                continue;
+            }
+
+            if (trimmedLine.StartsWith(FileImportPrefix))
+            {
+                string importFile = trimmedLine.Substring(FileImportPrefix.Length).Trim();
+                if (!Path.IsPathFullyQualified(importFile))
+                {
+                    string directory = Path.GetDirectoryName(file) ?? throw new InvalidOperationException($"Could not get directory for file: {file}");
+                    importFile = Path.Combine(directory, importFile);
+                }
+                ParseExclusionsFile(importFile);
+            }
+            else
+            {
+                Exclusion exclusion = new Exclusion(trimmedLine);
+                if(_exclusionRegex is not null && !_exclusionRegex.IsMatch(exclusion.Pattern))
+                {
+                    // Exclusion does not match the exclusion regex, so we can skip it
+                    return;
+                }
+                _storage.Add(file, exclusion);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if a line is whitespace or a comment.
+    /// <param name="line">The line to check.</param>
+    /// </summary>
+    private bool IsIgnorableLine(string line) =>
+        string.IsNullOrWhiteSpace(line) || line.StartsWith("#");
+}

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsLibrary.csproj
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsLibrary.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+  </ItemGroup>
+
+</Project>

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsStorage.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsStorage.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ExclusionsLibrary;
+
+internal class ExclusionsStorage
+{
+    /// <summary>
+    /// Storage for exclusions.
+    /// Key: file path.
+    /// Value: list of exclusions for the file.
+    /// </summary>
+    private Dictionary<string, List<Exclusion>> _storage = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExclusionsStorage"/> class.
+    /// </summary>
+    public ExclusionsStorage() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExclusionsStorage"/> class.
+    /// <param name="other">The storage to copy.</param>
+    /// </summary>
+    public ExclusionsStorage(ExclusionsStorage other)
+    {
+        foreach (string file in other._storage.Keys)
+        {
+            _storage[file] = other._storage[file].Select(e => new Exclusion(e)).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Gets all files in the storage.
+    /// </summary>
+    public IEnumerable<string> GetFiles() => _storage.Keys;
+
+    /// <summary>
+    /// Adds an exclusion to the storage.
+    /// <param name="file">The file to add the exclusion to.</param>
+    /// <param name="exclusion">The exclusion to add.</param>
+    /// </summary>
+    public void Add(string file, Exclusion exclusion)
+    {
+        if (!_storage.ContainsKey(file))
+        {
+            _storage[file] = new List<Exclusion>();
+        }
+        _storage[file].Add(exclusion);
+    }
+
+    /// <summary>
+    /// Removes a suffix from an exclusion in the storage.
+    /// If there are no suffixes left, the exclusion will be removed.
+    /// <param name="file">The file for the exclusion.</param>
+    /// <param name="pattern">The pattern to look for.</param>
+    /// <param name="suffix">The suffix to remove.</param>
+    /// </summary>
+    public void Remove(string file, string pattern, string? suffix)
+    {
+        if (_storage.ContainsKey(file))
+        {
+            Exclusion? exclusion = _storage[file].FirstOrDefault(e => e.Pattern == pattern);
+            if (exclusion is not null)
+            {
+                _storage[file].Remove(exclusion);
+                exclusion.Suffixes.Remove(suffix);
+                if (exclusion.Suffixes.Count > 0)
+                {
+                    _storage[file].Add(exclusion);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if the storage contains a file.
+    /// <param name="file">The file to check for.</param>
+    /// </summary>
+    public bool ContainsFile(string file) => _storage.ContainsKey(file);
+
+    /// <summary>
+    /// Gets an exclusion from the storage.
+    /// <param name="file">The file to get the exclusion from.</param>
+    /// <param name="pattern">The pattern to look for.</param>
+    /// </summary>
+    public Exclusion? GetExclusion(string file, string pattern) =>
+        _storage.ContainsKey(file) ? _storage[file].FirstOrDefault(e => e.Pattern == pattern) : null;
+
+    /// <summary>
+    /// Checks if the storage has a match for a file path and suffix input.
+    /// <param name="filePath">The file path to check.</param>
+    /// <param name="suffix">The suffix to narrow down the scope of exclusions.</param>
+    /// <param name="match">The match if found.</param>
+    /// </summary>
+    public bool HasMatch(string filePath, string? suffix, out (string file, string pattern) match)
+    {
+        foreach (string file in _storage.Keys)
+        {
+            foreach (Exclusion exclusion in _storage[file])
+            {
+                if (exclusion.HasMatch(filePath, suffix))
+                {
+                    match = (file, exclusion.Pattern);
+                    return true;
+                }
+            }
+        }
+
+        match = (string.Empty, string.Empty);
+        return false;
+    }
+}

--- a/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsStorage.cs
+++ b/src/SourceBuild/content/eng/tools/ExclusionsLibrary/ExclusionsStorage.cs
@@ -42,11 +42,12 @@ internal class ExclusionsStorage
     /// </summary>
     public void Add(string file, Exclusion exclusion)
     {
-        if (!_storage.ContainsKey(file))
+        if (!_storage.TryGetValue(file, out var exclusions))
         {
-            _storage[file] = new List<Exclusion>();
+            exclusions = new List<Exclusion>();
+            _storage[file] = exclusions;
         }
-        _storage[file].Add(exclusion);
+        exclusions.Add(exclusion);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR introduces the ExclusionsLibrary that will replace the exclusions helper used in BinaryToolKit and Microsoft.DotNet.SourceBuild.Tests.