### PR TITLE
fix small mistake of using environment provider

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistrySettings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistrySettings.cs
@@ -14,10 +14,10 @@ internal class RegistrySettings
 
         ChunkedUploadSizeBytes = environment.GetEnvironmentVariableAsNullableInt(EnvVariables.ChunkedUploadSizeBytes) ??
             environment.GetEnvironmentVariableAsNullableInt(EnvVariables.ChunkedUploadSizeBytesLegacy);
-        ForceChunkedUpload = Environment.GetEnvironmentVariable(EnvVariables.ForceChunkedUpload) is not null ?
+        ForceChunkedUpload = environment.GetEnvironmentVariable(EnvVariables.ForceChunkedUpload) is not null ?
             environment.GetEnvironmentVariableAsBool(EnvVariables.ForceChunkedUpload, defaultValue: false) :
             environment.GetEnvironmentVariableAsBool(EnvVariables.ForceChunkedUploadLegacy, defaultValue: false);
-        ParallelUploadEnabled = Environment.GetEnvironmentVariable(EnvVariables.ParallelUploadEnabled) is not null ?
+        ParallelUploadEnabled = environment.GetEnvironmentVariable(EnvVariables.ParallelUploadEnabled) is not null ?
             environment.GetEnvironmentVariableAsBool(EnvVariables.ParallelUploadEnabled, defaultValue: true) :
             environment.GetEnvironmentVariableAsBool(EnvVariables.ParallelUploadEnabledLegacy, defaultValue: true);
 


### PR DESCRIPTION
In `RegistrySettings` class, there is a `IEnvironmentProvider environment`  provided by constructor, but the code is still using `Environment` static class to fetch environment varables.

This PR fix this small mistake.

If it's intend to do this, I'll close this PR.