### PR TITLE
[ApiCompat] Warn if abstract keyword is removed from member

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -186,8 +186,8 @@
   <data name="CannotAddVirtualToMember" xml:space="preserve">
     <value>Cannot add virtual keyword to member '{0}'.</value>
   </data>
-  <data name="CannotRemoveVirtualFromMember" xml:space="preserve">
-    <value>Cannot remove virtual keyword from member '{0}'.</value>
+  <data name="CannotRemoveVirtualOrAbstractFromMember" xml:space="preserve">
+    <value>Cannot remove '{0}' keyword from member '{1}'.</value>
   </data>
   <data name="ApiCompatibilityHeader" xml:space="preserve">
     <value>API compatibility errors between '{0}' ({2}) and '{1}' ({3}):</value>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/CannotAddOrRemoveVirtualKeyword.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         leftMetadata,
                         rightMetadata,
                         DiagnosticIds.CannotRemoveVirtualFromMember,
-                        string.Format(Resources.CannotRemoveVirtualFromMember, left),
+                        string.Format(Resources.CannotRemoveVirtualOrAbstractFromMember, "virtual", left),
                         DifferenceType.Removed,
                         right));
                 }
@@ -83,6 +83,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         DiagnosticIds.CannotAddVirtualToMember,
                         string.Format(Resources.CannotAddVirtualToMember, right),
                         DifferenceType.Added,
+                        right));
+                }
+            }
+
+            if (left.IsAbstract)
+            {
+                if (!right.IsAbstract && !right.IsVirtual)
+                {
+                    // abstract can be made virtual but cannot remove abstract.
+                    differences.Add(new CompatDifference(
+                        leftMetadata,
+                        rightMetadata,
+                        DiagnosticIds.CannotRemoveVirtualFromMember,
+                        string.Format(Resources.CannotRemoveVirtualOrAbstractFromMember, "abstract", left),
+                        DifferenceType.Removed,
                         right));
                 }
             }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -122,9 +122,9 @@
         <target state="translated">U parametru typu {1} z(e) {2} nelze odebrat omezení {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Nelze odebrat virtuální klíčové slovo ze člena {0}.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Die Einschränkung „{0}“ für den Typparameter „{1}“ von „{2}“ kann nicht entfernt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Das virtuelle Schlüsselwort kann nicht aus dem Member „{0}“ entfernt werden.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -122,9 +122,9 @@
         <target state="translated">No se pueden quitar la restricción '{0}' en el parámetro de tipo '{1}' de '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">No se puede quitar la palabra clave virtual del miembro "{0}".</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Impossible de supprimer la contrainte « {0} » sur le paramètre de type « {1} » de « {2} ».</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Impossible de supprimer le mot-clé virtuel du membre '{0}'.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Impossibile rimuovere il vincolo '{0}' nel parametro di tipo '{1}' di '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Non è possibile rimuovere la parola chiave virtuale dal membro '{0}'.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -122,9 +122,9 @@
         <target state="translated">'{2}' の型パラメーター '{1}' の制約 '{0}' を削除できません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">メンバー '{0}' から仮想キーワードを削除できません。</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -122,9 +122,9 @@
         <target state="translated">형식 매개 변수 '{2}'의 '{1}'에서 제약 조건 '{0}'을(를) 제거할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">구성원 '{0}'에서 가상 키워드를 제거할 수 없습니다.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Nie można usunąć ograniczenia „{0}” w parametrze typu „{1}” z „{2}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Nie można usunąć wirtualnego słowa kluczowego z składowej „{0}”.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Não é possível remover a restrição '{0}' no parâmetro de tipo '{1}' de '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Não é possível remover a palavra-chave virtual do membro '{0}'.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -122,9 +122,9 @@
         <target state="translated">Не удалось удалить ограничение "{0}" для параметра типа "{1}" из "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Не удается удалить виртуальное ключевое слово из элемента "{0}".</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -122,9 +122,9 @@
         <target state="translated">'{1}'/'{2}' tür parametresindeki '{0}' kısıtlaması kaldırılamıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">Sanal anahtar sözcük, '{0}' üyesinden kaldırılamıyor.</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -122,9 +122,9 @@
         <target state="translated">无法移除 "{2}" 的类型参数 "{1}" 上的约束 "{0}"。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">无法从成员“{0}”中删除虚拟关键字。</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -122,9 +122,9 @@
         <target state="translated">無法移除 '{2}' 的類型參數 '{1}' 上的限制式 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotRemoveVirtualFromMember">
-        <source>Cannot remove virtual keyword from member '{0}'.</source>
-        <target state="translated">無法從成員 '{0}' 移除虛擬關鍵字。</target>
+      <trans-unit id="CannotRemoveVirtualOrAbstractFromMember">
+        <source>Cannot remove '{0}' keyword from member '{1}'.</source>
+        <target state="new">Cannot remove '{0}' keyword from member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ElementShouldNotBeNullAtIndex">

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
@@ -43,6 +43,20 @@ namespace CompatTests {{
                 false,
                 CreateDifferences((DifferenceType.Removed, "M:CompatTests.First.F")),
             };
+            // remove abstract from member
+            yield return new object[] {
+                CreateType(" abstract class", " public abstract void F();"),
+                CreateType(" abstract class", " public void F() {}"),
+                false,
+                CreateDifferences((DifferenceType.Removed, "M:CompatTests.First.F")),
+            };
+            // replace abstract with virtual (no diffs expected)
+            yield return new object[] {
+                CreateType(" abstract class", " public abstract void F();"),
+                CreateType(" abstract class", " public virtual void F() {}"),
+                false,
+                new CompatDifference[] { }
+            };
             // properties
             yield return new object[] {
                 CreateType(" class", " public virtual int F { get; }"),

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
@@ -55,7 +55,7 @@ namespace CompatTests {{
                 CreateType(" abstract class", " public abstract void F();"),
                 CreateType(" abstract class", " public virtual void F() {}"),
                 false,
-                new CompatDifference[] { }
+                CreateDifferences()
             };
             // properties
             yield return new object[] {
@@ -138,6 +138,13 @@ namespace CompatTests {{
                 CreateType(" class", " public virtual void F() {}"),
                 true,
                 CreateDifferences((DifferenceType.Added,"M:CompatTests.First.F" )),
+            };
+            // remove abstract from member
+            yield return new object[] {
+                CreateType(" abstract class", " public abstract void F();"),
+                CreateType(" abstract class", " public void F() {}"),
+                true,
+                CreateDifferences((DifferenceType.Removed, "M:CompatTests.First.F")),
             };
             // abstract -> virtual
             yield return new object[] {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/46794

Removing the `abstract` keyword from a member should be disallowed by ApiCompat, but it currently does not know how to handle that case like it used to in the old version.

The lack of warning in ApiCompat caused the introduction of this bug in maintenance-packages `System.Reflection.DispatchProxy`: https://github.com/dotnet/maintenance-packages/issues/194 which we fixed with https://github.com/dotnet/maintenance-packages/pull/202 