### PR TITLE
Define a RepositoryReference to sdk to get the live package sources in the NuGet.config

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -114,8 +114,6 @@
     <TestArgs Condition="'$(UseOfficialBuildVersioning)' != 'false'">$(FlagParameterPrefix)ci</TestArgs>
     <TestArgs>$(TestArgs) $(FlagParameterPrefix)configuration $(Configuration)</TestArgs>
     <TestArgs>$(TestArgs) /bl:artifacts/log/$(Configuration)/Test.binlog</TestArgs>
-
-    <TestCommand>$(BuildScript) $(TestActions) $(TestArgs)</TestCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnableExtraDebugging)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -763,6 +763,10 @@
     CleanupRepo" />
 
   <Target Name="RepoTest">
+    <PropertyGroup>
+      <TestCommand>$(BuildScript) $(TestActions) $(TestArgs)</TestCommand>
+    </PropertyGroup>
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Testing $(RepositoryName)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(TestCommand)" />

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -4,13 +4,7 @@
     <!-- The scenario-tests repo shouldn't be cleaned after building as we run tests from it. -->
     <CleanWhileBuilding>false</CleanWhileBuilding>
 
-    <ScenarioTestsArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'scenario-tests'))</ScenarioTestsArtifactsDir>
     <ScenarioTestsResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)', 'scenario-tests'))</ScenarioTestsResultsDir>
-    <!-- Use the updated NuGet.config file from the intermediate folder which contains the live local feeds. -->
-    <NuGetConfigInputForScenarioTests>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
-    <!-- TODO: Consolidate with the above line when building source-only: https://github.com/dotnet/source-build/issues/4841 -->
-    <NuGetConfigInputForScenarioTests Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizePath('$(SrcDir)', 'sdk', 'NuGet.config'))</NuGetConfigInputForScenarioTests>
-    <NuGetConfigOutputForScenarioTests>$(ScenarioTestsArtifactsDir)NuGet.config</NuGetConfigOutputForScenarioTests>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,24 +17,18 @@
     <RepositoryReference Include="source-build-reference-packages" />
   </ItemGroup>
 
-  <Target Name="SetupNuGetConfig"
-          Inputs="$(NuGetConfigInputForScenarioTests)"
-          Outputs="$(NuGetConfigOutputForScenarioTests)">
-    <Copy SourceFiles="$(NuGetConfigInputForScenarioTests)"
-          DestinationFiles="$(NuGetConfigOutputForScenarioTests)" />
-  </Target>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <!-- Depends on NuGet packages from the sdk repo and transitive repositories. -->
+    <RepositoryReference Include="sdk" />
+  </ItemGroup>
 
   <Target Name="PrepareScenarioTestsInputs"
-          DependsOnTargets="SetupNuGetConfig;DetermineSourceBuiltSdkVersion"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion"
           BeforeTargets="RepoTest">
     <PropertyGroup>
       <_CurrentDateTime>$([System.DateTime]::Now.ToString("yyyy-MM-dd_HH_mm_ss"))</_CurrentDateTime>
       <_TestXmlOutputPath>$(ScenarioTestsResultsDir)$(_CurrentDateTime).xml</_TestXmlOutputPath>
       <_ScenarioTestsAdditionalArgs>--xml $(_TestXmlOutputPath) --target-rid $(TargetRid) --no-cleanup --no-traits Category=MultiTFM</_ScenarioTestsAdditionalArgs>
-
-      <!-- Define the test root as a sub-directory of the scenario test artifacts directory. It needs to be a sub-directory because the scenario test execution
-           will clean that directory. Since we need the NuGet.config file that we copied in to be preserved, that's stored in the directory above the test root. -->
-      <_TestRoot>$(ScenarioTestsArtifactsDir)artifacts/</_TestRoot>
 
       <!-- It's necessary to explicitly define the path to the dotnet tool to prevent Arcade from attempting to derive it. Otherwise, it will run the dotnet
            install script to get a new one. We must use the locally built SDK instead in order to support non-portable RIDs for source build. -->
@@ -51,7 +39,6 @@
 
     <ItemGroup>
       <TestEnvironmentVariable Include="
-        TestRoot=$(_TestRoot);
         DotNetRoot=$(DotNetSdkExtractDir);
         TestSdkVersion=$(SourceBuiltSdkVersion);
         AdditionalTestArgs=$(_ScenarioTestsAdditionalArgs);

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -5,6 +5,10 @@
     <CleanWhileBuilding>false</CleanWhileBuilding>
 
     <ScenarioTestsResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestResultsDir)', 'scenario-tests'))</ScenarioTestsResultsDir>
+
+    <!-- Pass the path of the updated NuGet.config file in which contains the live source-built feeds. Skip this when building source-only
+         as in that configuration we currently don't want to use the live generated NuGet packages from the various repositories. -->
+    <TestArgs Condition="'$(NuGetConfigFile)' != '' and '$(DotNetBuildSourceOnly)' != 'true'">$(TestArgs) /p:RestoreConfigFile=$(NuGetConfigFile)</TestArgs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,6 +48,8 @@
         AdditionalTestArgs=$(_ScenarioTestsAdditionalArgs);
         DotNetTool=$(_DotNetTool);
         _InitializeDotNetCli=$(DotNetSdkExtractDir.TrimEnd('/\'))" />
+      <!-- Needed for miscellanous projects in various repos - see https://github.com/dotnet/source-build/issues/4081-->
+      <TestEnvironmentVariable Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != '' and '$(DotNetBuildSourceOnly)' != 'true'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4845
Unblocks https://github.com/dotnet/sdk/pull/46244

By defining a `RepositoryReference` to `sdk` in the `scenario-tests.proj` file, we ensure that the `NuGet.config` file in the `scenario-tests` repository includes the live package sources from the `sdk`. This change is necessary to prevent build failures in the `win-x64` vertical in an official build with unique versioning.

This is conditioned on when not building source-only as in that configuration, the live produced packages shouldn't be used, at least right now. This might change in the future when source-build will also enable unique versioning.

Additionally, stop putting the scenario-tests artifacts outside of the repo, under the VMR artifacts. This is necessary so that the NuGet.config in the repository gets used.