### PR TITLE
[release/8.0.4xx] Multi-arch OCI images export as tarballs

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -24,19 +24,24 @@ internal readonly struct BuiltImage
     internal required string ImageSha { get; init; }
 
     /// <summary>
-    /// Gets image size.
-    /// </summary>
-    internal required long ImageSize { get; init; }
-
-    /// <summary>
     /// Gets image manifest.
     /// </summary>
-    internal required ManifestV2 Manifest { get; init; }
+    internal required string Manifest { get; init; } 
+
+    /// <summary>
+    /// Gets manifest digest.
+    /// </summary>
+    internal required string ManifestDigest { get; init; }
 
     /// <summary>
     /// Gets manifest mediaType.
     /// </summary>
     internal required string ManifestMediaType { get; init; }
+
+    /// <summary>
+    /// Gets image layers.
+    /// </summary>
+    internal required List<ManifestLayer> Layers { get; init; }
 
     /// <summary>
     /// Gets layers descriptors.
@@ -45,7 +50,7 @@ internal readonly struct BuiltImage
     {
         get
         {
-            List<ManifestLayer> layersNode = Manifest.Layers ?? throw new NotImplementedException("Tried to get layer information but there is no layer node?");
+            List<ManifestLayer> layersNode = Layers ?? throw new NotImplementedException("Tried to get layer information but there is no layer node?");
             foreach (ManifestLayer layer in layersNode)
             {
                 yield return new(layer.mediaType, layer.digest, layer.size);

--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -16,12 +16,12 @@ internal readonly struct BuiltImage
     /// <summary>
     /// Gets image digest.
     /// </summary>
-    internal required string ImageDigest { get; init; }
+    internal string? ImageDigest { get; init; }
 
     /// <summary>
     /// Gets image SHA.
     /// </summary>
-    internal required string ImageSha { get; init; }
+    internal string? ImageSha { get; init; }
 
     /// <summary>
     /// Gets image manifest.

--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -44,6 +44,16 @@ internal readonly struct BuiltImage
     internal required List<ManifestLayer> Layers { get; init; }
 
     /// <summary>
+    /// Gets image OS.
+    /// </summary>
+    internal string OS { get; init; }
+
+    /// <summary>
+    /// Gets image architecture.
+    /// </summary>
+    internal string Architecture { get; init; }
+
+    /// <summary>
     /// Gets layers descriptors.
     /// </summary>
     internal IEnumerable<Descriptor> LayerDescriptors

--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -41,7 +41,7 @@ internal readonly struct BuiltImage
     /// <summary>
     /// Gets image layers.
     /// </summary>
-    internal required List<ManifestLayer> Layers { get; init; }
+    internal List<ManifestLayer>? Layers { get; init; }
 
     /// <summary>
     /// Gets image OS.

--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.NET.Build.Containers;
 /// <summary>
 /// Represents constructed image ready for further processing.
 /// </summary>
-internal sealed class BuiltImage
+internal readonly struct BuiltImage
 {
     /// <summary>
     /// Gets image configuration in JSON format.

--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.NET.Build.Containers;
 /// <summary>
 /// Represents constructed image ready for further processing.
 /// </summary>
-internal readonly struct BuiltImage
+internal sealed class BuiltImage
 {
     /// <summary>
     /// Gets image configuration in JSON format.
@@ -46,12 +46,12 @@ internal readonly struct BuiltImage
     /// <summary>
     /// Gets image OS.
     /// </summary>
-    internal string OS { get; init; }
+    internal string? OS { get; init; }
 
     /// <summary>
     /// Gets image architecture.
     /// </summary>
-    internal string Architecture { get; init; }
+    internal string? Architecture { get; init; }
 
     /// <summary>
     /// Gets layers descriptors.

--- a/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
@@ -17,6 +17,16 @@ internal sealed class DigestUtils
     /// </summary>
     internal static string GetDigestFromSha(string sha) => $"sha256:{sha}";
 
+    internal static string GetShaFromDigest(string digest)
+    {
+        if (!digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Invalid digest format. Digest must start with 'sha256:'.");
+        }
+
+        return digest.Substring("sha256:".Length);
+    }
+
     /// <summary>
     /// Gets the SHA of <paramref name="str"/>.
     /// </summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
@@ -21,7 +21,7 @@ internal sealed class DigestUtils
     {
         if (!digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
         {
-            throw new ArgumentException("Invalid digest format. Digest must start with 'sha256:'.");
+            throw new ArgumentException($"Invalid digest '{digest}'. Digest must start with 'sha256:'.");
         }
 
         return digest.Substring("sha256:".Length);

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.NET.Build.Containers.Resources;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace Microsoft.NET.Build.Containers;
 
@@ -86,9 +87,10 @@ internal sealed class ImageBuilder
             Config = imageJsonStr,
             ImageDigest = imageDigest,
             ImageSha = imageSha,
-            ImageSize = imageSize,
-            Manifest = newManifest,
-            ManifestMediaType = ManifestMediaType
+            Manifest = JsonSerializer.SerializeToNode(newManifest)?.ToJsonString() ?? "",
+            ManifestDigest = newManifest.GetDigest(),
+            ManifestMediaType = ManifestMediaType,
+            Layers = _manifest.Layers
         };
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -7,16 +7,6 @@ using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
 
-internal readonly struct ImageInfo
-{
-    internal string Config { get; init; }
-    internal string ManifestDigest { get; init; }
-    internal string Manifest { get; init; }
-    internal string ManifestMediaType { get; init; }
-
-    public override string ToString() => ManifestDigest;
-}
-
 internal static class ImageIndexGenerator
 {
     /// <summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -47,6 +47,11 @@ internal static class ImageIndexGenerator
 
     internal static string GenerateImageIndex(BuiltImage[] images, string manifestMediaType, string imageIndexMediaType)
     {
+        if (images.Length == 0)
+        {
+            throw new ArgumentException(string.Format(Strings.ImagesEmpty));
+        }
+        
         // Here we are using ManifestListV2 struct, but we could use ImageIndexV1 struct as well.
         // We are filling the same fields, so we can use the same struct.
         var manifests = new PlatformSpecificManifest[images.Length];

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -21,7 +21,7 @@ internal static class ImageIndexGenerator
     {
         if (images.Length == 0)
         {
-            throw new ArgumentException(string.Format(Strings.ImagesEmpty));
+            throw new ArgumentException(Strings.ImagesEmpty);
         }
 
         string manifestMediaType = images[0].ManifestMediaType;
@@ -49,9 +49,9 @@ internal static class ImageIndexGenerator
     {
         if (images.Length == 0)
         {
-            throw new ArgumentException(string.Format(Strings.ImagesEmpty));
+            throw new ArgumentException(Strings.ImagesEmpty);
         }
-        
+
         // Here we are using ManifestListV2 struct, but we could use ImageIndexV1 struct as well.
         // We are filling the same fields, so we can use the same struct.
         var manifests = new PlatformSpecificManifest[images.Length];

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -13,7 +13,7 @@ internal static class ImageIndexGenerator
     /// <summary>
     /// Generates an image index from the given images.
     /// </summary>
-    /// <param name="images"></param>
+    /// <param name="images">Images to generate image index from.</param>
     /// <returns>Returns json string of image index and image index mediaType.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="NotSupportedException"></exception>
@@ -45,6 +45,15 @@ internal static class ImageIndexGenerator
         }
     }
 
+    /// <summary>
+    /// Generates an image index from the given images.
+    /// </summary>
+    /// <param name="images">Images to generate image index from.</param>
+    /// <param name="manifestMediaType">Media type of the manifest.</param>
+    /// <param name="imageIndexMediaType">Media type of the produced image index.</param>
+    /// <returns>Returns json string of image index and image index mediaType.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="NotSupportedException"></exception>
     internal static string GenerateImageIndex(BuiltImage[] images, string manifestMediaType, string imageIndexMediaType)
     {
         if (images.Length == 0)
@@ -116,6 +125,7 @@ internal static class ImageIndexGenerator
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
+        // To avoid things like \u002B for '+' especially in media types ("application/vnd.oci.image.manifest.v1\u002Bjson"), we use UnsafeRelaxedJsonEscaping.
         var escapeOptions = new JsonSerializerOptions
         {
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -71,8 +71,8 @@ internal static class ImageIndexGenerator
                 digest = image.ManifestDigest,
                 platform = new PlatformInformation
                 {
-                    architecture = image.Architecture,
-                    os = image.OS
+                    architecture = image.Architecture!,
+                    os = image.OS!
                 }
             };
             manifests[i] = manifest;

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -92,6 +92,8 @@ internal static class ImageIndexGenerator
 
     internal static string GenerateImageIndexWithAnnotations(string manifestMediaType, string manifestDigest, long manifestSize, string repository, string[] tags)
     {
+        string containerdImageNamePrefix = repository.Contains('/') ? "docker.io/" : "docker.io/library/";
+        
         var manifests = new PlatformSpecificOciManifest[tags.Length];
         for (int i = 0; i < tags.Length; i++)
         {
@@ -103,7 +105,7 @@ internal static class ImageIndexGenerator
                 digest = manifestDigest,
                 annotations = new Dictionary<string, string> 
                 {
-                    { "io.containerd.image.name", $"docker.io/library/{repository}:{tag}" },
+                    { "io.containerd.image.name", $"{containerdImageNamePrefix}{repository}:{tag}" },
                     { "org.opencontainers.image.ref.name", tag } 
                 }
             };

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -46,6 +46,11 @@ internal static class ImageIndexGenerator
 
     internal static string GenerateImageIndex(BuiltImage[] images, string manifestMediaType, string imageIndexMediaType)
     {
+        if (images.Length == 0)
+        {
+            throw new ArgumentException(string.Format(Strings.ImagesEmpty));
+        }
+        
         // Here we are using ManifestListV2 struct, but we could use ImageIndexV1 struct as well.
         // We are filling the same fields, so we can use the same struct.
         var manifests = new PlatformSpecificManifest[images.Length];

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -51,7 +51,7 @@ internal static class ImagePublisher
     }
 
     public static async Task PublishImageAsync(
-        BuiltImage[] multiArchImage,
+        MultiArchImage multiArchImage,
         SourceImageReference sourceImageReference,
         DestinationImageReference destinationImageReference,
         Microsoft.Build.Utilities.TaskLoggingHelper Log,
@@ -82,16 +82,7 @@ internal static class ImagePublisher
                     Log,
                     BuildEngine,
                     cancellationToken,
-                    async (images, source, destination, token) =>
-                    {
-                        (string imageIndex, string mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
-                        await destinationImageReference.RemoteRegistry!.PushManifestListAsync(
-                            destinationImageReference.Repository,
-                            destinationImageReference.Tags,
-                            imageIndex,
-                            mediaType,
-                            cancellationToken).ConfigureAwait(false);
-                    },
+                    destinationImageReference.RemoteRegistry!.PushManifestListAsync,
                     Strings.ImageIndexUploadedToRegistry).ConfigureAwait(false);
                 break;
             default:

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -72,8 +72,7 @@ internal static class ImagePublisher
                     BuildEngine,
                     telemetry,
                     cancellationToken,
-                    destinationImageReference.LocalRegistry!.LoadAsync,
-                    logTipAboutContainerd : true).ConfigureAwait(false);
+                    destinationImageReference.LocalRegistry!.LoadAsync).ConfigureAwait(false);
                 break;
             case DestinationImageReferenceKind.RemoteRegistry:
                 await PushToRemoteRegistryAsync(
@@ -110,8 +109,7 @@ internal static class ImagePublisher
         IBuildEngine? BuildEngine,
         Telemetry telemetry,
         CancellationToken cancellationToken,
-        Func<T, SourceImageReference, DestinationImageReference, CancellationToken, Task> loadFunc,
-        bool logTipAboutContainerd = false)
+        Func<T, SourceImageReference, DestinationImageReference, CancellationToken, Task> loadFunc)
     {
         ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
         if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
@@ -148,10 +146,6 @@ internal static class ImagePublisher
         {
             telemetry.LogLocalLoadError();
             Log.LogErrorFromException(dle, showStackTrace: false);
-            if (logTipAboutContainerd && dle.Message.Contains("no such file or directory"))
-            {
-                Log.LogMessage(MessageImportance.High, Strings.TipToEnableContainerdForMultiArch);
-            }
         }
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -73,7 +73,7 @@ internal static class ImagePublisher
                     telemetry,
                     cancellationToken,
                     destinationImageReference.LocalRegistry!.LoadAsync,
-                    logWarningForMultiArch : true).ConfigureAwait(false);
+                    logTipAboutContainerd : true).ConfigureAwait(false);
                 break;
             case DestinationImageReferenceKind.RemoteRegistry:
                 await PushToRemoteRegistryAsync(
@@ -111,7 +111,7 @@ internal static class ImagePublisher
         Telemetry telemetry,
         CancellationToken cancellationToken,
         Func<T, SourceImageReference, DestinationImageReference, CancellationToken, Task> loadFunc,
-        bool logWarningForMultiArch = false)
+        bool logTipAboutContainerd = false)
     {
         ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
         if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
@@ -148,9 +148,9 @@ internal static class ImagePublisher
         {
             telemetry.LogLocalLoadError();
             Log.LogErrorFromException(dle, showStackTrace: false);
-            if (logWarningForMultiArch && dle.Message.Contains("no such file or directory"))
+            if (logTipAboutContainerd && dle.Message.Contains("no such file or directory"))
             {
-                Log.LogMessage(MessageImportance.High, "Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.");
+                Log.LogMessage(MessageImportance.High, Strings.TipToEnableContainerdForMultiArch);
             }
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -30,8 +30,7 @@ internal static class ImagePublisher
                     BuildEngine,
                     telemetry,
                     cancellationToken,
-                    destinationImageReference.LocalRegistry!.LoadAsync,
-                    Strings.ContainerBuilder_ImageUploadedToLocalDaemon).ConfigureAwait(false);
+                    destinationImageReference.LocalRegistry!.LoadAsync).ConfigureAwait(false);
                 break;
             case DestinationImageReferenceKind.RemoteRegistry:
                 await PushToRemoteRegistryAsync(
@@ -74,7 +73,6 @@ internal static class ImagePublisher
                     telemetry,
                     cancellationToken,
                     destinationImageReference.LocalRegistry!.LoadAsync,
-                    Strings.ContainerBuilder_ImageUploadedToLocalDaemon,
                     logWarningForMultiArch : true).ConfigureAwait(false);
                 break;
             case DestinationImageReferenceKind.RemoteRegistry:
@@ -113,7 +111,6 @@ internal static class ImagePublisher
         Telemetry telemetry,
         CancellationToken cancellationToken,
         Func<T, SourceImageReference, DestinationImageReference, CancellationToken, Task> loadFunc,
-        string successMessage,
         bool logWarningForMultiArch = false)
     {
         ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
@@ -128,7 +125,7 @@ internal static class ImagePublisher
             await loadFunc(image, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
             if (BuildEngine != null) 
             {
-                Log.LogMessage(MessageImportance.High, successMessage, destinationImageReference, localRegistry);
+                Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
             }
         }
         catch (ContainerHttpException e)

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -1,0 +1,121 @@
+// // Licensed to the .NET Foundation under one or more agreements.
+// // The .NET Foundation licenses this file to you under the MIT license.
+
+// using Microsoft.NET.Build.Containers.LocalDaemons;
+// using Microsoft.NET.Build.Containers.Resources;
+
+// namespace Microsoft.NET.Build.Containers;
+
+
+// internal static class ImagePublisher
+// {
+//     public static async Task PublishImage(BuiltImage builtImage, SourceImageReference sourceImageReference,
+//         DestinationImageReference destinationImageReference,
+//         Telemetry telemetry,
+//         CancellationToken cancellationToken)
+//     {
+//         cancellationToken.ThrowIfCancellationRequested();
+
+//         switch (destinationImageReference.Kind)
+//         {
+//             case DestinationImageReferenceKind.LocalRegistry:
+//                 await PushToLocalRegistryAsync(builtImage,
+//                     sourceImageReference,
+//                     destinationImageReference,
+//                     telemetry,
+//                     cancellationToken).ConfigureAwait(false);
+//                 break;
+//             case DestinationImageReferenceKind.RemoteRegistry:
+//                 await PushToRemoteRegistryAsync(builtImage,
+//                     sourceImageReference,
+//                     destinationImageReference,
+//                     cancellationToken).ConfigureAwait(false);
+//                 break;
+//             default:
+//                 throw new ArgumentOutOfRangeException();
+//         }
+
+//         telemetry.LogPublishSuccess();
+//     }
+
+//     private static async Task PushToLocalRegistryAsync(
+//         BuiltImage builtImage,
+//         SourceImageReference sourceImageReference,
+//         DestinationImageReference destinationImageReference,
+//         Telemetry telemetry,
+//         CancellationToken cancellationToken)
+//     {
+//         ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
+//         if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
+//         {
+//             telemetry.LogMissingLocalBinary();
+//             Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
+//             return;
+//         }
+//         try
+//         {
+//             await localRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
+//             SafeLog(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
+
+//             if (localRegistry is ArchiveFileRegistry archive)
+//             {
+//                 GeneratedArchiveOutputPath = archive.ArchiveOutputPath;
+//             }
+//         }
+//         catch (ContainerHttpException e)
+//         {
+//             if (BuildEngine != null)
+//             {
+//                 Log.LogErrorFromException(e, true);
+//             }
+//         }
+//         catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
+//         {
+//             telemetry.LogLocalLoadError();
+//             Log.LogErrorFromException(dle, showStackTrace: false);
+//         }
+//         catch (ArgumentException argEx)
+//         {
+//             Log.LogErrorFromException(argEx, showStackTrace: false);
+//         }
+//     }
+
+//     private static async Task PushToRemoteRegistryAsync(
+//         BuiltImage builtImage,
+//         SourceImageReference sourceImageReference,
+//         DestinationImageReference destinationImageReference,
+//         CancellationToken cancellationToken)
+//     {
+//         try
+//         {
+//             await destinationImageReference.RemoteRegistry!.PushAsync(
+//                 builtImage,
+//                 sourceImageReference,
+//                 destinationImageReference,
+//                 cancellationToken).ConfigureAwait(false);
+//             SafeLog(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, OutputRegistry);
+//         }
+//         catch (UnableToAccessRepositoryException)
+//         {
+//             if (BuildEngine != null)
+//             {
+//                 Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
+//             }
+//         }
+//         catch (ContainerHttpException e)
+//         {
+//             if (BuildEngine != null)
+//             {
+//                 Log.LogErrorFromException(e, true);
+//             }
+//         }
+//         catch (Exception e)
+//         {
+//             if (BuildEngine != null)
+//             {
+//                 Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
+//                 Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
+//             }
+//         }
+//     }
+// }

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -1,121 +1,262 @@
-// // Licensed to the .NET Foundation under one or more agreements.
-// // The .NET Foundation licenses this file to you under the MIT license.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
-// using Microsoft.NET.Build.Containers.LocalDaemons;
-// using Microsoft.NET.Build.Containers.Resources;
+using Microsoft.Build.Framework;
+using Microsoft.NET.Build.Containers.Resources;
 
-// namespace Microsoft.NET.Build.Containers;
+namespace Microsoft.NET.Build.Containers;
 
+internal static class ImagePublisher
+{
+    public static async Task PublishImage(
+        BuiltImage image,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
-// internal static class ImagePublisher
-// {
-//     public static async Task PublishImage(BuiltImage builtImage, SourceImageReference sourceImageReference,
-//         DestinationImageReference destinationImageReference,
-//         Telemetry telemetry,
-//         CancellationToken cancellationToken)
-//     {
-//         cancellationToken.ThrowIfCancellationRequested();
+        switch (destinationImageReference.Kind)
+        {
+            case DestinationImageReferenceKind.LocalRegistry:
+                await PushToLocalRegistryAsync(
+                    image,
+                    sourceImageReference,
+                    destinationImageReference,
+                    Log,
+                    BuildEngine,
+                    telemetry,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            case DestinationImageReferenceKind.RemoteRegistry:
+                await PushToRemoteRegistryAsync(
+                    image,
+                    sourceImageReference,
+                    destinationImageReference,
+                    Log,
+                    BuildEngine,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
 
-//         switch (destinationImageReference.Kind)
-//         {
-//             case DestinationImageReferenceKind.LocalRegistry:
-//                 await PushToLocalRegistryAsync(builtImage,
-//                     sourceImageReference,
-//                     destinationImageReference,
-//                     telemetry,
-//                     cancellationToken).ConfigureAwait(false);
-//                 break;
-//             case DestinationImageReferenceKind.RemoteRegistry:
-//                 await PushToRemoteRegistryAsync(builtImage,
-//                     sourceImageReference,
-//                     destinationImageReference,
-//                     cancellationToken).ConfigureAwait(false);
-//                 break;
-//             default:
-//                 throw new ArgumentOutOfRangeException();
-//         }
+        telemetry.LogPublishSuccess();
+    }
 
-//         telemetry.LogPublishSuccess();
-//     }
+    public static async Task PublishImage(
+        BuiltImage[] images,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
-//     private static async Task PushToLocalRegistryAsync(
-//         BuiltImage builtImage,
-//         SourceImageReference sourceImageReference,
-//         DestinationImageReference destinationImageReference,
-//         Telemetry telemetry,
-//         CancellationToken cancellationToken)
-//     {
-//         ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
-//         if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
-//         {
-//             telemetry.LogMissingLocalBinary();
-//             Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
-//             return;
-//         }
-//         try
-//         {
-//             await localRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
-//             SafeLog(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
+        switch (destinationImageReference.Kind)
+        {
+            case DestinationImageReferenceKind.LocalRegistry:
+                await PushToLocalRegistryAsync(
+                    images,
+                    sourceImageReference,
+                    destinationImageReference,
+                    Log,
+                    BuildEngine,
+                    telemetry,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            case DestinationImageReferenceKind.RemoteRegistry:
+                await PushToRemoteRegistryAsync(
+                    images,
+                    sourceImageReference,
+                    destinationImageReference,
+                    Log,
+                    BuildEngine,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
 
-//             if (localRegistry is ArchiveFileRegistry archive)
-//             {
-//                 GeneratedArchiveOutputPath = archive.ArchiveOutputPath;
-//             }
-//         }
-//         catch (ContainerHttpException e)
-//         {
-//             if (BuildEngine != null)
-//             {
-//                 Log.LogErrorFromException(e, true);
-//             }
-//         }
-//         catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
-//         {
-//             telemetry.LogLocalLoadError();
-//             Log.LogErrorFromException(dle, showStackTrace: false);
-//         }
-//         catch (ArgumentException argEx)
-//         {
-//             Log.LogErrorFromException(argEx, showStackTrace: false);
-//         }
-//     }
+        telemetry.LogPublishSuccess();
+    }
 
-//     private static async Task PushToRemoteRegistryAsync(
-//         BuiltImage builtImage,
-//         SourceImageReference sourceImageReference,
-//         DestinationImageReference destinationImageReference,
-//         CancellationToken cancellationToken)
-//     {
-//         try
-//         {
-//             await destinationImageReference.RemoteRegistry!.PushAsync(
-//                 builtImage,
-//                 sourceImageReference,
-//                 destinationImageReference,
-//                 cancellationToken).ConfigureAwait(false);
-//             SafeLog(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, OutputRegistry);
-//         }
-//         catch (UnableToAccessRepositoryException)
-//         {
-//             if (BuildEngine != null)
-//             {
-//                 Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
-//             }
-//         }
-//         catch (ContainerHttpException e)
-//         {
-//             if (BuildEngine != null)
-//             {
-//                 Log.LogErrorFromException(e, true);
-//             }
-//         }
-//         catch (Exception e)
-//         {
-//             if (BuildEngine != null)
-//             {
-//                 Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
-//                 Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
-//             }
-//         }
-//     }
-// }
+    private static async Task PushToLocalRegistryAsync(
+        BuiltImage image,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
+        if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
+        {
+            telemetry.LogMissingLocalBinary();
+            Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
+            return;
+        }
+        try
+        {
+            await localRegistry.LoadAsync(image, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
+            if (BuildEngine != null) 
+            {
+                Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
+            }
+        }
+        catch (ContainerHttpException e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+        }
+        catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
+        {
+            telemetry.LogLocalLoadError();
+            Log.LogErrorFromException(dle, showStackTrace: false);
+        }
+        catch (ArgumentException argEx)
+        {
+            Log.LogErrorFromException(argEx, showStackTrace: false);
+        }
+    }
+
+    private static async Task PushToLocalRegistryAsync(
+        BuiltImage[] images,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
+        if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
+        {
+            telemetry.LogMissingLocalBinary();
+            Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
+            return;
+        }
+        try
+        {
+            await localRegistry.LoadAsync(images, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
+            if (BuildEngine != null) 
+            {
+                Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
+            }
+        }
+        catch (ContainerHttpException e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+        }
+        catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
+        {
+            telemetry.LogLocalLoadError();
+            Log.LogErrorFromException(dle, showStackTrace: false);
+        }
+        catch (ArgumentException argEx)
+        {
+            Log.LogErrorFromException(argEx, showStackTrace: false);
+        }
+    }
+
+    private static async Task PushToRemoteRegistryAsync(
+        BuiltImage image,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await destinationImageReference.RemoteRegistry!.PushAsync(
+                image,
+                sourceImageReference,
+                destinationImageReference,
+                cancellationToken).ConfigureAwait(false);
+            if (BuildEngine != null) 
+            {
+                Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, destinationImageReference.RemoteRegistry!.RegistryName);
+            }
+        }
+        catch (UnableToAccessRepositoryException)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
+            }
+        }
+        catch (ContainerHttpException e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+        }
+        catch (Exception e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
+                Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
+            }
+        }
+    }
+
+    private static async Task PushToRemoteRegistryAsync(
+        BuiltImage[] images,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log,
+        IBuildEngine? BuildEngine,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            (string imageIndex, string mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
+            await destinationImageReference.RemoteRegistry!.PushManifestListAsync(
+                destinationImageReference.Repository,
+                destinationImageReference.Tags,
+                imageIndex,
+                mediaType,
+                cancellationToken).ConfigureAwait(false);
+            if (BuildEngine != null) 
+            {
+                Log.LogMessage(MessageImportance.High, Strings.ImageIndexUploadedToRegistry, destinationImageReference, destinationImageReference.RemoteRegistry!.RegistryName);
+            }
+        }
+        catch (UnableToAccessRepositoryException)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
+            }
+        }
+        catch (ContainerHttpException e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+        }
+        catch (Exception e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
+                Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
+            }
+        }
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -14,14 +14,22 @@ internal class ArchiveFileRegistry : ILocalRegistry
         ArchiveOutputPath = archiveOutputPath;
     }
 
-    private async Task LoadAsync<T>(T image, SourceImageReference sourceReference, 
+    internal async Task LoadAsync<T>(T image, SourceImageReference sourceReference, 
         DestinationImageReference destinationReference, CancellationToken cancellationToken,
         Func<T, SourceImageReference, DestinationImageReference, Stream, CancellationToken, Task> writeStreamFunc)
     {
         var fullPath = Path.GetFullPath(ArchiveOutputPath);
 
+        var directorySeparatorChar = Path.DirectorySeparatorChar;
+
+        // if doesn't end with a file extension, assume it's a directory
+        if (!fullPath.Split(directorySeparatorChar).Last().Contains('.'))
+        {
+           fullPath += Path.DirectorySeparatorChar;
+        }
+
         // pointing to a directory? -> append default name
-        if (Directory.Exists(fullPath) || ArchiveOutputPath.EndsWith("/") || ArchiveOutputPath.EndsWith("\\"))
+        if (fullPath.EndsWith(directorySeparatorChar))
         {
             fullPath = Path.Combine(fullPath, destinationReference.Repository + ".tar.gz");
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -46,10 +46,10 @@ internal class ArchiveFileRegistry : ILocalRegistry
         => await LoadAsync(image, sourceReference, destinationReference, cancellationToken,
             DockerCli.WriteImageToStreamAsync);
 
-    public async Task LoadAsync(BuiltImage[] images, SourceImageReference sourceReference,
+    public async Task LoadAsync(MultiArchImage multiArchImage, SourceImageReference sourceReference,
         DestinationImageReference destinationReference,
         CancellationToken cancellationToken) 
-        => await LoadAsync(images, sourceReference, destinationReference, cancellationToken,
+        => await LoadAsync(multiArchImage, sourceReference, destinationReference, cancellationToken,
             DockerCli.WriteMultiArchOciImageToStreamAsync);
 
     public Task<bool> IsAvailableAsync(CancellationToken cancellationToken) => Task.FromResult(true);

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -23,7 +23,7 @@ internal class ArchiveFileRegistry : ILocalRegistry
         var directorySeparatorChar = Path.DirectorySeparatorChar;
 
         // if doesn't end with a file extension, assume it's a directory
-        if (!fullPath.Split(directorySeparatorChar).Last().Contains('.'))
+        if (!Path.HasExtension(fullPath))
         {
            fullPath += Path.DirectorySeparatorChar;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -625,7 +625,7 @@ internal sealed class DockerCli
         }
     }
 
-    private static bool IsContainerdStoreEnabledForDocker()
+    internal static bool IsContainerdStoreEnabledForDocker()
     {
         try
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -311,7 +311,7 @@ internal sealed class DockerCli
         await WriteImageLayers(writer, image, sourceReference, d => $"{d.Substring("sha256:".Length)}/layer.tar", cancellationToken, layerTarballPaths)
             .ConfigureAwait(false);
 
-        string configTarballPath = $"{image.ImageSha}.json";
+        string configTarballPath = $"{image.ImageSha!}.json";
         await WriteImageConfig(writer, image, configTarballPath, cancellationToken)
             .ConfigureAwait(false);
 
@@ -492,7 +492,7 @@ internal sealed class DockerCli
         await WriteImageLayers(writer, image, sourceReference, d => $"{_blobsPath}/{d.Substring("sha256:".Length)}", cancellationToken)
             .ConfigureAwait(false);
 
-        await WriteImageConfig(writer, image, $"{_blobsPath}/{image.ImageSha}", cancellationToken)
+        await WriteImageConfig(writer, image, $"{_blobsPath}/{image.ImageSha!}", cancellationToken)
             .ConfigureAwait(false);
 
         await WriteManifestForOciImage(writer, image, cancellationToken)

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/DockerCli.cs
@@ -510,7 +510,7 @@ internal sealed class DockerCli
                 mediaType = SchemaTypes.OciManifestV1,
                 size = images[i].Manifest.Length,
                 digest = images[i].ManifestDigest,
-                platform = new PlatformInformation { architecture = images[i].Architecture, os = images[i].OS }
+                platform = new PlatformInformation { architecture = images[i].Architecture!, os = images[i].OS! }
             };
             manifests[i] = manifest;
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
@@ -14,6 +14,11 @@ internal interface ILocalRegistry {
     public Task LoadAsync(BuiltImage image, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Loads a multi-arch image (presumably from a tarball) into the local registry.
+    /// </summary>
+    public Task LoadAsync(BuiltImage[] images, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Checks to see if the local registry is available. This is used to give nice errors to the user.
     /// </summary>
     public Task<bool> IsAvailableAsync(CancellationToken cancellationToken);

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ILocalRegistry.cs
@@ -16,7 +16,7 @@ internal interface ILocalRegistry {
     /// <summary>
     /// Loads a multi-arch image (presumably from a tarball) into the local registry.
     /// </summary>
-    public Task LoadAsync(BuiltImage[] images, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
+    public Task LoadAsync(MultiArchImage multiArchImage, SourceImageReference sourceReference, DestinationImageReference destinationReference, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks to see if the local registry is available. This is used to give nice errors to the user.

--- a/src/Containers/Microsoft.NET.Build.Containers/MultiArchImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/MultiArchImage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.NET.Build.Containers;
 /// <summary>
 /// Represents constructed image ready for further processing.
 /// </summary>
-internal sealed class MultiArchImage
+internal readonly struct MultiArchImage
 {
     internal required string ImageIndex { get; init; }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/MultiArchImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/MultiArchImage.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// Represents constructed image ready for further processing.
+/// </summary>
+internal sealed class MultiArchImage
+{
+    internal required string ImageIndex { get; init; }
+
+    internal required string ImageIndexMediaType { get; init; }
+
+    internal BuiltImage[]? Images { get; init; }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -86,6 +86,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateLabels.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateLabels.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolName.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -34,6 +34,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedArchiveOutputPath
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Cancel() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.CreateImageIndex() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Dispose() -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedImageIndex.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedImageIndex.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ImageTags.get -> string![]!
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ImageTags.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedContainers.get -> Microsoft.Build.Framework.ITaskItem![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -251,6 +251,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateLabels.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateLabels.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -34,8 +34,6 @@ Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedArchiveOutputPath
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Cancel() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.CreateImageIndex() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Dispose() -> void
-Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedImageIndex.get -> string!
-Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedImageIndex.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ImageTags.get -> string![]!
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ImageTags.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedContainers.get -> Microsoft.Build.Framework.ITaskItem![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -19,6 +19,18 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UserBaseImage.
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantGlobalization.get -> bool
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.UsesInvariantGlobalization.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseRegistry.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseImageName.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseImageName.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseImageTag.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.BaseImageTag.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.ArchiveOutputPath.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.LocalRegistry.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.LocalRegistry.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedArchiveOutputPath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.GeneratedArchiveOutputPath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Cancel() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.CreateImageIndex() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateImageIndex.Dispose() -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -602,22 +602,20 @@ internal sealed class Registry
         // Tags can refer to an image manifest or an image manifest list.
         // In the first case, we push tags to the registry.
         // In the second case, we push the manifest digest so the manifest list can refer to it.
-        string manifestJson = JsonSerializer.SerializeToNode(builtImage.Manifest)?.ToJsonString() ?? "";
         if (pushTags)
         {
             Debug.Assert(destination.Tags.Length > 0);
             foreach (string tag in destination.Tags)
             {
                 _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
-                await _registryAPI.Manifest.PutAsync(destination.Repository, tag, manifestJson, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
+                await _registryAPI.Manifest.PutAsync(destination.Repository, tag, builtImage.Manifest, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
                 _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
             }
         }
         else
         {
-            string manifestDigest = builtImage.Manifest.GetDigest();
-            _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, manifestDigest);
-            await _registryAPI.Manifest.PutAsync(destination.Repository, manifestDigest, manifestJson, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, builtImage.ManifestDigest);
+            await _registryAPI.Manifest.PutAsync(destination.Repository, builtImage.ManifestDigest, builtImage.Manifest, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation(Strings.Registry_ManifestUploaded, RegistryName);
         }
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -525,13 +525,17 @@ internal sealed class Registry
 
     }
 
-    public async Task PushManifestListAsync(string repositoryName, string[] tags, string manifestListJson, string mediaType, CancellationToken cancellationToken)
+    public async Task PushManifestListAsync(
+        MultiArchImage multiArchImage,
+        SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        foreach (var tag in tags)
+        foreach (var tag in destinationImageReference.Tags)
         {
             _logger.LogInformation(Strings.Registry_TagUploadStarted, tag, RegistryName);
-            await _registryAPI.Manifest.PutAsync(repositoryName, tag, manifestListJson, mediaType, cancellationToken).ConfigureAwait(false);
+            await _registryAPI.Manifest.PutAsync(destinationImageReference.Repository, tag, multiArchImage.ImageIndex, multiArchImage.ImageIndexMediaType, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
         }          
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -3,11 +3,9 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.NET.Build.Containers.Resources;
-using NuGet.Packaging;
 using NuGet.RuntimeModel;
 using System.Diagnostics;
 using System.Net.Http.Json;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.NET.Build.Containers;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -595,7 +595,7 @@ internal sealed class Registry
         cancellationToken.ThrowIfCancellationRequested();
         using (MemoryStream stringStream = new MemoryStream(Encoding.UTF8.GetBytes(builtImage.Config)))
         {
-            var configDigest = builtImage.ImageDigest;
+            var configDigest = builtImage.ImageDigest!;
             _logger.LogInformation(Strings.Registry_ConfigUploadStarted, configDigest);
             await UploadBlobAsync(destination.Repository, configDigest, stringStream, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation(Strings.Registry_ConfigUploaded);

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -421,11 +421,47 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Cannot create image index because at least one of the provided images config is invalid..
+        /// </summary>
+        internal static string InvalidImageConfig {
+            get {
+                return ResourceManager.GetString("InvalidImageConfig", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create image index because at least one of the provided images' config is missing 'architecture'..
+        /// </summary>
+        internal static string ImageConfigMissingArchitecture {
+            get {
+                return ResourceManager.GetString("ImageConfigMissingArchitecture", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create image index because at least one of the provided images' config is missing 'os'..
+        /// </summary>
+        internal static string ImageConfigMissingOs {
+            get {
+                return ResourceManager.GetString("ImageConfigMissingOs", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Image index creation for Podman is not supported..
         /// </summary>
         internal static string ImageIndex_PodmanNotSupported {
             get {
                 return ResourceManager.GetString("ImageIndex_PodmanNotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings..
+        /// </summary>
+        internal static string TipToEnableContainerdForMultiArch {
+            get {
+                return ResourceManager.GetString("TipToEnableContainerdForMultiArch", resourceCulture);
             }
         }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -403,6 +403,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Image index creation for Podman is not supported..
+        /// </summary>
+        internal static string ImageIndex_PodmanNotSupported {
+            get {
+                return ResourceManager.GetString("ImageIndex_PodmanNotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2005: The inferred image name &apos;{0}&apos; contains entirely invalid characters. The valid characters for an image name are alphanumeric characters, -, /, or _, and the image name must start with an alphanumeric character..
         /// </summary>
         internal static string InvalidImageName_EntireNameIsInvalidCharacters {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -457,11 +457,11 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings..
+        ///   Looks up a localized string similar to CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings..
         /// </summary>
-        internal static string TipToEnableContainerdForMultiArch {
+        internal static string ImageLoadFailed_ContainerdStoreDisabled {
             get {
-                return ResourceManager.GetString("TipToEnableContainerdForMultiArch", resourceCulture);
+                return ResourceManager.GetString("ImageLoadFailed_ContainerdStoreDisabled", resourceCulture);
             }
         }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -205,6 +205,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Building image &apos;{0}&apos; for runtime identifier &apos;{1}&apos; on top of base image &apos;{2}&apos;..
+        /// </summary>
+        internal static string ContainerBuilder_StartBuildingImageForRid {
+            get {
+                return ResourceManager.GetString("ContainerBuilder_StartBuildingImageForRid", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER3001: Failed creating {0} process..
         /// </summary>
         internal static string ContainerRuntimeProcessCreationFailed {
@@ -376,7 +385,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot create manifest list (image index) because no images were provided..
+        ///   Looks up a localized string similar to Cannot create image index because no images were provided..
         /// </summary>
         internal static string ImagesEmpty {
             get {
@@ -394,7 +403,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot create manifest list (image index) because provided images are invalid. Items must have &apos;Config&apos;, &apos;Manifest&apos;, &apos;ManifestMediaType&apos; and &apos;ManifestDigest&apos; metadata..
+        ///   Looks up a localized string similar to Cannot create image index because provided images are invalid. Items must have &apos;Config&apos;, &apos;Manifest&apos;, &apos;ManifestMediaType&apos; and &apos;ManifestDigest&apos; metadata..
         /// </summary>
         internal static string InvalidImageMetadata {
             get {
@@ -402,6 +411,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create image index because at least one of the provided images manifest is invalid..
+        /// </summary>
+        internal static string InvalidImageManifest {
+            get {
+                return ResourceManager.GetString("InvalidImageManifest", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Image index creation for Podman is not supported..
         /// </summary>
@@ -565,7 +583,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;mediaType&apos; of manifests should be the same in manifest list (image index)..
+        ///   Looks up a localized string similar to &apos;mediaType&apos; of manifests should be the same in image index..
         /// </summary>
         internal static string MixedMediaTypes {
             get {
@@ -817,7 +835,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot create manifest list (image index) for the provided &apos;mediaType&apos; = &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Cannot create image index for the provided &apos;mediaType&apos; = &apos;{0}&apos;..
         /// </summary>
         internal static string UnsupportedMediaType {
             get {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -457,7 +457,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings..
+        ///   Looks up a localized string similar to Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings..
         /// </summary>
         internal static string TipToEnableContainerdForMultiArch {
             get {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -608,16 +608,7 @@ namespace Microsoft.NET.Build.Containers.Resources {
                 return ResourceManager.GetString("NormalizedContainerName", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to create tarball for oci image with multiple tags..
-        /// </summary>
-        internal static string OciImageMultipleTagsNotSupported {
-            get {
-                return ResourceManager.GetString("OciImageMultipleTagsNotSupported", resourceCulture);
-            }
-        }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CONTAINER2011: {0} &apos;{1}&apos; does not exist.
         /// </summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -244,9 +244,6 @@
     <value>CONTAINER2004: Unable to download layer with descriptor '{0}' from registry '{1}' because it does not exist.</value>
     <comment>{StrBegin="CONTAINER2004: "}</comment>
   </data>
-  <data name="OciImageMultipleTagsNotSupported" xml:space="preserve">
-    <value>Unable to create tarball for oci image with multiple tags.</value>
-  </data>
   <data name="UnsupportedMediaTypeForTarball" xml:space="preserve">
     <value>Unable to create tarball for mediaType '{0}'.</value>
   </data>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -366,7 +366,7 @@
     </comment>
   </data>
   <data name="MixedMediaTypes" xml:space="preserve">
-    <value>'mediaType' of manifests should be the same in manifest list (image index).</value>
+    <value>'mediaType' of manifests should be the same in image index.</value>
     <comment/>
   </data>
   <data name="UnsupportedMediaType" xml:space="preserve">
@@ -382,11 +382,27 @@
     <comment/>
   </data>
   <data name="InvalidImageManifest" xml:space="preserve">
-    <value>Cannot create image index because at least one of the provided images manifest is invalid.</value>
+    <value>Cannot create image index because at least one of the provided images' manifest is invalid.</value>
+    <comment/>
+  </data>
+  <data name="InvalidImageConfig" xml:space="preserve">
+    <value>Cannot create image index because at least one of the provided images' config is invalid.</value>
+    <comment/>
+  </data>
+  <data name="ImageConfigMissingArchitecture" xml:space="preserve">
+    <value>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</value>
+    <comment/>
+  </data>
+  <data name="ImageConfigMissingOs" xml:space="preserve">
+    <value>Cannot create image index because at least one of the provided images' config is missing 'os'.</value>
     <comment/>
   </data>
   <data name="ImageIndex_PodmanNotSupported" xml:space="preserve">
     <value>Image index creation for Podman is not supported.</value>
+    <comment/>
+  </data>
+  <data name="TipToEnableContainerdForMultiArch" xml:space="preserve">
+    <value>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</value>
     <comment/>
   </data>
   <data name="LocalDocker_FailedToGetConfig" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -189,6 +189,10 @@
     <value>CONTAINER1009: Failed to load image from local registry. stdout: {0}</value>
     <comment>{StrBegin="CONTAINER1009: "}</comment>
   </data>
+  <data name="ImageLoadFailed_ContainerdStoreDisabled" xml:space="preserve">
+    <value>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</value>
+    <comment>{StrBegin="CONTAINER1020: "}</comment>
+  </data>
   <data name="InvalidEnvVar" xml:space="preserve">
     <value>CONTAINER2015: {0}: '{1}' was not a valid Environment Variable. Ignoring.</value>
     <comment>{StrBegin="CONTAINER2015: "}</comment>
@@ -399,10 +403,6 @@
   </data>
   <data name="ImageIndex_PodmanNotSupported" xml:space="preserve">
     <value>Image index creation for Podman is not supported.</value>
-    <comment/>
-  </data>
-  <data name="TipToEnableContainerdForMultiArch" xml:space="preserve">
-    <value>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</value>
     <comment/>
   </data>
   <data name="LocalDocker_FailedToGetConfig" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -380,6 +380,10 @@
     <value>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</value>
     <comment/>
   </data>
+  <data name="ImageIndex_PodmanNotSupported" xml:space="preserve">
+    <value>Image index creation for Podman is not supported.</value>
+    <comment/>
+  </data>
   <data name="LocalDocker_FailedToGetConfig" xml:space="preserve">
     <value>Error while reading daemon config: {0}</value>
     <comment>{0} is the exception message that ends with period</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -358,6 +358,10 @@
     <value>Building image '{0}' with tags '{1}' on top of base image '{2}'.</value>
     <comment/>
   </data>
+  <data name="ContainerBuilder_StartBuildingImageForRid" xml:space="preserve">
+    <value>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</value>
+    <comment/>
+  </data>
   <data name="BuildingImageIndex" xml:space="preserve">
     <value>Building image index '{0}' on top of manifests {1}.</value>
     <comment>
@@ -369,15 +373,19 @@
     <comment/>
   </data>
   <data name="UnsupportedMediaType" xml:space="preserve">
-    <value>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</value>
+    <value>Cannot create image index for the provided 'mediaType' = '{0}'.</value>
     <comment/>
   </data>
   <data name="ImagesEmpty" xml:space="preserve">
-    <value>Cannot create manifest list (image index) because no images were provided.</value>
+    <value>Cannot create image index because no images were provided.</value>
     <comment/>
   </data>
   <data name="InvalidImageMetadata" xml:space="preserve">
-    <value>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</value>
+    <value>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</value>
+    <comment/>
+  </data>
+  <data name="InvalidImageManifest" xml:space="preserve">
+    <value>Cannot create image index because at least one of the provided images manifest is invalid.</value>
     <comment/>
   </data>
   <data name="ImageIndex_PodmanNotSupported" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -402,7 +402,7 @@
     <comment/>
   </data>
   <data name="TipToEnableContainerdForMultiArch" xml:space="preserve">
-    <value>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</value>
+    <value>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</value>
     <comment/>
   </data>
   <data name="LocalDocker_FailedToGetConfig" xml:space="preserve">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Nebyl zjištěn žádný objekt hostitele.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Požadovaná vlastnost '{0}' nebyla nastavena nebo je prázdná.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' nebyl platný název image kontejneru, byl normalizován na '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' neexistuje.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: Nepodařilo se načíst bitovou kopii z místního registru. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: Nepodařilo se načíst bitovou kopii z místního registru. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: Načítání imagí z místního registru se nepodporuje.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Požadovaná vlastnost '{0}' nebyla nastavena nebo je prázdná.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Sestavení image {0} se značkami {1} nad základní imagí {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: Nepovedlo se deserializovat token z JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' není platná proměnná prostředí. Ignorování.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -304,11 +304,6 @@
         <target state="translated">„{0}“ war kein gültiger Containerimagename, er wurde zu „{1}“ normalisiert.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} „{1}“ ist nicht vorhanden.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Das Image „{0}“ mit den Tags „{1}“ wird auf dem Basisimage „{2}“ erstellt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: Das Token konnte nicht aus JSON deserialisiert werden.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: Fehler beim Laden des Images aus der lokalen Registrierung. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: Fehler beim Laden des Images aus der lokalen Registrierung. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: Das Pullen von Images aus der lokalen Registrierung wird nicht unterstützt.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Die erforderliche Eigenschaft „{0}“ wurde nicht festgelegt oder ist leer.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Es wurde kein Hostobjekt erkannt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}“ war keine gültige Umgebungsvariable. Sie wird ignoriert.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Die erforderliche Eigenschaft „{0}“ wurde nicht festgelegt oder ist leer.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Compilando imagen "{0}" con etiquetas "{1}" encima de la imagen base "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: No se pudo deserializar el token de JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -164,6 +164,16 @@
         <target state="translated">No se detectó ningún objeto host.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" no era una variable de entorno válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: La propiedad necesaria "{0}" no se estableció o estaba vacía.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: no se pudo cargar la imagen desde el registro local. Stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -304,11 +304,6 @@
         <target state="translated">"{0}" no era un nombre de imagen de contenedor válido, se normalizó a "{1}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} "{1}" no existe</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: no se pudo cargar la imagen desde el registro local. Stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: No se admite la extracción de imágenes del registro local.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: La propiedad necesaria "{0}" no se estableció o estaba vacía.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Génération de l’image «{0}» avec des balises «{1}» au-dessus de l’image de base «{2}».</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: impossible de désérialiser le jeton à partir de JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: Échec du chargement de l'image à partir du registre local. sortie standard : {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: Échec du chargement de l'image à partir du registre local. sortie standard : {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: L'extraction d'images à partir du registre local n'est pas prise en charge.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: la propriété requise '{0}' n’a pas été définie ou vide.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Aucun objet hôte détecté.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0} : '{1}' n’était pas une variable d’environnement valide. Ignorant.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: la propriété requise '{0}' n’a pas été définie ou vide.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' n’était pas un nom d’image conteneur valide, il a été normalisé pour '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' n’existe pas</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Compilazione dell'immagine '{0}' con i tag '{1}' sopra l'immagine di base '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: non è stato possibile deserializzare il token da JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine dal registro locale. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' non è un nome di immagine contenitore valido, è stato normalizzato in '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' non esiste</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: non è stato possibile caricare l'immagine dal registro locale. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: il pull di immagini dal registro locale non è supportato.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: la proprietà obbligatoria '{0}' non è stata impostata o è vuota.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Nessun oggetto host rilevato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' non è una variabile di ambiente valida. Il valore verrà ignorato.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: la proprietà obbligatoria '{0}' non è stata impostata o è vuota.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: ローカル レジストリからイメージを読み込めませんでした。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: ローカル レジストリからのイメージのプルはサポートされていません。</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 必要なプロパティ '{0}' が設定されていなかったか、空でした。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -164,6 +164,16 @@
         <target state="translated">ホスト オブジェクトが検出されませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' は有効な環境変数ではありませんでした。無視しています。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 必要なプロパティ '{0}' が設定されていなかったか、空でした。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -79,6 +79,11 @@
         <target state="translated">基本イメージ '{0}' の上にタグ '{1}' 付きのイメージ '{2}' をビルドしています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: JSON からトークンを逆シリアル化できませんでした。</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' は有効な環境変数ではありませんでした。無視しています。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' は有効なコンテナー イメージ名ではありませんでした。'{1}' に正規化されました</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' が存在しません</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: ローカル レジストリからイメージを読み込めませんでした。stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}'은(는) 유효한 컨테이너 이미지 이름이 아닙니다. '{1}'(으)로 정규화되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}'이(가) 존재하지 않습니다.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -164,6 +164,16 @@
         <target state="translated">호스트 개체가 검색되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}'은(는) 유효한 환경 변수가 아닙니다. 무시 중.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 필수 속성 '{0}'이(가) 설정되지 않았거나 비어 있습니다.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: 로컬 레지스트리에서 이미지를 로드하지 못했습니다. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: 로컬 레지스트리에서 이미지 끌어오기가 지원되지 않습니다.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 필수 속성 '{0}'이(가) 설정되지 않았거나 비어 있습니다.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -79,6 +79,11 @@
         <target state="translated">기본 이미지 '{2}' 위에 '{1}' 태그가 있는 '{0}' 이미지를 빌드하는 중입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: JSON에서 토큰을 역직렬화할 수 없습니다.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}'은(는) 유효한 환경 변수가 아닙니다. 무시 중.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: 로컬 레지스트리에서 이미지를 로드하지 못했습니다. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -304,11 +304,6 @@
         <target state="translated">Nazwa „{0}” nie była prawidłową nazwą obrazu kontenera, została znormalizowana do „{1}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} „{1}” nie istnieje</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: Nie można załadować obrazu z rejestru lokalnego. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Nie wykryto obiektu hosta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: wymagana właściwość „{0}” nie została ustawiona lub jest pusta.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: Nie można załadować obrazu z rejestru lokalnego. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: Ściąganie obrazów z rejestru lokalnego nie jest obsługiwane.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: wymagana właściwość „{0}” nie została ustawiona lub jest pusta.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Tworzenie obrazu „{0}” z tagami „{1}” nad obrazem podstawowym „{2}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: nie można zdeserializować tokenu z pliku JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: „{1}” nie jest prawidłową zmienną środowiskową. Ignorowanie.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Nenhum objeto de host detectado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: A propriedade obrigatória '{0}' não foi definida ou está vazia.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: falha ao carregar a imagem do registro local. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' não era um nome de imagem de contêiner válido, foi normalizado para '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' não existe</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Construindo imagem '{0}' com tags '{1}' em cima da imagem base '{2}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: não foi possível desserializar o token do JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' não era uma variável de ambiente válida. Ignorando.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: falha ao carregar a imagem do registro local. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: A extração de imagens do registro local não é suportada.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: A propriedade obrigatória '{0}' não foi definida ou está vazia.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -304,11 +304,6 @@
         <target state="translated">"{0}" не является допустимым именем образа контейнера, оно нормализовано до "{1}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} "{1}" не существует</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: не удалось загрузить образ из локального реестра. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: извлечение образов из локального реестра не поддерживается.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: обязательное свойство "{0}" не установлено или пусто.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Объект узла не обнаружен.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: обязательное свойство "{0}" не установлено или пусто.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: не удалось загрузить образ из локального реестра. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -79,6 +79,11 @@
         <target state="translated">Выполняется сборка образа "{0}" с тегами "{1}" поверх базового образа "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: не удалось десериализовать токен из JSON.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" не является допустимой переменной среды. Пропуск.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}', geçerli bir kapsayıcı görüntüsü adı değildi, '{1}' olarak normalleştirildi</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' yok</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -79,6 +79,11 @@
         <target state="translated">'{1}' etiketli '{0}' resmi, '{2}' temel görüntüsünün üzerinde oluşturuluyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: Belirteç, JSON'dan seri durumdan çıkarılamadı.</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: Görüntü yerel kayıt defterinden yüklenemedi. stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: Görüntü yerel kayıt defterinden yüklenemedi. stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: Yerel kayıt defterinden görüntü çekme desteklenmiyor.</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Gerekli '{0}' özelliği ayarlanmadı veya boş değil.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -164,6 +164,16 @@
         <target state="translated">Ana bilgisayar nesnesi algılanmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' geçerli bir Ortam Değişkeni değildi. Görmezden geliniyor.</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: Gerekli '{0}' özelliği ayarlanmadı veya boş değil.</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -164,6 +164,16 @@
         <target state="translated">未检测到主机对象。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" 不是有效的环境变量。忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 未设置必需属性 "{0}" 或为空。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: 未能从本地注册表加载映像。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: 不支持从本地注册表拉取映像。</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 未设置必需属性 "{0}" 或为空。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -304,11 +304,6 @@
         <target state="translated">“{0}”不是有效的容器映像名称，已规范化为“{1}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} {1} 不存在</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -79,6 +79,11 @@
         <target state="translated">在基本映像“{2}”顶部构建标记为“{1}”的映像“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: 无法从 JSON 反序列化令牌。</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: "{1}" 不是有效的环境变量。忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: 未能从本地注册表加载映像。stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -164,6 +164,16 @@
         <target state="translated">未偵測到主機物件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageConfigMissingArchitecture">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'architecture'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'architecture'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImageConfigMissingOs">
+        <source>Cannot create image index because at least one of the provided images' config is missing 'os'.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is missing 'os'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageIndexUploadedToRegistry">
         <source>Pushed image index '{0}' to registry '{1}'.</source>
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
@@ -194,9 +204,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' 不是有效的環境變數。正在忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageConfig">
+        <source>Cannot create image index because at least one of the provided images' config is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' config is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageManifest">
-        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
-        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <source>Cannot create image index because at least one of the provided images' manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images' manifest is invalid.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageMetadata">
@@ -290,8 +305,8 @@
         <note>{StrBegin="CONTAINER2016: "}</note>
       </trans-unit>
       <trans-unit id="MixedMediaTypes">
-        <source>'mediaType' of manifests should be the same in manifest list (image index).</source>
-        <target state="new">'mediaType' of manifests should be the same in manifest list (image index).</target>
+        <source>'mediaType' of manifests should be the same in image index.</source>
+        <target state="new">'mediaType' of manifests should be the same in image index.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoRequestUriSpecified">
@@ -393,6 +408,11 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 必要的屬性 '{0}' 未設定或是空的。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
+      </trans-unit>
+      <trans-unit id="TipToEnableContainerdForMultiArch">
+        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -164,6 +164,11 @@
         <target state="new">Pushed image index '{0}' to registry '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImageIndex_PodmanNotSupported">
+        <source>Image index creation for Podman is not supported.</source>
+        <target state="new">Image index creation for Podman is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImageLoadFailed">
         <source>CONTAINER1009: Failed to load image from local registry. stdout: {0}</source>
         <target state="translated">CONTAINER1009: 無法從本機登錄載入映像。stdout: {0}</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -410,8 +410,8 @@
         <note>{StrBegin="CONTAINER4001: "}</note>
       </trans-unit>
       <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensude that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
+        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
+        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
         <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -79,6 +79,11 @@
         <target state="translated">在基礎映像 '{2}' 上建立具有標記 '{1}' 的映像 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainerBuilder_StartBuildingImageForRid">
+        <source>Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</source>
+        <target state="new">Building image '{0}' for runtime identifier '{1}' on top of base image '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CouldntDeserializeJsonToken">
         <source>CONTAINER1007: Could not deserialize token from JSON.</source>
         <target state="translated">CONTAINER1007: 無法從 JSON 還原序列化權杖。</target>
@@ -180,8 +185,8 @@
         <note>{StrBegin="CONTAINER1010: "}</note>
       </trans-unit>
       <trans-unit id="ImagesEmpty">
-        <source>Cannot create manifest list (image index) because no images were provided.</source>
-        <target state="new">Cannot create manifest list (image index) because no images were provided.</target>
+        <source>Cannot create image index because no images were provided.</source>
+        <target state="new">Cannot create image index because no images were provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEnvVar">
@@ -189,9 +194,14 @@
         <target state="translated">CONTAINER2015: {0}: '{1}' 不是有效的環境變數。正在忽略。</target>
         <note>{StrBegin="CONTAINER2015: "}</note>
       </trans-unit>
+      <trans-unit id="InvalidImageManifest">
+        <source>Cannot create image index because at least one of the provided images manifest is invalid.</source>
+        <target state="new">Cannot create image index because at least one of the provided images manifest is invalid.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidImageMetadata">
-        <source>Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
-        <target state="new">Cannot create manifest list (image index) because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
+        <source>Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</source>
+        <target state="new">Cannot create image index because provided images are invalid. Items must have 'Config', 'Manifest', 'ManifestMediaType' and 'ManifestDigest' metadata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidImageName_EntireNameIsInvalidCharacters">
@@ -420,8 +430,8 @@
         <note>{StrBegin="CONTAINER2001: "}</note>
       </trans-unit>
       <trans-unit id="UnsupportedMediaType">
-        <source>Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</source>
-        <target state="new">Cannot create manifest list (image index) for the provided 'mediaType' = '{0}'.</target>
+        <source>Cannot create image index for the provided 'mediaType' = '{0}'.</source>
+        <target state="new">Cannot create image index for the provided 'mediaType' = '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnsupportedMediaTypeForTarball">

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -189,6 +189,11 @@
         <target state="translated">CONTAINER1009: 無法從本機登錄載入映像。stdout: {0}</target>
         <note>{StrBegin="CONTAINER1009: "}</note>
       </trans-unit>
+      <trans-unit id="ImageLoadFailed_ContainerdStoreDisabled">
+        <source>CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</source>
+        <target state="new">CONTAINER1020: Failed to load image because containerd image store is not enabled for Docker. Tip: You can enable it by checking 'Use containerd for pulling and storing images' in Docker Desktop settings.</target>
+        <note>{StrBegin="CONTAINER1020: "}</note>
+      </trans-unit>
       <trans-unit id="ImagePullNotSupported">
         <source>CONTAINER1010: Pulling images from local registry is not supported.</source>
         <target state="translated">CONTAINER1010: 不支援從本機登錄提取映像。</target>
@@ -408,11 +413,6 @@
         <source>CONTAINER4001: Required property '{0}' was not set or empty.</source>
         <target state="translated">CONTAINER4001: 必要的屬性 '{0}' 未設定或是空的。</target>
         <note>{StrBegin="CONTAINER4001: "}</note>
-      </trans-unit>
-      <trans-unit id="TipToEnableContainerdForMultiArch">
-        <source>Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</source>
-        <target state="new">Tip: For multi-arch image publishing, ensure that 'Use containerd for pulling and storing images' is checked in Docker Desktop settings.</target>
-        <note />
       </trans-unit>
       <trans-unit id="TooManyRetries">
         <source>CONTAINER1006: Too many retries, stopping.</source>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -304,11 +304,6 @@
         <target state="translated">'{0}' 不是有效的容器映像名稱，已標準化為 '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="OciImageMultipleTagsNotSupported">
-        <source>Unable to create tarball for oci image with multiple tags.</source>
-        <target state="new">Unable to create tarball for oci image with multiple tags.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PublishDirectoryDoesntExist">
         <source>CONTAINER2011: {0} '{1}' does not exist</source>
         <target state="translated">CONTAINER2011: {0} '{1}' 不存在</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
+using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers.Tasks;
 
@@ -85,5 +86,7 @@ partial class CreateImageIndex
         ImageTags = Array.Empty<string>();
         GeneratedArchiveOutputPath = string.Empty;
         GeneratedImageIndex = string.Empty;
+
+        TaskResources = Resource.Manager;
     }
 } 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
@@ -11,7 +11,6 @@ partial class CreateImageIndex
     /// The base registry to pull from.
     /// Ex: mcr.microsoft.com
     /// </summary>
-    [Required]
     public string BaseRegistry { get; set; }
 
     /// <summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
@@ -61,8 +61,17 @@ partial class CreateImageIndex
     [Required]
     public string[] ImageTags { get; set; }
 
+    /// <summary>
+    /// The generated archive output path.
+    /// </summary>
     [Output]
     public string GeneratedArchiveOutputPath { get; set; }
+
+    /// <summary>
+    /// The generated image index (manifest list) in JSON format.
+    /// </summary>
+    [Output]
+    public string GeneratedImageIndex { get; set; }
 
     public CreateImageIndex()
     {
@@ -76,5 +85,6 @@ partial class CreateImageIndex
         Repository = string.Empty;
         ImageTags = Array.Empty<string>();
         GeneratedArchiveOutputPath = string.Empty;
+        GeneratedImageIndex = string.Empty;
     }
 } 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.Interface.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Containers.Tasks;
+
+partial class CreateImageIndex
+{
+    /// <summary>
+    /// The base registry to pull from.
+    /// Ex: mcr.microsoft.com
+    /// </summary>
+    [Required]
+    public string BaseRegistry { get; set; }
+
+    /// <summary>
+    /// The base image to pull.
+    /// Ex: dotnet/runtime
+    /// </summary>
+    [Required]
+    public string BaseImageName { get; set; }
+
+    /// <summary>
+    /// The base image tag.
+    /// Ex: 6.0
+    /// </summary>
+    [Required]
+    public string BaseImageTag { get; set; }
+
+    /// <summary>
+    /// Manifests to include in the image index.
+    /// </summary>
+    [Required]
+    public ITaskItem[] GeneratedContainers { get; set; }
+
+    /// <summary>
+    /// The registry to push the image index to.
+    /// </summary>
+    public string OutputRegistry { get; set; }
+
+    /// <summary>
+    /// The file path to which to write a tar.gz archive of the container image.
+    /// </summary>
+    public string ArchiveOutputPath { get; set; }
+
+    /// <summary>
+    /// The kind of local registry to use, if any.
+    /// </summary>
+    public string LocalRegistry { get; set; }
+
+    /// <summary>
+    /// The name of the output image index (manifest list) that will be pushed to the registry.
+    /// </summary>
+    [Required]
+    public string Repository { get; set; }
+
+    /// <summary>
+    /// The tag to associate with the new image index (manifest list).
+    /// </summary>
+    [Required]
+    public string[] ImageTags { get; set; }
+
+    [Output]
+    public string GeneratedArchiveOutputPath { get; set; }
+
+    public CreateImageIndex()
+    {
+        BaseRegistry = string.Empty;
+        BaseImageName = string.Empty;
+        BaseImageTag = string.Empty;
+        GeneratedContainers = Array.Empty<ITaskItem>();
+        OutputRegistry = string.Empty;
+        ArchiveOutputPath = string.Empty;
+        LocalRegistry = string.Empty;
+        Repository = string.Empty;
+        ImageTags = Array.Empty<string>();
+        GeneratedArchiveOutputPath = string.Empty;
+    }
+} 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -83,7 +83,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
 
         var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
-        await ImagePublisher.PublishImageAsync(multiArchImage, sourceImageReference, destinationImageReference, Log, BuildEngine != null, telemetry, cancellationToken)
+        await ImagePublisher.PublishImageAsync(multiArchImage, sourceImageReference, destinationImageReference, Log, telemetry, cancellationToken)
             .ConfigureAwait(false); 
 
         return !Log.HasLoggedErrors;

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -132,8 +132,6 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
         ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
         ILogger logger = msbuildLoggerFactory.CreateLogger<CreateImageIndex>();
 
-        // Look up in CreateNewImage how the image is published to registry/local daemon/tarball
-
         RegistryMode sourceRegistryMode = BaseRegistry.Equals(OutputRegistry, StringComparison.InvariantCultureIgnoreCase) ? RegistryMode.PullFromOutput : RegistryMode.Pull;
         Registry? sourceRegistry = IsLocalPull ? null : new Registry(BaseRegistry, logger, sourceRegistryMode);
         SourceImageReference sourceImageReference = new(sourceRegistry, BaseImageName, BaseImageTag);
@@ -153,7 +151,7 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
             return false;
         }
 
-        var telemetry = CreateTelemetryContext(sourceImageReference, destinationImageReference);
+        var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
         switch (destinationImageReference.Kind)
         {
@@ -166,9 +164,7 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
                 break;
             case DestinationImageReferenceKind.RemoteRegistry:
                 await PushToRemoteRegistryAsync(images,
-                    sourceImageReference,
                     destinationImageReference,
-                    telemetry,
                     cancellationToken).ConfigureAwait(false);
                 break;
             default:
@@ -220,9 +216,8 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
         }
     }
 
-    private async Task PushToRemoteRegistryAsync(BuiltImage[] images, SourceImageReference sourceImageReference,
+    private async Task PushToRemoteRegistryAsync(BuiltImage[] images,
         DestinationImageReference destinationImageReference,
-        Telemetry telemetry,
         CancellationToken cancellationToken)
     {
         try
@@ -328,110 +323,5 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
             throw new ArgumentException("Image config should contain 'os'.");
 
         return (architecture, os);
-    }
-
-    private Telemetry CreateTelemetryContext(SourceImageReference source, DestinationImageReference destination)
-    {
-        var context = new PublishTelemetryContext(
-            source.Registry is not null ? GetRegistryType(source.Registry) : null,
-            null, // we don't support local pull yet, but we may in the future
-            destination.RemoteRegistry is not null ? GetRegistryType(destination.RemoteRegistry) : null,
-            destination.LocalRegistry is not null ? GetLocalStorageType(destination.LocalRegistry) : null);
-        return new Telemetry(Log, context);
-    }
-
-    private RegistryType GetRegistryType(Registry r)
-    {
-        if (r.IsMcr) return RegistryType.MCR;
-        if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
-        if (r.IsAmazonECRRegistry) return RegistryType.AWS;
-        if (r.IsAzureContainerRegistry) return RegistryType.Azure;
-        if (r.IsGoogleArtifactRegistry) return RegistryType.Google;
-        if (r.IsDockerHub) return RegistryType.DockerHub;
-        return RegistryType.Other;
-    }
-
-    private LocalStorageType GetLocalStorageType(ILocalRegistry r)
-    {
-        if (r is ArchiveFileRegistry) return LocalStorageType.Tarball;
-        var d = r as DockerCli;
-        System.Diagnostics.Debug.Assert(d != null, "Unknown local registry type");
-        if (d.GetCommand() == DockerCli.DockerCommand) return LocalStorageType.Docker;
-        else return LocalStorageType.Podman;
-    }
-
-    /// <summary>
-    /// Interesting data about the container publish - used to track the usage rates of various sources/targets of the process
-    /// and to help diagnose issues with the container publish overall.
-    /// </summary>
-    /// <param name="RemotePullType">If the base image came from a remote registry, what kind of registry was it?</param>
-    /// <param name="LocalPullType">If the base image came from a local store of some kind, what kind of store was it?</param>
-    /// <param name="RemotePushType">If the new image is being pushed to a remote registry, what kind of registry is it?</param>
-    /// <param name="LocalPushType">If the new image is being stored in a local store of some kind, what kind of store is it?</param>
-    private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
-    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
-    private enum LocalStorageType { Docker, Podman, Tarball }
-
-    private class Telemetry(Microsoft.Build.Utilities.TaskLoggingHelper Log, PublishTelemetryContext context)
-    {
-        private IDictionary<string, string?> ContextProperties() => new Dictionary<string, string?>
-            {
-                { nameof(context.RemotePullType), context.RemotePullType?.ToString() },
-                { nameof(context.LocalPullType), context.LocalPullType?.ToString() },
-                { nameof(context.RemotePushType), context.RemotePushType?.ToString() },
-                { nameof(context.LocalPushType), context.LocalPushType?.ToString() }
-            };
-
-        public void LogPublishSuccess()
-        {
-            Log.LogTelemetry("sdk/container/publish/success", ContextProperties());
-        }
-
-        public void LogUnknownRepository()
-        {
-            var props = ContextProperties();
-            props.Add("error", "unknown_repository");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogCredentialFailure(SourceImageReference _)
-        {
-            var props = ContextProperties();
-            props.Add("error", "credential_failure");
-            props.Add("direction", "pull");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogCredentialFailure(DestinationImageReference d)
-        {
-            var props = ContextProperties();
-            props.Add("error", "credential_failure");
-            props.Add("direction", "push");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogRidMismatch(string desiredRid, string[] availableRids)
-        {
-            var props = ContextProperties();
-            props.Add("error", "rid_mismatch");
-            props.Add("target_rid", desiredRid);
-            props.Add("available_rids", string.Join(",", availableRids));
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogMissingLocalBinary()
-        {
-            var props = ContextProperties();
-            props.Add("error", "missing_binary");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogLocalLoadError()
-        {
-            var props = ContextProperties();
-            props.Add("error", "local_load");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -135,17 +135,26 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
         return images;
     }
 
-    private static (string, string) GetArchitectureAndOsFromConfig(string config)
+    private (string, string) GetArchitectureAndOsFromConfig(string config)
     {
-        var configJson = JsonNode.Parse(config) as JsonObject ??
-            throw new ArgumentException("Image config should be a JSON object.");
-
-        var architecture = configJson["architecture"]?.ToString() ??
-            throw new ArgumentException("Image config should contain 'architecture'.");
-
-        var os = configJson["os"]?.ToString() ??
-            throw new ArgumentException("Image config should contain 'os'.");
-
+        var configJson = JsonNode.Parse(config) as JsonObject;
+        if (configJson is null)
+        {
+            Log.LogError(Strings.InvalidImageConfig);
+            return (string.Empty, string.Empty);
+        }
+        var architecture = configJson["architecture"]?.ToString();
+        if (architecture is null)
+        {
+            Log.LogError(Strings.ImageConfigMissingArchitecture);
+            return (string.Empty, string.Empty);
+        } 
+        var os = configJson["os"]?.ToString();
+        if (os is null)
+        {
+            Log.LogError(Strings.ImageConfigMissingOs);
+            return (string.Empty, string.Empty);
+        }
         return (architecture, os);
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -52,8 +52,6 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
             return false;
         }
 
-        
-
         using MSBuildLoggerProvider loggerProvider = new(Log);
         ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
         ILogger logger = msbuildLoggerFactory.CreateLogger<CreateImageIndex>();

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -69,18 +69,19 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
             LocalRegistry);
 
         var images = ParseImages(destinationImageReference.Kind);
-
         if (Log.HasLoggedErrors)
         {
             return false;
         }
 
-        GeneratedArchiveOutputPath = ArchiveOutputPath;
+        logger.LogInformation(Strings.BuildingImageIndex, destinationImageReference, string.Join(", ", images.Select(i => i.ManifestDigest)));
 
         var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
         await ImagePublisher.PublishImageAsync(images, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
             .ConfigureAwait(false);
+
+        GeneratedArchiveOutputPath = ArchiveOutputPath;
 
         return !Log.HasLoggedErrors;
     }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -23,7 +23,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
         _cancellationTokenSource.Dispose();
     }
 
-    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry);
+    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry.Trim());
 
     public override bool Execute()
     {

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
-using Microsoft.NET.Build.Containers.LocalDaemons;
 using Microsoft.NET.Build.Containers.Logging;
 using Microsoft.NET.Build.Containers.Resources;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -127,6 +125,12 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
     internal async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (LocalRegistry == "Podman")
+        {
+            Log.LogError(Strings.ImageIndex_PodmanNotSupported);
+            return false;
+        }
 
         using MSBuildLoggerProvider loggerProvider = new(Log);
         ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -52,6 +52,8 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
             return false;
         }
 
+        
+
         using MSBuildLoggerProvider loggerProvider = new(Log);
         ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
         ILogger logger = msbuildLoggerFactory.CreateLogger<CreateImageIndex>();

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -155,7 +155,7 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
 
         var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
-        await ImagePublisher.PublishImage(images, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+        await ImagePublisher.PublishImageAsync(images, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
             .ConfigureAwait(false);
 
         return !Log.HasLoggedErrors;

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
+using Microsoft.NET.Build.Containers.LocalDaemons;
 using Microsoft.NET.Build.Containers.Logging;
 using Microsoft.NET.Build.Containers.Resources;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -15,6 +18,27 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
 {
     #region Parameters
     /// <summary>
+    /// The base registry to pull from.
+    /// Ex: mcr.microsoft.com
+    /// </summary>
+    [Required]
+    public string BaseRegistry { get; set; }
+
+    /// <summary>
+    /// The base image to pull.
+    /// Ex: dotnet/runtime
+    /// </summary>
+    [Required]
+    public string BaseImageName { get; set; }
+
+    /// <summary>
+    /// The base image tag.
+    /// Ex: 6.0
+    /// </summary>
+    [Required]
+    public string BaseImageTag { get; set; }
+
+    /// <summary>
     /// Manifests to include in the image index.
     /// </summary>
     [Required]
@@ -23,8 +47,17 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
     /// <summary>
     /// The registry to push the image index to.
     /// </summary>
-    [Required]
     public string OutputRegistry { get; set; }
+
+    /// <summary>
+    /// The file path to which to write a tar.gz archive of the container image.
+    /// </summary>
+    public string ArchiveOutputPath { get; set; }
+
+    /// <summary>
+    /// The kind of local registry to use, if any.
+    /// </summary>
+    public string LocalRegistry { get; set; }
 
     /// <summary>
     /// The name of the output image index (manifest list) that will be pushed to the registry.
@@ -38,6 +71,9 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
     [Required]
     public string[] ImageTags { get; set; }
 
+    [Output]
+    public string GeneratedArchiveOutputPath { get; set; }
+
     /// <summary>
     /// The generated image index (manifest list) in JSON format.
     /// </summary>
@@ -46,10 +82,16 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
 
     public CreateImageIndex()
     {
+        BaseRegistry = string.Empty;
+        BaseImageName = string.Empty;
+        BaseImageTag = string.Empty;
         GeneratedContainers = Array.Empty<ITaskItem>();
         OutputRegistry = string.Empty;
+        ArchiveOutputPath = string.Empty;
+        LocalRegistry = string.Empty;
         Repository = string.Empty;
         ImageTags = Array.Empty<string>();
+        GeneratedArchiveOutputPath = string.Empty;
         GeneratedImageIndex = string.Empty;
     }
     #endregion
@@ -62,6 +104,8 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
     {
         _cancellationTokenSource.Dispose();
     }
+
+    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry);
 
     public override bool Execute()
     {
@@ -84,25 +128,79 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var images = ParseImages();
+        using MSBuildLoggerProvider loggerProvider = new(Log);
+        ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
+        ILogger logger = msbuildLoggerFactory.CreateLogger<CreateImageIndex>();
+
+        // Look up in CreateNewImage how the image is published to registry/local daemon/tarball
+
+        RegistryMode sourceRegistryMode = BaseRegistry.Equals(OutputRegistry, StringComparison.InvariantCultureIgnoreCase) ? RegistryMode.PullFromOutput : RegistryMode.Pull;
+        Registry? sourceRegistry = IsLocalPull ? null : new Registry(BaseRegistry, logger, sourceRegistryMode);
+        SourceImageReference sourceImageReference = new(sourceRegistry, BaseImageName, BaseImageTag);
+
+        DestinationImageReference destinationImageReference = DestinationImageReference.CreateFromSettings(
+            Repository,
+            ImageTags,
+            msbuildLoggerFactory,
+            ArchiveOutputPath,
+            OutputRegistry,
+            LocalRegistry);
+
+        var images = ParseImages(destinationImageReference.Kind);
+
         if (Log.HasLoggedErrors)
         {
             return false;
         }
 
-        using MSBuildLoggerProvider loggerProvider = new(Log);
-        ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
-        ILogger logger = msbuildLoggerFactory.CreateLogger<CreateImageIndex>();
+        var telemetry = CreateTelemetryContext(sourceImageReference, destinationImageReference);
 
-        logger.LogInformation(Strings.BuildingImageIndex, GetRepositoryAndTagsString(), string.Join(", ", images.Select(i => i.ManifestDigest)));
+        switch (destinationImageReference.Kind)
+        {
+            case DestinationImageReferenceKind.LocalRegistry:
+                await PushToLocalRegistryAsync(images,
+                    sourceImageReference,
+                    destinationImageReference,
+                    telemetry,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            case DestinationImageReferenceKind.RemoteRegistry:
+                await PushToRemoteRegistryAsync(images,
+                    sourceImageReference,
+                    destinationImageReference,
+                    telemetry,
+                    cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
 
+        telemetry.LogPublishSuccess();
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private async Task PushToLocalRegistryAsync(BuiltImage[] images, SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
+        if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
+        {
+            telemetry.LogMissingLocalBinary();
+            Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
+            return;
+        }
         try
         {
-            (string imageIndex, string mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
+            await localRegistry.LoadAsync(images, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
+            SafeLog(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
 
-            GeneratedImageIndex = imageIndex;
-
-            await PushToRemoteRegistry(GeneratedImageIndex, mediaType, logger, cancellationToken);
+            if (localRegistry is ArchiveFileRegistry archive)
+            {
+                GeneratedArchiveOutputPath = archive.ArchiveOutputPath;
+            }
         }
         catch (ContainerHttpException e)
         {
@@ -111,17 +209,65 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
                 Log.LogErrorFromException(e, true);
             }
         }
-        catch (ArgumentException ex)
+        catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
         {
-            Log.LogErrorFromException(ex);
+            telemetry.LogLocalLoadError();
+            Log.LogErrorFromException(dle, showStackTrace: false);
         }
-
-        return !Log.HasLoggedErrors;
+        catch (ArgumentException argEx)
+        {
+            Log.LogErrorFromException(argEx, showStackTrace: false);
+        }
     }
 
-    private ImageInfo[] ParseImages()
+    private async Task PushToRemoteRegistryAsync(BuiltImage[] images, SourceImageReference sourceImageReference,
+        DestinationImageReference destinationImageReference,
+        Telemetry telemetry,
+        CancellationToken cancellationToken)
     {
-        var images = new ImageInfo[GeneratedContainers.Length];
+        try
+        {
+            (string imageIndex, string mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
+            await destinationImageReference.RemoteRegistry!.PushManifestListAsync(
+                destinationImageReference.Repository,
+                destinationImageReference.Tags,
+                imageIndex,
+                mediaType,
+                cancellationToken).ConfigureAwait(false);
+            SafeLog(Strings.ImageIndexUploadedToRegistry, destinationImageReference, OutputRegistry);
+        }
+        catch (UnableToAccessRepositoryException)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
+            }
+        }
+        catch (ContainerHttpException e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+        }
+        catch (Exception e)
+        {
+            if (BuildEngine != null)
+            {
+                Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
+                Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
+            }
+        }
+    }
+
+    private void SafeLog(string message, params object[] formatParams)
+    {
+        if (BuildEngine != null) Log.LogMessage(MessageImportance.High, message, formatParams);
+    }
+
+    private BuiltImage[] ParseImages(DestinationImageReferenceKind destinationKind)
+    {
+        var images = new BuiltImage[GeneratedContainers.Length];
 
         for (int i = 0; i < GeneratedContainers.Length; i++)
         {
@@ -132,38 +278,160 @@ public sealed class CreateImageIndex : Microsoft.Build.Utilities.Task, ICancelab
             string manifest = unparsedImage.GetMetadata("Manifest");
             string manifestMediaType = unparsedImage.GetMetadata("ManifestMediaType");
 
+            //TODO: add manifestmedia type to the error message
             if (string.IsNullOrEmpty(config) || string.IsNullOrEmpty(manifestDigest) || string.IsNullOrEmpty(manifest))
             {
                 Log.LogError(Strings.InvalidImageMetadata, unparsedImage.ItemSpec);
                 break;
             }
 
-            images[i] = new ImageInfo
+            var manifestV2 = JsonSerializer.Deserialize<ManifestV2>(manifest);
+            if (manifestV2 == null)
+            {
+                //TODO: log new error about manifest not deserealized
+                Log.LogError(Strings.InvalidImageMetadata, unparsedImage.ItemSpec);
+                break;
+            }
+
+            string imageDigest = manifestV2.Config.digest;
+            string imageSha = DigestUtils.GetShaFromDigest(imageDigest);
+            // We don't need layers for remote registry, as the individual images should be pushed already
+            var layers = destinationKind == DestinationImageReferenceKind.RemoteRegistry ? null : manifestV2.Layers;
+            (string architecture, string os) = GetArchitectureAndOsFromConfig(config);
+
+            images[i] = new BuiltImage()
             {
                 Config = config,
-                ManifestDigest = manifestDigest,
+                ImageDigest = imageDigest,
+                ImageSha = imageSha,
                 Manifest = manifest,
-                ManifestMediaType = manifestMediaType
+                ManifestDigest = manifestDigest,
+                ManifestMediaType = manifestMediaType,
+                Layers = layers,
+                OS = os,
+                Architecture = architecture
             };
         }
 
         return images;
     }
 
-    private async Task PushToRemoteRegistry(string manifestList, string mediaType, ILogger logger, CancellationToken cancellationToken)
+    private static (string, string) GetArchitectureAndOsFromConfig(string config)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        Debug.Assert(ImageTags.Length > 0);
-        var registry = new Registry(OutputRegistry, logger, RegistryMode.Push);
-        await registry.PushManifestListAsync(Repository, ImageTags, manifestList, mediaType, cancellationToken).ConfigureAwait(false);
-        logger.LogInformation(Strings.ImageIndexUploadedToRegistry, GetRepositoryAndTagsString(), OutputRegistry);
+        var configJson = JsonNode.Parse(config) as JsonObject ??
+            throw new ArgumentException("Image config should be a JSON object.");
+
+        var architecture = configJson["architecture"]?.ToString() ??
+            throw new ArgumentException("Image config should contain 'architecture'.");
+
+        var os = configJson["os"]?.ToString() ??
+            throw new ArgumentException("Image config should contain 'os'.");
+
+        return (architecture, os);
     }
 
-    private string? _repositoryAndTagsString = null;
-
-    private string GetRepositoryAndTagsString()
+    private Telemetry CreateTelemetryContext(SourceImageReference source, DestinationImageReference destination)
     {
-        _repositoryAndTagsString ??= $"{Repository}:{string.Join(", ", ImageTags)}";
-        return _repositoryAndTagsString;
+        var context = new PublishTelemetryContext(
+            source.Registry is not null ? GetRegistryType(source.Registry) : null,
+            null, // we don't support local pull yet, but we may in the future
+            destination.RemoteRegistry is not null ? GetRegistryType(destination.RemoteRegistry) : null,
+            destination.LocalRegistry is not null ? GetLocalStorageType(destination.LocalRegistry) : null);
+        return new Telemetry(Log, context);
+    }
+
+    private RegistryType GetRegistryType(Registry r)
+    {
+        if (r.IsMcr) return RegistryType.MCR;
+        if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
+        if (r.IsAmazonECRRegistry) return RegistryType.AWS;
+        if (r.IsAzureContainerRegistry) return RegistryType.Azure;
+        if (r.IsGoogleArtifactRegistry) return RegistryType.Google;
+        if (r.IsDockerHub) return RegistryType.DockerHub;
+        return RegistryType.Other;
+    }
+
+    private LocalStorageType GetLocalStorageType(ILocalRegistry r)
+    {
+        if (r is ArchiveFileRegistry) return LocalStorageType.Tarball;
+        var d = r as DockerCli;
+        System.Diagnostics.Debug.Assert(d != null, "Unknown local registry type");
+        if (d.GetCommand() == DockerCli.DockerCommand) return LocalStorageType.Docker;
+        else return LocalStorageType.Podman;
+    }
+
+    /// <summary>
+    /// Interesting data about the container publish - used to track the usage rates of various sources/targets of the process
+    /// and to help diagnose issues with the container publish overall.
+    /// </summary>
+    /// <param name="RemotePullType">If the base image came from a remote registry, what kind of registry was it?</param>
+    /// <param name="LocalPullType">If the base image came from a local store of some kind, what kind of store was it?</param>
+    /// <param name="RemotePushType">If the new image is being pushed to a remote registry, what kind of registry is it?</param>
+    /// <param name="LocalPushType">If the new image is being stored in a local store of some kind, what kind of store is it?</param>
+    private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
+    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
+    private enum LocalStorageType { Docker, Podman, Tarball }
+
+    private class Telemetry(Microsoft.Build.Utilities.TaskLoggingHelper Log, PublishTelemetryContext context)
+    {
+        private IDictionary<string, string?> ContextProperties() => new Dictionary<string, string?>
+            {
+                { nameof(context.RemotePullType), context.RemotePullType?.ToString() },
+                { nameof(context.LocalPullType), context.LocalPullType?.ToString() },
+                { nameof(context.RemotePushType), context.RemotePushType?.ToString() },
+                { nameof(context.LocalPushType), context.LocalPushType?.ToString() }
+            };
+
+        public void LogPublishSuccess()
+        {
+            Log.LogTelemetry("sdk/container/publish/success", ContextProperties());
+        }
+
+        public void LogUnknownRepository()
+        {
+            var props = ContextProperties();
+            props.Add("error", "unknown_repository");
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
+        public void LogCredentialFailure(SourceImageReference _)
+        {
+            var props = ContextProperties();
+            props.Add("error", "credential_failure");
+            props.Add("direction", "pull");
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
+        public void LogCredentialFailure(DestinationImageReference d)
+        {
+            var props = ContextProperties();
+            props.Add("error", "credential_failure");
+            props.Add("direction", "push");
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
+        public void LogRidMismatch(string desiredRid, string[] availableRids)
+        {
+            var props = ContextProperties();
+            props.Add("error", "rid_mismatch");
+            props.Add("target_rid", desiredRid);
+            props.Add("available_rids", string.Join(",", availableRids));
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
+        public void LogMissingLocalBinary()
+        {
+            var props = ContextProperties();
+            props.Add("error", "missing_binary");
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
+        public void LogLocalLoadError()
+        {
+            var props = ContextProperties();
+            props.Add("error", "local_load");
+            Log.LogTelemetry("sdk/container/publish/error", props);
+        }
+
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -23,7 +23,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
         _cancellationTokenSource.Dispose();
     }
 
-    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry.Trim());
+    private bool IsLocalPull => string.IsNullOrWhiteSpace(BaseRegistry);
 
     public override bool Execute()
     {

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -83,7 +83,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
 
         var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
-        await ImagePublisher.PublishImageAsync(multiArchImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+        await ImagePublisher.PublishImageAsync(multiArchImage, sourceImageReference, destinationImageReference, Log, BuildEngine != null, telemetry, cancellationToken)
             .ConfigureAwait(false); 
 
         return !Log.HasLoggedErrors;

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -20,7 +20,6 @@ partial class CreateNewImage
     /// The base registry to pull from.
     /// Ex: mcr.microsoft.com
     /// </summary>
-    [Required]
     public string BaseRegistry { get; set; }
 
     /// <summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -161,6 +161,11 @@ partial class CreateNewImage
     [Required]
     public bool GenerateDigestLabel { get; set; }
 
+    /// <summary>
+    /// If true, the tooling will skip the publishing step.
+    /// </summary>
+    public bool SkipPublishing { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -170,9 +170,9 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         cancellationToken.ThrowIfCancellationRequested();
 
         // at this point we're done with modifications and are just pushing the data other places
-        GeneratedContainerManifest = JsonSerializer.Serialize(builtImage.Manifest);
+        GeneratedContainerManifest = builtImage.Manifest;
         GeneratedContainerConfiguration = builtImage.Config;
-        GeneratedContainerDigest = builtImage.Manifest.GetDigest();
+        GeneratedContainerDigest = builtImage.ManifestDigest;
         GeneratedArchiveOutputPath = ArchiveOutputPath;
         GeneratedContainerMediaType = builtImage.ManifestMediaType;
         GeneratedContainerNames = destinationImageReference.FullyQualifiedImageNames().Select(name => new Microsoft.Build.Utilities.TaskItem(name)).ToArray();

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -72,7 +72,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             OutputRegistry,
             LocalRegistry);
 
-        var telemetry = CreateTelemetryContext(sourceImageReference, destinationImageReference);
+        var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
         ImageBuilder? imageBuilder;
         if (sourceRegistry is { } registry)
@@ -190,7 +190,6 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                 await PushToRemoteRegistryAsync(builtImage,
                     sourceImageReference,
                     destinationImageReference,
-                    telemetry,
                     cancellationToken).ConfigureAwait(false);
                 break;
             default:
@@ -244,7 +243,6 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     private async Task PushToRemoteRegistryAsync(BuiltImage builtImage, SourceImageReference sourceImageReference,
         DestinationImageReference destinationImageReference,
-        Telemetry telemetry,
         CancellationToken cancellationToken)
     {
         try
@@ -348,110 +346,5 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         return ImageBuilder.DetermineEntrypointAndCmd(entrypoint, entrypointArgs, cmd, appCommand, appCommandArgs, appCommandInstruction, baseImageEntrypoint,
             logWarning: s => Log.LogWarningWithCodeFromResources(s),
             logError: (s, a) => { if (a is null) Log.LogErrorWithCodeFromResources(s); else Log.LogErrorWithCodeFromResources(s, a); });
-    }
-
-    private Telemetry CreateTelemetryContext(SourceImageReference source, DestinationImageReference destination)
-    {
-        var context = new PublishTelemetryContext(
-            source.Registry is not null ? GetRegistryType(source.Registry) : null,
-            null, // we don't support local pull yet, but we may in the future
-            destination.RemoteRegistry is not null ? GetRegistryType(destination.RemoteRegistry) : null,
-            destination.LocalRegistry is not null ? GetLocalStorageType(destination.LocalRegistry) : null);
-        return new Telemetry(Log, context);
-    }
-
-    private RegistryType GetRegistryType(Registry r)
-    {
-        if (r.IsMcr) return RegistryType.MCR;
-        if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
-        if (r.IsAmazonECRRegistry) return RegistryType.AWS;
-        if (r.IsAzureContainerRegistry) return RegistryType.Azure;
-        if (r.IsGoogleArtifactRegistry) return RegistryType.Google;
-        if (r.IsDockerHub) return RegistryType.DockerHub;
-        return RegistryType.Other;
-    }
-
-    private LocalStorageType GetLocalStorageType(ILocalRegistry r)
-    {
-        if (r is ArchiveFileRegistry) return LocalStorageType.Tarball;
-        var d = r as DockerCli;
-        System.Diagnostics.Debug.Assert(d != null, "Unknown local registry type");
-        if (d.GetCommand() == DockerCli.DockerCommand) return LocalStorageType.Docker;
-        else return LocalStorageType.Podman;
-    }
-
-    /// <summary>
-    /// Interesting data about the container publish - used to track the usage rates of various sources/targets of the process
-    /// and to help diagnose issues with the container publish overall.
-    /// </summary>
-    /// <param name="RemotePullType">If the base image came from a remote registry, what kind of registry was it?</param>
-    /// <param name="LocalPullType">If the base image came from a local store of some kind, what kind of store was it?</param>
-    /// <param name="RemotePushType">If the new image is being pushed to a remote registry, what kind of registry is it?</param>
-    /// <param name="LocalPushType">If the new image is being stored in a local store of some kind, what kind of store is it?</param>
-    private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
-    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
-    private enum LocalStorageType { Docker, Podman, Tarball }
-
-    private class Telemetry(Microsoft.Build.Utilities.TaskLoggingHelper Log, PublishTelemetryContext context)
-    {
-        private IDictionary<string, string?> ContextProperties() => new Dictionary<string, string?>
-            {
-                { nameof(context.RemotePullType), context.RemotePullType?.ToString() },
-                { nameof(context.LocalPullType), context.LocalPullType?.ToString() },
-                { nameof(context.RemotePushType), context.RemotePushType?.ToString() },
-                { nameof(context.LocalPushType), context.LocalPushType?.ToString() }
-            };
-
-        public void LogPublishSuccess()
-        {
-            Log.LogTelemetry("sdk/container/publish/success", ContextProperties());
-        }
-
-        public void LogUnknownRepository()
-        {
-            var props = ContextProperties();
-            props.Add("error", "unknown_repository");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogCredentialFailure(SourceImageReference _)
-        {
-            var props = ContextProperties();
-            props.Add("error", "credential_failure");
-            props.Add("direction", "pull");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogCredentialFailure(DestinationImageReference d)
-        {
-            var props = ContextProperties();
-            props.Add("error", "credential_failure");
-            props.Add("direction", "push");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogRidMismatch(string desiredRid, string[] availableRids)
-        {
-            var props = ContextProperties();
-            props.Add("error", "rid_mismatch");
-            props.Add("target_rid", desiredRid);
-            props.Add("available_rids", string.Join(",", availableRids));
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogMissingLocalBinary()
-        {
-            var props = ContextProperties();
-            props.Add("error", "missing_binary");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
-        public void LogLocalLoadError()
-        {
-            var props = ContextProperties();
-            props.Add("error", "local_load");
-            Log.LogTelemetry("sdk/container/publish/error", props);
-        }
-
     }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -183,7 +183,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         if (!SkipPublishing)
         {
-            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine != null, telemetry, cancellationToken)
                 .ConfigureAwait(false);
         }
         

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -120,13 +120,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             return !Log.HasLoggedErrors;
         }
 
-        if (BuildEngine != null) 
-        {
-            (string message, object[] parameters) = SkipPublishing ?
-                ( Strings.ContainerBuilder_StartBuildingImageForRid, new object[] { Repository, ContainerRuntimeIdentifier, sourceImageReference }) :
-                ( Strings.ContainerBuilder_StartBuildingImage, new object[] { Repository, String.Join(",", ImageTags), sourceImageReference });
-            Log.LogMessage(MessageImportance.High, message, parameters);
-        }
+        (string message, object[] parameters) = SkipPublishing ?
+            ( Strings.ContainerBuilder_StartBuildingImageForRid, new object[] { Repository, ContainerRuntimeIdentifier, sourceImageReference }) :
+            ( Strings.ContainerBuilder_StartBuildingImage, new object[] { Repository, String.Join(",", ImageTags), sourceImageReference });
+        Log.LogMessage(MessageImportance.High, message, parameters);
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);
@@ -183,7 +180,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         if (!SkipPublishing)
         {
-            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine != null, telemetry, cancellationToken)
+            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, telemetry, cancellationToken)
                 .ConfigureAwait(false);
         }
         

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -23,7 +23,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
     /// </summary>
     public string ToolPath { get; set; }
 
-    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry.Trim());
+    private bool IsLocalPull => string.IsNullOrWhiteSpace(BaseRegistry);
 
     public void Cancel() => _cancellationTokenSource.Cancel();
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -23,7 +23,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
     /// </summary>
     public string ToolPath { get; set; }
 
-    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry);
+    private bool IsLocalPull => string.IsNullOrEmpty(BaseRegistry.Trim());
 
     public void Cancel() => _cancellationTokenSource.Cancel();
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -122,7 +122,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         if (BuildEngine != null) 
         {
-            Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
+            (string message, object[] parameters) = SkipPublishing ?
+                ( Strings.ContainerBuilder_StartBuildingImageForRid, new object[] { Repository, ContainerRuntimeIdentifier, sourceImageReference }) :
+                ( Strings.ContainerBuilder_StartBuildingImage, new object[] { Repository, String.Join(",", ImageTags), sourceImageReference });
+            Log.LogMessage(MessageImportance.High, message, parameters);
         }
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -178,9 +178,12 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         GeneratedContainerMediaType = builtImage.ManifestMediaType;
         GeneratedContainerNames = destinationImageReference.FullyQualifiedImageNames().Select(name => new Microsoft.Build.Utilities.TaskItem(name)).ToArray();
 
-        await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
-            .ConfigureAwait(false);
-
+        if (!SkipPublishing)
+        {
+            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        
         return !Log.HasLoggedErrors;
     }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
-using Microsoft.NET.Build.Containers.LocalDaemons;
 using Microsoft.NET.Build.Containers.Logging;
 using Microsoft.NET.Build.Containers.Resources;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -122,7 +120,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             return !Log.HasLoggedErrors;
         }
 
-        SafeLog(Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
+        if (BuildEngine != null) 
+        {
+            Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_StartBuildingImage, Repository, String.Join(",", ImageTags), sourceImageReference);
+        }
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
         imageBuilder.AddLayer(newLayer);
@@ -177,105 +178,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         GeneratedContainerMediaType = builtImage.ManifestMediaType;
         GeneratedContainerNames = destinationImageReference.FullyQualifiedImageNames().Select(name => new Microsoft.Build.Utilities.TaskItem(name)).ToArray();
 
-        switch (destinationImageReference.Kind)
-        {
-            case DestinationImageReferenceKind.LocalRegistry:
-                await PushToLocalRegistryAsync(builtImage,
-                    sourceImageReference,
-                    destinationImageReference,
-                    telemetry,
-                    cancellationToken).ConfigureAwait(false);
-                break;
-            case DestinationImageReferenceKind.RemoteRegistry:
-                await PushToRemoteRegistryAsync(builtImage,
-                    sourceImageReference,
-                    destinationImageReference,
-                    cancellationToken).ConfigureAwait(false);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
-
-        telemetry.LogPublishSuccess();
+        await ImagePublisher.PublishImage(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+            .ConfigureAwait(false);
 
         return !Log.HasLoggedErrors;
-    }
-
-    private async Task PushToLocalRegistryAsync(BuiltImage builtImage, SourceImageReference sourceImageReference,
-        DestinationImageReference destinationImageReference,
-        Telemetry telemetry,
-        CancellationToken cancellationToken)
-    {
-        ILocalRegistry localRegistry = destinationImageReference.LocalRegistry!;
-        if (!(await localRegistry.IsAvailableAsync(cancellationToken).ConfigureAwait(false)))
-        {
-            telemetry.LogMissingLocalBinary();
-            Log.LogErrorWithCodeFromResources(nameof(Strings.LocalRegistryNotAvailable));
-            return;
-        }
-        try
-        {
-            await localRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
-            SafeLog(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
-
-            if (localRegistry is ArchiveFileRegistry archive)
-            {
-                GeneratedArchiveOutputPath = archive.ArchiveOutputPath;
-            }
-        }
-        catch (ContainerHttpException e)
-        {
-            if (BuildEngine != null)
-            {
-                Log.LogErrorFromException(e, true);
-            }
-        }
-        catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
-        {
-            telemetry.LogLocalLoadError();
-            Log.LogErrorFromException(dle, showStackTrace: false);
-        }
-        catch (ArgumentException argEx)
-        {
-            Log.LogErrorFromException(argEx, showStackTrace: false);
-        }
-    }
-
-    private async Task PushToRemoteRegistryAsync(BuiltImage builtImage, SourceImageReference sourceImageReference,
-        DestinationImageReference destinationImageReference,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await destinationImageReference.RemoteRegistry!.PushAsync(
-                builtImage,
-                sourceImageReference,
-                destinationImageReference,
-                cancellationToken).ConfigureAwait(false);
-            SafeLog(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, OutputRegistry);
-        }
-        catch (UnableToAccessRepositoryException)
-        {
-            if (BuildEngine != null)
-            {
-                Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
-            }
-        }
-        catch (ContainerHttpException e)
-        {
-            if (BuildEngine != null)
-            {
-                Log.LogErrorFromException(e, true);
-            }
-        }
-        catch (Exception e)
-        {
-            if (BuildEngine != null)
-            {
-                Log.LogErrorWithCodeFromResources(nameof(Strings.RegistryOutputPushFailed), e.Message);
-                Log.LogMessage(MessageImportance.Low, "Details: {0}", e);
-            }
-        }
     }
 
     private void SetPorts(ImageBuilder image, ITaskItem[] exposedPorts)
@@ -322,11 +228,6 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             var value = envVar.GetMetadata("Value");
             img.AddEnvironmentVariable(envVar.ItemSpec, value);
         }
-    }
-
-    private void SafeLog(string message, params object[] formatParams)
-    {
-        if (BuildEngine != null) Log.LogMessage(MessageImportance.High, message, formatParams);
     }
 
     public void Dispose()

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -178,7 +178,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         GeneratedContainerMediaType = builtImage.ManifestMediaType;
         GeneratedContainerNames = destinationImageReference.FullyQualifiedImageNames().Select(name => new Microsoft.Build.Utilities.TaskItem(name)).ToArray();
 
-        await ImagePublisher.PublishImage(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
+        await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, BuildEngine, telemetry, cancellationToken)
             .ConfigureAwait(false);
 
         return !Log.HasLoggedErrors;

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/Telemetry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/Telemetry.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Build.Containers.LocalDaemons;
+
+namespace Microsoft.NET.Build.Containers.Tasks;
+
+internal class Telemetry
+{
+    /// <summary>
+    /// Interesting data about the container publish - used to track the usage rates of various sources/targets of the process
+    /// and to help diagnose issues with the container publish overall.
+    /// </summary>
+    /// <param name="RemotePullType">If the base image came from a remote registry, what kind of registry was it?</param>
+    /// <param name="LocalPullType">If the base image came from a local store of some kind, what kind of store was it?</param>
+    /// <param name="RemotePushType">If the new image is being pushed to a remote registry, what kind of registry is it?</param>
+    /// <param name="LocalPushType">If the new image is being stored in a local store of some kind, what kind of store is it?</param>
+    private record class PublishTelemetryContext(RegistryType? RemotePullType, LocalStorageType? LocalPullType, RegistryType? RemotePushType, LocalStorageType? LocalPushType);
+    private enum RegistryType { Azure, AWS, Google, GitHub, DockerHub, MCR, Other }
+    private enum LocalStorageType { Docker, Podman, Tarball }
+
+    private readonly Microsoft.Build.Utilities.TaskLoggingHelper Log;
+    private readonly PublishTelemetryContext Context;
+
+    internal Telemetry(
+        SourceImageReference source,
+        DestinationImageReference destination,
+        Microsoft.Build.Utilities.TaskLoggingHelper Log)
+    {
+        this.Log = Log;
+        Context = new PublishTelemetryContext(
+            source.Registry is not null ? GetRegistryType(source.Registry) : null,
+            null, // we don't support local pull yet, but we may in the future
+            destination.RemoteRegistry is not null ? GetRegistryType(destination.RemoteRegistry) : null,
+            destination.LocalRegistry is not null ? GetLocalStorageType(destination.LocalRegistry) : null);
+    }
+
+    private RegistryType GetRegistryType(Registry r)
+    {
+        if (r.IsMcr) return RegistryType.MCR;
+        if (r.IsGithubPackageRegistry) return RegistryType.GitHub;
+        if (r.IsAmazonECRRegistry) return RegistryType.AWS;
+        if (r.IsAzureContainerRegistry) return RegistryType.Azure;
+        if (r.IsGoogleArtifactRegistry) return RegistryType.Google;
+        if (r.IsDockerHub) return RegistryType.DockerHub;
+        return RegistryType.Other;
+    }
+
+    private LocalStorageType GetLocalStorageType(ILocalRegistry r)
+    {
+        if (r is ArchiveFileRegistry) return LocalStorageType.Tarball;
+        var d = r as DockerCli;
+        System.Diagnostics.Debug.Assert(d != null, "Unknown local registry type");
+        if (d.GetCommand() == DockerCli.DockerCommand) return LocalStorageType.Docker;
+        else return LocalStorageType.Podman;
+    }
+
+    private IDictionary<string, string?> ContextProperties() => new Dictionary<string, string?>
+        {
+            { nameof(Context.RemotePullType), Context.RemotePullType?.ToString() },
+            { nameof(Context.LocalPullType), Context.LocalPullType?.ToString() },
+            { nameof(Context.RemotePushType), Context.RemotePushType?.ToString() },
+            { nameof(Context.LocalPushType), Context.LocalPushType?.ToString() }
+        };
+
+    public void LogPublishSuccess()
+    {
+        Log.LogTelemetry("sdk/container/publish/success", ContextProperties());
+    }
+
+    public void LogUnknownRepository()
+    {
+        var props = ContextProperties();
+        props.Add("error", "unknown_repository");
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+
+    public void LogCredentialFailure(SourceImageReference _)
+    {
+        var props = ContextProperties();
+        props.Add("error", "credential_failure");
+        props.Add("direction", "pull");
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+
+    public void LogCredentialFailure(DestinationImageReference d)
+    {
+        var props = ContextProperties();
+        props.Add("error", "credential_failure");
+        props.Add("direction", "push");
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+
+    public void LogRidMismatch(string desiredRid, string[] availableRids)
+    {
+        var props = ContextProperties();
+        props.Add("error", "rid_mismatch");
+        props.Add("target_rid", desiredRid);
+        props.Add("available_rids", string.Join(",", availableRids));
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+
+    public void LogMissingLocalBinary()
+    {
+        var props = ContextProperties();
+        props.Add("error", "missing_binary");
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+
+    public void LogLocalLoadError()
+    {
+        var props = ContextProperties();
+        props.Add("error", "local_load");
+        Log.LogTelemetry("sdk/container/publish/error", props);
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/Telemetry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Telemetry.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.NET.Build.Containers.LocalDaemons;
 
-namespace Microsoft.NET.Build.Containers.Tasks;
+namespace Microsoft.NET.Build.Containers;
 
 internal class Telemetry
 {

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -297,12 +297,6 @@
   </Target>
 
   <Target Name="_PublishMultiArchContainers" DependsOnTargets="$(PublishContainerDependsOn)" >
-    <Error Text="ContainerArchiveOutputPath is invalid. It can only be a directory in multi-arch scenario because the runtime identifier is appended in the end of the filename."
-      Condition="'$(ContainerArchiveOutputPath)' != '' and
-                 !$(ContainerArchiveOutputPath.EndsWith('/')) and
-                 !$(ContainerArchiveOutputPath.EndsWith('\\')) and
-                 $(ContainerArchiveOutputPath.EndsWith('.tar.gz'))" />
-
     <PropertyGroup>
       <!--We want to skip publishing individual images in case of multi-arch tarball publishing or local daemon (only docker) publishing because all images are published in one tarball.-->
       <!--We don't want to skip publishing individual images in case of remote registry because the individual images should be available in the registry before image index is pushed.-->
@@ -400,10 +394,6 @@
         Include="$([System.String]::Copy('%(_ParsedContainerEnvironmentVariables.Identity)').Split(':')[0])"
         Value="$([System.String]::Copy('%(_ParsedContainerEnvironmentVariables.Identity)').Split(':')[1])" />
     </ItemGroup>
-    <PropertyGroup>
-      <!-- We've already validated that ContainerArchiveOutputPath is pointing to a directory. -->
-      <ContainerArchiveOutputPath Condition="'$(ContainerArchiveOutputPath)' != ''">$([System.IO.Path]::Combine($(ContainerArchiveOutputPath), $(ContainerRepository)-$(ContainerRuntimeIdentifier).tar.gz))</ContainerArchiveOutputPath>
-    </PropertyGroup>
   </Target>
 
   <Target Name="PublishContainer"

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -363,9 +363,7 @@
                       ImageTags="@(ContainerImageTags)"
                       BaseRegistry="$(ContainerBaseRegistry)"
                       BaseImageName="$(ContainerBaseName)"
-                      BaseImageTag="$(ContainerBaseTag)">
-      <Output TaskParameter="GeneratedImageIndex" PropertyName="GeneratedImageIndex" />
-    </CreateImageIndex>
+                      BaseImageTag="$(ContainerBaseTag)" />
   </Target>
 
   <Target Name="_ParseItemsForPublishingSingleContainer">

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -307,11 +307,12 @@
       <!--We want to skip publishing individual images in case of multi-arch tarball publishing or local daemon (only docker) publishing because all images are published in one tarball.-->
       <!--We don't want to skip publishing individual images in case of remote registry because the individual images should be available in the registry before image index is pushed.-->
       <!--We don't want to skip publishing individual images in case of local daemon podman because podman loads multi-arch tarball differently - only individual image for the current platform.-->
-      <_IsTarballPublishing Condition="'$(ContainerArchiveOutputPath)' != ''">true</_IsTarballPublishing>
-      <_IsLocalDockerPublishing Condition="$(ContainerRegistry) == '' and ($(LocalRegistry) == '' or $(LocalRegistry) == 'Docker')">true</_IsLocalDockerPublishing>
-     
       <_SkipContainerPublishing>false</_SkipContainerPublishing>
-      <_SkipContainerPublishing Condition="'$(_IsTarballPublishing)' == 'true' or '$(_IsLocalDockerPublishing)' == 'true'">true</_SkipContainerPublishing>
+      <_SkipContainerPublishing Condition="$(ContainerArchiveOutputPath) != '' or ( $(ContainerRegistry) == '' and ( $(LocalRegistry) == '' or $(LocalRegistry) == 'Docker' ) )">true</_SkipContainerPublishing>
+    
+      <!--We want to skip CreateImageIndex task in case of local daemon podman because it is not supported.-->
+      <_SkipCreateImageIndex>false</_SkipCreateImageIndex>
+      <_SkipCreateImageIndex Condition="$(ContainerArchiveOutputPath) == '' and $(ContainerRegistry) == '' and $(LocalRegistry) == 'Podman'">true</_SkipCreateImageIndex>
     </PropertyGroup>
 
     <ItemGroup>
@@ -353,7 +354,8 @@
         <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainers" />
     </MSBuild>
 
-    <CreateImageIndex GeneratedContainers="@(GeneratedContainers)"
+    <CreateImageIndex Condition="'$(_SkipCreateImageIndex)' == 'false' "
+                      GeneratedContainers="@(GeneratedContainers)"
                       LocalRegistry="$(LocalRegistry)"
                       OutputRegistry="$(ContainerRegistry)"
                       ArchiveOutputPath="$(ContainerArchiveOutputPath)"

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -340,16 +340,15 @@
         <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainers" />
     </MSBuild>
 
-    <PropertyGroup>
-      <_SkipCreateImageIndex>false</_SkipCreateImageIndex>
-      <_SkipCreateImageIndex Condition="'$(ContainerRegistry)' == ''">true</_SkipCreateImageIndex>
-    </PropertyGroup>
-
-    <CreateImageIndex Condition="'$(_SkipCreateImageIndex)' == 'false' "
-                      GeneratedContainers="@(GeneratedContainers)"
+    <CreateImageIndex GeneratedContainers="@(GeneratedContainers)"
+                      LocalRegistry="$(LocalRegistry)"
                       OutputRegistry="$(ContainerRegistry)"
+                      ArchiveOutputPath="$(ContainerArchiveOutputPath)"
                       Repository="$(ContainerRepository)"
-                      ImageTags="@(ContainerImageTags)">
+                      ImageTags="@(ContainerImageTags)"
+                      BaseRegistry="$(ContainerBaseRegistry)"
+                      BaseImageName="$(ContainerBaseName)"
+                      BaseImageTag="$(ContainerBaseTag)">
       <Output TaskParameter="GeneratedImageIndex" PropertyName="GeneratedImageIndex" />
     </CreateImageIndex>
   </Target>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -274,6 +274,7 @@
                     ContainerRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
                     ContainerUser="$(ContainerUser)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                    SkipPublishing="$(_SkipContainerPublishing)"
                     GenerateLabels="$(ContainerGenerateLabels)"
                     GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"> <!-- The RID graph path is provided as a property by the SDK. -->
 
@@ -302,6 +303,17 @@
                  !$(ContainerArchiveOutputPath.EndsWith('\\')) and
                  $(ContainerArchiveOutputPath.EndsWith('.tar.gz'))" />
 
+    <PropertyGroup>
+      <!--We want to skip publishing individual images in case of multi-arch tarball publishing or local daemon (only docker) publishing because all images are published in one tarball.-->
+      <!--We don't want to skip publishing individual images in case of remote registry because the individual images should be available in the registry before image index is pushed.-->
+      <!--We don't want to skip publishing individual images in case of local daemon podman because podman loads multi-arch tarball differently - only individual image for the current platform.-->
+      <_IsTarballPublishing Condition="'$(ContainerArchiveOutputPath)' != ''">true</_IsTarballPublishing>
+      <_IsLocalDockerPublishing Condition="$(ContainerRegistry) == '' and ($(LocalRegistry) == '' or $(LocalRegistry) == 'Docker')">true</_IsLocalDockerPublishing>
+     
+      <_SkipContainerPublishing>false</_SkipContainerPublishing>
+      <_SkipContainerPublishing Condition="'$(_IsTarballPublishing)' == 'true' or '$(_IsLocalDockerPublishing)' == 'true'">true</_SkipContainerPublishing>
+    </PropertyGroup>
+
     <ItemGroup>
       <_rids Include="$(ContainerRuntimeIdentifiers)" Condition="'$(ContainerRuntimeIdentifiers)' != ''" />
       <_rids Include="$(RuntimeIdentifiers)" Condition="'$(ContainerRuntimeIdentifiers)' == '' and '$(RuntimeIdentifiers)' != ''" />
@@ -328,7 +340,8 @@
           _ContainerEnvironmentVariables=@(ContainerEnvironmentVariable->'%(Identity):%(Value)');
           ContainerUser=$(ContainerUser);
           ContainerGenerateLabels=$(ContainerGenerateLabels);
-          ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest)
+          ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest);
+          _SkipContainerPublishing=$(_SkipContainerPublishing)
         "/>
       <_rids Remove ="$(_rids)" />
     </ItemGroup>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -357,7 +357,10 @@
                       ImageTags="@(ContainerImageTags)"
                       BaseRegistry="$(ContainerBaseRegistry)"
                       BaseImageName="$(ContainerBaseName)"
-                      BaseImageTag="$(ContainerBaseTag)" />
+                      BaseImageTag="$(ContainerBaseTag)">
+      <Output TaskParameter="GeneratedImageIndex" PropertyName="GeneratedImageIndex" />
+      <Output TaskParameter="GeneratedArchiveOutputPath" PropertyName="GeneratedArchiveOutputPath" />
+    </CreateImageIndex>
   </Target>
 
   <Target Name="_ParseItemsForPublishingSingleContainer">

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ArchiveFileRegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ArchiveFileRegistryTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Build.Containers.LocalDaemons;
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests;
+
+public class ArchiveFileRegistryTests
+{
+    [Fact]
+    public async Task ArchiveOutputPathIsExistingDirectory_CreatesFileWithRepositoryNameAndTarGz()
+    {
+        string archiveOutputPath = TestSettings.TestArtifactsDirectory;
+        string expectedCreatedFilePath = Path.Combine(TestSettings.TestArtifactsDirectory, "repository.tar.gz");
+
+        await CreateRegistryAndCallLoadAsync(archiveOutputPath).ConfigureAwait(false);
+        
+        Assert.True(File.Exists(expectedCreatedFilePath));    
+    }  
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ArchiveOutputPathIsNonExistingDirectory_CreatesDirectoryAndFileWithRepositoryNameAndTarGz(bool includeDirectorySeperatorAtTheEnd)
+    {
+        string archiveOutputPath = Path.Combine(
+            TestSettings.TestArtifactsDirectory,
+             "nonexisting" + (includeDirectorySeperatorAtTheEnd ? Path.DirectorySeparatorChar : ""));
+        string expectedCreatedFilePath = Path.Combine(archiveOutputPath, "repository.tar.gz");
+
+        await CreateRegistryAndCallLoadAsync(archiveOutputPath).ConfigureAwait(false);
+        
+        Assert.True(File.Exists(expectedCreatedFilePath));    
+    }
+
+    [Fact]
+    public async Task ArchiveOutputPathIsCustomFileNameInExistingDirectory_CreatesFileWithThatName()
+    {
+        string archiveOutputPath = Path.Combine(TestSettings.TestArtifactsDirectory, "custom-name.withextension");
+        string expectedCreatedFilePath = archiveOutputPath;
+
+        await CreateRegistryAndCallLoadAsync(archiveOutputPath).ConfigureAwait(false);
+        
+        Assert.True(File.Exists(expectedCreatedFilePath));    
+    }
+
+    [Fact]
+    public async Task ArchiveOutputPathIsCustomFileNameInNonExistingDirectory_CreatesDirectoryAndFileWithThatName()
+    {
+        string archiveOutputPath = Path.Combine(TestSettings.TestArtifactsDirectory, $"nonexisting-directory{Path.AltDirectorySeparatorChar}custom-name.withextension");
+        string expectedCreatedFilePath = archiveOutputPath;
+
+        await CreateRegistryAndCallLoadAsync(archiveOutputPath).ConfigureAwait(false);
+        
+        Assert.True(File.Exists(expectedCreatedFilePath));    
+    }
+
+    private async Task CreateRegistryAndCallLoadAsync(string archiveOutputPath)
+    {
+        var registry = new ArchiveFileRegistry(archiveOutputPath);
+        var destinationImageReference = new DestinationImageReference(registry, "repository", ["tag"]);
+
+        await registry.LoadAsync(
+            "test image",
+            new SourceImageReference(),
+            destinationImageReference,
+            CancellationToken.None,
+            async (img, srcRef, destRef, stream, token) =>
+            {
+                await Task.CompletedTask;
+            }).ConfigureAwait(false);
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -7,6 +7,8 @@ static class ContainerCli
 {
     public static bool IsPodman => _isPodman.Value;
 
+    public static bool IsAvailable => _isAvailable.Value;
+
     public static RunExeCommand PullCommand(ITestOutputHelper log, params string[] args)
       => CreateCommand(log, "pull", args);
 
@@ -63,4 +65,7 @@ static class ContainerCli
 
     private static readonly Lazy<bool> _isPodman =
       new(() => new DockerCli(loggerFactory: new TestLoggerFactory()).GetCommand() == DockerCli.PodmanCommand);
+
+    private static readonly Lazy<bool> _isAvailable =
+      new(() => new DockerCli(loggerFactory: new TestLoggerFactory()).IsAvailable());
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -9,6 +9,8 @@ static class ContainerCli
 
     public static bool IsAvailable => _isAvailable.Value;
 
+    public static bool IsContainerdStoreEnabledForDocker => DockerCli.IsContainerdStoreEnabledForDocker();
+
     public static RunExeCommand PullCommand(ITestOutputHelper log, params string[] args)
       => CreateCommand(log, "pull", args);
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -36,9 +36,6 @@ static class ContainerCli
     public static RunExeCommand PortCommand(ITestOutputHelper log, string containerName, int port)
       => CreateCommand(log, "port", containerName, port.ToString());
 
-    public static RunExeCommand ImagesCommand(ITestOutputHelper log, params string[] args)
-      => CreateCommand(log, "images", args);
-
     private static RunExeCommand CreateCommand(ITestOutputHelper log, string command, params string[] args)
     {
         string commandPath = IsPodman ? "podman" : "docker";

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -37,6 +37,9 @@ static class ContainerCli
     public static RunExeCommand PortCommand(ITestOutputHelper log, string containerName, int port)
       => CreateCommand(log, "port", containerName, port.ToString());
 
+    public static RunExeCommand ImagesCommand(ITestOutputHelper log, params string[] args)
+      => CreateCommand(log, "images", args);
+
     private static RunExeCommand CreateCommand(ITestOutputHelper log, string command, params string[] args)
     {
         string commandPath = IsPodman ? "podman" : "docker";

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/ContainerCli.cs
@@ -12,9 +12,6 @@ static class ContainerCli
     public static RunExeCommand PullCommand(ITestOutputHelper log, params string[] args)
       => CreateCommand(log, "pull", args);
 
-    public static RunExeCommand TagCommand(ITestOutputHelper log, params string[] args)
-      => CreateCommand(log, "tag", args);
-
     public static RunExeCommand PushCommand(ITestOutputHelper log, params string[] args)
       => CreateCommand(log, "push", args);
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -44,18 +44,18 @@ public class CreateImageIndexTests
         cii.GeneratedContainers = [image1, image2];
         Assert.True(cii.Execute(), FormatBuildMessages(errors));
 
-        // Assert that the image index is created correctly
-        cii.GeneratedImageIndex.Should().NotBeNullOrEmpty();
-        var imageIndex = cii.GeneratedImageIndex.FromJson<ManifestListV2>();
-        imageIndex.manifests.Should().HaveCount(2);
+        // // Assert that the image index is created correctly
+        // cii.GeneratedImageIndex.Should().NotBeNullOrEmpty();
+        // var imageIndex = cii.GeneratedImageIndex.FromJson<ManifestListV2>();
+        // imageIndex.manifests.Should().HaveCount(2);
 
-        imageIndex.manifests[0].digest.Should().Be(image1.GetMetadata("ManifestDigest"));
-        imageIndex.manifests[0].platform.os.Should().Be("linux");
-        imageIndex.manifests[0].platform.architecture.Should().Be("amd64");
+        // imageIndex.manifests[0].digest.Should().Be(image1.GetMetadata("ManifestDigest"));
+        // imageIndex.manifests[0].platform.os.Should().Be("linux");
+        // imageIndex.manifests[0].platform.architecture.Should().Be("amd64");
 
-        imageIndex.manifests[1].digest.Should().Be(image2.GetMetadata("ManifestDigest"));
-        imageIndex.manifests[1].platform.os.Should().Be("linux");
-        imageIndex.manifests[1].platform.architecture.Should().Be("arm64");
+        // imageIndex.manifests[1].digest.Should().Be(image2.GetMetadata("ManifestDigest"));
+        // imageIndex.manifests[1].platform.os.Should().Be("linux");
+        // imageIndex.manifests[1].platform.architecture.Should().Be("arm64");
 
         // Assert that the image index is pushed to the registry
         var loggerFactory = new TestLoggerFactory(_testOutput);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -44,19 +44,6 @@ public class CreateImageIndexTests
         cii.GeneratedContainers = [image1, image2];
         Assert.True(cii.Execute(), FormatBuildMessages(errors));
 
-        // // Assert that the image index is created correctly
-        // cii.GeneratedImageIndex.Should().NotBeNullOrEmpty();
-        // var imageIndex = cii.GeneratedImageIndex.FromJson<ManifestListV2>();
-        // imageIndex.manifests.Should().HaveCount(2);
-
-        // imageIndex.manifests[0].digest.Should().Be(image1.GetMetadata("ManifestDigest"));
-        // imageIndex.manifests[0].platform.os.Should().Be("linux");
-        // imageIndex.manifests[0].platform.architecture.Should().Be("amd64");
-
-        // imageIndex.manifests[1].digest.Should().Be(image2.GetMetadata("ManifestDigest"));
-        // imageIndex.manifests[1].platform.os.Should().Be("linux");
-        // imageIndex.manifests[1].platform.architecture.Should().Be("arm64");
-
         // Assert that the image index is pushed to the registry
         var loggerFactory = new TestLoggerFactory(_testOutput);
         var logger = loggerFactory.CreateLogger(nameof(CreateImageIndex_Baseline));

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -44,6 +44,19 @@ public class CreateImageIndexTests
         cii.GeneratedContainers = [image1, image2];
         Assert.True(cii.Execute(), FormatBuildMessages(errors));
 
+        // Assert that the image index is created correctly
+        cii.GeneratedImageIndex.Should().NotBeNullOrEmpty();
+        var imageIndex = cii.GeneratedImageIndex.FromJson<ManifestListV2>();
+        imageIndex.manifests.Should().HaveCount(2);
+
+        imageIndex.manifests[0].digest.Should().Be(image1.GetMetadata("ManifestDigest"));
+        imageIndex.manifests[0].platform.os.Should().Be("linux");
+        imageIndex.manifests[0].platform.architecture.Should().Be("amd64");
+
+        imageIndex.manifests[1].digest.Should().Be(image2.GetMetadata("ManifestDigest"));
+        imageIndex.manifests[1].platform.os.Should().Be("linux");
+        imageIndex.manifests[1].platform.architecture.Should().Be("arm64");
+
         // Assert that the image index is pushed to the registry
         var loggerFactory = new TestLoggerFactory(_testOutput);
         var logger = loggerFactory.CreateLogger(nameof(CreateImageIndex_Baseline));

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerIsAvailableAndSupportsArchFact.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerIsAvailableAndSupportsArchFact.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests;
+
+public class DockerIsAvailableAndSupportsArchFactAttribute : FactAttribute
+{
+    public DockerIsAvailableAndSupportsArchFactAttribute(string arch, bool checkContainerdStoreAvailability = false)
+    {
+        if (!DockerSupportsArchHelper.DaemonIsAvailable)
+        {
+            base.Skip = "Skipping test because Docker is not available on this host.";
+        }
+        else if (checkContainerdStoreAvailability && !DockerSupportsArchHelper.IsContainerdStoreEnabledForDocker)
+        {
+            base.Skip = "Skipping test because Docker daemon is not using containerd as the storage driver.";
+        }
+        else if (!DockerSupportsArchHelper.DaemonSupportsArch(arch))
+        {
+            base.Skip = $"Skipping test because Docker daemon does not support {arch}.";
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerIsAvailableAndSupportsArchTheory.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerIsAvailableAndSupportsArchTheory.cs
@@ -1,26 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
-
-public class DockerIsAvailableAndSupportsArchFactAttribute : FactAttribute
-{
-    public DockerIsAvailableAndSupportsArchFactAttribute(string arch, bool checkContainerdStoreAvailability = false)
-    {
-        if (!DockerSupportsArchHelper.DaemonIsAvailable)
-        {
-            base.Skip = "Skipping test because Docker is not available on this host.";
-        }
-        else if (checkContainerdStoreAvailability && !DockerSupportsArchHelper.IsContainerdStoreEnabledForDocker)
-        {
-            base.Skip = "Skipping test because Docker daemon is not using containerd as the storage driver.";
-        }
-        else if (!DockerSupportsArchHelper.DaemonSupportsArch(arch))
-        {
-            base.Skip = $"Skipping test because Docker daemon does not support {arch}.";
-        }
-    }
-}
 
 public class DockerIsAvailableAndSupportsArchTheoryAttribute : TheoryAttribute
 {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
@@ -3,17 +3,17 @@
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
-public class DockerSupportsArchFactAttribute : FactAttribute
+public class DockerIsAvailableAndSupportsArchFactAttribute : FactAttribute
 {
-    private readonly string _arch;
-
-    public DockerSupportsArchFactAttribute(string arch)
+    public DockerIsAvailableAndSupportsArchFactAttribute(string arch)
     {
-        _arch = arch;
-
-        if (!DockerSupportsArchHelper.DaemonSupportsArch(_arch))
+        if (!DockerSupportsArchHelper.DaemonIsAvailable)
         {
-            base.Skip = $"Skipping test because Docker daemon does not support {_arch}.";
+            base.Skip = "Skipping test because Docker is not available on this host.";
+        }
+        else if (!DockerSupportsArchHelper.DaemonSupportsArch(arch))
+        {
+            base.Skip = $"Skipping test because Docker daemon does not support {arch}.";
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
@@ -5,11 +5,15 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 public class DockerIsAvailableAndSupportsArchFactAttribute : FactAttribute
 {
-    public DockerIsAvailableAndSupportsArchFactAttribute(string arch)
+    public DockerIsAvailableAndSupportsArchFactAttribute(string arch, bool checkContainerdStoreAvailability = false)
     {
         if (!DockerSupportsArchHelper.DaemonIsAvailable)
         {
             base.Skip = "Skipping test because Docker is not available on this host.";
+        }
+        else if (checkContainerdStoreAvailability && !DockerSupportsArchHelper.IsContainerdStoreEnabledForDocker)
+        {
+            base.Skip = "Skipping test because Docker daemon is not using containerd as the storage driver.";
         }
         else if (!DockerSupportsArchHelper.DaemonSupportsArch(arch))
         {

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchFact.cs
@@ -21,3 +21,22 @@ public class DockerIsAvailableAndSupportsArchFactAttribute : FactAttribute
         }
     }
 }
+
+public class DockerIsAvailableAndSupportsArchTheoryAttribute : TheoryAttribute
+{
+    public DockerIsAvailableAndSupportsArchTheoryAttribute(string arch, bool checkContainerdStoreAvailability = false)
+    {
+        if (!DockerSupportsArchHelper.DaemonIsAvailable)
+        {
+            base.Skip = "Skipping test because Docker is not available on this host.";
+        }
+        else if (checkContainerdStoreAvailability && !DockerSupportsArchHelper.IsContainerdStoreEnabledForDocker)
+        {
+            base.Skip = "Skipping test because Docker daemon is not using containerd as the storage driver.";
+        }
+        else if (!DockerSupportsArchHelper.DaemonSupportsArch(arch))
+        {
+            base.Skip = $"Skipping test because Docker daemon does not support {arch}.";
+        }
+    }
+}

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
@@ -34,6 +34,8 @@ public class DockerSupportsArchInlineData : DataAttribute
 
 internal static class DockerSupportsArchHelper
 {
+    internal static bool DaemonIsAvailable => ContainerCli.IsAvailable;
+
     internal static bool DaemonSupportsArch(string arch)
     {
         // an optimization - this doesn't change over time so we can compute it once

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerSupportsArchInlineData.cs
@@ -36,6 +36,8 @@ internal static class DockerSupportsArchHelper
 {
     internal static bool DaemonIsAvailable => ContainerCli.IsAvailable;
 
+    internal static bool IsContainerdStoreEnabledForDocker => ContainerCli.IsContainerdStoreEnabledForDocker;
+
     internal static bool DaemonSupportsArch(string arch)
     {
         // an optimization - this doesn't change over time so we can compute it once

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1033,6 +1033,8 @@ public class EndToEndTests : IDisposable
         CommandResult processResultX64 = ContainerCli.RunCommand(
             _testOutput,
             "--rm",
+            "--platform",
+            "linux/amd64",
             "--name",
             $"test-container-{imageName}-x64",
             imageX64Tagged)
@@ -1056,6 +1058,8 @@ public class EndToEndTests : IDisposable
         CommandResult processResultArm64 = ContainerCli.RunCommand(
             _testOutput,
             "--rm",
+            "--platform",
+            "linux/arm64",
             "--name",
             $"test-container-{imageName}-arm64",
             imageArm64Tagged)

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -235,9 +235,10 @@ public class EndToEndTests : IDisposable
             Config = builtImage.Config,
             ImageDigest = builtImage.ImageDigest,
             ImageSha = builtImage.ImageSha,
-            ImageSize = builtImage.ImageSize,
             Manifest = builtImage.Manifest,
+            ManifestDigest = builtImage.ManifestDigest,
             ManifestMediaType = SchemaTypes.OciManifestV1,
+            Layers = builtImage.Layers
         };
 
         return ociImage;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -722,7 +722,7 @@ public class EndToEndTests : IDisposable
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
     }
 
-    [DockerSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_LocalRegistry()
     {
         string imageName = NewImageName();
@@ -923,7 +923,7 @@ public class EndToEndTests : IDisposable
     private string GetPublishArtifactsPath(string projectDir, string rid, string configuration = "Debug")
         => Path.Combine(projectDir, "bin", configuration, ToolsetInfo.CurrentTargetFramework, rid, "publish");
 
-    [DockerSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_ArchivePublishing()
     {
         string imageName = NewImageName();
@@ -996,7 +996,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_RemoteRegistry()
     {
         string imageName = NewImageName();
@@ -1125,7 +1125,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_EnvVariables()
     {
         string imageName = NewImageName();
@@ -1192,7 +1192,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
     public void EndToEndMultiArch_Ports()
     {
         string imageName = NewImageName();

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -4,7 +4,6 @@
 using System.Formats.Tar;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using Microsoft.Build.Logging;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Build.Containers.LocalDaemons;
 using Microsoft.NET.Build.Containers.Resources;

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -722,7 +722,7 @@ public class EndToEndTests : IDisposable
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
     }
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_LocalRegistry()
     {
         string imageName = NewImageName();
@@ -905,7 +905,7 @@ public class EndToEndTests : IDisposable
     private string GetPublishArtifactsPath(string projectDir, string rid, string configuration = "Debug")
         => Path.Combine(projectDir, "bin", configuration, ToolsetInfo.CurrentTargetFramework, rid, "publish");
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_ArchivePublishing()
     {
         string imageName = NewImageName();
@@ -974,7 +974,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_RemoteRegistry()
     {
         string imageName = NewImageName();
@@ -1053,7 +1053,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_ContainerRuntimeIdentifiersOverridesRuntimeIdentifiers()
     {
         // Create a new console project
@@ -1088,7 +1088,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_EnvVariables()
     {
         string imageName = NewImageName();
@@ -1158,7 +1158,7 @@ public class EndToEndTests : IDisposable
         newProjectDir.Delete(true);
     }
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64")]
+    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_Ports()
     {
         string imageName = NewImageName();
@@ -1256,7 +1256,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(checkContainerdStoreAvailability: true)]
     public void EndToEndMultiArch_Labels()
     {
         string imageName = NewImageName();

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -721,10 +721,11 @@ public class EndToEndTests : IDisposable
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
     }
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
-    public void EndToEndMultiArch_LocalRegistry()
+    [InlineData("endtoendmultiarch-localregisty")]
+    [InlineData("myteam/endtoendmultiarch-localregisty")]
+    [DockerIsAvailableAndSupportsArchTheory("linux/arm64", checkContainerdStoreAvailability: true)]
+    public void EndToEndMultiArch_LocalRegistry(string imageName)
     {
-        string imageName = NewImageName();
         string tag = "1.0";
         string image = $"{imageName}:{tag}";
 
@@ -759,7 +760,7 @@ public class EndToEndTests : IDisposable
             "--platform",
             "linux/amd64",
             "--name",
-            $"test-container-{imageName}-x64",
+            $"test-container-{imageName.Replace('/', '-')}-x64",
             image)
         .Execute();
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
@@ -770,7 +771,7 @@ public class EndToEndTests : IDisposable
             "--platform",
             "linux/arm64",
             "--name",
-            $"test-container-{imageName}-arm64",
+            $"test-container-{imageName.Replace('/', '-')}-arm64",
             image)
         .Execute();
         processResultArm64.Should().Pass().And.HaveStdOut("Hello, World!");
@@ -904,10 +905,11 @@ public class EndToEndTests : IDisposable
     private string GetPublishArtifactsPath(string projectDir, string rid, string configuration = "Debug")
         => Path.Combine(projectDir, "bin", configuration, ToolsetInfo.CurrentTargetFramework, rid, "publish");
 
-    [DockerIsAvailableAndSupportsArchFact("linux/arm64", checkContainerdStoreAvailability: true)]
-    public void EndToEndMultiArch_ArchivePublishing()
+    [InlineData("endtoendmultiarch-archivepublishing")]
+    [InlineData("myteam/endtoendmultiarch-archivepublishing")]
+    [DockerIsAvailableAndSupportsArchTheory("linux/arm64", checkContainerdStoreAvailability: true)]
+    public void EndToEndMultiArch_ArchivePublishing(string imageName)
     {
-        string imageName = NewImageName();
         string tag = "1.0";
         string image = $"{imageName}:{tag}";
         string archiveOutput = TestSettings.TestArtifactsDirectory;
@@ -953,7 +955,7 @@ public class EndToEndTests : IDisposable
             "--platform",
             "linux/amd64",
             "--name",
-            $"test-container-{imageName}-x64",
+            $"test-container-{imageName.Replace('/', '-')}-x64",
             image)
         .Execute();
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
@@ -964,7 +966,7 @@ public class EndToEndTests : IDisposable
             "--platform",
             "linux/arm64",
             "--name",
-            $"test-container-{imageName}-arm64",
+            $"test-container-{imageName.Replace('/', '-')}-arm64",
             image)
         .Execute();
         processResultArm64.Should().Pass().And.HaveStdOut("Hello, World!");

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -928,7 +928,7 @@ public class EndToEndTests : IDisposable
         string imageName = NewImageName();
         string tag = "1.0";
         string image = $"{imageName}:{tag}";
-        string archiveOutput = Path.Combine(TestSettings.TestArtifactsDirectory, "tarballs-output");
+        string archiveOutput = TestSettings.TestArtifactsDirectory;
         string imageTarball = Path.Combine(archiveOutput, $"{imageName}.tar.gz");
 
         // Create a new console project

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1010,9 +1010,9 @@ public class EndToEndTests : IDisposable
         commandResult.Should().Pass()
             .And.HaveStdOutContaining(GetPublishArtifactsPath(newProjectDir.FullName, "linux-x64"))
             .And.HaveStdOutContaining(GetPublishArtifactsPath(newProjectDir.FullName, "linux-arm64"))
-            .And.HaveStdOutContaining($"Pushed image '{imageX64}' to registry")
-            .And.HaveStdOutContaining($"Pushed image '{imageArm64}' to registry")
-            .And.HaveStdOutContaining($"Pushed image index '{imageIndex}' to registry '{registry}'");
+            .And.HaveStdOutContaining($"Pushed image '{imageX64}' to registry '{registry}'.")
+            .And.HaveStdOutContaining($"Pushed image '{imageArm64}' to registry '{registry}'.")
+            .And.HaveStdOutContaining($"Pushed image index '{imageIndex}' to registry '{registry}'.");
 
 
         // Check that the containers can be run

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerAvailableUtils.cs
@@ -25,17 +25,20 @@ public class DockerAvailableFactAttribute : FactAttribute
 {
     public static string LocalRegistry => DockerCliStatus.LocalRegistry;
 
-    public DockerAvailableFactAttribute(bool skipPodman = false)
+    public DockerAvailableFactAttribute(bool skipPodman = false, bool checkContainerdStoreAvailability = false)
     {
         if (!DockerCliStatus.IsAvailable)
         {
             base.Skip = "Skipping test because Docker is not available on this host.";
         }
-
-        if (skipPodman && DockerCliStatus.Command == DockerCli.PodmanCommand)
+        else if (checkContainerdStoreAvailability && !DockerCli.IsContainerdStoreEnabledForDocker())
+        {
+            base.Skip = "Skipping test because Docker daemon is not using containerd as the storage driver.";
+        }
+        else if (skipPodman && DockerCliStatus.Command == DockerCli.PodmanCommand)
         {
             base.Skip = $"Skipping test with {DockerCliStatus.Command} cli.";
-        }
+        }      
     }
 }
 

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
@@ -104,7 +104,7 @@ public class ImageIndexGeneratorTests
         ];
 
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
-        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.docker.distribution.manifest.list.v2\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.docker.distribution.manifest.list.v2+json\",\"manifests\":[{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
         Assert.Equal(SchemaTypes.DockerManifestListV2, mediaType);
     }
 
@@ -138,7 +138,7 @@ public class ImageIndexGeneratorTests
         ];
 
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
-        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
         Assert.Equal(SchemaTypes.OciImageIndexV1, mediaType);
     }
 
@@ -146,6 +146,6 @@ public class ImageIndexGeneratorTests
     public void GenerateImageIndexWithAnnotations()
     {
         string imageIndex = ImageIndexGenerator.GenerateImageIndexWithAnnotations("mediaType", "sha256:digest", 3, "repository", ["1.0", "2.0"]);
-        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"repository:1.0\",\"org.opencontainers.image.ref.name\":\"1.0\"}},{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"repository:2.0\",\"org.opencontainers.image.ref.name\":\"2.0\"}}]}", imageIndex);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"docker.io/library/repository:1.0\",\"org.opencontainers.image.ref.name\":\"1.0\"}},{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"docker.io/library/repository:2.0\",\"org.opencontainers.image.ref.name\":\"2.0\"}}]}", imageIndex);
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
@@ -96,7 +96,7 @@ public class ImageIndexGeneratorTests
         ];
 
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
-        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.docker.distribution.manifest.list.v2\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\",\"variant\":null,\"features\":null,\"os.version\":null}},{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\",\"variant\":null,\"features\":null,\"os.version\":null}}]}", imageIndex);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.docker.distribution.manifest.list.v2\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.docker.distribution.manifest.v2\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
         Assert.Equal(SchemaTypes.DockerManifestListV2, mediaType);
     }
 
@@ -130,7 +130,7 @@ public class ImageIndexGeneratorTests
         ];
 
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
-        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\",\"variant\":null,\"features\":null,\"os.version\":null}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\",\"variant\":null,\"features\":null,\"os.version\":null}}]}", imageIndex);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
         Assert.Equal(SchemaTypes.OciImageIndexV1, mediaType);
     }
 }

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
@@ -31,8 +31,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "",
                 ManifestDigest = "",
                 ManifestMediaType = "unsupported"
@@ -53,8 +51,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "",
                 ManifestDigest = "",
                 ManifestMediaType = supportedMediaType,
@@ -62,8 +58,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "",
                 ManifestDigest = "",
                 ManifestMediaType = "anotherMediaType"
@@ -82,8 +76,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "123",
                 ManifestDigest = "sha256:digest1",
                 ManifestMediaType = SchemaTypes.DockerManifestV2,
@@ -93,8 +85,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "123",
                 ManifestDigest = "sha256:digest2",
                 ManifestMediaType = SchemaTypes.DockerManifestV2,
@@ -116,8 +106,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "123",
                 ManifestDigest = "sha256:digest1",
                 ManifestMediaType = SchemaTypes.OciManifestV1,
@@ -127,8 +115,6 @@ public class ImageIndexGeneratorTests
             new BuiltImage
             {
                 Config = "",
-                ImageDigest = "",
-                ImageSha = "",
                 Manifest = "123",
                 ManifestDigest = "sha256:digest2",
                 ManifestMediaType = SchemaTypes.OciManifestV1,

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
@@ -10,7 +10,7 @@ public class ImageIndexGeneratorTests
     [Fact]
     public void ImagesCannotBeEmpty()
     {
-        ImageInfo[] images = Array.Empty<ImageInfo>();
+        BuiltImage[] images = Array.Empty<BuiltImage>();
         var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images));
         Assert.Equal(Strings.ImagesEmpty, ex.Message);
     }
@@ -18,13 +18,18 @@ public class ImageIndexGeneratorTests
     [Fact]
     public void UnsupportedMediaTypeThrows()
     {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
+        BuiltImage[] images = 
+        [
+            new BuiltImage
             {
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
+                Manifest = "",
+                ManifestDigest = "",
                 ManifestMediaType = "unsupported"
             }
-        };
+        ];
 
         var ex = Assert.Throws<NotSupportedException>(() => ImageIndexGenerator.GenerateImageIndex(images));
         Assert.Equal(string.Format(Strings.UnsupportedMediaType, "unsupported"), ex.Message);
@@ -33,80 +38,29 @@ public class ImageIndexGeneratorTests
     [Theory]
     [InlineData(SchemaTypes.DockerManifestV2)]
     [InlineData(SchemaTypes.OciManifestV1)]
-    public void ConfigIsNotJsonObjectThrows(string supportedMediaType)
-    {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
-            {
-                Config = "[]",
-                Manifest = "",
-                ManifestMediaType = supportedMediaType
-            }
-        };
-
-        var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images));
-        Assert.Equal($"Config should be a JSON object. (Parameter 'Config')", ex.Message);
-    }
-
-    [Theory]
-    [InlineData(SchemaTypes.DockerManifestV2)]
-    [InlineData(SchemaTypes.OciManifestV1)]
-    public void ConfigDoesNotContainArchitectureThrows(string supportedMediaType)
-    {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
-            {
-                Config = "{}",
-                Manifest = "",
-                ManifestMediaType = supportedMediaType
-            }
-        };
-
-        var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images));
-        Assert.Equal($"Config should contain 'architecture'. (Parameter 'Config')", ex.Message);
-    }
-
-    [Theory]
-    [InlineData(SchemaTypes.DockerManifestV2)]
-    [InlineData(SchemaTypes.OciManifestV1)]
-    public void ConfigDoesNotContainOsThrows(string supportedMediaType)
-    {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
-            {
-               Config = "{\"architecture\":\"arch1\"}",
-               Manifest = "",
-               ManifestMediaType = supportedMediaType
-            }
-        };
-
-        var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images));
-        Assert.Equal($"Config should contain 'os'. (Parameter 'Config')", ex.Message);
-    }
-
-    [Theory]
-    [InlineData(SchemaTypes.DockerManifestV2)]
-    [InlineData(SchemaTypes.OciManifestV1)]
     public void ImagesWithMixedMediaTypes(string supportedMediaType)
     {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
-            {
-                Config = "{\"architecture\":\"arch1\",\"os\":\"os1\"}",
-                Manifest =  "",
-                ManifestMediaType = supportedMediaType
-            },
-            new ImageInfo
+        BuiltImage[] images = 
+        [
+            new BuiltImage
             {
                 Config = "",
+                ImageDigest = "",
+                ImageSha = "",
                 Manifest = "",
+                ManifestDigest = "",
+                ManifestMediaType = supportedMediaType,
+            },
+            new BuiltImage
+            {
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
+                Manifest = "",
+                ManifestDigest = "",
                 ManifestMediaType = "anotherMediaType"
             }
-        };
+        ];
 
         var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images));
         Assert.Equal(Strings.MixedMediaTypes, ex.Message);
@@ -115,21 +69,29 @@ public class ImageIndexGeneratorTests
     [Fact]
     public void GenerateDockerManifestList()
     {
-        ImageInfo[] images =
+        BuiltImage[] images =
         [
-            new ImageInfo
+            new BuiltImage
             {
-                Config = "{\"architecture\":\"arch1\",\"os\":\"os1\"}",
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
+                Manifest = "123",
                 ManifestDigest = "sha256:digest1",
-                Manifest = "123",
-                ManifestMediaType = SchemaTypes.DockerManifestV2
+                ManifestMediaType = SchemaTypes.DockerManifestV2,
+                Architecture = "arch1",
+                OS = "os1"
             },
-            new ImageInfo
+            new BuiltImage
             {
-                Config = "{\"architecture\":\"arch2\",\"os\":\"os2\"}",
-                ManifestDigest = "sha256:digest2",
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
                 Manifest = "123",
-                ManifestMediaType = SchemaTypes.DockerManifestV2
+                ManifestDigest = "sha256:digest2",
+                ManifestMediaType = SchemaTypes.DockerManifestV2,
+                Architecture = "arch2",
+                OS = "os2"
             }
         ];
 
@@ -141,23 +103,31 @@ public class ImageIndexGeneratorTests
     [Fact]
     public void GenerateOciImageIndex()
     {
-        ImageInfo[] images = new ImageInfo[]
-        {
-            new ImageInfo
+        BuiltImage[] images =
+        [
+            new BuiltImage
             {
-                Config = "{\"architecture\":\"arch1\",\"os\":\"os1\"}",
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
+                Manifest = "123",
                 ManifestDigest = "sha256:digest1",
-                Manifest = "123",
-                ManifestMediaType = SchemaTypes.OciManifestV1
+                ManifestMediaType = SchemaTypes.OciManifestV1,
+                Architecture = "arch1",
+                OS = "os1"
             },
-            new ImageInfo
+            new BuiltImage
             {
-                Config = "{\"architecture\":\"arch2\",\"os\":\"os2\"}",
-                ManifestDigest = "sha256:digest2",
+                Config = "",
+                ImageDigest = "",
+                ImageSha = "",
                 Manifest = "123",
-                ManifestMediaType = SchemaTypes.OciManifestV1
+                ManifestDigest = "sha256:digest2",
+                ManifestMediaType = SchemaTypes.OciManifestV1,
+                Architecture = "arch2",
+                OS = "os2"
             }
-        };
+        ];
 
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
         Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\",\"variant\":null,\"features\":null,\"os.version\":null}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\",\"variant\":null,\"features\":null,\"os.version\":null}}]}", imageIndex);

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/ImageIndexGeneratorTests.cs
@@ -16,6 +16,14 @@ public class ImageIndexGeneratorTests
     }
 
     [Fact]
+    public void ImagesCannotBeEmpty_SpecifiedMediaType()
+    {
+        BuiltImage[] images = Array.Empty<BuiltImage>();
+        var ex = Assert.Throws<ArgumentException>(() => ImageIndexGenerator.GenerateImageIndex(images, "manifestMediaType", "imageIndexMediaType"));
+        Assert.Equal(Strings.ImagesEmpty, ex.Message);
+    }
+
+    [Fact]
     public void UnsupportedMediaTypeThrows()
     {
         BuiltImage[] images = 
@@ -132,5 +140,12 @@ public class ImageIndexGeneratorTests
         var (imageIndex, mediaType) = ImageIndexGenerator.GenerateImageIndex(images);
         Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest1\",\"platform\":{\"architecture\":\"arch1\",\"os\":\"os1\"}},{\"mediaType\":\"application/vnd.oci.image.manifest.v1\\u002Bjson\",\"size\":3,\"digest\":\"sha256:digest2\",\"platform\":{\"architecture\":\"arch2\",\"os\":\"os2\"}}]}", imageIndex);
         Assert.Equal(SchemaTypes.OciImageIndexV1, mediaType);
+    }
+
+    [Fact]
+    public void GenerateImageIndexWithAnnotations()
+    {
+        string imageIndex = ImageIndexGenerator.GenerateImageIndexWithAnnotations("mediaType", "sha256:digest", 3, "repository", ["1.0", "2.0"]);
+        Assert.Equal("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1\\u002Bjson\",\"manifests\":[{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"repository:1.0\",\"org.opencontainers.image.ref.name\":\"1.0\"}},{\"mediaType\":\"mediaType\",\"size\":3,\"digest\":\"sha256:digest\",\"platform\":{},\"annotations\":{\"io.containerd.image.name\":\"repository:2.0\",\"org.opencontainers.image.ref.name\":\"2.0\"}}]}", imageIndex);
     }
 }


### PR DESCRIPTION
### Context

Fixes https://github.com/dotnet/sdk-container-builds/issues/609

This is a feature request from partner team - support publishing multi-arch OCI image as one combined tarball. Currently we publish separate tarballs for each architecture.

### Customer impact

Without this feature customers will not be able to export multi-arch OCI image as one combined tarball, they will get separate tarballs for each architecture, and will have to combine them manually to achieve this.

### Details

**Current behavior for multi-arch image publishing**

- remote registry - create single-arch image for each arch and publish them to the remote registry, then create image index based on them and load to remote registry
- local daemon (docker/podman) - create single-arch image for each arch and publish them to the local daemon
- tarball - create single-arch image for each arch and publish them as separate tarballs

**Behaviour after this PR**

- remote registry - create single-arch image for each arch and publish them to the remote registry, then create image index based on them and load to remote registry (same as before)
- local daemon (docker) - create one multi-arch image and publish it to the local daemon
- local daemon (podman) - create single-arch image for each arch and publish them to the local daemon (same as before; support for podman will be added in the future)
- tarball - create one multi-arch image and publish it as a tarball

_Note_: in order to load a multi-arch oci image tarball, containerd image store should be enabled for Docker.

### Changes made 

1. Added support for multi-arch OCI tarballs creation in `DockerCli`.
2. Refactored the code to extract publishing logic from `CreateNewImage` task into a separate class, to be able to reuse it in `CreateImageIndex` task.
3. Added `SkipPublishing` parameter in `CreateNewImage` task, in order to create an image but skip publish it (this is needed for multi-arch tarball publishing because we need to publish one combined tarball)
4. More refactoring

### Testing
Modified end to end multi-arch tests to reflect the new behavior. Tested manually as well.

### Risks
_Low_  - new tests ensure the scenarios are now covered, the existing tests ensure that other scenarios were not affected.