### PR TITLE
Set and/or respect NUGET_PACKAGES env var correctly in VMR builds

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -82,6 +82,11 @@
        Keep in sync with props/targets in the Arcade.Sdk. -->
   <PropertyGroup Condition="'$(SkipArcadeSdkImport)' == 'true'">
     <!-- RepoLayout.props -->
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' != ''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(NUGET_PACKAGES)' != ''">$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)'))</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' == 'Windows_NT'">$([MSBuild]::NormalizeDirectory('$(UserProfile)', '.nuget', 'packages'))</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' != 'Windows_NT'">$([MSBuild]::NormalizeDirectory('$(HOME)', '.nuget', 'packages'))</NuGetPackageRoot>
+
     <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))'))</RepoRoot>
 
     <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -76,13 +76,6 @@
     <TargetRid Condition="'$(ShortStack)' == 'true' and '$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</TargetRid>
   </PropertyGroup>
 
-  <!-- Set NuGetPackageRoot before Arcade SDK sets it. -->
-  <PropertyGroup>
-    <!-- Set RestorePackagesPath so that we don't accidentally pull some packages from the global location. -->
-    <RestorePackagesPath Condition="'$(RestorePackagesPath)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '.packages'))</RestorePackagesPath>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(RestorePackagesPath)</NuGetPackageRoot>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
 
   <!-- Init basic Arcade props, if the project importing this file doesn't use Arcade.

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -294,13 +294,6 @@ if [[ "$sourceOnly" == "true" ]]; then
   export NUGET_PACKAGES="$scriptroot/.packages/"
   export RESTORENOHTTPCACHE=true
 
-  if [[ "$test" == true ]]; then
-    # Use a custom package cache for tests to make prebuilt detection work.
-    export NUGET_PACKAGES="${NUGET_PACKAGES}tests/"
-  fi
-
-  echo "NuGet packages cache: '${NUGET_PACKAGES}'."
-
   # For build purposes, we need to make sure we have all the SourceLink information
   if [ "$test" != "true" ]; then
     GIT_DIR="$scriptroot/.git"

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -254,6 +254,8 @@ function Build {
       fi
     fi
 
+    echo "$NUGET_PACKAGES"
+
     if [ "$ci" == "true" ]; then
       properties+=( "/p:ContinuousIntegrationBuild=true" )
     fi

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -214,7 +214,7 @@ targets="/t:Build"
 if [[ "$test" == true ]]; then
   project="$scriptroot/test/tests.proj"
   targets="$targets;VSTest"
-  properties+=( "/p:_IsTesting=true" )
+  properties+=( "/p:Test=true" )
 
   # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
   export MSBUILDENSURESTDOUTFORTASKPROCESSES=1

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -244,17 +244,15 @@ function Build {
       properties+=( "/p:ContinuousIntegrationBuild=true" )
     fi
 
-    if [ "$test" != "true" ]; then
-      initSourceOnlyBinaryLog=""
-      if [[ "$binary_log" == true ]]; then
-        initSourceOnlyBinaryLog="/bl:\"$log_dir/init-source-only.binlog\""
-      fi
-
-      "$CLI_ROOT/dotnet" build-server shutdown --msbuild
-      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/init-source-only.proj" $initSourceOnlyBinaryLog "${properties[@]}"
-      # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
-      "$CLI_ROOT/dotnet" build-server shutdown --msbuild
+    initSourceOnlyBinaryLog=""
+    if [[ "$binary_log" == true ]]; then
+      initSourceOnlyBinaryLog="/bl:\"$log_dir/init-source-only.binlog\""
     fi
+
+    "$CLI_ROOT/dotnet" build-server shutdown --msbuild
+    "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/init-source-only.proj" $initSourceOnlyBinaryLog "${properties[@]}"
+    # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
+    "$CLI_ROOT/dotnet" build-server shutdown --msbuild
 
     # Point MSBuild to the custom SDK resolvers folder, so it will pick up our custom SDK Resolver
     export MSBUILDADDITIONALSDKRESOLVERSFOLDER="$scriptroot/artifacts/toolset/VSSdkResolvers/"

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -294,6 +294,13 @@ if [[ "$sourceOnly" == "true" ]]; then
   export NUGET_PACKAGES="$scriptroot/.packages/"
   export RESTORENOHTTPCACHE=true
 
+  if [[ "$test" == true ]]; then
+    # Use a custom package cache for tests to make prebuilt detection work.
+    export NUGET_PACKAGES="${NUGET_PACKAGES}tests/"
+  fi
+
+  echo "NuGet packages cache: '${NUGET_PACKAGES}'"
+
   # For build purposes, we need to make sure we have all the SourceLink information
   if [ "$test" != "true" ]; then
     GIT_DIR="$scriptroot/.git"

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -214,6 +214,8 @@ targets="/t:Build"
 if [[ "$test" == true ]]; then
   project="$scriptroot/test/tests.proj"
   targets="$targets;VSTest"
+  properties+=( "/p:_IsTesting=true" )
+
   # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
   export MSBUILDENSURESTDOUTFORTASKPROCESSES=1
   # Ensure all test projects share stdout (https://github.com/dotnet/source-build/issues/4635#issuecomment-2397464519)

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -43,8 +43,6 @@ function Get-Usage() {
   Write-Host ""
 }
 
-$useGlobalNuGetCache=$false
-
 . $PSScriptRoot\common\tools.ps1
 
 if ($help) {
@@ -78,10 +76,6 @@ if ($cleanWhileBuilding) {
 
 function Build {
   InitializeToolset
-
-  # Manually unset NUGET_PACKAGES as InitializeToolset sets it unconditionally.
-  # The env var shouldn't be set so that the RestorePackagesPath msbuild property is respected.
-  $env:NUGET_PACKAGES=''
 
   $bl = if ($binaryLog) { '/bl:' + (Join-Path $LogDir 'Build.binlog') } else { '' }
 

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -58,6 +58,8 @@ $targets = "/t:Build"
 if ($test) {
   $project = Join-Path (Join-Path $RepoRoot "test") "tests.proj"
   $targets += ";VSTest"
+  $arguments += "/p:_IsTesting=true"
+
   # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
   $env:MSBUILDENSURESTDOUTFORTASKPROCESSES="1"
 }

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -58,7 +58,7 @@ $targets = "/t:Build"
 if ($test) {
   $project = Join-Path (Join-Path $RepoRoot "test") "tests.proj"
   $targets += ";VSTest"
-  $arguments += "/p:_IsTesting=true"
+  $arguments += "/p:Test=true"
 
   # Workaround for vstest hangs (https://github.com/microsoft/vstest/issues/5091) [TODO]
   $env:MSBUILDENSURESTDOUTFORTASKPROCESSES="1"

--- a/src/SourceBuild/content/eng/tools/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(ReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(_IsTesting)' != 'true'">$(ReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
   </PropertyGroup>
 
 </Project>

--- a/src/SourceBuild/content/eng/tools/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/Directory.Build.props
@@ -2,8 +2,10 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
+  <!-- Don't use these feeds when testing. Projects under this directory are referenced by
+       test projects. This makes sure that the feeds aren't used. -->
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(_IsTesting)' != 'true'">$(ReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(ReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
   </PropertyGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -180,11 +180,9 @@
     <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
 
     <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
-         or the user package cache (local dev builds).
-         Don't set NUGET_PACKAGES when building source-only as NUGET_PACKAGES is already explicitly set in the build invocation
-         when running tests, in order for pre-built detection to work. -->
+         or the user package cache (local dev builds). -->
     <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
-    <TestEnvironmentVariable Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <TestEnvironmentVariable Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -45,6 +45,9 @@
     <RepoAssetManifestsDir>$([MSBuild]::NormalizeDirectory('$(AssetManifestsIntermediateDir)', '$(RepositoryName)'))</RepoAssetManifestsDir>
     <IntermediateSymbolsRepoDir>$([MSBuild]::NormalizeDirectory('$(IntermediateSymbolsRootDir)', '$(RepositoryName)'))</IntermediateSymbolsRepoDir>
 
+    <RepoArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts'))</RepoArtifactsDir>
+    <RepoArtifactsPackageCache>$([MSBuild]::NormalizeDirectory('$(RepoArtifactsDir)', 'sb', 'package-cache'))</RepoArtifactsPackageCache>
+
     <SourceBuiltSdksDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-built-sdks'))</SourceBuiltSdksDir>
 
     <SbrpCacheNuGetSourceName>source-build-reference-package-cache</SbrpCacheNuGetSourceName>
@@ -199,6 +202,10 @@
 
     <!--ASP.NET dev server request logs -->
     <EnvironmentVariables Include="RAZORBUILDSERVER_LOG=$(AspNetRazorBuildServerLogFile)" />
+
+    <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
+         or the user package cache (local dev builds). -->
+    <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
   </ItemGroup>
 
   <!-- If we're using the bootstrapped arcade, we can set the override here. -->

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -180,9 +180,11 @@
     <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
 
     <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
-         or the user package cache (local dev builds). -->
+         or the user package cache (local dev builds).
+         Don't set NUGET_PACKAGES when building source-only as NUGET_PACKAGES is already explicitly set in the build invocation
+         when running tests, in order for pre-built detection to work. -->
     <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
-    <TestEnvironmentVariable Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
+    <TestEnvironmentVariable Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -178,6 +178,11 @@
 
     <!-- Needed for miscellanous projects in various repos - see https://github.com/dotnet/source-build/issues/4081-->
     <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
+
+    <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
+         or the user package cache (local dev builds). -->
+    <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
+    <TestEnvironmentVariable Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">
@@ -202,10 +207,6 @@
 
     <!--ASP.NET dev server request logs -->
     <EnvironmentVariables Include="RAZORBUILDSERVER_LOG=$(AspNetRazorBuildServerLogFile)" />
-
-    <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
-         or the user package cache (local dev builds). -->
-    <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
   </ItemGroup>
 
   <!-- If we're using the bootstrapped arcade, we can set the override here. -->

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -20,9 +20,6 @@
     <RepoArtifactsNonShippingPackagesDir Condition="'$(ReferenceOnlyRepoArtifacts)' != 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsNonShippingPackagesDir)', '$(RepositoryName)'))</RepoArtifactsNonShippingPackagesDir>
     <RepoArtifactsNonShippingPackagesDir Condition="'$(ReferenceOnlyRepoArtifacts)' == 'true'">$(ReferencePackagesDir)</RepoArtifactsNonShippingPackagesDir>
 
-    <RepoArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts'))</RepoArtifactsDir>
-    <RepoArtifactsPackageCache>$([MSBuild]::NormalizeDirectory('$(RepoArtifactsDir)', 'sb', 'package-cache'))</RepoArtifactsPackageCache>
-
     <!-- Pass location for packages -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltShippingPackagesDir=$(RepoArtifactsShippingPackagesDir)</BuildArgs>
     <!-- Trim the trailing slash as it breaks argument parsing on Windows if this is the last argument. -->

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <RepositoryReference Include="sdk" />
-    <RepositoryReference Include="scenario-tests" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildPass)' == '2'">

--- a/src/SourceBuild/content/test/Directory.Build.props
+++ b/src/SourceBuild/content/test/Directory.Build.props
@@ -1,10 +1,5 @@
 <Project>
 
-  <!-- When building source-only, use a custom package cache for tests to make prebuilt detection work. -->
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RestorePackagesPath>$([MSBuild]::NormalizeDirectory('$(RestorePackagesPath)', 'tests'))</RestorePackagesPath>
-  </PropertyGroup>
-
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
-    <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NuGet.ProjectModel" />
-    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" IncludeAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" IncludeAssets="all" />
+    <PackageReference Include="NuGet.ProjectModel" IncludeAssets="all" />
+    <PackageReference Include="NuGet.Protocol" IncludeAssets="all" />
 
     <ProjectReference Include="$(RepositoryEngineeringDir)tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
   </ItemGroup>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" IncludeAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" IncludeAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" IncludeAssets="all" />
-    <PackageReference Include="NuGet.ProjectModel" IncludeAssets="all" />
-    <PackageReference Include="NuGet.Protocol" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="Newtonsoft.Json" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="NuGet.ProjectModel" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="NuGet.Protocol" IncludeAssets="all" ExcludeAssets="none" />
 
     <ProjectReference Include="$(RepositoryEngineeringDir)tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
   </ItemGroup>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/Microsoft.DotNet.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" IncludeAssets="all" ExcludeAssets="none" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="all" ExcludeAssets="none" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" IncludeAssets="all" ExcludeAssets="none" />
-    <PackageReference Include="Newtonsoft.Json" IncludeAssets="all" ExcludeAssets="none" />
-    <PackageReference Include="NuGet.ProjectModel" IncludeAssets="all" ExcludeAssets="none" />
-    <PackageReference Include="NuGet.Protocol" IncludeAssets="all" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.ProjectModel" />
+    <PackageReference Include="NuGet.Protocol" />
 
     <ProjectReference Include="$(RepositoryEngineeringDir)tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4865
Fixes https://github.com/dotnet/source-build/issues/4598

Only the inner-build gets the package cache set [by ArPow source-build targets](https://github.com/dotnet/arcade/blob/bbea86c614fcf4380c58c80eacd279a0b8305a79/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets#L81) but not the outer-build. This results in the global package cache getting polluted with -dev packages when doing a dev local build.

- Correctly set NUGET_PACKAGES for the outer- and inner-build.
- Correctly set NUGET_PACKAGES in the VMR orchestrator by using the eng/common defaults

Validation builds:
- dotnet-unified-build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2633988&view=results
- dotnet-source-build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2633985&view=results