### PR TITLE
Use dotnet run in case of --arch in dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -69,18 +69,18 @@ namespace Microsoft.DotNet.Cli
                 return ExitCodes.GenericFailure;
             }
 
-            (IEnumerable<Module> modules, bool restored) = GetProjectsProperties(projectOrSolutionFilePath, isSolution, buildOptions);
+            (IEnumerable<Module> projects, bool restored) = GetProjectsProperties(projectOrSolutionFilePath, isSolution, buildOptions);
 
-            InitializeTestApplications(modules);
+            InitializeTestApplications(projects);
 
             return restored ? ExitCodes.Success : ExitCodes.GenericFailure;
         }
 
         private int RunBuild(string filePath, bool isSolution, BuildOptions buildOptions)
         {
-            (IEnumerable<Module> modules, bool restored) = GetProjectsProperties(filePath, isSolution, buildOptions);
+            (IEnumerable<Module> projects, bool restored) = GetProjectsProperties(filePath, isSolution, buildOptions);
 
-            InitializeTestApplications(modules);
+            InitializeTestApplications(projects);
 
             return restored ? ExitCodes.Success : ExitCodes.GenericFailure;
         }
@@ -121,15 +121,15 @@ namespace Microsoft.DotNet.Cli
             return true;
         }
 
-        private (IEnumerable<Module>, bool Restored) GetProjectsProperties(string solutionOrProjectFilePath, bool isSolution, BuildOptions buildOptions)
+        private (IEnumerable<Module> Projects, bool Restored) GetProjectsProperties(string solutionOrProjectFilePath, bool isSolution, BuildOptions buildOptions)
         {
-            (IEnumerable<Module> allProjects, bool isBuiltOrRestored) = isSolution ?
+            (IEnumerable<Module> projects, bool isBuiltOrRestored) = isSolution ?
                 MSBuildUtility.GetProjectsFromSolution(solutionOrProjectFilePath, buildOptions) :
                 MSBuildUtility.GetProjectsFromProject(solutionOrProjectFilePath, buildOptions);
 
-            LogProjectProperties(allProjects);
+            LogProjectProperties(projects);
 
-            return (allProjects, isBuiltOrRestored);
+            return (projects, isBuiltOrRestored);
         }
 
         private void LogProjectProperties(IEnumerable<Module> modules)

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli
     {
         private readonly List<string> _args;
         private readonly TestApplicationActionQueue _actionQueue;
-        private TerminalTestReporter _output;
+        private readonly TerminalTestReporter _output;
 
         private readonly ConcurrentBag<TestApplication> _testApplications = new();
         private bool _areTestingPlatformApplications = true;

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.DotNet.Tools.Common;
-using Microsoft.Testing.TestInfrastructure;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
 
 namespace Microsoft.DotNet.Cli
@@ -175,7 +174,6 @@ namespace Microsoft.DotNet.Cli
 
         private static Dictionary<string, string> GetGlobalProperties(BuildOptions buildOptions)
         {
-            DebuggerUtility.AttachCurrentProcessToVSProcessPID(24736);
             var globalProperties = new Dictionary<string, string>();
 
             if (!string.IsNullOrEmpty(buildOptions.Configuration))

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Cli
             return solutionFullPath;
         }
 
-        internal static bool IsBinaryLoggerEnabled(List<string> args, out string binLogFileName)
+        internal static bool IsBinaryLoggerEnabled(ref List<string> args, out string binLogFileName)
         {
             binLogFileName = string.Empty;
             var binLogArgs = new List<string>();

--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli
 {
-    internal record TestOptions(bool HasListTests, string Configuration, string Architecture);
+    internal record TestOptions(bool HasListTests, string Configuration, string Architecture, bool HasFilterMode, bool IsHelp);
 
     internal record BuildOptions(string ProjectPath, string SolutionPath, string DirectoryPath, bool HasNoRestore, bool HasNoBuild, string Configuration, string RuntimeIdentifier, bool AllowBinLog, string BinLogFileName, int DegreeOfParallelism);
 }

--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli
 {
-    internal record BuildConfigurationOptions(bool HasListTests, string Configuration, string Architecture);
+    internal record TestOptions(bool HasListTests, string Configuration, string Architecture);
 
     internal record BuildOptions(string ProjectPath, string SolutionPath, string DirectoryPath, bool HasNoRestore, bool HasNoBuild, string Configuration, string RuntimeIdentifier, bool AllowBinLog, string BinLogFileName, int DegreeOfParallelism);
 }

--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -5,5 +5,5 @@ namespace Microsoft.DotNet.Cli
 {
     internal record TestOptions(bool HasListTests, string Configuration, string Architecture, bool HasFilterMode, bool IsHelp);
 
-    internal record BuildOptions(string ProjectPath, string SolutionPath, string DirectoryPath, bool HasNoRestore, bool HasNoBuild, string Configuration, string RuntimeIdentifier, bool AllowBinLog, string BinLogFileName, int DegreeOfParallelism);
+    internal record BuildOptions(string ProjectPath, string SolutionPath, string DirectoryPath, bool HasNoRestore, bool HasNoBuild, string Configuration, string RuntimeIdentifier, bool AllowBinLog, string BinLogFileName, int DegreeOfParallelism, List<string> UnmatchedTokens);
 }

--- a/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
@@ -100,9 +100,9 @@ namespace Microsoft.DotNet.Cli
             return string.IsNullOrEmpty(fileDirectory) ? Directory.GetCurrentDirectory() : fileDirectory;
         }
 
-        public static IEnumerable<Module> GetProjectProperties(string projectFilePath, ProjectCollection projectCollection)
+        public static IEnumerable<Module> GetProjectProperties(string projectFilePath, IDictionary<string, string> globalProperties, ProjectCollection projectCollection)
         {
-            var project = projectCollection.LoadProject(projectFilePath);
+            var project = projectCollection.LoadProject(projectFilePath, globalProperties, null);
             return GetModulesFromProject(project);
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -46,15 +46,15 @@ namespace Microsoft.DotNet.Cli
             _ = _executionIds.GetOrAdd(executionId, _ => string.Empty);
         }
 
-        public async Task<int> RunAsync(bool hasFilterMode, bool enableHelp, TestOptions testOptions)
+        public async Task<int> RunAsync(TestOptions testOptions)
         {
-            if (hasFilterMode && !ModulePathExists())
+            if (testOptions.HasFilterMode && !ModulePathExists())
             {
                 return 1;
             }
 
             bool isDll = _module.TargetPath.HasExtension(CliConstants.DLLExtension);
-            var processStartInfo = CreateProcessStartInfo(hasFilterMode, isDll, testOptions, enableHelp);
+            var processStartInfo = CreateProcessStartInfo(isDll, testOptions);
 
             _testAppPipeConnectionLoop = Task.Run(async () => await WaitConnectionAsync(_cancellationToken.Token), _cancellationToken.Token);
             var testProcessResult = await StartProcess(processStartInfo);
@@ -64,12 +64,12 @@ namespace Microsoft.DotNet.Cli
             return testProcessResult;
         }
 
-        private ProcessStartInfo CreateProcessStartInfo(bool hasFilterMode, bool isDll, TestOptions testOptions, bool enableHelp)
+        private ProcessStartInfo CreateProcessStartInfo(bool isDll, TestOptions testOptions)
         {
             var processStartInfo = new ProcessStartInfo
             {
-                FileName = GetFileName(hasFilterMode, isDll, testOptions),
-                Arguments = GetArguments(hasFilterMode, isDll, testOptions, enableHelp),
+                FileName = GetFileName(testOptions.HasFilterMode, isDll, testOptions),
+                Arguments = GetArguments(testOptions.HasFilterMode, isDll, testOptions, testOptions.IsHelp),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -68,8 +68,8 @@ namespace Microsoft.DotNet.Cli
         {
             var processStartInfo = new ProcessStartInfo
             {
-                FileName = GetFileName(isDll, testOptions),
-                Arguments = GetArguments(isDll, testOptions),
+                FileName = GetFileName(testOptions, isDll),
+                Arguments = GetArguments(testOptions, isDll),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli
             return processStartInfo;
         }
 
-        private string GetFileName(bool isDll, TestOptions testOptions)
+        private string GetFileName(TestOptions testOptions, bool isDll)
         {
             if (testOptions.HasFilterMode || !IsArchitectureSpecified(testOptions))
             {
@@ -89,11 +89,11 @@ namespace Microsoft.DotNet.Cli
             return Environment.ProcessPath;
         }
 
-        private string GetArguments(bool isDll, TestOptions testOptions)
+        private string GetArguments(TestOptions testOptions, bool isDll)
         {
             if (testOptions.HasFilterMode || !IsArchitectureSpecified(testOptions))
             {
-                return BuildArgs(isDll, testOptions);
+                return BuildArgs(testOptions, isDll);
             }
 
             return BuildArgsWithDotnetRun(testOptions);
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.Cli
             return true;
         }
 
-        private string BuildArgs(bool isDll, TestOptions testOptions)
+        private string BuildArgs(TestOptions testOptions, bool isDll)
         {
             StringBuilder builder = new();
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -13,13 +13,9 @@ namespace Microsoft.DotNet.Cli
     internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
     {
         private MSBuildHandler _msBuildHandler;
-        private TestModulesFilterHandler _testModulesFilterHandler;
         private TerminalTestReporter _output;
-        private bool _isHelp;
-        private int _degreeOfParallelism;
         private TestApplicationActionQueue _actionQueue;
-        private List<string> _args;
-        private ConcurrentDictionary<TestApplication, (string ModulePath, string TargetFramework, string Architecture, string ExecutionId)> _executions = new();
+        private readonly ConcurrentDictionary<TestApplication, (string ModulePath, string TargetFramework, string Architecture, string ExecutionId)> _executions = new();
         private byte _cancelled;
         private bool _isDiscovery;
         private TestApplicationsEventHandlers _eventHandlers;
@@ -34,49 +30,33 @@ namespace Microsoft.DotNet.Cli
             bool hasFailed = false;
             try
             {
-                SetupCancelKeyPressHandler();
+                PrepareEnvironment(parseResult, out TestOptions testOptions, out List<string> args, out int degreeOfParallelism);
 
-                _degreeOfParallelism = GetDegreeOfParallelism(parseResult);
-                TestOptions testOptions = GetTestOptions(parseResult);
+                InitializeOutput(degreeOfParallelism, testOptions.IsHelp);
 
-                _isDiscovery = parseResult.HasOption(TestingPlatformOptions.ListTestsOption);
-                _args = [.. parseResult.UnmatchedTokens];
-                _isHelp = ContainsHelpOption(parseResult.GetArguments());
+                InitializeActionQueue(degreeOfParallelism, testOptions, testOptions.IsHelp);
 
-                InitializeOutput(_degreeOfParallelism);
-
-                bool filterModeEnabled = parseResult.HasOption(TestingPlatformOptions.TestModulesFilterOption);
-                if (_isHelp)
-                {
-                    InitializeHelpActionQueue(_degreeOfParallelism, testOptions, filterModeEnabled);
-                }
-                else
-                {
-                    InitializeTestExecutionActionQueue(_degreeOfParallelism, testOptions, filterModeEnabled);
-                }
-
-                _msBuildHandler = new(_args, _actionQueue, _output);
-                _testModulesFilterHandler = new(_args, _actionQueue);
+                _msBuildHandler = new(args, _actionQueue, _output);
+                TestModulesFilterHandler testModulesFilterHandler = new(args, _actionQueue);
 
                 _eventHandlers = new TestApplicationsEventHandlers(_executions, _output);
 
-                if (filterModeEnabled)
+                if (testOptions.HasFilterMode)
                 {
-                    if (!_testModulesFilterHandler.RunWithTestModulesFilter(parseResult))
+                    if (!testModulesFilterHandler.RunWithTestModulesFilter(parseResult))
                     {
                         return ExitCodes.GenericFailure;
                     }
                 }
                 else
                 {
-                    if (!_msBuildHandler.RunMSBuild(GetBuildOptions(parseResult)))
+                    if (!_msBuildHandler.RunMSBuild(GetBuildOptions(parseResult, degreeOfParallelism)))
                     {
                         return ExitCodes.GenericFailure;
                     }
 
-                    if (!_msBuildHandler.EnqueueTestApplications())
+                    if (!EnqueueTestApplications())
                     {
-                        _output.WriteMessage(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
                         return ExitCodes.GenericFailure;
                     }
                 }
@@ -93,6 +73,44 @@ namespace Microsoft.DotNet.Cli
             return hasFailed ? ExitCodes.GenericFailure : ExitCodes.Success;
         }
 
+        private void PrepareEnvironment(ParseResult parseResult, out TestOptions testOptions, out List<string> args, out int degreeOfParallelism)
+        {
+            SetupCancelKeyPressHandler();
+
+            degreeOfParallelism = GetDegreeOfParallelism(parseResult);
+
+            bool filterModeEnabled = parseResult.HasOption(TestingPlatformOptions.TestModulesFilterOption);
+            bool isHelp = ContainsHelpOption(parseResult.GetArguments());
+
+            testOptions = GetTestOptions(parseResult, filterModeEnabled, isHelp);
+
+            args = [.. parseResult.UnmatchedTokens];
+            _isDiscovery = parseResult.HasOption(TestingPlatformOptions.ListTestsOption);
+        }
+
+        private void InitializeActionQueue(int degreeOfParallelism, TestOptions testOptions, bool isHelp)
+        {
+            if (isHelp)
+            {
+                InitializeHelpActionQueue(degreeOfParallelism, testOptions);
+            }
+            else
+            {
+                InitializeTestExecutionActionQueue(degreeOfParallelism, testOptions);
+            }
+        }
+
+        private bool EnqueueTestApplications()
+        {
+            if (!_msBuildHandler.EnqueueTestApplications())
+            {
+                _output.WriteMessage(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
+                return false;
+            }
+
+            return true;
+        }
+
         private void SetupCancelKeyPressHandler()
         {
             Console.CancelKeyPress += (s, e) =>
@@ -102,7 +120,7 @@ namespace Microsoft.DotNet.Cli
             };
         }
 
-        private void InitializeOutput(int degreeOfParallelism)
+        private void InitializeOutput(int degreeOfParallelism, bool isHelp)
         {
             var console = new SystemConsole();
             _output = new TerminalTestReporter(console, new TerminalTestReporterOptions()
@@ -114,13 +132,13 @@ namespace Microsoft.DotNet.Cli
                 ShowAssemblyStartAndComplete = true,
             });
 
-            if (!_isHelp)
+            if (!isHelp)
             {
-                _output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, _isDiscovery, _isHelp);
+                _output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, _isDiscovery, isHelp);
             }
         }
 
-        private void InitializeHelpActionQueue(int degreeOfParallelism, TestOptions buildConfigurationOptions, bool filterModeEnabled)
+        private void InitializeHelpActionQueue(int degreeOfParallelism, TestOptions testOptions)
         {
             _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
             {
@@ -129,11 +147,11 @@ namespace Microsoft.DotNet.Cli
                 testApp.TestProcessExited += _eventHandlers.OnTestProcessExited;
                 testApp.ExecutionIdReceived += _eventHandlers.OnExecutionIdReceived;
 
-                return await testApp.RunAsync(filterModeEnabled, enableHelp: true, buildConfigurationOptions);
+                return await testApp.RunAsync(testOptions);
             });
         }
 
-        private void InitializeTestExecutionActionQueue(int degreeOfParallelism, TestOptions buildConfigurationOptions, bool filterModeEnabled)
+        private void InitializeTestExecutionActionQueue(int degreeOfParallelism, TestOptions testOptions)
         {
             _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
             {
@@ -146,7 +164,7 @@ namespace Microsoft.DotNet.Cli
                 testApp.TestProcessExited += _eventHandlers.OnTestProcessExited;
                 testApp.ExecutionIdReceived += _eventHandlers.OnExecutionIdReceived;
 
-                return await testApp.RunAsync(filterModeEnabled, enableHelp: false, buildConfigurationOptions);
+                return await testApp.RunAsync(testOptions);
             });
         }
 
@@ -157,12 +175,14 @@ namespace Microsoft.DotNet.Cli
             return degreeOfParallelism;
         }
 
-        private static TestOptions GetTestOptions(ParseResult parseResult) =>
+        private static TestOptions GetTestOptions(ParseResult parseResult, bool hasFilterMode, bool isHelp) =>
             new(parseResult.HasOption(TestingPlatformOptions.ListTestsOption),
                 parseResult.GetValue(TestingPlatformOptions.ConfigurationOption),
-                parseResult.GetValue(TestingPlatformOptions.ArchitectureOption));
+                parseResult.GetValue(TestingPlatformOptions.ArchitectureOption),
+                hasFilterMode,
+                isHelp);
 
-        private BuildOptions GetBuildOptions(ParseResult parseResult)
+        private static BuildOptions GetBuildOptions(ParseResult parseResult, int degreeOfParallelism)
         {
             bool allowBinLog = MSBuildUtility.IsBinaryLoggerEnabled([.. parseResult.UnmatchedTokens], out string binLogFileName);
 
@@ -177,7 +197,7 @@ namespace Microsoft.DotNet.Cli
                     string.Empty,
                 allowBinLog,
                 binLogFileName,
-                _degreeOfParallelism);
+                degreeOfParallelism);
         }
 
         private static bool ContainsHelpOption(IEnumerable<string> args) => args.Contains(CliConstants.HelpOptionKey) || args.Contains(CliConstants.HelpOptionKey.Substring(0, 2));

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -55,8 +55,9 @@ namespace Microsoft.DotNet.Cli
                         return ExitCodes.GenericFailure;
                     }
 
-                    if (!EnqueueTestApplications())
+                    if (!_msBuildHandler.EnqueueTestApplications())
                     {
+                        _output.WriteMessage(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
                         return ExitCodes.GenericFailure;
                     }
                 }
@@ -98,17 +99,6 @@ namespace Microsoft.DotNet.Cli
             {
                 InitializeTestExecutionActionQueue(degreeOfParallelism, testOptions);
             }
-        }
-
-        private bool EnqueueTestApplications()
-        {
-            if (!_msBuildHandler.EnqueueTestApplications())
-            {
-                _output.WriteMessage(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
-                return false;
-            }
-
-            return true;
         }
 
         private void SetupCancelKeyPressHandler()

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli
                 SetupCancelKeyPressHandler();
 
                 _degreeOfParallelism = GetDegreeOfParallelism(parseResult);
-                BuildConfigurationOptions buildConfigurationOptions = GetBuildConfigurationOptions(parseResult);
+                TestOptions testOptions = GetTestOptions(parseResult);
 
                 _isDiscovery = parseResult.HasOption(TestingPlatformOptions.ListTestsOption);
                 _args = [.. parseResult.UnmatchedTokens];
@@ -48,11 +48,11 @@ namespace Microsoft.DotNet.Cli
                 bool filterModeEnabled = parseResult.HasOption(TestingPlatformOptions.TestModulesFilterOption);
                 if (_isHelp)
                 {
-                    InitializeHelpActionQueue(_degreeOfParallelism, buildConfigurationOptions, filterModeEnabled);
+                    InitializeHelpActionQueue(_degreeOfParallelism, testOptions, filterModeEnabled);
                 }
                 else
                 {
-                    InitializeTestExecutionActionQueue(_degreeOfParallelism, buildConfigurationOptions, filterModeEnabled);
+                    InitializeTestExecutionActionQueue(_degreeOfParallelism, testOptions, filterModeEnabled);
                 }
 
                 _msBuildHandler = new(_args, _actionQueue, _output);
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Cli
             }
         }
 
-        private void InitializeHelpActionQueue(int degreeOfParallelism, BuildConfigurationOptions buildConfigurationOptions, bool filterModeEnabled)
+        private void InitializeHelpActionQueue(int degreeOfParallelism, TestOptions buildConfigurationOptions, bool filterModeEnabled)
         {
             _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
             {
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Cli
             });
         }
 
-        private void InitializeTestExecutionActionQueue(int degreeOfParallelism, BuildConfigurationOptions buildConfigurationOptions, bool filterModeEnabled)
+        private void InitializeTestExecutionActionQueue(int degreeOfParallelism, TestOptions buildConfigurationOptions, bool filterModeEnabled)
         {
             _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
             {
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Cli
             return degreeOfParallelism;
         }
 
-        private static BuildConfigurationOptions GetBuildConfigurationOptions(ParseResult parseResult) =>
+        private static TestOptions GetTestOptions(ParseResult parseResult) =>
             new(parseResult.HasOption(TestingPlatformOptions.ListTestsOption),
                 parseResult.GetValue(TestingPlatformOptions.ConfigurationOption),
                 parseResult.GetValue(TestingPlatformOptions.ArchitectureOption));

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli
             bool hasFailed = false;
             try
             {
-                PrepareEnvironment(parseResult, out TestOptions testOptions, out List<string> args, out int degreeOfParallelism);
+                PrepareEnvironment(parseResult, out TestOptions testOptions, out int degreeOfParallelism);
 
                 InitializeOutput(degreeOfParallelism, testOptions.IsHelp);
 
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli
             return hasFailed ? ExitCodes.GenericFailure : ExitCodes.Success;
         }
 
-        private void PrepareEnvironment(ParseResult parseResult, out TestOptions testOptions, out List<string> args, out int degreeOfParallelism)
+        private void PrepareEnvironment(ParseResult parseResult, out TestOptions testOptions, out int degreeOfParallelism)
         {
             SetupCancelKeyPressHandler();
 
@@ -86,7 +86,6 @@ namespace Microsoft.DotNet.Cli
 
             testOptions = GetTestOptions(parseResult, filterModeEnabled, isHelp);
 
-            args = [.. parseResult.UnmatchedTokens];
             _isDiscovery = parseResult.HasOption(TestingPlatformOptions.ListTestsOption);
         }
 

--- a/test/Microsoft.NET.TestFramework/Utilities/RegexPatternHelper.cs
+++ b/test/Microsoft.NET.TestFramework/Utilities/RegexPatternHelper.cs
@@ -7,17 +7,17 @@ namespace Microsoft.NET.TestFramework.Utilities
 {
     public static class RegexPatternHelper
     {
-        public static string GenerateProjectRegexPattern(string projectName, string result, bool useCurrentVersion, string? exitCode = null)
+        public static string GenerateProjectRegexPattern(string projectName, string result, bool useCurrentVersion, string configuration, string? exitCode = null)
         {
             string version = useCurrentVersion ? ToolsetInfo.CurrentTargetFramework : DotnetVersionHelper.GetPreviousDotnetVersion();
             string exitCodePattern = exitCode == null ? string.Empty : $@".*\s+Exit code: {exitCode}";
-            return $@".+{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)\s{result}{exitCodePattern}";
+            return $@".+{configuration}{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)\s{result}{exitCodePattern}";
         }
 
-        public static string GenerateProjectRegexPattern(string projectName, bool useCurrentVersion, string prefix, List<string>? suffix = null)
+        public static string GenerateProjectRegexPattern(string projectName, bool useCurrentVersion, string configuration, string prefix, List<string>? suffix = null)
         {
             string version = useCurrentVersion ? ToolsetInfo.CurrentTargetFramework : DotnetVersionHelper.GetPreviousDotnetVersion();
-            string pattern = $@"{prefix}.*{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)";
+            string pattern = $@"{prefix}.*{configuration}{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)";
 
             if (suffix == null)
             {

--- a/test/Microsoft.NET.TestFramework/Utilities/RegexPatternHelper.cs
+++ b/test/Microsoft.NET.TestFramework/Utilities/RegexPatternHelper.cs
@@ -14,10 +14,15 @@ namespace Microsoft.NET.TestFramework.Utilities
             return $@".+{configuration}{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)\s{result}{exitCodePattern}";
         }
 
-        public static string GenerateProjectRegexPattern(string projectName, bool useCurrentVersion, string configuration, string prefix, List<string>? suffix = null)
+        public static string GenerateProjectRegexPattern(string projectName, bool useCurrentVersion, string configuration, string prefix, List<string>? suffix = null, bool addVersionAndArchPattern = true)
         {
             string version = useCurrentVersion ? ToolsetInfo.CurrentTargetFramework : DotnetVersionHelper.GetPreviousDotnetVersion();
-            string pattern = $@"{prefix}.*{configuration}{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll\s+\({version}\|[a-zA-Z][1-9]+\)";
+            string pattern = $@"{prefix}.*{configuration}{PathUtility.GetDirectorySeparatorChar()}{version}{PathUtility.GetDirectorySeparatorChar()}{projectName}\.dll";
+
+            if (addVersionAndArchPattern)
+            {
+                pattern += @$"\s+\({version}\|[a-zA-Z][1-9]+\)";
+            }
 
             if (suffix == null)
             {

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, "Discovered 0 tests"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
 
                 result.StdOut
                     .Should().Contain("Discovered 0 tests.");
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, "Discovered 0 tests"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, "Discovered 0 tests"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", true, "Discovered 0 tests"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
                 Assert.Matches(@"Discovered 0 tests.*", result.StdOut);
             }
 
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, "Discovered 1 tests", ["Test0"]), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 1 tests", ["Test0"]), result.StdOut);
                 Assert.Matches(@"Discovered 1 tests.*", result.StdOut);
             }
 
@@ -96,8 +96,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, "Discovered 2 tests", ["Test0", "Test2"]), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, "Discovered 1 tests", ["Test1"]), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 2 tests", ["Test0", "Test2"]), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, configuration, "Discovered 1 tests", ["Test1"]), result.StdOut);
                 Assert.Matches(@"Discovered 3 tests.*", result.StdOut);
             }
 
@@ -120,8 +120,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", false, "Discovered 3 tests", ["TestMethod1", "TestMethod2", "TestMethod3"]), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, "Discovered 2 tests", ["TestMethod1", "TestMethod3"]), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", false, configuration, "Discovered 3 tests", ["TestMethod1", "TestMethod2", "TestMethod3"]), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 2 tests", ["TestMethod1", "TestMethod3"]), result.StdOut);
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -132,9 +132,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, "8"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "failed", true, "2"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", "failed", true, "9"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration, "8"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "failed", true, configuration, "2"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", "failed", true, configuration, "9"), result.StdOut);
 
                 result.StdOut
                     .Should().Contain("Test run summary: Failed!")

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -28,8 +28,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false));
-                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, useCurrentVersion: true));
+                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
+                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, useCurrentVersion: true, configuration));
 
                 MatchCollection skippedTestsMatches = Regex.Matches(result.StdOut!, "skipped Test2");
                 MatchCollection failedTestsMatches = Regex.Matches(result.StdOut!, "failed Test3");
@@ -67,8 +67,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false));
-                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true));
+                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
+                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true, configuration));
 
                 MatchCollection skippedTestsMatches = Regex.Matches(result.StdOut!, "skipped Test1");
                 MatchCollection failedTestsMatches = Regex.Matches(result.StdOut!, "failed Test2");
@@ -113,8 +113,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false));
-                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true));
+                MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
+                MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true, configuration));
 
                 MatchCollection failedTestsMatches = Regex.Matches(result.StdOut!, "failed TestMethod3");
 

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -55,8 +55,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(TestingPlatformOptions.SolutionOption.Name, testSolutionPath,
                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true), result.StdOut);
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -78,8 +78,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             // Assert that only TestProject ran
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true), result.StdOut);
-            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
+            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -99,8 +99,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             // Assert that only TestProject ran
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true), result.StdOut);
-            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
+            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -32,9 +32,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(TestingPlatformOptions.ProjectOption.Name, testProjectPath,
                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            var testAppArgs = Regex.Matches(result.StdOut!, TestApplicationArgsPattern);
-            string fullProjectPath = $"{testInstance.TestRoot}{Path.DirectorySeparatorChar}{testProjectPath}";
-            Assert.Contains($"{TestingPlatformOptions.ProjectOption.Name} \"{fullProjectPath}\"", testAppArgs.FirstOrDefault()?.Value.Split(TestApplicationArgsSeparator)[0]);
+            Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "exec", addVersionAndArchPattern: false));
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -262,26 +260,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
-        public void RunTestProjectSolutionWithConfigurationOption_ShouldReturnZeroAsExitCode(string configuration)
-        {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
-                .WithSource();
-
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .WithEnableTestingPlatform()
-                                    .WithTraceOutput()
-                                    .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
-
-            var testAppArgs = Regex.Matches(result.StdOut!, TestApplicationArgsPattern);
-            Assert.Contains($"{TestingPlatformOptions.ConfigurationOption.Name} {configuration}", testAppArgs.FirstOrDefault()?.Value.Split(TestApplicationArgsSeparator)[0]);
-
-            result.ExitCode.Should().Be(ExitCodes.Success);
-        }
-
-        [InlineData(TestingConstants.Debug)]
-        [InlineData(TestingConstants.Release)]
-        [Theory]
         public void RunTestProjectSolutionWithArchOption_ShouldReturnZeroAsExitCode(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
@@ -319,7 +297,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnableTestingPlatform()
                                     .WithTraceOutput()
-                                    .Execute(TestingPlatformOptions.ProjectOption.Name, @"TestProject.csproj",
+                                    .Execute(TestingPlatformOptions.ProjectOption.Name, "TestProject.csproj",
+                                            TestingPlatformOptions.ArchitectureOption.Name, "x64",
                                             TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             // Assert that the bin folder hasn't been modified

--- a/test/dotnet-test.Tests/MSBuildHandlerTests.cs
+++ b/test/dotnet-test.Tests/MSBuildHandlerTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger:custom.binlog" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--someOtherArg" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.False(result);
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger", "--someOtherArg" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger", "--binaryLogger:custom1.binlog", "--binaryLogger:custom2.binlog" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger:" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var args = new List<string> { "--binaryLogger:" };
 
             // Act
-            var result = MSBuildUtility.IsBinaryLoggerEnabled(args, out string binLogFileName);
+            var result = MSBuildUtility.IsBinaryLoggerEnabled(ref args, out string binLogFileName);
 
             // Assert
             Assert.True(result);


### PR DESCRIPTION
This pull request includes several changes to improve code readability and consistency in the `dotnet-test` command implementation. The most important changes involve making variables readonly where applicable, renaming variables for clarity, and refactoring methods to reduce redundancy.

### Codebase Improvements:

* Made `_output` and `_executionIds` readonly in `MSBuildHandler` and `TestApplication` classes respectively to ensure immutability. [[1]](diffhunk://#diff-d09dff37dec2091ac10348e8908259990c9e6dbcd5707f166e94f1c32b1e44c2L15-R15) [[2]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL24-R24)
* Renamed variables from `modules` to `projects` to better reflect their purpose in the `MSBuildHandler` and `MSBuildUtility` classes. [[1]](diffhunk://#diff-d09dff37dec2091ac10348e8908259990c9e6dbcd5707f166e94f1c32b1e44c2L72-R83) [[2]](diffhunk://#diff-d09dff37dec2091ac10348e8908259990c9e6dbcd5707f166e94f1c32b1e44c2L124-R132) [[3]](diffhunk://#diff-750583b9174273b35d6402b8e0a89b207ecfd941d69158c76210be14961923f0L17-R17) [[4]](diffhunk://#diff-750583b9174273b35d6402b8e0a89b207ecfd941d69158c76210be14961923f0L35-R39) [[5]](diffhunk://#diff-750583b9174273b35d6402b8e0a89b207ecfd941d69158c76210be14961923f0L62-R62)
* Refactored `RunAsync` and related methods in `TestApplication` to use `TestOptions` instead of multiple parameters, simplifying method signatures and improving readability. [[1]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL49-R57) [[2]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL67-R112) [[3]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL257-R300) [[4]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL267-R317) [[5]](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL289-L318)
* Updated `BuildOptions` and `TestOptions` records in `Options.cs` to include new fields and improve clarity.
* Modified `GetProjectProperties` in `SolutionAndProjectUtility` to accept `globalProperties` parameter, enhancing flexibility.

Relates to #45927