### PR TITLE
Enable dotnet SDK to support targeting android-arm64/x64 with CoreCLR

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -239,9 +239,15 @@
         linux-musl-loongarch64;
         " />
 
+      <Net10RuntimePackRids Include="
+        @(Net80RuntimePackRids);
+        android-arm64;
+        android-x64;
+        " />
+
       <NetCoreAppHostRids Include="@(Net90AppHostRids)" />
 
-      <NetCoreRuntimePackRids Include="@(Net90RuntimePackRids)" />
+      <NetCoreRuntimePackRids Include="@(Net10RuntimePackRids)" />
 
       <!--
         In source-only builds, we build the current RID from source, which may be

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -240,7 +240,7 @@
         " />
 
       <Net10RuntimePackRids Include="
-        @(Net80RuntimePackRids);
+        @(Net90RuntimePackRids);
         android-arm64;
         android-x64;
         " />

--- a/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
+++ b/src/Installer/redist-installer/targets/GenerateBundledVersions.targets
@@ -239,7 +239,7 @@
         linux-musl-loongarch64;
         " />
 
-      <Net10RuntimePackRids Include="
+      <Net100RuntimePackRids Include="
         @(Net90RuntimePackRids);
         android-arm64;
         android-x64;
@@ -247,7 +247,7 @@
 
       <NetCoreAppHostRids Include="@(Net90AppHostRids)" />
 
-      <NetCoreRuntimePackRids Include="@(Net10RuntimePackRids)" />
+      <NetCoreRuntimePackRids Include="@(Net100RuntimePackRids)" />
 
       <!--
         In source-only builds, we build the current RID from source, which may be


### PR DESCRIPTION
## Description

This PR adds `android-arm64` and `android-x64` rids to the `NetCoreRuntimePackRids` to support targeting Android with CoreCLR.

The CoreCLR Android runtime packs are introduced in https://github.com/dotnet/runtime/pull/110471.

## Out of scope

This PR doesn't include `android-arm`, `android-x86`, and NativeAOT support. The follow-up work is tracked in https://github.com/dotnet/runtime/issues/111491