### PR TITLE
Add tests for help in dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -146,8 +146,6 @@ namespace Microsoft.DotNet.Cli
 
         private static readonly CliCommand Command = ConstructCommand();
 
-
-
         public static CliCommand GetCommand()
         {
             return Command;

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Tools.Common;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
@@ -51,7 +52,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Extension Options:\s+--[\s\S]*", result.StdOut);
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
 
-                string otherTestProjectDllRegex = @$"\s+.*\\{ToolsetInfo.CurrentTargetFramework}\\OtherTestProject\.dll.*\s+--report-trx\s+--report-trx-filename";
+                string directorySeparator = PathUtility.GetDirectorySeparatorChar();
+                string otherTestProjectDllRegex = @$"\s+.*{directorySeparator}{ToolsetInfo.CurrentTargetFramework}{directorySeparator}OtherTestProject\.dll.*\s+--report-trx\s+--report-trx-filename";
 
                 Assert.Matches(@$"Unavailable extension options:{otherTestProjectDllRegex}", result.StdOut);
             }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -53,9 +53,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
 
                 string directorySeparator = PathUtility.GetDirectorySeparatorChar();
-                string otherTestProjectDllRegex = @$"\s+.*{directorySeparator}{ToolsetInfo.CurrentTargetFramework}{directorySeparator}OtherTestProject\.dll.*\s+--report-trx\s+--report-trx-filename";
+                string otherTestProjectPattern = @$"Unavailable extension options:\s+.*{directorySeparator}{ToolsetInfo.CurrentTargetFramework}{directorySeparator}OtherTestProject\.dll.*\s+(--report-trx\s+--report-trx-filename|--report-trx-filename\s+--report-trx)";
 
-                Assert.Matches(@$"Unavailable extension options:{otherTestProjectDllRegex}", result.StdOut);
+                Assert.Matches(otherTestProjectPattern, result.StdOut);
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using dotnet.Tests;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
@@ -12,8 +11,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         {
         }
 
-        [InlineData(Constants.Debug)]
-        [InlineData(Constants.Release)]
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
         [Theory]
         public void RunHelpOnTestProject_ShouldReturnZeroAsExitCode(string configuration)
         {
@@ -26,20 +25,21 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(@"Extension options:\s+--[\s\S]*", result.StdOut);
+                Assert.Matches(@"Extension Options:\s+--[\s\S]*", result.StdOut);
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
-        [InlineData(Constants.Debug)]
-        [InlineData(Constants.Release)]
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
         [Theory]
         public void RunHelpOnMultipleTestProjects_ShouldReturnZeroAsExitCode(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("ProjectSolutionForMultipleTFMs", Guid.NewGuid().ToString())
                 .WithSource();
+            testInstance.WithTargetFramework($"{DotnetVersionHelper.GetPreviousDotnetVersion()}", "TestProject");
 
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
@@ -48,13 +48,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                Assert.Matches(@"Extension options:\s+--[\s\S]*", result.StdOut);
+                Assert.Matches(@"Extension Options:\s+--[\s\S]*", result.StdOut);
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
 
-                string net9ProjectDllRegex = @"\s+.*\\net9\.0\\TestProjectWithNet9\.dll.*\s+--report-trx\s+--report-trx-filename";
-                string net48ProjectExeRegex = @"\s+.*\\net4\.8\\TestProjectWithNetFramework\.exe.*\s+--report-trx\s+--report-trx-filename";
+                string otherTestProjectDllRegex = @$"\s+.*\\{ToolsetInfo.CurrentTargetFramework}\\OtherTestProject\.dll.*\s+--report-trx\s+--report-trx-filename";
 
-                Assert.Matches(@$"Unavailable extension options:(?:({net9ProjectDllRegex})|({net48ProjectExeRegex}))(?:({net48ProjectExeRegex})|({net9ProjectDllRegex}))", result.StdOut);
+                Assert.Matches(@$"Unavailable extension options:{otherTestProjectDllRegex}", result.StdOut);
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -56,7 +56,6 @@
     <Compile Include="..\Microsoft.DotNet.CommandFactory.Tests\**\*.cs" LinkBase="CommandFactory" />
     <Compile Include="..\Microsoft.DotNet.Configurer.UnitTests\**\*.cs" LinkBase="Configurer" />
     <Compile Include="..\Microsoft.DotNet.ShellShim.Tests\**\*.cs" LinkBase="ShellShim" />
-    <Compile Remove="..\dotnet-test.Tests\GivenDotnetTestBuildsAndRunsHelp.cs" />
     <Compile Remove="..\dotnet-test.Tests\MSBuildHandlerTests.cs" />
 
     <None Include="..\Microsoft.DotNet.ShellShim.Tests\WpfBinaryTestAsssets\testwpf.dll" LinkBase="WpfBinaryTestAsssets">


### PR DESCRIPTION
This pull request includes several updates to the `test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs` file and related project files to improve test consistency and accuracy. The most important changes are summarized below:

### Updates to test constants and assertions:

* Changed `InlineData` attributes to use `TestingConstants` instead of `Constants` for better clarity and consistency.
* Updated regex patterns in assertions to match the correct output format and handle different directory separators. [[1]](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664L29-R43) [[2]](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664L51-R58)

### Project file adjustments:

* Removed unnecessary `Compile` directive for `GivenDotnetTestBuildsAndRunsHelp.cs` in `dotnet.Tests.csproj`.

### Namespace updates:

* Updated namespace usage to `Microsoft.DotNet.Tools.Common` for better alignment with the project structure.

Relates to https://github.com/dotnet/sdk/issues/45927