### PR TITLE
slnx: ParseAndValidateArguments include .slnx

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/SlnArgumentValidator.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/SlnArgumentValidator.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Tools.Sln
 {
@@ -29,7 +30,7 @@ namespace Microsoft.DotNet.Tools.Sln
                 throw new GracefulException(LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             }
 
-            var slnFile = _arguments.FirstOrDefault(path => path.EndsWith(".sln"));
+            var slnFile = _arguments.FirstOrDefault(path => path.HasExtension(".sln") || path.HasExtension(".slnx"));
             if (slnFile != null)
             {
                 string args;
@@ -46,7 +47,7 @@ namespace Microsoft.DotNet.Tools.Sln
                     args = "";
                 }
 
-                var projectArgs = string.Join(" ", _arguments.Where(path => !path.EndsWith(".sln")));
+                var projectArgs = string.Join(" ", _arguments.Where(path => !path.HasExtension(".sln") && !path.HasExtension(".slnx")));
                 string command = commandType == CommandType.Add ? "add" : "remove";
                 throw new GracefulException(new string[]
                 {

--- a/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -1153,6 +1153,8 @@ Options:
         [Theory]
         [InlineData("sln", ".sln")]
         [InlineData("solution", ".sln")]
+        [InlineData("sln", ".slnx")]
+        [InlineData("solution", ".slnx")]
         public void WhenSolutionIsPassedAsProjectItPrintsSuggestionAndUsage(string solutionCommand, string solutionExtension)
         {
             VerifySuggestionAndUsage(solutionCommand, "", solutionExtension);
@@ -1161,6 +1163,8 @@ Options:
         [Theory]
         [InlineData("sln", ".sln")]
         [InlineData("solution", ".sln")]
+        [InlineData("sln", ".slnx")]
+        [InlineData("solution", ".slnx")]
         public void WhenSolutionIsPassedAsProjectWithInRootItPrintsSuggestionAndUsage(string solutionCommand, string solutionExtension)
         {
             VerifySuggestionAndUsage(solutionCommand, "--in-root", solutionExtension);
@@ -1169,6 +1173,8 @@ Options:
         [Theory]
         [InlineData("sln", ".sln")]
         [InlineData("solution", ".sln")]
+        [InlineData("sln", ".slnx")]
+        [InlineData("solution", ".slnx")]
         public void WhenSolutionIsPassedAsProjectWithSolutionFolderItPrintsSuggestionAndUsage(string solutionCommand, string solutionExtension)
         {
             VerifySuggestionAndUsage(solutionCommand, "--solution-folder", solutionExtension);

--- a/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
@@ -627,24 +627,26 @@ Options:
         }
 
         [Theory]
-        [InlineData("sln")]
-        [InlineData("solution")]
-        public void WhenSolutionIsPassedAsProjectItPrintsSuggestionAndUsage(string solutionCommand)
+        [InlineData("sln", ".sln")]
+        [InlineData("solution", ".sln")]
+        [InlineData("sln", ".slxn")]
+        [InlineData("solution", ".slnx")]
+        public void WhenSolutionIsPassedAsProjectItPrintsSuggestionAndUsage(string solutionCommand, string solutionExtension)
         {
             var projectDirectory = _testAssetsManager
-                .CopyTestAsset("TestAppWithSlnAndCsprojFiles", identifier: $"{solutionCommand}")
+                .CopyTestAsset("TestAppWithSlnAndCsprojFiles", identifier: $"{solutionCommand}{solutionExtension}")
                 .WithSource()
                 .Path;
 
             var projectArg = Path.Combine("Lib", "Lib.csproj");
             var cmd = new DotnetCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute(solutionCommand, "remove", "App.sln", projectArg);
+                .Execute(solutionCommand, "remove", $"App{solutionExtension}", projectArg);
             cmd.Should().Fail();
             cmd.StdErr.Should().BeVisuallyEquivalentTo(
-                string.Format(CommonLocalizableStrings.SolutionArgumentMisplaced, "App.sln") + Environment.NewLine
+                string.Format(CommonLocalizableStrings.SolutionArgumentMisplaced, $"App{solutionExtension}") + Environment.NewLine
                 + CommonLocalizableStrings.DidYouMean + Environment.NewLine
-                 + $"  dotnet solution App.sln remove {projectArg}"
+                 + $"  dotnet solution App{solutionExtension} remove {projectArg}"
             );
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized("");
         }

--- a/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
@@ -629,7 +629,7 @@ Options:
         [Theory]
         [InlineData("sln", ".sln")]
         [InlineData("solution", ".sln")]
-        [InlineData("sln", ".slxn")]
+        [InlineData("sln", ".slnx")]
         [InlineData("solution", ".slnx")]
         public void WhenSolutionIsPassedAsProjectItPrintsSuggestionAndUsage(string solutionCommand, string solutionExtension)
         {


### PR DESCRIPTION
Noticed tests for command suggestions when misplacing arguments were not updated for slnx support on `dotnet sln add` and `dotnet sln remove`. This adds support for such tests.