### PR TITLE
Handle bad upgrade state without blocking the SDK

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.Workloads.Workload
             PrintWorkloadSetTransition(workloadSetVersion);
             var workloadSet = _workloadInstaller.InstallWorkloadSet(context, workloadSetVersion);
 
-            return _workloadManifestUpdater.CalculateManifestUpdatesForWorkloadSet(workloadSet);
+            return workloadSet is null ? Enumerable.Empty<ManifestVersionUpdate>() : _workloadManifestUpdater.CalculateManifestUpdatesForWorkloadSet(workloadSet);
         }
 
         private void PrintWorkloadSetTransition(string newVersion)

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.cs
@@ -539,7 +539,11 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                     {
                         var workloadSetVersion = Path.GetFileName(workloadSetDirectory);
                         var workloadSet = WorkloadSet.FromWorkloadSetFolder(workloadSetDirectory, workloadSetVersion, featureBand);
-                        availableWorkloadSets[workloadSet.Version!] = workloadSet;
+
+                        if (workloadSet is not null)
+                        {
+                            availableWorkloadSets[workloadSet.Version!] = workloadSet;
+                        }
                     }
                 }
             }

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 #endif
         }
 
-        public static WorkloadSet FromWorkloadSetFolder(string path, string workloadSetVersion, SdkFeatureBand defaultFeatureBand)
+        public static WorkloadSet? FromWorkloadSetFolder(string path, string workloadSetVersion, SdkFeatureBand defaultFeatureBand)
         {
             WorkloadSet? workloadSet = null;
             foreach (var jsonFile in Directory.GetFiles(path, "*.workloadset.json"))
@@ -107,7 +107,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             if (workloadSet == null)
             {
-                throw new InvalidOperationException("No workload set information found in: " + path);
+                return null;
             }
 
             if (File.Exists(Path.Combine(path, "baseline.workloadset.json")))


### PR DESCRIPTION
Fixes AB #2357570

# Description

The proximal cause of this is that /usr/share/dotnet/sdk-manifests/8.0.100/workloadsets/8.0.402-baseline.24467.1 is a path that exists, but there are no workload sets inside. The PR that I mentioned to Marc in our triage meeting today was actually backported to 8.0.4xx and made it into 8.0.4012, so it wasn’t the issue that I’d initially expected.

The real issue is that that folder is empty. There is no point in which we create that folder without putting a workload set in it. However, I noticed that that folder is for the 8.0.402 SDK, and when the customer ran dotnet –info, it claimed to be 8.0.404. That discrepancy suggests that the 8.0.402 SDK was installed at some point then partially uninstalled—the workload set was deleted, but the folder was not deleted, perhaps because it was in use—and then the 8.0.404 SDK was installed on top.

While looking for corroborating evidence online, I came across [this comment](https://github.com/dotnet/sdk/issues/44082#issuecomment-2407996101) from baronfel in which he suggested the issue may be that we are marking the baseline workload set but not the folders during RPM construction. That may be fixable, though he later suggested that it may not be sufficient.

# Customer Impact

Customers using the affected (broken) installs can't do basic SDK tasks like run dotnet --info

# User-reported

Yes

# Testing

I made an 8.0.100 folder with a workloadsets folder inside that had a valid (older) feature band folder that was empty, just as in the original report. I tried updating workloads, and it succeeded. I debugged the code and stopped at the point where this had previously failed and verified that it returned null instead of throwing then ignored the null result, not failing and moving on as intended.

# Risk

Low—deletes an error and accounts for the possible null response.

# Workaround

In the short term, I’d suggest that the customer should just delete the (empty) directory, as that’s the easiest workaround. As a fix from our side, I propose deleting the error, as it isn’t a critical failure anyway. That should have minimal risk, and it would be a very small change.