### PR TITLE
Create dependencies for each dotnet/templating version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,7 +5,35 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Edge" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Utils" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateSearch.Common" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Mocks" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.TestHelper" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="10.0.100-preview.2.25080.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateSearch.TemplateDiscovery" Version="10.0.100-preview.2.25080.1">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,17 +25,17 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>413bd7e00eb0a8ff708625c97f7921b52cec090a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.TestHelper" Version="10.0.100-preview.2.25080.1">
+    <Dependency Name="Microsoft.TemplateEngine.TestHelper" Version="10.0.100-preview.2.25104.14">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+      <Sha>413bd7e00eb0a8ff708625c97f7921b52cec090a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="10.0.100-preview.2.25080.1">
+    <Dependency Name="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="10.0.100-preview.2.25104.14">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+      <Sha>413bd7e00eb0a8ff708625c97f7921b52cec090a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateSearch.TemplateDiscovery" Version="10.0.100-preview.2.25080.1">
+    <Dependency Name="Microsoft.TemplateSearch.TemplateDiscovery" Version="10.0.100-preview.2.25104.14">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>7137d45fe29466e53caadc374472912811f6522e</Sha>
+      <Sha>413bd7e00eb0a8ff708625c97f7921b52cec090a</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.templating" Version="10.0.100-preview.2.25104.14">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -203,7 +203,7 @@
     <MicrosoftTemplateEngineEdgePackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateEngineEdgePackageVersion>
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>10.0.100-preview.2.25104.141</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateSearchCommonPackageVersion>
     <!-- test dependencies -->
     <MicrosoftTemplateEngineMocksPackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateEngineMocksPackageVersion>
     <MicrosoftTemplateEngineTestHelperPackageVersion>10.0.100-preview.2.25104.14</MicrosoftTemplateEngineTestHelperPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -200,15 +200,15 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
     <MicrosoftTemplateEngineAbstractionsPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineAbstractionsPackageVersion>
-    <MicrosoftTemplateEngineEdgePackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineEdgePackageVersion>
-    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
-    <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateSearchCommonPackageVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateSearchCommonPackageVersion>
+    <MicrosoftTemplateEngineEdgePackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineEdgePackageVersion>
+    <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
+    <MicrosoftTemplateEngineUtilsPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineUtilsPackageVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateSearchCommonPackageVersion>
     <!-- test dependencies -->
     <MicrosoftTemplateEngineMocksPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineMocksPackageVersion>
-    <MicrosoftTemplateEngineTestHelperPackageVersion>$(MicrosoftTemplateEngineMocksPackageVersion)</MicrosoftTemplateEngineTestHelperPackageVersion>
-    <MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>$(MicrosoftTemplateEngineAbstractionsPackageVersion)</MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>
-    <MicrosoftTemplateSearchTemplateDiscoveryPackageVersion>$(MicrosoftTemplateEngineMocksPackageVersion)</MicrosoftTemplateSearchTemplateDiscoveryPackageVersion>
+    <MicrosoftTemplateEngineTestHelperPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineTestHelperPackageVersion>
+    <MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateEngineAuthoringTemplateVerifierVersion>
+    <MicrosoftTemplateSearchTemplateDiscoveryPackageVersion>10.0.100-preview.2.25080.1</MicrosoftTemplateSearchTemplateDiscoveryPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/visualfsharp -->


### PR DESCRIPTION
This is necessary so that dependency flow inside the VMR (product build and source-build) and correctly upgrade the version to the live one.