### PR TITLE
Fix workload set install folder Fixes #46312

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/FileBasedInstaller.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             string workloadSetPackageVersion = WorkloadSetVersion.ToWorkloadSetPackageVersion(workloadSetVersion, out SdkFeatureBand workloadSetFeatureBand);
             var workloadSetPackageId = GetManifestPackageId(new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId), workloadSetFeatureBand);
 
-            var workloadSetPath = Path.Combine(_workloadRootDir, "sdk-manifests", _sdkFeatureBand.ToString(), "workloadsets", workloadSetVersion);
+            var workloadSetPath = Path.Combine(_workloadRootDir, "sdk-manifests", workloadSetFeatureBand.ToString(), "workloadsets", workloadSetVersion);
 
             try
             {


### PR DESCRIPTION
Fixes #46312

https://github.com/dotnet/sdk/pull/46351When we installed a workload set, we'd use the current SDK's feature band as part of the path, but if it was a workload set for a different feature band (as, for instance, installed via dotnet workload update --version x), then it would assume that workload set was in the feature band folder for the current feature band. Since the resolver is fairly precise with its expectations, it rejects this workload set.

In my dogfood folder, the correct location is:
C:\GitHub\sdkRelease\artifacts\bin\redist\Debug\dotnet\sdk-manifests\9.0.100\workloadsets\9.0.101

But using a 9.0.2xx SDK, it would install to:
C:\GitHub\sdkRelease\artifacts\bin\redist\Debug\dotnet\sdk-manifests\9.0.200\workloadsets\9.0.101

This switches to using the feature band from the workload set itself, resolving the issue.

Note that this was a FileBasedInstaller-specific problem. I verified that MSI-based installs were not affected, which incidentally means this better aligns to their behavior.