### PR TITLE
Support short forms of some options in dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DotNet.Cli
     {
         public const string DotnetRunCommand = "dotnet run";
         public const string HelpOptionKey = "--help";
+        public const string ShortHelpOptionKey = "-h";
         public const string ServerOptionKey = "--server";
         public const string DotNetTestPipeOptionKey = "--dotnet-test-pipe";
         public const string FrameworkOptionKey = "--framework";

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -204,7 +204,7 @@ namespace Microsoft.DotNet.Cli
                 msbuildArgs);
         }
 
-        private static bool ContainsHelpOption(IEnumerable<string> args) => args.Contains(CliConstants.HelpOptionKey) || args.Contains(CliConstants.HelpOptionKey.Substring(0, 2));
+        private static bool ContainsHelpOption(IEnumerable<string> args) => args.Contains(CliConstants.HelpOptionKey) || args.Contains(CliConstants.ShortHelpOptionKey);
 
         private void CompleteRun()
         {

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.ExactlyOne
         };
 
-        public static readonly CliOption<string> ListTestsOption = new("--list-tests")
+        public static readonly CliOption<string> ListTestsOption = new("--list-tests", "-t")
         {
             Description = LocalizableStrings.CmdListTestsDescription,
             Arity = ArgumentArity.Zero

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnableTestingPlatform()
-                                    .Execute(CliConstants.HelpOptionKey, TestingPlatformOptions.ConfigurationOption.Name, configuration);
+                                    .Execute(CliConstants.ShortHelpOptionKey, TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             if (!TestContext.IsLocalized())
             {


### PR DESCRIPTION
This pull request includes changes to the `dotnet-test` command to support a short help option (`-h`) and to add a short alias (`-t`) for the `--list-tests` option. The most important changes include updating constants, modifying helper methods, and adjusting test cases.

Support for short help option and list tests alias:

* [`src/Cli/dotnet/commands/dotnet-test/CliConstants.cs`](diffhunk://#diff-9d50307560684be5ff6645d5063347e8a3fed77cfb7dbc50d07282c9f7f20cbaR10): Added `ShortHelpOptionKey` constant for the short help option (`-h`).
* [`src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs`](diffhunk://#diff-8f93b408e20e044d1173a5796eb10d0a44c00bed96736aec60c1b3e31995539cL207-R207): Updated `ContainsHelpOption` method to check for the new `ShortHelpOptionKey`.
* [`src/Cli/dotnet/commands/dotnet-test/TestingPlatformOptions.cs`](diffhunk://#diff-5cc1a183bdeed9ddf1c62d0892dd3eb7cd6232642cd424ff995b28264f9e12dcL49-R49): Added short alias (`-t`) for the `--list-tests` option.
* [`test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs`](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664L48-R48): Modified test case to use the new `ShortHelpOptionKey` instead of the long help option key.

Relates to https://github.com/dotnet/sdk/issues/45927