### PR TITLE
Create dependencies for aspnetcore template packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -139,14 +139,6 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>6908aead3a8b313798c381d5e435e9e6068301a7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.11">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>a4a2e3f31ddc2adb52ebd3204ea6f650d89caf3f</Sha>
@@ -364,6 +356,42 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Web.ItemTemplates.10.0" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Web.ProjectTemplates.10.0" Version="10.0.0-alpha.2.25073.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
+    </Dependency>
     <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.aspnetcore" Version="10.0.0-alpha.2.25073.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -387,22 +415,6 @@
       <Uri>https://github.com/dotnet/razor</Uri>
       <Sha>b10bc23eb5ee2203c38584e9838f9a6f486b699b</Sha>
       <SourceBuild RepoName="razor" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.2.25081.2" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -553,10 +565,6 @@
     <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.2.25103.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>219622a23cef3dde6a08378ac9829cb2b242cead</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="10.0.0-alpha.2.25073.4">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>febd7e8bdf05f17fb4e0e4dd3123e9538fbf7e7b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Win32.SystemEvents" Version="10.0.0-preview.2.25103.10">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,7 +83,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>10.0.0-preview.2.25081.2</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftDotNetWinFormsProjectTemplatesPackageVersion>10.0.0-preview.2.25081.2</MicrosoftDotNetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
@@ -237,6 +237,8 @@
     <MicrosoftAspNetCoreTestHostPackageVersion>10.0.0-alpha.2.25073.4</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>10.0.0-alpha.2.25073.4</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftAspNetCoreAppRefInternalPackageVersion>10.0.0-alpha.2.25073.4</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <MicrosoftDotNetWebItemTemplates100PackageVersion>10.0.0-alpha.2.25073.4</MicrosoftDotNetWebItemTemplates100PackageVersion>
+    <MicrosoftDotNetWebProjectTemplates100PackageVersion>10.0.0-alpha.2.25073.4</MicrosoftDotNetWebProjectTemplates100PackageVersion>
     <VSRedistCommonAspNetCoreSharedFrameworkx64100PackageVersion>10.0.0-alpha.2.25073.4</VSRedistCommonAspNetCoreSharedFrameworkx64100PackageVersion>
     <dotnetdevcertsPackageVersion>10.0.0-alpha.2.25073.4</dotnetdevcertsPackageVersion>
     <dotnetuserjwtsPackageVersion>10.0.0-alpha.2.25073.4</dotnetuserjwtsPackageVersion>
@@ -252,12 +254,6 @@
     <!-- Dependencies from https://github.com/dotnet/wpf -->
     <MicrosoftNETSdkWindowsDesktopPackageVersion>10.0.0-preview.2.25103.1</MicrosoftNETSdkWindowsDesktopPackageVersion>
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>10.0.0-preview.2.25103.1</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Template versions">
-    <!-- 10.0 Template versions -->
-    <AspNetCorePackageVersionFor100Templates>$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)</AspNetCorePackageVersionFor100Templates>
-    <MicrosoftDotnetWinFormsProjectTemplates100PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates100PackageVersion>
-    <MicrosoftDotNetWpfProjectTemplates100PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates100PackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Infrastructure and test only dependencies">
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>

--- a/src/Installer/redist-installer/targets/BundledTemplates.targets
+++ b/src/Installer/redist-installer/targets/BundledTemplates.targets
@@ -22,7 +22,7 @@
   <ItemGroup Label=".NET 10.0 templates">
     <Bundled100Templates Include="Microsoft.DotNet.Web.ItemTemplates.10.0" PackageVersion="$(MicrosoftDotNetWebItemTemplates100PackageVersion)" />
     <Bundled100Templates Include="Microsoft.DotNet.Web.ProjectTemplates.10.0" PackageVersion="$(MicrosoftDotNetWebProjectTemplates100PackageVersion)" UseVersionForTemplateInstallPath="true" />
-    <Bundled100Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <Bundled100Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotNetWinFormsProjectTemplatesPackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <Bundled100Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 

--- a/src/Installer/redist-installer/targets/BundledTemplates.targets
+++ b/src/Installer/redist-installer/targets/BundledTemplates.targets
@@ -20,10 +20,10 @@
   </Target>
 
   <ItemGroup Label=".NET 10.0 templates">
-    <Bundled100Templates Include="Microsoft.DotNet.Web.ItemTemplates.10.0" PackageVersion="$(AspNetCorePackageVersionFor100Templates)" />
-    <Bundled100Templates Include="Microsoft.DotNet.Web.ProjectTemplates.10.0" PackageVersion="$(AspNetCorePackageVersionFor100Templates)" UseVersionForTemplateInstallPath="true" />
-    <Bundled100Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates100PackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
-    <Bundled100Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates100PackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <Bundled100Templates Include="Microsoft.DotNet.Web.ItemTemplates.10.0" PackageVersion="$(MicrosoftDotNetWebItemTemplates100PackageVersion)" />
+    <Bundled100Templates Include="Microsoft.DotNet.Web.ProjectTemplates.10.0" PackageVersion="$(MicrosoftDotNetWebProjectTemplates100PackageVersion)" UseVersionForTemplateInstallPath="true" />
+    <Bundled100Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <Bundled100Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/patches/wpf/0001-Create-arch-neutral-packages-when-building-inside-th.patch
+++ b/src/SourceBuild/patches/wpf/0001-Create-arch-neutral-packages-when-building-inside-th.patch
@@ -1,0 +1,30 @@
+From 2c9670d56a70dc78cad3f94cd815fc75638fd034 Mon Sep 17 00:00:00 2001
+From: Viktor Hofer <viktor.hofer@microsoft.com>
+Date: Tue, 4 Feb 2025 23:47:43 +0100
+Subject: [PATCH] Create arch neutral packages when building inside the VMR
+ (#10405)
+
+Backport: https://github.com/dotnet/wpf/pull/10405
+
+---
+ packaging/Directory.Build.props | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/packaging/Directory.Build.props b/packaging/Directory.Build.props
+index a1f50ce3d..15516fade 100644
+--- a/packaging/Directory.Build.props
++++ b/packaging/Directory.Build.props
+@@ -16,10 +16,11 @@
+       Set $(IsPackable) = true, except when
+           $(CreateArchNeutralPackage) == true && $(Platform) != x86
+         The idea here is that for arch-neutral packages, only the x86 build phase will generate the nuget package
+-        The platform/RID specific packages will be generated in their respective $(Platform) specific build phases
++        The platform/RID specific packages will be generated in their respective $(Platform) specific build phases.
++        Platform neutral packages should always get generated when building the product (DotNetBuild=true).
+     -->
+     <IsPackable>true</IsPackable>
+-    <IsPackable Condition="('$(Platform)'!='AnyCPU' and '$(Platform)'!='Win32' and '$(Platform)'!='x86') and '$(CreateArchNeutralPackage)'=='true'">false</IsPackable>
++    <IsPackable Condition="('$(Platform)'!='AnyCPU' and '$(Platform)'!='Win32' and '$(Platform)'!='x86') and '$(CreateArchNeutralPackage)'=='true' and '$(DotNetBuild)' != 'true'">false</IsPackable>
+   </PropertyGroup>
+ 
+   <PropertyGroup>

--- a/src/SourceBuild/patches/wpf/0004-Fix-the-ArtifactsPackagingDir-on-win-x64.patch
+++ b/src/SourceBuild/patches/wpf/0004-Fix-the-ArtifactsPackagingDir-on-win-x64.patch
@@ -1,0 +1,24 @@
+From 5d5f1c9eff148801ac0116c5b33d3b1608340d30 Mon Sep 17 00:00:00 2001
+From: Viktor Hofer <viktor.hofer@microsoft.com>
+Date: Wed, 5 Feb 2025 12:44:01 +0100
+Subject: [PATCH 4/4] Fix the ArtifactsPackagingDir on win-x64
+
+Backport: https://github.com/dotnet/wpf/pull/10411
+
+---
+ eng/WpfArcadeSdk/tools/Packaging.props | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/eng/WpfArcadeSdk/tools/Packaging.props b/eng/WpfArcadeSdk/tools/Packaging.props
+index ad1383c18..b052f0484 100644
+--- a/eng/WpfArcadeSdk/tools/Packaging.props
++++ b/eng/WpfArcadeSdk/tools/Packaging.props
+@@ -1,7 +1,6 @@
+ <Project>
+   <PropertyGroup>
+-    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'=='' and $(Platform.EndsWith('x64'))">$(ArtifactsDir)packaging\$(Configuration)\$(Platform)\</ArtifactsPackagingDir>
+-    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'=='' and !$(Platform.EndsWith('x64'))">$(ArtifactsDir)packaging\$(Configuration)\</ArtifactsPackagingDir>
++    <ArtifactsPackagingDir Condition="'$(ArtifactsPackagingDir)'==''">$(ArtifactsDir)packaging\$(Configuration)\</ArtifactsPackagingDir>
+ 
+     <!-- We like using RID prefix when generating nuget package names -->
+     <PackageRuntimeIdentifierPrefix Condition="'$(Platform)'!='AnyCPU' and '$(Platform)'!='Win32'">runtime.win-$(Platform)</PackageRuntimeIdentifierPrefix>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4886
Blocked on https://github.com/dotnet/source-build/issues/4885

This is necessary so that dependency flow inside the VMR (product build and source-build) and correctly upgrade the template package versions to the live ones (winforms, wpf and aspnetcore).

Also group all aspnetcore dependencies together in the Version.Details.xml file.