### PR TITLE
Add ARM64 job flag

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -22,6 +22,10 @@ parameters:
   displayName: Run A Test Build
   type: boolean
   default: false
+- name: enableArm64Job
+  displayName: Enables the ARM64 job
+  type: boolean
+  default: false
 
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml
@@ -292,7 +296,7 @@ extends:
               officialBuildProperties: $(_officialBuildProperties)
               runTests: false
       ### ARM64 TESTBUILD ###
-      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if and(or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')), eq(parameters.enableArm64Job, true)) }}:
         - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
           parameters:
             pool:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -9,6 +9,12 @@ pr:
     - release/*
     - internal/release/*
 
+parameters:
+- name: enableArm64Job
+  displayName: Enables the ARM64 job
+  type: boolean
+  default: false
+
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml
 # Variables used: DncEngPublicBuildPool
@@ -59,17 +65,18 @@ stages:
         os: macOS
       helixTargetQueue: osx.13.amd64.open
   ### ARM64 ###
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
-    parameters:
-      pool:
-        name: Azure Pipelines
-        vmImage: macOS-latest
-        os: macOS
-      helixTargetQueue: osx.13.arm64.open
-      macOSJobParameterSets:
-      - categoryName: TestBuild
-        buildArchitecture: arm64
-        runtimeIdentifier: osx-arm64
+  - ${{ if eq(parameters.enableArm64Job, true) }}:
+    - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
+      parameters:
+        pool:
+          name: Azure Pipelines
+          vmImage: macOS-latest
+          os: macOS
+        helixTargetQueue: osx.13.arm64.open
+        macOSJobParameterSets:
+        - categoryName: TestBuild
+          buildArchitecture: arm64
+          runtimeIdentifier: osx-arm64
 
   ############### SOURCE BUILD ###############
   - template: /eng/common/templates/job/source-build.yml


### PR DESCRIPTION
Related: https://teams.microsoft.com/l/message/19:2db9948434504972b9bc70d3b3ad71e2@thread.skype/1733772847082?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4ba7372f-2799-4677-89f0-7a1aaea3706c&parentMessageId=1733772847082&teamName=.NET%20Developer%20Experience&channelName=CLI&createdTime=1733772847082

## Summary

The ARM64 job has been consistently failing. While this is being investigated, I've added a flag that enables/disables this job. By default, it is set to `false`. While this problem is being investigated, anyone doing investigations can either run the branch manually and check the checkbox to enable the job, or in their branch, set the default for this parameter to `true`.

I will backport these to other branches as those branches become no longer in lockdown.