### PR TITLE
Enable roslyn tests in VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
 
-    <!-- Tests are failing to build: https://github.com/dotnet/roslyn/issues/76960 -->
-    <DotNetBuildTestsOptOut>true</DotNetBuildTestsOptOut>
-
     <!-- Roslyn's build.cmd adds -build automatically. On non-windows, use the default -->
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(FlagParameterPrefix)restore</BuildActions>
     <BuildActions Condition="'$(BuildOS)' == 'windows'">$(BuildActions) $(FlagParameterPrefix)pack</BuildActions>

--- a/src/SourceBuild/patches/roslyn/0004-Enable-tests-in-VMR.patch
+++ b/src/SourceBuild/patches/roslyn/0004-Enable-tests-in-VMR.patch
@@ -3,7 +3,7 @@ From: "Nikola Milosavljevic (CLR) false" <nikolam@microsoft.com>
 Date: Tue, 11 Feb 2025 23:44:46 -0800
 Subject: [PATCH] Enable tests in VMR
 
-Backport: https://github.com/dotnet/roslyn/issues/76960
+Backport: https://github.com/dotnet/roslyn/pull/77179
 ---
  eng/Directory.Packages.props | 4 ++--
  eng/Versions.props           | 8 ++++++++

--- a/src/SourceBuild/patches/roslyn/0004-Enable-tests-in-VMR.patch
+++ b/src/SourceBuild/patches/roslyn/0004-Enable-tests-in-VMR.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Nikola Milosavljevic (CLR) false" <nikolam@microsoft.com>
+Date: Tue, 11 Feb 2025 23:44:46 -0800
+Subject: [PATCH] Enable tests in VMR
+
+Backport: https://github.com/dotnet/roslyn/issues/76960
+---
+ eng/Directory.Packages.props | 4 ++--
+ eng/Versions.props           | 8 ++++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Directory.Packages.props b/eng/Directory.Packages.props
+index e28bb02fdaa..2d5be90f1cc 100644
+--- a/eng/Directory.Packages.props
++++ b/eng/Directory.Packages.props
+@@ -142,8 +142,8 @@
+     -->
+     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="17.10.72-preview" />
+     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
+-    <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(_MicrosoftTestPlatformVersion)" />
+-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(_MicrosoftTestPlatformVersion)" />
++    <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
++    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
+     <PackageVersion Include="Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace" Version="9.0.0-preview.25064.4" />
+ 
+     <!--
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 24ca795bf35..a0df3fcf5d9 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -107,4 +107,12 @@
+     <!-- Prohibit the usage of .NET Standard 1.x dependencies. -->
+     <FlagNetStandard1XDependencies Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</FlagNetStandard1XDependencies>
+   </PropertyGroup>
++  <PropertyGroup>
++    <!--
++      Test SDK should match the version of TestPlatform packages required by this repo and defined
++      in Directory.Packages.props - Microsoft.TestPlatform.TranslationLayer and Microsoft.TestPlatform.ObjectModel.
++      This version needs to match the Test SDK version consumed by Arcade.
++    -->
++    <MicrosoftNETTestSdkVersion>17.5.0</MicrosoftNETTestSdkVersion>
++  </PropertyGroup>
+ </Project>


### PR DESCRIPTION
Roslyn tests are failing in VMR with mismatched package version errors - see tracking issue in Roslyn: https://github.com/dotnet/roslyn/issues/76960, i.e.:
```
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109: Detected package downgrade: Microsoft.TestPlatform.ObjectModel from 17.12.0 to centrally defined 17.5.0. Update the centrally managed package version to a higher version.  [C:\git\dotnet\src\roslyn\Roslyn.sln]
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109:  Microsoft.CodeAnalysis.UnitTests -> Microsoft.NET.Test.Sdk 17.12.0 -> Microsoft.TestPlatform.TestHost 17.12.0 -> Microsoft.TestPlatform.ObjectModel (>= 17.12.0)  [C:\git\dotnet\src\roslyn\Roslyn.sln]
C:\git\dotnet\src\roslyn\src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj : error NU1109:  Microsoft.CodeAnalysis.UnitTests -> Microsoft.TestPlatform.ObjectModel (>= 17.5.0) [C:\git\dotnet\src\roslyn\Roslyn.sln]
```

The fix is to explicitly set the version of `Microsoft.NET.Test.Sdk` that is consumed by arcade version that Roslyn uses.