### PR TITLE
Fix bug when adding solution folder containing `..`

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -102,6 +102,12 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 string relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionFileFullPath), projectPath);
                 // Add fallback solution folder
                 string relativeSolutionFolder = Path.GetDirectoryName(relativePath);
+                // Don't add solution folder if it contains ..
+                if (relativeSolutionFolder.Contains(".."))
+                {
+                    relativeSolutionFolder = string.Empty;
+                }
+
                 if (!_inRoot && solutionFolder is null && !string.IsNullOrEmpty(relativeSolutionFolder))
                 {
                     if (relativeSolutionFolder.Split(Path.DirectorySeparatorChar).LastOrDefault() == Path.GetFileNameWithoutExtension(relativePath))

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -100,13 +100,9 @@ namespace Microsoft.DotNet.Tools.Sln.Add
             foreach (var projectPath in projectPaths)
             {
                 string relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionFileFullPath), projectPath);
-                // Add fallback solution folder
-                string relativeSolutionFolder = Path.GetDirectoryName(relativePath);
-                // Don't add solution folder if it contains ..
-                if (relativeSolutionFolder.Contains(".."))
-                {
-                    relativeSolutionFolder = string.Empty;
-                }
+                // Add fallback solution folder if relative path does not contain `..`.
+                string relativeSolutionFolder =  relativePath.Contains("..")
+                    ? string.Empty : Path.GetDirectoryName(relativePath);
 
                 if (!_inRoot && solutionFolder is null && !string.IsNullOrEmpty(relativeSolutionFolder))
                 {

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Sln.Add
             {
                 string relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionFileFullPath), projectPath);
                 // Add fallback solution folder if relative path does not contain `..`.
-                string relativeSolutionFolder =  relativePath.Contains("..")
+                string relativeSolutionFolder =  relativePath.Split(Path.DirectorySeparatorChar).Any(p => p == "..")
                     ? string.Empty : Path.GetDirectoryName(relativePath);
 
                 if (!_inRoot && solutionFolder is null && !string.IsNullOrEmpty(relativeSolutionFolder))


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2321742

When attempting to add a project in a parent directory (e.g., `dotnet sln add ../foo/bar.csproj`), the tool automatically generates solution folder `../foo`. vs-solutionpersistence generates folders and subfolders dynamically, causing a folder `..` to be created. 

When adding projects from outside the solution directory, the tool should not create solution folders.