### PR TITLE
Allow repos to opt-out of building tests

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -88,8 +88,6 @@
     <BuildArgs Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">$(BuildArgs) /p:DotNetBuildPass=$(DotNetBuildPass)</BuildArgs>
 
     <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=true</BuildArgs>
-    <!-- Only pass when enabled to reduce command line noise. -->
-    <BuildArgs Condition="'$(DotNetBuildTests)' == 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
     <BuildArgs Condition="'$(NuGetConfigFile)' != ''">$(BuildArgs) /p:RestoreConfigFile=$(NuGetConfigFile)</BuildArgs>
     <!-- TODO rename this property https://github.com/dotnet/source-build/issues/4165 -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(BuildArgs) /p:DotNetBuildUseMonoRuntime=$(DotNetBuildUseMonoRuntime)</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -459,6 +459,9 @@
            ProcessFrameworkReferences not be able to restore for the given RID.  -->
       <BuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true' and '@(TransitiveRepositoryReference->AnyHaveMetadataValue('Identity', 'runtime'))' == 'true'">$(BuildArgs) /p:DotNetBuildTargetRidOnly=true</BuildArgs>
 
+      <!-- Only pass when enabled to reduce command line noise. -->
+      <BuildArgs Condition="'$(DotNetBuildTests)' == 'true' and '$(DoNotBuildTests)' != 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
+
       <BuildCommand Condition="'$(BuildCommand)' == '' and '$(IsUtilityProject)' != 'true'">$(BuildScript) $(BuildActions) $(BuildArgs)</BuildCommand>
     </PropertyGroup>
   </Target>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -37,6 +37,9 @@
     <BuildArgs>$(BuildArgs) /p:PortableBuild=$(PortableBuild)</BuildArgs>
     <BuildArgs Condition="'$(ShortStack)' != 'true' and '$(TargetOS)' != 'linux-musl'">$(BuildArgs) /p:RuntimeOS=$(RuntimeOS)</BuildArgs>
     <BuildArgs Condition="'$(ShortStack)' != 'true' and '$(TargetOS)' != 'linux-musl'">$(BuildArgs) /p:BaseOS=$(BaseOS)</BuildArgs>
+
+    <!-- Only pass when enabled to reduce command line noise. -->
+    <BuildArgs Condition="'$(DotNetBuildTests)' == 'true' and '$(DotNetBuildTestsOptOut)' != 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -458,9 +461,6 @@
            live runtime. Exclude from source-only builds which don't use the portable RID format which causes the
            ProcessFrameworkReferences not be able to restore for the given RID.  -->
       <BuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true' and '@(TransitiveRepositoryReference->AnyHaveMetadataValue('Identity', 'runtime'))' == 'true'">$(BuildArgs) /p:DotNetBuildTargetRidOnly=true</BuildArgs>
-
-      <!-- Only pass when enabled to reduce command line noise. -->
-      <BuildArgs Condition="'$(DotNetBuildTests)' == 'true' and '$(DoNotBuildTests)' != 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
 
       <BuildCommand Condition="'$(BuildCommand)' == '' and '$(IsUtilityProject)' != 'true'">$(BuildScript) $(BuildActions) $(BuildArgs)</BuildCommand>
     </PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -30,6 +30,7 @@
     <BuildArgs>$(BuildArgs) /p:EnablePackageValidation=false</BuildArgs>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <DoNotBuildTests>true</DoNotBuildTests>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -30,7 +30,9 @@
     <BuildArgs>$(BuildArgs) /p:EnablePackageValidation=false</BuildArgs>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <DoNotBuildTests>true</DoNotBuildTests>
+
+    <!-- Tests are failing to build: https://github.com/dotnet/aspnetcore/issues/60095 -->
+    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/efcore.proj
+++ b/src/SourceBuild/content/repo-projects/efcore.proj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <DoNotBuildTests>true</DoNotBuildTests>
+  </PropertyGroup>
+
   <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="runtime" />

--- a/src/SourceBuild/content/repo-projects/efcore.proj
+++ b/src/SourceBuild/content/repo-projects/efcore.proj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DoNotBuildTests>true</DoNotBuildTests>
+    <!-- Tests are failing to build: https://github.com/dotnet/efcore/issues/35547 -->
+    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <DoNotBuildTests>true</DoNotBuildTests>
 
     <!-- Roslyn's build.cmd adds -build automatically. On non-windows, use the default -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(FlagParameterPrefix)restore</BuildActions>

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <DoNotBuildTests>true</DoNotBuildTests>
+
+    <!-- Tests are failing to build: https://github.com/dotnet/roslyn/issues/76960 -->
+    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
 
     <!-- Roslyn's build.cmd adds -build automatically. On non-windows, use the default -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(FlagParameterPrefix)restore</BuildActions>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-    <DoNotBuildTests>true</DoNotBuildTests>
+
+    <!-- Tests are failing to build: https://github.com/microsoft/vstest/issues/14994 -->
+    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+    <DoNotBuildTests>true</DoNotBuildTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -8,6 +8,10 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
+         verticals that are built in the first build pass.
+         Disabling this project as references are not building in this case. -->
+    <ExcludeFromBuild Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">true</ExcludeFromBuild>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 
     <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests

--- a/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
+++ b/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>net472;$(ToolsetTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(ToolsetTargetFramework)</TargetFrameworks>
+    <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
+         verticals that are built in the first build pass. -->
+    <TargetFrameworks Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">$(ToolsetTargetFramework)</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)' == '$(ToolsetTargetFramework)'">Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 


### PR DESCRIPTION
This is a prerequisite for us enabling tests in VMR, i.e. https://github.com/dotnet/sdk/pull/44843

This PR sets the new opt-out property for repos that are not ready to build tests, for some reason. I will create issues for each of those repos with detailed info about test failures and steps forward. PRs with fixes would follow soon after.

This PR also fixes the issue with building tests in `sdk` repo.

I understand that the new property `DoNotBuildTests` has a very similar name to the property we use to enable tests: `DotNetBuildTests`. If there is a significant risk of confusion, we can change the name to something else.