### PR TITLE
Enable building tests in efcore repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/efcore.proj
+++ b/src/SourceBuild/content/repo-projects/efcore.proj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!-- Tests are failing to build: https://github.com/dotnet/efcore/issues/35547 -->
-    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
-  </PropertyGroup>
-
   <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="runtime" />


### PR DESCRIPTION
A fix was made in `efcore` repo to unblock building repo tests, by disabling a subset of them: https://github.com/dotnet/efcore/pull/35569 There is a tracking issue for re-enabling those disabled tests: https://github.com/dotnet/efcore/issues/35547

The change is now present in VMR.