### PR TITLE
Fix array length Fixes #45632

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Uuid.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Uuid.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Cli.Utils
             Array.Copy(namespaceBytes, streamToHash, namespaceBytes.Length);
             Array.Copy(nameBytes, 0, streamToHash, namespaceBytes.Length, nameBytes.Length);
 
-            var hashResult = XxHash3.Hash(streamToHash); // This is just used for generating a named pipe so we don't need a cryptographic hash
+            var hashResult = XxHash128.Hash(streamToHash); // This is just used for generating a named pipe so we don't need a cryptographic hash
 
             var res = new byte[16];
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Uuid.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Uuid.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Hashing;
 
 namespace Microsoft.DotNet.Cli.Utils
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils
             Array.Copy(nameBytes, 0, streamToHash, namespaceBytes.Length, nameBytes.Length);
 
             var hashResult = XxHash128.Hash(streamToHash); // This is just used for generating a named pipe so we don't need a cryptographic hash
+            Debug.Assert(hashResult.Length >= 16);
 
             var res = new byte[16];
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/45632

https://github.com/dotnet/sdk/pull/42775 changed the hash function we used from one that generates a 64-bit hash to one that generates an 8-bit hash. We were only actually using 16 bits of the hash, but 16 bits of an 8-bit hash is a source array not long enough error. This upgrades to a 16-bit hash from the same hash family.

Here's the before-and-after next to each other:
![image](https://github.com/user-attachments/assets/207675f7-2369-4dbb-9adf-e41314961646)
