### PR TITLE
Fix missing flag for --debug in VS

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -43,6 +43,8 @@ function CreateBuildEnvScripts()
 @echo off
 title SDK Build ($RepoRoot)
 set DOTNET_MULTILEVEL_LOOKUP=0
+REM https://aka.ms/vs/unsigned-dotnet-debugger-lib
+set VSDebugger_ValidateDotnetDebugLibSignatures=0
 
 set DOTNET_ROOT=$env:DOTNET_INSTALL_DIR
 set DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_INSTALL_DIR
@@ -60,6 +62,8 @@ DOSKEY killdotnet=taskkill /F /IM dotnet.exe /T ^& taskkill /F /IM VSTest.Consol
   $scriptContents = @"
 `$host.ui.RawUI.WindowTitle = "SDK Build ($RepoRoot)"
 `$env:DOTNET_MULTILEVEL_LOOKUP=0
+# https://aka.ms/vs/unsigned-dotnet-debugger-lib
+`$env:VSDebugger_ValidateDotnetDebugLibSignatures=0
 
 `$env:DOTNET_ROOT="$env:DOTNET_INSTALL_DIR"
 `$env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR="$env:DOTNET_INSTALL_DIR"


### PR DESCRIPTION
## Summary
I went to go debug a CLI command via `--debug` and when attaching the debugger in VS, it was showing a pop-up and ***not allowing*** you to debug. It directs you to go here: https://aka.ms/vs/unsigned-dotnet-debugger-lib

After looking at the doc, I've modified our `sdk-build-env` scripts to include the missing flag, `VSDebugger_ValidateDotnetDebugLibSignatures`, set to 0 so you can properly debug local builds.