### PR TITLE
Update SDK-PR-guide.md to include branch lockdown label

### DIFF
--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -52,7 +52,7 @@ jobs:
 
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
-            prs=$(gh pr list --state open --json number,baseRefName,author)
+            prs=$(gh pr list --state open --json number,baseRefName,author --limit 200)
             echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
 

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -47,12 +47,16 @@ jobs:
             echo "Within the label period. Adding labels to PRs..."
 
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
-            prs=$(gh pr list --state open --json number,headRefName,author --jq '.[] | select(.author.login == "app/dotnet-maestro") | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number')
+            echo "Running gh pr list query..."
+            prs=$(gh pr list --state open --json number,headRefName,author)
+            echo "PRs JSON: $prs"
+            filtered_prs=$(echo "$prs" | jq '.[] | select(.author.login == "app/dotnet-maestro") | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number')
+            echo "Filtered PRs JSON: $filtered_prs"
 
             # Loop through PRs and add label
-            for pr in $prs; do
+            for pr in $filtered_prs; do
               echo "Adding label to PR #$pr"
-              # gh pr edit $pr --add-label "Branch Lockdown"
+              gh pr edit $pr --add-label "Branch Lockdown"
             done
           else
             echo "Outside the label period. No labels added."

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -24,10 +24,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Determine the third Tuesday of the current month
-          third_tuesday=$(date -d "third Tuesday of $(date +%Y-%m)" +%Y-%m-%d)
+          third_tuesday=$(date -d "$(date +%Y-%m-01) +14 days" +%Y-%m-%d)
+          while [ $(date -d "$third_tuesday" +%u) -ne 2 ]; do
+            third_tuesday=$(date -d "$third_tuesday + 1 day" +%Y-%m-%d)
+          done
           
           # Determine the first Tuesday of the current month
-          first_tuesday=$(date -d "first Tuesday of $(date +%Y-%m)" +%Y-%m-%d)
+          first_tuesday=$(date -d "$(date +%Y-%m-01)" +%Y-%m-%d)
+          while [ $(date -d "$first_tuesday" +%u) -ne 2 ]; do
+            first_tuesday=$(date -d "$first_tuesday + 1 day" +%Y-%m-%d)
+          done
 
           # Get current date
           current_date=$(date +%Y-%m-%d)

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,9 +1,10 @@
 name: Add Branch Lockdown Label to PRs
 
 on:
-  schedule:
-    # Run daily at 00:00 UTC
-    - cron: '0 23 * * *'
+  pull_request:
+    branches-ignore:
+      - main
+      - release/9.0.3xx
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:
@@ -47,32 +48,21 @@ jobs:
           if [[ "$current_date" > "$third_tuesday" || "$current_date" < "$first_tuesday" ]]; then
             echo "Within the label period. Adding labels to PRs..."
 
-            # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
-            echo "Running gh pr list query..."
-            prs=$(gh pr list --state open --limit 100 --json number,baseRefName,author,labels)
-            echo "Total PRs Count: $(echo "$prs" | jq length)"
-            echo "PRs JSON: $prs"
+            # List of known branches
+            known_branches=("release/8.*" "release/9.*")
+            exclude_branch="release/9.0.3xx"
 
-            echo "Filtering PRs created by app/dotnet-maestro..."
-            prs_by_author=$(echo "$prs" | jq '[.[] | select(.author.login == "app/dotnet-maestro")]')
-            echo "PRs by app/dotnet-maestro JSON: $prs_by_author"
-            echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
+            # Get the target branch of the PR
+            pr_branch="${{ github.event.pull_request.base.ref }}"
 
-            echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
-            prs_targeting_branches=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
-            echo "Filtered PRs targeting specific branches JSON: $prs_targeting_branches"
-            echo "Count of PRs targeting specific branches: $(echo "$prs_targeting_branches" | jq length)"
-
-            echo "Filtering PRs without Branch Lockdown label..."
-            filtered_prs=$(echo "$prs_targeting_branches" | jq '[.[] | select(.labels | map(.name) | index("Branch Lockdown") | not) | .number]')
-            echo "Filtered PRs without Branch Lockdown label JSON: $filtered_prs"
-            echo "Count of Filtered PRs without Branch Lockdown label: $(echo "$filtered_prs" | jq length)"
-
-            # Loop through filtered PRs and add label
-            for pr in $(echo "$filtered_prs" | jq -r '.[]'); do
-              echo "Adding label to PR #$pr"
-              gh pr edit $pr --add-label "Branch Lockdown"
-            done
+            # Check if the PR branch is in the list of known branches and not the excluded branch, and if the current date is within the specified range
+            for branch in "${known_branches[@]}"; do
+              if [[ "$pr_branch" =~ $branch && "$pr_branch" != "$exclude_branch" && "$current_date" > "$start_date" && "$current_date" < "$end_date" ]]; then
+                echo "Adding Branch Lockdown label to PR #${{ github.event.pull_request.number }} targeting branch $pr_branch"
+                gh pr edit ${{ github.event.pull_request.number }} --add-label "Branch Lockdown"
+                break
+              fi
+          done
           else
             echo "Outside the label period. No labels added."
           fi

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -52,7 +52,7 @@ jobs:
 
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
-            prs=$(gh pr list --state open --json number,baseRefName,author --limit 200)
+            prs=$(gh pr list --state open --limit 100 --json number,baseRefName,author,labels)
             echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
 
@@ -62,9 +62,14 @@ jobs:
             echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
 
             echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
-            filtered_prs=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not) | .number]')
-            echo "Filtered PRs JSON: $filtered_prs"
-            echo "Count of Filtered PRs: $(echo "$filtered_prs" | jq length)"
+            prs_targeting_branches=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
+            echo "Filtered PRs targeting specific branches JSON: $prs_targeting_branches"
+            echo "Count of PRs targeting specific branches: $(echo "$prs_targeting_branches" | jq length)"
+
+            echo "Filtering PRs without Branch Lockdown label..."
+            filtered_prs=$(echo "$prs_targeting_branches" | jq '[.[] | select(.labels | map(.name) | index("Branch Lockdown") | not) | .number]')
+            echo "Filtered PRs without Branch Lockdown label JSON: $filtered_prs"
+            echo "Count of Filtered PRs without Branch Lockdown label: $(echo "$filtered_prs" | jq length)"
 
             # Loop through filtered PRs and add label
             for pr in $(echo "$filtered_prs" | jq -r '.[]'); do

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -49,12 +49,21 @@ jobs:
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
             prs=$(gh pr list --state open --json number,headRefName,author)
+            echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
-            filtered_prs=$(echo "$prs" | jq '.[] | select(.author.login == "app/dotnet-maestro") | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number')
-            echo "Filtered PRs JSON: $filtered_prs"
 
-            # Loop through PRs and add label
-            for pr in $filtered_prs; do
+            echo "Filtering PRs created by app/dotnet-maestro..."
+            prs_by_author=$(echo "$prs" | jq '[.[] | select(.author.login == "app/dotnet-maestro")]')
+            echo "PRs by app/dotnet-maestro JSON: $prs_by_author"
+            echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
+
+            echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
+            filtered_prs=$(echo "$prs_by_author" | jq '[.[] | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number]')
+            echo "Filtered PRs JSON: $filtered_prs"
+            echo "Count of Filtered PRs: $(echo "$filtered_prs" | jq length)"
+
+            # Loop through filtered PRs and add label
+            for pr in $(echo "$filtered_prs" | jq -r '.[]'); do
               echo "Adding label to PR #$pr"
               gh pr edit $pr --add-label "Branch Lockdown"
             done

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,0 +1,50 @@
+name: Label PRs
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Add label to PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Determine the third Tuesday of the current month
+          third_tuesday=$(date -d "third Tuesday of $(date +%Y-%m)" +%Y-%m-%d)
+          
+          # Determine the first Tuesday of the current month
+          first_tuesday=$(date -d "first Tuesday of $(date +%Y-%m)" +%Y-%m-%d)
+
+          # Get current date
+          current_date=$(date +%Y-%m-%d)
+
+          echo "Current Date: $current_date"
+          echo "Third Tuesday of the month: $third_tuesday"
+          echo "First Tuesday of the month: $first_tuesday"
+
+          # Check if the current date is after the third Tuesday of this month or before the first Tuesday of this month
+          if [[ "$current_date" > "$third_tuesday" || "$current_date" < "$first_tuesday" ]]; then
+            echo "Within the label period. Adding labels to PRs..."
+
+            # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
+            prs=$(gh pr list --state open --json number,headRefName,author --jq '.[] | select(.author.login == "app/dotnet-maestro") | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number')
+
+            # Loop through PRs and add label
+            for pr in $prs; do
+              echo "Adding label to PR #$pr"
+              gh pr edit $pr --add-label "Branch Lockdown"
+            done
+          else
+            echo "Outside the label period. No labels added."
+          fi

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -2,9 +2,6 @@ name: Add Branch Lockdown Label to PRs
 
 on:
   pull_request:
-    branches-ignore:
-      - main
-      - release/9.0.3xx
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:
@@ -54,10 +51,10 @@ jobs:
 
             # Get the target branch of the PR
             pr_branch="${{ github.event.pull_request.base.ref }}"
-
+            
             # Check if the PR branch is in the list of known branches and not the excluded branch, and if the current date is within the specified range
             for branch in "${known_branches[@]}"; do
-              if [[ "$pr_branch" =~ $branch && "$pr_branch" != "$exclude_branch" && "$current_date" > "$start_date" && "$current_date" < "$end_date" ]]; then
+              if [[ "$pr_branch" =~ $branch && "$pr_branch" != "$exclude_branch" ]]; then
                 echo "Adding Branch Lockdown label to PR #${{ github.event.pull_request.number }} targeting branch $pr_branch"
                 gh pr edit ${{ github.event.pull_request.number }} --add-label "Branch Lockdown"
                 break

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,4 +1,4 @@
-name: Label PRs
+name: Add Branch Lockdown Label to PRs
 
 on:
   schedule:
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  actions: write # For managing the operation state cache
+  issues: write
 
 jobs:
   add-label:

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -48,7 +48,7 @@ jobs:
 
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
-            prs=$(gh pr list --state open --json number,headRefName,author)
+            prs=$(gh pr list --state open --json number,baseRefName,author)
             echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
 
@@ -58,7 +58,7 @@ jobs:
             echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
 
             echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
-            filtered_prs=$(echo "$prs_by_author" | jq '[.[] | select(.headRefName | test("^release/[89].*")) | select(.headRefName | test("^release/9.0.3xx") | not) | .number]')
+            filtered_prs=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not) | .number]')
             echo "Filtered PRs JSON: $filtered_prs"
             echo "Count of Filtered PRs: $(echo "$filtered_prs" | jq length)"
 

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -3,15 +3,16 @@ name: Add Branch Lockdown Label to PRs
 on:
   schedule:
     # Run daily at 00:00 UTC
-    - cron: '0 0 * * *'
+    - cron: '0 23 * * *'
   workflow_dispatch: # Allows manual triggering of the workflow
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
 permissions:
   actions: write # For managing the operation state cache
   issues: write
+  pull-requests: write # Adding this to allow label addition
 
 jobs:
   add-label:

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install jq
-        run: sudo apt-get install -y jq
-
       - name: Add label to PRs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,7 +1,7 @@
 name: Add Branch Lockdown Label to PRs
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -5,14 +5,10 @@ on:
     # Run daily at 00:00 UTC
     - cron: '0 23 * * *'
   workflow_dispatch: # Allows manual triggering of the workflow
-  pull_request_target:
-    branches:
-      - main
 
 permissions:
   actions: write # For managing the operation state cache
   issues: write
-  pull-requests: write # Adding this to allow label addition
 
 jobs:
   add-label:

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -5,6 +5,9 @@ on:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
   workflow_dispatch: # Allows manual triggering of the workflow
+  pull_request:
+    branches:
+      - main
 
 jobs:
   add-label:
@@ -43,7 +46,7 @@ jobs:
             # Loop through PRs and add label
             for pr in $prs; do
               echo "Adding label to PR #$pr"
-              gh pr edit $pr --add-label "Branch Lockdown"
+              # gh pr edit $pr --add-label "Branch Lockdown"
             done
           else
             echo "Outside the label period. No labels added."

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Check if the current date is after the third Tuesday of this month or before the first Tuesday of this month
           if [[ "$current_date" > "$third_tuesday" || "$current_date" < "$first_tuesday" ]]; then
-            echo "Within the label period. Adding labels to PRs..."
+            echo "Within the label period. Checking if the branch matches..."
 
             # List of known branches
             known_branches=("release/8.*" "release/9.*")
@@ -58,6 +58,8 @@ jobs:
                 echo "Adding Branch Lockdown label to PR #${{ github.event.pull_request.number }} targeting branch $pr_branch"
                 gh pr edit ${{ github.event.pull_request.number }} --add-label "Branch Lockdown"
                 break
+              else
+                echo "PR branch $pr_branch does not match $branch. No labels added."
               fi
           done
           else

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -53,12 +53,10 @@ jobs:
 
             echo "Filtering PRs created by app/dotnet-maestro..."
             prs_by_author=$(echo "$prs" | jq '[.[] | select(.author.login == "app/dotnet-maestro")]')
-            echo "PRs by app/dotnet-maestro JSON: $prs_by_author"
             echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
 
             echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
             prs_targeting_branches=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
-            echo "Filtered PRs targeting specific branches JSON: $prs_targeting_branches"
             echo "Count of PRs targeting specific branches: $(echo "$prs_targeting_branches" | jq length)"
 
             echo "Filtering PRs without Branch Lockdown label..."

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -2,9 +2,6 @@ name: Add Branch Lockdown Label to PRs
 
 on:
   pull_request_target:
-    branches-ignore:
-    - main
-    - release/9.0.3xx
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:
@@ -14,6 +11,11 @@ permissions:
 jobs:
   add-label:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -50,7 +52,7 @@ jobs:
 
             # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
-            prs=$(gh pr list --state open --limit 100 --json number,baseRefName,author,labels)
+            prs=$(gh pr list --state open --limit 200 --json number,baseRefName,author,labels)
             echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
 

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -50,18 +50,14 @@ jobs:
           if [[ "$current_date" > "$third_tuesday" || "$current_date" < "$first_tuesday" ]]; then
             echo "Within the label period. Checking if the branch matches..."
 
-            # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
+            # Get all open PRs targeting branches release/8* and release/9* excluding release/9.0.3xx
             echo "Running gh pr list query..."
             prs=$(gh pr list --state open --limit 200 --json number,baseRefName,author,labels)
             echo "Total PRs Count: $(echo "$prs" | jq length)"
             echo "PRs JSON: $prs"
 
-            echo "Filtering PRs created by app/dotnet-maestro..."
-            prs_by_author=$(echo "$prs" | jq '[.[] | select(.author.login == "app/dotnet-maestro")]')
-            echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
-
             echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
-            prs_targeting_branches=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
+            prs_targeting_branches=$(echo "$prs" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
             echo "Count of PRs targeting specific branches: $(echo "$prs_targeting_branches" | jq length)"
 
             echo "Filtering PRs without Branch Lockdown label..."

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,7 +1,7 @@
 name: Add Branch Lockdown Label to PRs
 
 on:
-  pull_request_target:
+  pull_request:
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
 
       - name: Add label to PRs
         env:
@@ -42,23 +45,32 @@ jobs:
           if [[ "$current_date" > "$third_tuesday" || "$current_date" < "$first_tuesday" ]]; then
             echo "Within the label period. Checking if the branch matches..."
 
-            # List of known branches
-            known_branches=("release/8.*" "release/9.*")
-            exclude_branch="release/9.0.3xx"
+            # Get all open PRs created by app/dotnet-maestro and targeting branches release/8* and release/9* excluding release/9.0.3xx
+            echo "Running gh pr list query..."
+            prs=$(gh pr list --state open --limit 100 --json number,baseRefName,author,labels)
+            echo "Total PRs Count: $(echo "$prs" | jq length)"
+            echo "PRs JSON: $prs"
 
-            # Get the target branch of the PR
-            pr_branch="${{ github.event.pull_request.base.ref }}"
-            
-            # Check if the PR branch is in the list of known branches and not the excluded branch, and if the current date is within the specified range
-            for branch in "${known_branches[@]}"; do
-              if [[ "$pr_branch" =~ $branch && "$pr_branch" != "$exclude_branch" ]]; then
-                echo "Adding Branch Lockdown label to PR #${{ github.event.pull_request.number }} targeting branch $pr_branch"
-                gh pr edit ${{ github.event.pull_request.number }} --add-label "Branch Lockdown"
-                break
-              else
-                echo "PR branch $pr_branch does not match $branch. No labels added."
-              fi
-          done
+            echo "Filtering PRs created by app/dotnet-maestro..."
+            prs_by_author=$(echo "$prs" | jq '[.[] | select(.author.login == "app/dotnet-maestro")]')
+            echo "PRs by app/dotnet-maestro JSON: $prs_by_author"
+            echo "Count of PRs by app/dotnet-maestro: $(echo "$prs_by_author" | jq length)"
+
+            echo "Filtering PRs targeting release/8* and release/9* excluding release/9.0.3xx..."
+            prs_targeting_branches=$(echo "$prs_by_author" | jq '[.[] | select(.baseRefName | test("^release/[89].*")) | select(.baseRefName | test("^release/9.0.3xx") | not)]')
+            echo "Filtered PRs targeting specific branches JSON: $prs_targeting_branches"
+            echo "Count of PRs targeting specific branches: $(echo "$prs_targeting_branches" | jq length)"
+
+            echo "Filtering PRs without Branch Lockdown label..."
+            filtered_prs=$(echo "$prs_targeting_branches" | jq '[.[] | select(.labels | map(.name) | index("Branch Lockdown") | not) | .number]')
+            echo "Filtered PRs without Branch Lockdown label JSON: $filtered_prs"
+            echo "Count of Filtered PRs without Branch Lockdown label: $(echo "$filtered_prs" | jq length)"
+
+            # Loop through filtered PRs and add label
+            for pr in $(echo "$filtered_prs" | jq -r '.[]'); do
+              echo "Adding label to PR #$pr"
+              gh pr edit $pr --add-label "Branch Lockdown"
+            done
           else
             echo "Outside the label period. No labels added."
           fi

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -1,7 +1,10 @@
 name: Add Branch Lockdown Label to PRs
 
 on:
-  pull_request:
+  pull_request_target:
+    branches-ignore:
+    - main
+    - release/9.0.3xx
   workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:

--- a/documentation/project-docs/SDK-PR-guide.md
+++ b/documentation/project-docs/SDK-PR-guide.md
@@ -26,7 +26,7 @@ After the minor release locks down, it transitions into servicing / "QB" (Quarte
 ### Servicing releases
 The .NET SDK has monthly servicing releases (e.g.`7.0.100` VS `7.0.101`) aligning with the .NET Runtime servicing releases. These are for top fixes and security updates only to limit risk.
 Any servicing release is open for check-ins from the day the [branding PRs](https://github.com/dotnet/sdk/pulls?q=is%3Apr+branding) are merged (~1st of each month) and when code complete is (typically two weeks later).
-The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. Final signoffs are typically in the last week of each month.
+The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. We use the `Branch Lockdown` label to mark PRs that should go into the next servicing release but the branch is currently not open. Final signoffs are typically in the last week of each month.
 
 ### Schedule
 | Release Type | Frequency    | Lockdown Release  | Branch Open | Lockdown Date (estimate) |
@@ -36,7 +36,7 @@ The servicing branches are locked from the time of code complete to the next bra
 | Servicing    | Monthly      | N/A               | After branding, ~1st of the month | Third Tuesday of prior month (signoff is ~28th of each month) |
 
 ### Tactics approval
-Even releases that are in lockdown can still take changes as long as they are approved and the final build isn't complete. To bring a change through tactics, mark it with the label servicing-consider and update the description to include 5 sections (Description, Customer Impact, Regression?, Risk, Testing). See previously approved bugs for examples by looking for the [servicing-approved](https://github.com/dotnet/sdk/pulls?q=is%3Apr+label%3AServicing-approved+is%3Aclosed) label.
+Even releases that are in lockdown can still take changes as long as they are approved and the final build isn't complete. To bring a change through tactics, mark it with the label `servicing-consider` and update the description to include 5 sections (Description, Customer Impact, Regression?, Risk, Testing). See previously approved bugs for examples by looking for the [servicing-approved](https://github.com/dotnet/sdk/pulls?q=is%3Apr+label%3AServicing-approved+is%3Aclosed) label.
 
 ## External contributions
 External contributions are encouraged and welcome. There are so many teams working in this repo that it can be hard to track. Contributors looking to learn more about how to contribute should check out the [Developer Guide](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/developer-guide.md).


### PR DESCRIPTION
I included a comment in the PR guide about the lockdown label
Additionally, I added a workflow to automatically add that label.

- The branch is generally open between the first tuesday of the month when branding goes in until the third tuesday of the month (basically a week after the internal to public merge).
- Outside of that window, let's automatically add the label to any 8/9 base branch PR
- The workflow uses the permissions of the target branch as well as the source for the target branch so won't run until it's merged
- I configured it to run on all PRs but will only check into main. 
- When it runs, it'll search all PRs and label them all so we don't need to configure it to run elsewhere.
- I check if it's a PR against the 8 or 9 branches filtering out 9.0.3xx
- I check if it already has the label