### PR TITLE
Add tests for globbing filter

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli
 
         private static IEnumerable<string> GetMatchedModulePaths(string testModules, string rootDirectory)
         {
-            var testModulePatterns = testModules.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            var testModulePatterns = testModules.Split([';'], StringSplitOptions.RemoveEmptyEntries);
 
             Matcher matcher = new();
             matcher.AddIncludePatterns(testModulePatterns);

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
@@ -2,91 +2,90 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using dotnet.Tests;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
-    public class GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter : SdkTest
-    {
-        private const string TestApplicationArgsPattern = @".*(Test application arguments).*";
+	public class GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter : SdkTest
+	{
+		private const string TestApplicationArgsPattern = @".*(Test application arguments).*";
 
-        public GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter(ITestOutputHelper log) : base(log)
-        {
-        }
+		public GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter(ITestOutputHelper log) : base(log)
+		{
+		}
 
-        [InlineData(Constants.Debug)]
-        [InlineData(Constants.Release)]
-        [Theory]
-        public void RunTestProjectWithFilterOfDll_ShouldReturnZeroAsExitCode(string configuration)
-        {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
-                .WithSource();
+		[InlineData(TestingConstants.Debug)]
+		[InlineData(TestingConstants.Release)]
+		[Theory]
+		public void RunTestProjectWithFilterOfDll_ShouldReturnZeroAsExitCode(string configuration)
+		{
+			TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
+				.WithSource();
 
-            new BuildCommand(testInstance)
-                .Execute()
-                .Should().Pass();
+			new BuildCommand(testInstance)
+				.Execute()
+				.Should().Pass();
 
-            var binDirectory = new FileInfo($"{testInstance.Path}/bin").Directory;
-            var binDirectoryLastWriteTime = binDirectory?.LastWriteTime;
+			var binDirectory = new FileInfo($"{testInstance.Path}{Path.DirectorySeparatorChar}bin").Directory;
+			var binDirectoryLastWriteTime = binDirectory?.LastWriteTime;
 
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .WithEnableTestingPlatform()
-                                    .Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll",
-                                    TestingPlatformOptions.ConfigurationOption.Name, configuration);
+			CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+									.WithWorkingDirectory(testInstance.Path)
+									.WithEnableTestingPlatform()
+									.Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
+									TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            // Assert that the bin folder hasn't been modified
-            Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
+			// Assert that the bin folder hasn't been modified
+			Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
 
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut
-                    .Should().Contain("Test run summary: Passed!")
-                    .And.Contain("total: 2")
-                    .And.Contain("succeeded: 1")
-                    .And.Contain("failed: 0")
-                    .And.Contain("skipped: 1");
-            }
+			if (!TestContext.IsLocalized())
+			{
+				result.StdOut
+					.Should().Contain("Test run summary: Passed!")
+					.And.Contain("total: 2")
+					.And.Contain("succeeded: 1")
+					.And.Contain("failed: 0")
+					.And.Contain("skipped: 1");
+			}
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
-        }
+			result.ExitCode.Should().Be(ExitCodes.Success);
+		}
 
-        [InlineData(Constants.Debug)]
-        [InlineData(Constants.Release)]
-        [Theory]
-        public void RunTestProjectWithFilterOfDllWithRootDirectory_ShouldReturnZeroAsExitCode(string configuration)
-        {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
-                .WithSource();
+		[InlineData(TestingConstants.Debug)]
+		[InlineData(TestingConstants.Release)]
+		[Theory]
+		public void RunTestProjectWithFilterOfDllWithRootDirectory_ShouldReturnZeroAsExitCode(string configuration)
+		{
+			TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
+				.WithSource();
 
-            new BuildCommand(testInstance)
-                .Execute()
-                .Should().Pass();
+			new BuildCommand(testInstance)
+				.Execute()
+				.Should().Pass();
 
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .WithEnableTestingPlatform()
-                                    .WithTraceOutput()
-                                    .Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll",
-                                    TestingPlatformOptions.TestModulesRootDirectoryOption.Name, testInstance.TestRoot,
-                                    TestingPlatformOptions.ConfigurationOption.Name, configuration);
+			CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+									.WithWorkingDirectory(testInstance.Path)
+									.WithEnableTestingPlatform()
+									.WithTraceOutput()
+									.Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
+									TestingPlatformOptions.TestModulesRootDirectoryOption.Name, testInstance.TestRoot,
+									TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
 
-            var testAppArgs = Regex.Matches(result.StdOut!, TestApplicationArgsPattern);
-            Assert.Contains($"exec {testInstance.TestRoot}\\bin\\Debug\\net8.0\\TestProject.dll", testAppArgs.FirstOrDefault()?.Value);
+			var testAppArgs = Regex.Matches(result.StdOut!, TestApplicationArgsPattern);
+			Assert.Contains(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "exec", addVersionAndArchPattern: false), testAppArgs.FirstOrDefault()?.Value);
 
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut
-                    .Should().Contain("Test run summary: Passed!")
-                    .And.Contain("total: 2")
-                    .And.Contain("succeeded: 1")
-                    .And.Contain("failed: 0")
-                    .And.Contain("skipped: 1");
-            }
+			if (!TestContext.IsLocalized())
+			{
+				result.StdOut
+					.Should().Contain("Test run summary: Passed!")
+					.And.Contain("total: 2")
+					.And.Contain("succeeded: 1")
+					.And.Contain("failed: 0")
+					.And.Contain("skipped: 1");
+			}
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
-        }
-    }
+			result.ExitCode.Should().Be(ExitCodes.Success);
+		}
+	}
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
@@ -1,91 +1,84 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
-	public class GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter : SdkTest
-	{
-		private const string TestApplicationArgsPattern = @".*(Test application arguments).*";
+    public class GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter : SdkTest
+    {
+        private const string TestApplicationArgsPattern = @".*(Test application arguments).*";
 
-		public GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter(ITestOutputHelper log) : base(log)
-		{
-		}
+        public GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter(ITestOutputHelper log) : base(log)
+        {
+        }
 
-		[InlineData(TestingConstants.Debug)]
-		[InlineData(TestingConstants.Release)]
-		[Theory]
-		public void RunTestProjectWithFilterOfDll_ShouldReturnZeroAsExitCode(string configuration)
-		{
-			TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
-				.WithSource();
+        [Fact]
+        public void RunTestProjectWithFilterOfDll_ShouldReturnZeroAsExitCode()
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
+                .WithSource();
 
-			new BuildCommand(testInstance)
-				.Execute()
-				.Should().Pass();
+            new BuildCommand(testInstance)
+                .Execute()
+                .Should().Pass();
 
-			var binDirectory = new FileInfo($"{testInstance.Path}{Path.DirectorySeparatorChar}bin").Directory;
-			var binDirectoryLastWriteTime = binDirectory?.LastWriteTime;
+            var binDirectory = new FileInfo($"{testInstance.Path}{Path.DirectorySeparatorChar}bin").Directory;
+            var binDirectoryLastWriteTime = binDirectory?.LastWriteTime;
 
-			CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-									.WithWorkingDirectory(testInstance.Path)
-									.WithEnableTestingPlatform()
-									.Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
-									TestingPlatformOptions.ConfigurationOption.Name, configuration);
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnableTestingPlatform()
+                                    .Execute(TestingPlatformOptions.TestModulesFilterOption.Name, $"**/bin/**/Debug/{ToolsetInfo.CurrentTargetFramework}/TestProject.dll".Replace('/', Path.DirectorySeparatorChar));
 
-			// Assert that the bin folder hasn't been modified
-			Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
+            // Assert that the bin folder hasn't been modified
+            Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, "Debug"), result.StdOut);
 
-			if (!TestContext.IsLocalized())
-			{
-				result.StdOut
-					.Should().Contain("Test run summary: Passed!")
-					.And.Contain("total: 2")
-					.And.Contain("succeeded: 1")
-					.And.Contain("failed: 0")
-					.And.Contain("skipped: 1");
-			}
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("total: 2")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 1");
+            }
 
-			result.ExitCode.Should().Be(ExitCodes.Success);
-		}
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
 
-		[InlineData(TestingConstants.Debug)]
-		[InlineData(TestingConstants.Release)]
-		[Theory]
-		public void RunTestProjectWithFilterOfDllWithRootDirectory_ShouldReturnZeroAsExitCode(string configuration)
-		{
-			TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
-				.WithSource();
+        [Fact]
+        public void RunTestProjectWithFilterOfDllWithRootDirectory_ShouldReturnZeroAsExitCode()
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithTests", Guid.NewGuid().ToString())
+                .WithSource();
 
-			new BuildCommand(testInstance)
-				.Execute()
-				.Should().Pass();
+            new BuildCommand(testInstance)
+                .Execute()
+                .Should().Pass();
 
-			CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-									.WithWorkingDirectory(testInstance.Path)
-									.WithEnableTestingPlatform()
-									.WithTraceOutput()
-									.Execute(TestingPlatformOptions.TestModulesFilterOption.Name, "**/bin/**/Debug/net8.0/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
-									TestingPlatformOptions.TestModulesRootDirectoryOption.Name, testInstance.TestRoot,
-									TestingPlatformOptions.ConfigurationOption.Name, configuration);
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnableTestingPlatform()
+                                    .WithTraceOutput()
+                                    .Execute(TestingPlatformOptions.TestModulesFilterOption.Name, $"**/bin/**/Debug/{ToolsetInfo.CurrentTargetFramework}/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
+                                    TestingPlatformOptions.TestModulesRootDirectoryOption.Name, testInstance.TestRoot);
 
 
-			var testAppArgs = Regex.Matches(result.StdOut!, TestApplicationArgsPattern);
-			Assert.Contains(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "exec", addVersionAndArchPattern: false), testAppArgs.FirstOrDefault()?.Value);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, "Debug"), result.StdOut);
 
-			if (!TestContext.IsLocalized())
-			{
-				result.StdOut
-					.Should().Contain("Test run summary: Passed!")
-					.And.Contain("total: 2")
-					.And.Contain("succeeded: 1")
-					.And.Contain("failed: 0")
-					.And.Contain("skipped: 1");
-			}
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("total: 2")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 1");
+            }
 
-			result.ExitCode.Should().Be(ExitCodes.Success);
-		}
-	}
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+    }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -132,9 +132,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration, "8"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "failed", true, configuration, "2"), result.StdOut);
-                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", "failed", true, configuration, "9"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration, "8"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Failed, true, configuration, "2"), result.StdOut);
+                Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("AnotherTestProject", TestingConstants.Failed, true, configuration, "9"), result.StdOut);
 
                 result.StdOut
                     .Should().Contain("Test run summary: Failed!")

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -53,8 +53,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(TestingPlatformOptions.SolutionOption.Name, testSolutionPath,
                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -76,8 +76,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             // Assert that only TestProject ran
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
-            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
+            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -97,8 +97,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             // Assert that only TestProject ran
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", "failed", true, configuration), result.StdOut);
-            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", "passed", true, configuration), result.StdOut);
+            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
+            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -57,7 +57,6 @@
     <Compile Include="..\Microsoft.DotNet.Configurer.UnitTests\**\*.cs" LinkBase="Configurer" />
     <Compile Include="..\Microsoft.DotNet.ShellShim.Tests\**\*.cs" LinkBase="ShellShim" />
     <Compile Remove="..\dotnet-test.Tests\GivenDotnetTestBuildsAndRunsHelp.cs" />
-    <Compile Remove="..\dotnet-test.Tests\GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs" />
 
     <None Include="..\Microsoft.DotNet.ShellShim.Tests\WpfBinaryTestAsssets\testwpf.dll" LinkBase="WpfBinaryTestAsssets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This pull request includes several changes to `dotnet-test` related files, focusing on improvements to test handling and updating patterns for better consistency and reliability. The most important changes include updates to test methods, adjustments to file paths, and the removal of unnecessary code.

### Test Method Updates:
* Changed test methods from `[Theory]` with `[InlineData]` to `[Fact]` and removed configuration parameters for simplicity. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs`) [[1]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5L4-R15) [[2]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5L55-R96)

### File Path Adjustments:
* Updated file paths to use `Path.DirectorySeparatorChar` for better cross-platform compatibility. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs`)
* Modified file paths in test commands to dynamically use the current target framework. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs`)

### Code Cleanup:
* Removed unused imports and constants from test files. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs`)
* Removed unnecessary `Compile` directive from the project file. (`test/dotnet.Tests/dotnet.Tests.csproj`)

### Consistency Improvements:
* Replaced hardcoded strings with constants from `TestingConstants` for better maintainability. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs`, `test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs`) [[1]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L135-R137) [[2]](diffhunk://#diff-e0dd463d104b0f2f4bd1779aae3185e8b80cc98903643f41a203732c2d4b0e24L56-R57) [[3]](diffhunk://#diff-e0dd463d104b0f2f4bd1779aae3185e8b80cc98903643f41a203732c2d4b0e24L79-R80) [[4]](diffhunk://#diff-e0dd463d104b0f2f4bd1779aae3185e8b80cc98903643f41a203732c2d4b0e24L100-R101)

### Pattern Matching:
* Updated regex patterns to use helper methods for generating project regex patterns. (`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs`)

These changes aim to improve the reliability and maintainability of the test suite by simplifying test methods, ensuring cross-platform compatibility, and using consistent patterns and constants.

Relates to https://github.com/dotnet/sdk/issues/45927