### PR TITLE
Use internationally viable formatting for dates used in, for example, file paths

### DIFF
--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// The locale-neutral timestamp prefix.
         /// </summary>
-        protected static string TimeStamp => $"[{DateTime.Now:u}]";
+        protected static string TimeStamp => $"[{DateTime.Now.ToString("u").Replace(':', '_').Replace(' ', '_')}]";
 
         /// <summary>
         /// Creates a new <see cref="TimestampedFileLogger"/> instance.

--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO.Pipes;
 using System.Runtime.Versioning;
 
@@ -42,7 +43,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// The locale-neutral timestamp prefix.
         /// </summary>
-        protected static string TimeStamp => $"[{DateTime.Now.ToString("u").Replace(':', '_').Replace(' ', '_')}]";
+        protected static string TimeStamp => $"[{string.Create(CultureInfo.InvariantCulture, $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log")}]";
 
         /// <summary>
         /// Creates a new <see cref="TimestampedFileLogger"/> instance.

--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// The locale-neutral timestamp prefix.
         /// </summary>
-        protected static string TimeStamp => $"[{string.Create(CultureInfo.InvariantCulture, $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log")}]";
+        protected static string TimeStamp => $"[{string.Create(CultureInfo.InvariantCulture, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}")}]";
 
         /// <summary>
         /// Creates a new <see cref="TimestampedFileLogger"/> instance.

--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Installer.Windows
         /// <summary>
         /// The locale-neutral timestamp prefix.
         /// </summary>
-        protected static string TimeStamp => $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}]";
+        protected static string TimeStamp => $"[{DateTime.Now:u}]";
 
         /// <summary>
         /// Creates a new <see cref="TimestampedFileLogger"/> instance.

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             bool shouldLog = true)
         {
             ISynchronizingLogger logger =
-                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log"))
+                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:u}.log"))
                           : new NullInstallerLogger();
             InstallClientElevationContext elevationContext = new(logger);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1127,7 +1127,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             bool shouldLog = true)
         {
             ISynchronizingLogger logger =
-                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now.ToString("u").Replace(':', '_').Replace(' ', '_')}.log"))
+                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), string.Create(CultureInfo.InvariantCulture, $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log")))
                           : new NullInstallerLogger();
             InstallClientElevationContext elevationContext = new(logger);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/install/NetSdkMsiInstallerClient.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Text.Json;
 using Microsoft.DotNet.Cli;
@@ -1125,7 +1127,7 @@ namespace Microsoft.DotNet.Workloads.Workload.Install
             bool shouldLog = true)
         {
             ISynchronizingLogger logger =
-                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:u}.log"))
+                shouldLog ? new TimestampedFileLogger(Path.Combine(Path.GetTempPath(), $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now.ToString("u").Replace(':', '_').Replace(' ', '_')}.log"))
                           : new NullInstallerLogger();
             InstallClientElevationContext elevationContext = new(logger);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/46727
Fixes https://github.com/dotnet/sdk/issues/37932
(@MiYanni commented that it looks similar to the issue I'd been looking at. Turns out 46727 is a dupe, but since I have a PR out already, I'll leave them up and close both via this.)

This replaces an explicit format with "u" for two specific DateTime.ToString instances. Lowercase u is for a sortable, universal date/time pattern:
![image](https://github.com/user-attachments/assets/f9bcc298-9385-49c4-b1dc-414f85524aff)

(https://learn.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings)

I saw a number of other instances in which we currently use an explicit string format like this. I was a little split on whether I should change them all without looking at it too closely, but I can if desired.