### PR TITLE
[ApiDiff] Allow passing diagnostic options to all Compat places that use CSharpCompilationOptions

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpFileBuilder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.GenAPI
         {
             _textWriter = textWriter;
             _header = header;
-            _docGenerator = new CSharpAssemblyDocumentGenerator(log, loader, symbolFilter, attributeDataSymbolFilter, exceptionMessage, includeAssemblyAttributes, metadataReferences, addPartialModifier);
+            _docGenerator = new CSharpAssemblyDocumentGenerator(log, loader, symbolFilter, attributeDataSymbolFilter, exceptionMessage, includeAssemblyAttributes, metadataReferences, addPartialModifier: addPartialModifier);
         }
 
         /// <inheritdoc />

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.GenAPI
                 log,
                 assembliesPaths,
                 assemblyReferencesPaths,
-                respectInternals);
+                respectInternals: respectInternals);
 
             Run(log,
                 loader,

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoader.cs
@@ -57,17 +57,19 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         /// <param name="log">The logger instance to use for message logging.</param>
         /// <param name="assembliesPaths">A collection of paths where the assembly DLLs should be searched.</param>
         /// <param name="assemblyReferencesPaths">An optional collection of paths where the assembly references should be searched.</param>
+        /// <param name="diagnosticOptions">An optional list of diagnostic options to use when compiling the loaded assemblies.</param>
         /// <param name="respectInternals">Whether to include internal symbols or not.</param>
         /// <returns>A tuple containing an assembly symbol loader and its corresponding dictionary of assembly symbols.</returns>
-        public static (AssemblySymbolLoader, Dictionary<string, IAssemblySymbol>) CreateFromFiles(ILog log, string[] assembliesPaths, string[]? assemblyReferencesPaths, bool respectInternals = false)
+        public static (AssemblySymbolLoader, Dictionary<string, IAssemblySymbol>) CreateFromFiles(ILog log, string[] assembliesPaths, string[]? assemblyReferencesPaths, IEnumerable<KeyValuePair<string, ReportDiagnostic>>? diagnosticOptions = null, bool respectInternals = false)
         {
             if (assembliesPaths.Length == 0)
             {
-                return (new AssemblySymbolLoader(log, resolveAssemblyReferences: true, includeInternalSymbols: respectInternals), new Dictionary<string, IAssemblySymbol>());
+                return (new AssemblySymbolLoader(log, diagnosticOptions, resolveAssemblyReferences: true, includeInternalSymbols: respectInternals),
+                        new Dictionary<string, IAssemblySymbol>());
             }
 
             bool atLeastOneReferencePath = assemblyReferencesPaths?.Count() > 0;
-            AssemblySymbolLoader loader = new(log, resolveAssemblyReferences: atLeastOneReferencePath, respectInternals);
+            AssemblySymbolLoader loader = new(log, diagnosticOptions, resolveAssemblyReferences: atLeastOneReferencePath, includeInternalSymbols: respectInternals);
             if (atLeastOneReferencePath)
             {
                 loader.AddReferenceSearchPaths(assemblyReferencesPaths!);
@@ -97,14 +99,18 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         /// Creates a new instance of the <see cref="AssemblySymbolLoader"/> class.
         /// </summary>
         /// <param name="log">A logger instance for logging message.</param>
+        /// <param name="diagnosticOptions">An optional list of diagnostic options to use when compiling the loaded assemblies.</param>
         /// <param name="resolveAssemblyReferences">True to attempt to load references for loaded assemblies from the locations specified with <see cref="AddReferenceSearchPaths(string[])"/>. Default is false.</param>
         /// <param name="includeInternalSymbols">True to include all internal metadata for assemblies loaded. Default is false which only includes public and some internal metadata. <seealso cref="MetadataImportOptions"/></param>
-        public AssemblySymbolLoader(ILog log, bool resolveAssemblyReferences = false, bool includeInternalSymbols = false)
+        public AssemblySymbolLoader(ILog log, IEnumerable<KeyValuePair<string, ReportDiagnostic>>? diagnosticOptions = null, bool resolveAssemblyReferences = false, bool includeInternalSymbols = false)
         {
             _log = log;
             _loadedAssemblies = [];
-            CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable,
-                metadataImportOptions: includeInternalSymbols ? MetadataImportOptions.Internal : MetadataImportOptions.Public);
+            CSharpCompilationOptions compilationOptions = new(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable,
+                metadataImportOptions: includeInternalSymbols ? MetadataImportOptions.Internal : MetadataImportOptions.Public,
+                specificDiagnosticOptions: diagnosticOptions);
             _cSharpCompilation = CSharpCompilation.Create($"AssemblyLoader_{DateTime.Now:MM_dd_yy_HH_mm_ss_FFF}", options: compilationOptions);
             _resolveReferences = resolveAssemblyReferences;
         }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/AssemblySymbolLoaderFactory.cs
@@ -14,6 +14,6 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
     {
         /// <inheritdoc />
         public IAssemblySymbolLoader Create(bool shouldResolveReferences) =>
-            new AssemblySymbolLoader(log, shouldResolveReferences, includeInternalSymbols);
+            new AssemblySymbolLoader(log, resolveAssemblyReferences: shouldResolveReferences, includeInternalSymbols: includeInternalSymbols);
     }
 }

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
@@ -31,12 +31,13 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         }
 
         public static Stream EmitAssemblyStreamFromSyntax(string syntax,
+            IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null,
             bool enableNullable = false,
             byte[] publicKey = null,
             [CallerMemberName] string assemblyName = "",
             bool allowUnsafe = false)
         {
-            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe);
+            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
 
             Assert.Empty(compilation.GetDiagnostics());
 
@@ -76,9 +77,9 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             return compilation.Assembly;
         }
 
-        private static CSharpCompilation CreateCSharpCompilationFromSyntax(string syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe)
+        private static CSharpCompilation CreateCSharpCompilationFromSyntax(string syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
         {
-            CSharpCompilation compilation = CreateCSharpCompilation(name, enableNullable, publicKey, allowUnsafe);
+            CSharpCompilation compilation = CreateCSharpCompilation(name, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
             return compilation.AddSyntaxTrees(GetSyntaxTree(syntax));
         }
 
@@ -94,7 +95,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             return CSharpSyntaxTree.ParseText(syntax, ParseOptions);
         }
 
-        private static CSharpCompilation CreateCSharpCompilation(string name, bool enableNullable, byte[] publicKey, bool allowUnsafe)
+        private static CSharpCompilation CreateCSharpCompilation(string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
         {
             bool publicSign = publicKey != null ? true : false;
             var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
@@ -102,7 +103,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
                                                                   cryptoPublicKey: publicSign ? publicKey.ToImmutableArray() : default,
                                                                   nullableContextOptions: enableNullable ? NullableContextOptions.Enable : NullableContextOptions.Disable,
                                                                   allowUnsafe: allowUnsafe,
-                                                                  specificDiagnosticOptions: DiagnosticOptions);
+                                                                  specificDiagnosticOptions: diagnosticOptions ?? DiagnosticOptions);
 
             return CSharpCompilation.Create(name, options: compilationOptions, references: DefaultReferences);
         }

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;
-using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 using Moq;
 
 namespace Microsoft.DotNet.GenAPI.Tests
@@ -40,7 +39,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
             Mock<ILog> log = new();
 
             (IAssemblySymbolLoader loader, Dictionary<string, IAssemblySymbol> assemblySymbols) = TestAssemblyLoaderFactory
-                .CreateFromTexts(log.Object, assemblyTexts: [(assemblyName, original)], respectInternals: includeInternalSymbols, allowUnsafe);
+                .CreateFromTexts(log.Object, assemblyTexts: [(assemblyName, original)], respectInternals: includeInternalSymbols, allowUnsafe: allowUnsafe);
 
             ISymbolFilter symbolFilter = SymbolFilterFactory.GetFilterFromList([], null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols);
             ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromList(excludedAttributeList, null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols);


### PR DESCRIPTION
Follow up of https://github.com/dotnet/sdk/pull/46380

This PR is part of the work needed to create an ApiDiff tool that reuses some of the code from Microsoft.DotNet.GenAPI. The idea is to make the larger PR smaller and make it easier to review: https://github.com/dotnet/sdk/pull/45389

The proposed changes in this PR include:

- Add a new argument to all the methods that create a CSharpCompilationOptions object so that the caller can specify an optional list of diagnostic options to change the behavior of their detection.
