### PR TITLE
Enable building tests in vstest repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-
-    <!-- Tests are failing to build: https://github.com/microsoft/vstest/issues/14994 -->
-    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A fix was made in `vstest` repo to unblock building tests: https://github.com/microsoft/vstest/issues/14994

The change is now present in VMR.