### PR TITLE
Make the default VMR build behavior for non-source-only builds dev/ci

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -364,7 +364,6 @@ jobs:
     - script: build.cmd
         $(baseArguments)
         $(targetArguments)
-        $(devArguments)
         $(signArguments)
         $(buildPassArguments)
         ${{ parameters.extraProperties }}
@@ -375,7 +374,6 @@ jobs:
       - script: build.cmd
           $(baseArguments)
           $(targetArguments)
-          $(devArguments)
           $(buildPassArguments)
           ${{ parameters.extraProperties }}
           -test

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -43,11 +43,6 @@ parameters:
   type: boolean
   default: false
 
-- name: useDevVersions
-  displayName: True when build output uses dev/CI versioning instead of official build versioning
-  type: boolean
-  default: false
-
 - name: sign
   displayName: True when build output should be signed (includes dry runs)
   type: boolean
@@ -208,17 +203,9 @@ jobs:
     - name: targetArguments
       value: /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }}
 
-    ### Dev versions variables
-    - ${{ if eq(parameters.useDevVersions, 'True') }}:
-      - name: devArguments
-        value: -dev
-    - ${{ else }}:
-      - name: devArguments
-        value: ''
-
     ### Signing variables
     - ${{ if eq(parameters.sign, 'True') }}:
-      - ${{ if or(eq(parameters.useDevVersions, 'True'), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         # The _SignType variable is used by microbuild installation
         - name: _SignType
           value: ''
@@ -469,10 +456,6 @@ jobs:
           customBuildArgs="$customBuildArgs --use-mono-runtime"
         fi
 
-        if [[ '${{ parameters.useDevVersions }}' == 'True' ]]; then
-          customBuildArgs="$customBuildArgs --dev"
-        fi
-
         if [[ '${{ parameters.sign }}' == 'True' ]] && [[ '${{ parameters.buildSourceOnly }}' != 'True' ]]; then
           customBuildArgs="$customBuildArgs --sign"
           if [[ '$(_SignType)' == 'real' ]] || [[ '$(_SignType)' == 'test' ]]; then
@@ -565,10 +548,6 @@ jobs:
 
           if [[ ! -z '${{ parameters.targetArchitecture }}' ]]; then
             extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArchitecture }}"
-          fi
-
-          if [[ '${{ parameters.useDevVersions }}' == 'True' ]]; then
-            customBuildArgs="$customBuildArgs --dev"
           fi
 
           if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -198,7 +198,7 @@ jobs:
   - ${{ if eq(parameters.targetOS, 'windows') }}:
     ## Basic arguments
     - name: baseArguments
-      value:  -ci -cleanWhileBuilding -prepareMachine -c ${{ parameters.configuration }} /p:VerticalName=$(Agent.JobName) /p:ArtifactsStagingDir=$(artifactsStagingDir)
+      value: -ci -cleanWhileBuilding -prepareMachine -c ${{ parameters.configuration }} $(officialBuildParameter) /p:VerticalName=$(Agent.JobName) /p:ArtifactsStagingDir=$(artifactsStagingDir)
 
     - name: targetArguments
       value: /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }}
@@ -428,7 +428,7 @@ jobs:
 
         customEnvVars=""
         customPreBuildArgs=""
-        customBuildArgs="--ci --clean-while-building --prepareMachine -c ${{ parameters.configuration }}"
+        customBuildArgs="--ci --clean-while-building --prepareMachine -c ${{ parameters.configuration }} $(officialBuildParameter)"
 
         if [[ '${{ parameters.runOnline }}' == 'True' ]]; then
           customBuildArgs="$customBuildArgs --online"
@@ -534,7 +534,7 @@ jobs:
           customPreBuildArgs=''
           customBuildArgs=''
           extraBuildProperties=''
-          customBuildArgs="--ci --prepareMachine -c ${{ parameters.configuration }}"
+          customBuildArgs="--ci --prepareMachine -c ${{ parameters.configuration }} $(officialBuildParameter)"
 
           if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
             customPreBuildArgs="$customPreBuildArgs sudo"

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -373,17 +373,6 @@ stages:
           image: ${{ variables.ubuntuContainerImage }}
         targetOS: linux
         targetArchitecture: x64
-        useDevVersions: true # Use dev versions for CI validation of the experience.
-
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows_DevVersions
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ variables.VmrBranch }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x86
-        useDevVersions: true # Use dev versions for CI validation of the experience.
 
 #### VERTICAL BUILD (Official) ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:
@@ -406,6 +395,16 @@ stages:
         pool: ${{ parameters.pool_Windows }}
         targetOS: windows
         targetArchitecture: x64
+
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        vmrBranch: ${{ variables.VmrBranch }}
+        sign: ${{ variables.signEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x86
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -806,16 +805,6 @@ stages:
             pool: ${{ parameters.pool_Windows }}
             targetOS: windows
             targetArchitecture: arm64
-
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            buildName: Windows
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            sign: ${{ variables.signEnabled }}
-            pool: ${{ parameters.pool_Windows }}
-            targetOS: windows
-            targetArchitecture: x86
 
         - template: ../jobs/vmr-build.yml
           parameters:

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -23,6 +23,15 @@ variables:
 - name: defaultContainerOptions
   value: --privileged
 
+- name: isOfficialBuild
+  value: ${{ and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}
+
+- name: officialBuildParameter
+  ${{ if eq(variables['isOfficialBuild'], true) }}:
+    value: /p:OfficialBuildId=$(Build.BuildNumber)
+  ${{ else }}:
+    value: ''
+
 - ${{ if eq(parameters.desiredSigning, 'Signed') }}:
   - name: signEnabled
     value: true

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -176,8 +176,6 @@
     <PrebuiltSourceBuiltPackagesPath>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'previously-source-built'))</PrebuiltSourceBuiltPackagesPath>
     <PrebuiltSourceBuiltPackagesPath Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(CustomPrebuiltSourceBuiltPackagesPath)'))</PrebuiltSourceBuiltPackagesPath>
 
-    <GitInfoDir>$([MSBuild]::NormalizeDirectory('$(PrereqsDir)', 'git-info'))</GitInfoDir>
-
     <PackageReportDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'prebuilt-report'))</PackageReportDir>
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
     <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -37,8 +37,6 @@ usage()
 
   echo "Non-source-only settings:"
   echo "  --build-repo-tests              Build repository tests"
-  echo "  --dev                           Use -dev or -ci versioning instead of .NET official build versions"
-
 
   echo "Advanced settings:"
   echo "  --ci                            Set when running on CI server"
@@ -89,7 +87,6 @@ packagesPreviouslySourceBuiltDir="${packagesDir}previously-source-built/"
 ci=false
 exclude_ci_binary_log=false
 prepare_machine=false
-use_dev_versioning=false
 target_rid=
 system_libs=
 
@@ -196,9 +193,6 @@ while [[ $# > 0 ]]; do
     -use-mono-runtime)
       properties+=( "/p:DotNetBuildUseMonoRuntime=true" )
       ;;
-    -dev)
-      use_dev_versioning=true
-      ;;
     *)
       properties+=( "$1" )
       ;;
@@ -211,10 +205,6 @@ if [[ "$ci" == true ]]; then
   if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi
-fi
-
-if [[ "$use_dev_versioning" == true && "$sourceOnly" != true ]]; then
-  properties+=( "/p:UseOfficialBuildVersioning=false" )
 fi
 
 # Never use the global nuget cache folder

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -17,7 +17,6 @@ Param(
   [switch][Alias('cwb')]$cleanWhileBuilding,
   [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch] $prepareMachine,
-  [switch] $dev,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -41,7 +40,6 @@ function Get-Usage() {
   Write-Host "  -cleanWhileBuilding     Cleans each repo after building (reduces disk space usage, short: -cwb)"
   Write-Host "  -excludeCIBinarylog     Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
-  Write-Host "  -dev                    Use -dev or -ci versioning instead of .NET official build versions"
   Write-Host ""
 }
 
@@ -76,10 +74,6 @@ if ($buildRepoTests) {
 
 if ($cleanWhileBuilding) {
   $arguments += "/p:CleanWhileBuilding=true"
-}
-
-if ($dev) {
-  $arguments += "/p:UseOfficialBuildVersioning=false"
 }
 
 function Build {

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -68,7 +68,7 @@
   <!-- Add 100 to the revision number for non-source-only builds to avoid clashing with the existing msft official builds.
        Source-only builds don't update the revision as the assets don't get published to the same locations as the msft build and
        still use the OfficialBuildId from repositories, not the pipeline. -->
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+  <PropertyGroup Condition="'$(OfficialBuildId)' != '' and '$(DotNetBuildSourceOnly)' != 'true'">
     <OfficialBuildId>$(OfficialBuildId.Split('.')[0]).$([MSBuild]::Add($(OfficialBuildId.Split('.')[1]), 100))</OfficialBuildId>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -1,10 +1,11 @@
-<Project>
+<Project TreatAsLocalProperty="OfficialBuildId">
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <RepositoryName>$(MSBuildProjectName)</RepositoryName>
-    <GitInfoRepoPropsFile>$(GitInfoDir)$(RepositoryName).props</GitInfoRepoPropsFile>
+
+    <GitInfoRepoPropsFile>$([MSBuild]::NormalizePath('$(PrereqsDir)', 'git-info', '$(RepositoryName).props'))</GitInfoRepoPropsFile>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <RunEachTargetSeparately>false</RunEachTargetSeparately>
     <!-- If this is a dev build with parallelism enabled, ensure that RunEachTargetSeparately is true so that StopOnFirstFailure will be honored.
@@ -13,7 +14,9 @@
     <RunEachTargetSeparately Condition="'$(BuildInParallel)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">true</RunEachTargetSeparately>
   </PropertyGroup>
 
-  <Import Project="$(GitInfoRepoPropsFile)" Condition="Exists('$(GitInfoRepoPropsFile)') and '$(UseOfficialBuildVersioning)' != 'false'" />
+    <!-- TODO: Remove this import when the default build behavior for source-only builds changes to dev.
+         https://github.com/dotnet/source-build/issues/4855 -->
+  <Import Project="$(GitInfoRepoPropsFile)" Condition="Exists('$(GitInfoRepoPropsFile)') and '$(DotNetBuildSourceOnly)' == 'true'" />
 
   <PropertyGroup>
     <!-- Fake, to satisfy the SDK. -->
@@ -62,6 +65,13 @@
     <ArcadeFalseBoolBuildArg>false</ArcadeFalseBoolBuildArg>
   </PropertyGroup>
 
+  <!-- Add 100 to the revision number for non-source-only builds to avoid clashing with the existing msft official builds.
+       Source-only builds don't update the revision as the assets don't get published to the same locations as the msft build and
+       still use the OfficialBuildId from repositories, not the pipeline. -->
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <OfficialBuildId>$(OfficialBuildId.Split('.')[0]).$([MSBuild]::Add($(OfficialBuildId.Split('.')[1]), 100))</OfficialBuildId>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- By default, use the eng/common/build.cmd/sh script -->
     <BuildScript>$([MSBuild]::NormalizePath('$(ProjectDirectory)', 'eng', 'common', 'build$(ShellExtension)'))</BuildScript>
@@ -72,7 +82,8 @@
     <BuildActions>$(BuildActions) $(FlagParameterPrefix)publish</BuildActions>
     <BuildActions Condition="'$(Sign)' == 'true'">$(BuildActions) $(FlagParameterPrefix)sign</BuildActions>
 
-    <!-- TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior changes to dev -->
+    <!-- TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior for source-only builds changes to dev.
+         https://github.com/dotnet/source-build/issues/4855 -->
     <BuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(FlagParameterPrefix)ci</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)configuration $(Configuration)</BuildArgs>
     <BuildArgs>$(BuildArgs) -bl</BuildArgs>
@@ -87,19 +98,18 @@
     <!-- Pass through DotNetBuildPass for join point vertical support. -->
     <BuildArgs Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">$(BuildArgs) /p:DotNetBuildPass=$(DotNetBuildPass)</BuildArgs>
 
+    <!-- Only pass these properites through when necessary to reduce command line noise. -->
     <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=true</BuildArgs>
-    <!-- Only pass when enabled to reduce command line noise. -->
     <BuildArgs Condition="'$(DotNetBuildTests)' == 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
     <BuildArgs Condition="'$(NuGetConfigFile)' != ''">$(BuildArgs) /p:RestoreConfigFile=$(NuGetConfigFile)</BuildArgs>
-    <!-- TODO rename this property https://github.com/dotnet/source-build/issues/4165 -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(BuildArgs) /p:DotNetBuildUseMonoRuntime=$(DotNetBuildUseMonoRuntime)</BuildArgs>
+    <BuildArgs Condition="'$(OfficialBuildId)' != ''">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
+    <BuildArgs Condition="'$(ForceDryRunSigning)' != ''">$(BuildArgs) /p:ForceDryRunSigning=$(ForceDryRunSigning)</BuildArgs>
+
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
-    <BuildArgs Condition="'$(OfficialBuildId)' != '' and '$(DotNetBuildSourceOnly)' == 'true'">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</BuildArgs>
-    <!-- Add 100 to patch version for Unified Build -->
-    <BuildArgs Condition="'$(OfficialBuildId)' != '' and '$(DotNetBuildSourceOnly)' != 'true'">$(BuildArgs) /p:OfficialBuildId=$(OfficialBuildId.Split('.')[0]).$([MSBuild]::Add($(OfficialBuildId.Split('.')[1]), 100))</BuildArgs>
-    <BuildArgs Condition="'$(ForceDryRunSigning)' != ''">$(BuildArgs) /p:ForceDryRunSigning=$(ForceDryRunSigning)</BuildArgs>
+
     <!-- PGO assets by default are "Vertical" visibilty. Each repo will enable the specific artifacts it must publish externally -->
     <BuildArgs Condition="'$(PgoInstrument)' == 'true'">$(BuildArgs) /p:DefaultArtifactVisibility=Vertical</BuildArgs>
   </PropertyGroup>
@@ -115,7 +125,9 @@
     <TestActions>$(FlagParameterPrefix)restore</TestActions>
     <TestActions>$(TestActions) $(FlagParameterPrefix)test</TestActions>
 
-    <TestArgs Condition="'$(UseOfficialBuildVersioning)' != 'false'">$(FlagParameterPrefix)ci</TestArgs>
+    <!-- TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior for source-only builds changes to dev.
+         https://github.com/dotnet/source-build/issues/4855 -->
+    <TestArgs Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(FlagParameterPrefix)ci</TestArgs>
     <TestArgs>$(TestArgs) $(FlagParameterPrefix)configuration $(Configuration)</TestArgs>
     <TestArgs>$(TestArgs) /bl:artifacts/log/$(Configuration)/Test.binlog</TestArgs>
   </PropertyGroup>
@@ -143,8 +155,9 @@
     <EnvironmentVariables Include="_InitializeToolset=$(SourceBuiltSdksDir)Microsoft.DotNet.Arcade.Sdk/tools/Build.proj"
                           Condition="'$(UseBootstrapArcade)' != 'true'" />
 
-    <!-- We pass '-ci', but also apply ci mode via env var for edge cases. (E.g. misbehaving inner builds.) -->
-    <!-- TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior changes to dev -->
+    <!-- We pass '-ci', but also apply ci mode via env var for edge cases. (E.g. misbehaving inner builds.).
+         TODO: Remove the DotNetBuildSourceOnly condition when the default build behavior for source-only builds changes to dev.
+         https://github.com/dotnet/source-build/issues/4855 -->
     <EnvironmentVariables Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'" Include="ContinuousIntegrationBuild=true" />
 
     <!-- Turn off node reuse for source build because repos use conflicting versions

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -1,3 +1,4 @@
+<!-- Use TreatAsLocalProperty to make the globally passed-in OfficialBuildId property mutable. -->
 <Project TreatAsLocalProperty="OfficialBuildId">
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -13,7 +13,7 @@
     <BuildScript>$(ProjectDirectory)build$(ShellExtension)</BuildScript>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BuildOS)' == 'windows' and '$(UseOfficialBuildVersioning)' != 'false'">
+  <PropertyGroup Condition="'$(BuildOS)' == 'windows' and '$(OfficialBuildId)' != ''">
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)officialBuildId $(OfficialBuildId)</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)officialSkipTests true</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)officialSkipApplyOptimizationData true</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -31,7 +31,7 @@
 
     <BuildArgs Condition="'$(TargetRid)' == 'linux-x64' or '$(TargetRid)' == 'linux-arm64' ">$(BuildArgs) /p:BuildSdkDeb=true /p:BuildSdkRpm=true</BuildArgs>
     <!-- https://github.com/dotnet/source-build/issues/4693 -->
-    <BuildArgs Condition="'$(TargetOS)' == 'windows' and '$(UseOfficialBuildVersioning)' != 'true'">$(BuildArgs) /p:SkipBuildingInstallers=true /p:SkipBuildingSdkBundle=true</BuildArgs>
+    <BuildArgs Condition="'$(TargetOS)' == 'windows'">$(BuildArgs) /p:SkipBuildingInstallers=true /p:SkipBuildingSdkBundle=true</BuildArgs>
 
     <BuildArgs>$(BuildArgs) /p:PublicBaseURL=file:%2F%2F$(ArtifactsAssetsDir)</BuildArgs>
     <!-- In non-source-only scenarios, currently consume aspnetcore from the normal public base url -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4613

Validation builds:
- dotnet-unified-build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2631403&view=results
- dotnet-source-build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2631407&view=results