### PR TITLE
Do not pass raw messages to string.Format

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -28,11 +28,23 @@ namespace Microsoft.Extensions.Tools.Internal
         [MemberNotNullWhen(true, nameof(Format), nameof(Emoji))]
         public bool TryGetMessage(string? prefix, object?[] args, [NotNullWhen(true)] out string? message)
         {
+            // Messages without Id are created by IReporter.Verbose|Output|Warn|Error helpers.
+            // They do not have arguments and we shouldn't interpret Format as a string with holes.
+            // Eventually, all messages should have a descriptor (so we can localize them) and this can be removed.
+            if (Id == null)
+            {
+                Debug.Assert(args is null or []);
+                Debug.Assert(HasMessage);
+                message = prefix + Format;
+                return true;
+            }
+
             if (!HasMessage)
             {
                 message = null;
                 return false;
             }
+
 
             message = prefix + string.Format(Format, args);
             return true;

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Extensions.Tools.Internal
             var dotnetWatchDefaultPrefix = $"dotnet watch {(suppressEmojis ? ":" : "⌚")} ";
 
             // stdout
-            reporter.Verbose("verbose");
-            Assert.Equal($"{dotnetWatchDefaultPrefix}verbose" + EOL, testConsole.GetOutput());
+            reporter.Verbose("verbose {0}");
+            Assert.Equal($"{dotnetWatchDefaultPrefix}verbose {{0}}" + EOL, testConsole.GetOutput());
             testConsole.Clear();
 
             reporter.Output("out");


### PR DESCRIPTION
Ports fix for https://github.com/dotnet/sdk/issues/46463 to 9.0.1xx


### Context

The change fixes crash that occurs when dotnet-watch attempts to print a message that contains `{` character in file name or other argument. These are mistakenly interpreted as formatting placeholders.

### Customer impact

dotnet-watch crashes when file path contains `{`.

### Details

### Changes made


### Testing

Unit test added.

### Risks

Small.


