### PR TITLE
Add test case for adding projects outside solution dir descendants

### DIFF
--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Dir/App.sln
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Dir/App.sln
@@ -1,0 +1,5 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Dir/App.slnx
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Dir/App.slnx
@@ -1,0 +1,1 @@
+<Solution />

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Lib/Lib.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Lib/Lib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Lib/Library.cs
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInParentDir/Lib/Library.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Lib
+{
+    public class Library
+    {
+        public static string GetMessage()
+        {
+            return "Message from Lib";
+        }
+    }
+}

--- a/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -1096,6 +1096,24 @@ Options:
                 .Should().BeVisuallyEquivalentTo(expectedSlnContents);
         }
 
+        [Theory]
+        [InlineData("sln", ".sln")]
+        [InlineData("sln", ".slnx")]
+        [InlineData("solution", ".sln")]
+        [InlineData("solution", ".slnx")]
+        public void WhenAddingProjectOutsideDirectoryItShouldNotAddSolutionFolders(string solutionCommand, string solutionExtension)
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndCsprojInParentDir", identifier: $"GivenDotnetSlnAdd-{solutionCommand}{solutionExtension}")
+                .WithSource()
+                .Path;
+            var projectToAdd = Path.Combine("..", "Lib", "Lib.csproj");
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(Path.Join(projectDirectory, "Dir"))
+                .Execute(solutionCommand, $"App{solutionExtension}", "add", projectToAdd);
+            cmd.Should().Pass(); // TODO: Check actual contents
+        }
+
         private string GetExpectedSlnContents(
             string slnPath,
             string slnTemplateName,

--- a/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnAdd.cs
@@ -1101,7 +1101,7 @@ Options:
         [InlineData("sln", ".slnx")]
         [InlineData("solution", ".sln")]
         [InlineData("solution", ".slnx")]
-        public void WhenAddingProjectOutsideDirectoryItShouldNotAddSolutionFolders(string solutionCommand, string solutionExtension)
+        public async Task WhenAddingProjectOutsideDirectoryItShouldNotAddSolutionFolders(string solutionCommand, string solutionExtension)
         {
             var projectDirectory = _testAssetsManager
                 .CopyTestAsset("TestAppWithSlnAndCsprojInParentDir", identifier: $"GivenDotnetSlnAdd-{solutionCommand}{solutionExtension}")
@@ -1111,7 +1111,12 @@ Options:
             var cmd = new DotnetCommand(Log)
                 .WithWorkingDirectory(Path.Join(projectDirectory, "Dir"))
                 .Execute(solutionCommand, $"App{solutionExtension}", "add", projectToAdd);
-            cmd.Should().Pass(); // TODO: Check actual contents
+            cmd.Should().Pass();
+            // Should have no solution folders
+            ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(Path.Join(projectDirectory, "Dir", $"App{solutionExtension}"));
+            SolutionModel solution = await serializer.OpenAsync(Path.Join(projectDirectory, "Dir", $"App{solutionExtension}"), CancellationToken.None);
+            solution.SolutionProjects.Count.Should().Be(1);
+            solution.SolutionFolders.Count.Should().Be(0);
         }
 
         private string GetExpectedSlnContents(


### PR DESCRIPTION
Adds missing tests for #46456 
This has apparently been a common issue that was not considered when migrating to the new solutionpersistence parser due to a lack of tests. 
This adds a simple test scenario to avoid breaking this behavior in the future. 