### PR TITLE
Simplify SB bootstrap package logic

### DIFF
--- a/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -3,27 +3,12 @@
   <Import Project="$(MSBuildProjectDirectory)/PackageVersions.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <BaseOutputPath>$(MSBuildProjectDirectory)/artifacts/</BaseOutputPath>
     <RestorePackagesPath>$(MSBuildProjectDirectory)/artifacts/restoredPkgs/</RestorePackagesPath>
     <UnpackedTarPath>$(MSBuildProjectDirectory)/artifacts/unpacked/</UnpackedTarPath>
     <NewTarballName>$(ArchiveDir)Private.SourceBuilt.Artifacts.Bootstrap.tar.gz</NewTarballName>
   </PropertyGroup>
-
-  <ItemDefinitionGroup>
-    <PortablePackage>
-      <IsNative>false</IsNative>
-    </PortablePackage>
-  </ItemDefinitionGroup>
-
-  <ItemGroup>
-    <UnixRid Include="linux-x64" />
-    <UnixRid Include="linux-musl-x64" />
-    <UnixRid Include="linux-arm64" />
-    <UnixRid Include="linux-musl-arm64" />
-    <UnixRid Include="osx-x64" />
-    <UnixRid Include="osx-arm64" />
-  </ItemGroup>
 
   <!-- 
     These packages will be replaced with ms-built packages downloaded from official package feeds.
@@ -31,77 +16,25 @@
     to determine the version.
   -->
   <ItemGroup>
-    <RuntimePack Include="Microsoft.AspNetCore.App.Runtime" Version="[$(MicrosoftAspNetCoreAppRefPackageVersion)]" />
-    <RuntimePack Include="Microsoft.NETCore.App.Crossgen2" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <RuntimePack Include="Microsoft.NETCore.App.Host" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <RuntimePack Include="Microsoft.NETCore.App.Runtime" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.AspNetCore.App.Runtime.$(PortableRid)" Version="[$(MicrosoftAspNetCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
 
-    <PortablePackage Include="Microsoft.DotNet.ILCompiler" Version="[$(MicrosoftDotNetILCompilerVersion)]" />
-    <PortablePackage Include="Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
-    <PortablePackage Include="Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
-    <PortablePackage Include="Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
-    <PortablePackage Include="Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
+    <PackageDownload Include="runtime.$(PortableRid).Microsoft.DotNet.ILCompiler" Version="[$(MicrosoftDotNetILCompilerVersion)]" />
+    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
+    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
+    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
+    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
 
-    <PortablePackage Include="System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" IsNative="true" />
+    <PackageDownload Include="runtime.$(PortableRid).runtime.native.System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" />
     <!-- These packages don't actually exist -->
     <ExcludedPackage Include="runtime.linux-musl-x64.runtime.native.System.IO.Ports" />
     <ExcludedPackage Include="runtime.linux-musl-arm64.runtime.native.System.IO.Ports" />
   </ItemGroup>
 
-  <Target Name="GetPackagesToDownload"
-          AfterTargets="CollectPackageDownloads"
-          Returns="@(PackageDownload)">
-    <ItemGroup>
-      <!-- Generate a cross-product between runtime packs and Unix RIDs -->
-      <RuntimePackWithUnixRid Include="@(RuntimePack)">
-        <UnixRid>%(UnixRid.Identity)</UnixRid>
-      </RuntimePackWithUnixRid>
-
-      <!-- Generate a cross-product between portable packages and Unix RIDs -->
-      <PortablePackageWithUnixRid Include="@(PortablePackage)">
-        <UnixRid>%(UnixRid.Identity)</UnixRid>
-      </PortablePackageWithUnixRid>
-
-    </ItemGroup>
-    <ItemGroup>
-      <!--
-            Generate package names for runtime packs by concatenating the base name with the Unix RID
-            (e.g. Microsoft.AspNetCore.App.Runtime.linux-x64)
-        -->
-      <PackageWithName Include="@(RuntimePackWithUnixRid)">
-        <PackageName>%(RuntimePackWithUnixRid.Identity).%(RuntimePackWithUnixRid.UnixRid)</PackageName>
-      </PackageWithName>
-
-      <!--
-            Include the base name of each portable package (e.g. Microsoft.NETCore.ILAsm)
-            Exclude any that are native packages.
-        -->
-      <PackageWithName Include="@(PortablePackageWithUnixRid)" Condition=" '%(PortablePackageWithUnixRid.IsNative)' != 'true' ">
-        <PackageName>%(PortablePackageWithUnixRid.Identity)</PackageName>
-      </PackageWithName>
-
-      <!--
-            Generate Unix RID package names for portable packages by concatenating the base name with the Unix RID
-            (e.g. runtime.linux-x64.Microsoft.NETCore.ILAsm)
-            Do this for two groups: native and non-native packages. They have different naming conventions.
-        -->
-      <PackageWithName Include="@(PortablePackageWithUnixRid)" Condition=" '%(PortablePackageWithUnixRid.IsNative)' != 'true' ">
-        <PackageName>runtime.%(PortablePackageWithUnixRid.UnixRid).%(PortablePackageWithUnixRid.Identity)</PackageName>
-      </PackageWithName>
-      <PackageWithName Include="@(PortablePackageWithUnixRid)" Condition=" '%(PortablePackageWithUnixRid.IsNative)' == 'true' ">
-        <PackageName>runtime.%(PortablePackageWithUnixRid.UnixRid).runtime.native.%(PortablePackageWithUnixRid.Identity)</PackageName>
-      </PackageWithName>
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageDownload Include="@(PackageWithName -> '%(PackageName)')" />
-      <PackageDownload Remove="@(ExcludedPackage)" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="BuildBoostrapPreviouslySourceBuilt"
-          AfterTargets="Restore"
-          DependsOnTargets="GetPackagesToDownload">
+          AfterTargets="Restore">
     <ItemGroup>
       <RestoredNupkgs Include="$(RestorePackagesPath)**/*.nupkg" />
       <PrevSBArchive Include="$(ArchiveDir)Private.SourceBuilt.Artifacts.*.tar.gz" />

--- a/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -16,21 +16,61 @@
     to determine the version.
   -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.AspNetCore.App.Runtime.$(PortableRid)" Version="[$(MicrosoftAspNetCoreAppRefPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Host.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.$(PortableRid)" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <RuntimePack Include="Microsoft.AspNetCore.App.Runtime" Version="[$(MicrosoftAspNetCoreAppRefPackageVersion)]" />
+    <RuntimePack Include="Microsoft.NETCore.App.Crossgen2" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <RuntimePack Include="Microsoft.NETCore.App.Host" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <RuntimePack Include="Microsoft.NETCore.App.Runtime" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
 
-    <PackageDownload Include="runtime.$(PortableRid).Microsoft.DotNet.ILCompiler" Version="[$(MicrosoftDotNetILCompilerVersion)]" />
-    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
-    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
-    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
-    <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
-    <PackageDownload Include="runtime.$(PortableRid).runtime.native.System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" />
+    <PortablePackage Include="Microsoft.DotNet.ILCompiler" Version="[$(MicrosoftDotNetILCompilerVersion)]" />
+    <PortablePackage Include="Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
+    <PortablePackage Include="Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
+    <PortablePackage Include="Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
+    <PortablePackage Include="Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
+
+    <PortablePackage Include="System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" IsNative="true" />
   </ItemGroup>
 
+  <Target Name="GetPackagesToDownload"
+          AfterTargets="CollectPackageDownloads"
+          Returns="@(PackageDownload)">
+    <ItemGroup>
+      <!--
+            Generate package names for runtime packs by concatenating the base name with the portable RID
+            (e.g. Microsoft.AspNetCore.App.Runtime.linux-x64)
+        -->
+      <PackageWithName Include="@(RuntimePack)">
+        <PackageName>%(RuntimePack.Identity).$(PortableRid)</PackageName>
+      </PackageWithName>
+
+      <!--
+            Include the base name of each portable package (e.g. Microsoft.NETCore.ILAsm)
+            Exclude any that are native packages.
+        -->
+      <PackageWithName Include="@(PortablePackage)" Condition=" '%(PortablePackage.IsNative)' != 'true' ">
+        <PackageName>%(PortablePackage.Identity)</PackageName>
+      </PackageWithName>
+
+      <!--
+            Generate Unix RID package names for portable packages by concatenating the base name with the portable RID
+            (e.g. runtime.linux-x64.Microsoft.NETCore.ILAsm)
+            Do this for two groups: native and non-native packages. They have different naming conventions.
+        -->
+      <PackageWithName Include="@(PortablePackage)" Condition=" '%(PortablePackage.IsNative)' != 'true' ">
+        <PackageName>runtime.$(PortableRid).%(PortablePackage.Identity)</PackageName>
+      </PackageWithName>
+      <PackageWithName Include="@(PortablePackage)" Condition=" '%(PortablePackage.IsNative)' == 'true' ">
+        <PackageName>runtime.$(PortableRid).runtime.native.%(PortablePackage.Identity)</PackageName>
+      </PackageWithName>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageDownload Include="@(PackageWithName -> '%(PackageName)')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="BuildBoostrapPreviouslySourceBuilt"
-          AfterTargets="Restore">
+          AfterTargets="Restore"
+          DependsOnTargets="GetPackagesToDownload">
     <ItemGroup>
       <RestoredNupkgs Include="$(RestorePackagesPath)**/*.nupkg" />
       <PrevSBArchive Include="$(ArchiveDir)Private.SourceBuilt.Artifacts.*.tar.gz" />

--- a/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -26,11 +26,7 @@
     <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
     <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
     <PackageDownload Include="runtime.$(PortableRid).Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
-
     <PackageDownload Include="runtime.$(PortableRid).runtime.native.System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" />
-    <!-- These packages don't actually exist -->
-    <ExcludedPackage Include="runtime.linux-musl-x64.runtime.native.System.IO.Ports" />
-    <ExcludedPackage Include="runtime.linux-musl-arm64.runtime.native.System.IO.Ports" />
   </ItemGroup>
 
   <Target Name="BuildBoostrapPreviouslySourceBuilt"

--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -83,7 +83,7 @@ while :; do
     --artifacts-rid)
       artifactsRid=$2
       ;;
-    -rid|-target-rid)
+    --rid|--target-rid)
       target_rid=$2
       shift
       ;;
@@ -185,7 +185,8 @@ function BootstrapArtifacts {
   DOTNET_SDK_PATH="$REPO_ROOT/.dotnet"
 
   # Create working directory for running bootstrap project
-  workingDir=$(mktemp -d)
+  workingDir="$REPO_ROOT/artifacts/prep-bootstrap"
+  mkdir -p "$workingDir"
   echo "  Building bootstrap previously source-built in $workingDir"
 
   # Copy bootstrap project to working dir

--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -13,6 +13,7 @@
 ###   --no-sdk                    Exclude the download of the .NET SDK
 ###   --artifacts-rid             The RID of the previously source-built artifacts archive to download
 ###                               Default is centos.9-x64
+###   --rid, --target-rid <value> Overrides the target rid for the build. e.g. alpine.3.18-arm64, fedora.37-x64, freebsd.13-arm64, ubuntu.19.10-x64
 ###   --runtime-source-feed       URL of a remote server or a local directory, from which SDKs and
 ###                               runtimes can be downloaded
 ###   --runtime-source-feed-key   Key for accessing the above server, if necessary
@@ -48,6 +49,7 @@ downloadPrebuilts=true
 removeBinaries=true
 installDotnet=true
 artifactsRid=$defaultArtifactsRid
+target_rid=''
 runtime_source_feed='' # IBM requested these to support s390x scenarios
 runtime_source_feed_key='' # IBM requested these to support s390x scenarios
 
@@ -80,6 +82,10 @@ while :; do
       ;;
     --artifacts-rid)
       artifactsRid=$2
+      ;;
+    -rid|-target-rid)
+      target_rid=$2
+      shift
       ;;
     --runtime-source-feed)
       runtime_source_feed=$2
@@ -192,11 +198,16 @@ function BootstrapArtifacts {
   echo "  Retrieving PackageVersions.props from existing archive"
   sourceBuiltArchive=$(find "$packagesArchiveDir" -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz')
   if [ -f "$sourceBuiltArchive" ]; then
-      tar -xzf "$sourceBuiltArchive" -C "$workingDir" PackageVersions.props
+    tar -xzf "$sourceBuiltArchive" -C "$workingDir" PackageVersions.props
+  fi
+
+  properties=( "/p:ArchiveDir=$packagesArchiveDir" )
+  if [[ -n "$target_rid" ]]; then
+    properties+=( "/p:TargetRid=$target_rid" )
   fi
 
   # Run restore on project to initiate download of bootstrap packages
-  "$DOTNET_SDK_PATH/dotnet" restore "$workingDir/buildBootstrapPreviouslySB.csproj" /bl:artifacts/log/prep-bootstrap.binlog /fileLoggerParameters:LogFile=artifacts/log/prep-bootstrap.log /p:ArchiveDir="$packagesArchiveDir"
+  "$DOTNET_SDK_PATH/dotnet" restore "$workingDir/buildBootstrapPreviouslySB.csproj" /bl:artifacts/log/prep-bootstrap.binlog /fileLoggerParameters:LogFile=artifacts/log/prep-bootstrap.log "${properties[@]}"
 
   # Remove working directory
   rm -rf "$workingDir"


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3631

With the UB work, I propose refactoring the buildBootstrapPreviouslySB.csproj to make use of the PortableRid property to:

1. Simplify the msbuild logic by utilizing the PortableRid property.
2. Only download the packages for the current RID.
3. Surface a rid option in the prep script for advanced scenarios (e.g. target a different rid)