### PR TITLE
Remove native AOT error when skipping native compilation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -231,6 +231,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETSdkError Condition="'$(PublishAot)' == 'true' and
                             '$(_IsPublishing)' != 'true' and
                             '$(PublishAotUsingRuntimePack)' == 'true' and
+                            '$(NativeCompilationDuringPublish)' != 'false' and
                             '$(_TargetFrameworkVersionWithoutV)' >= '10.0'"
                  ResourceName="NativeCompilationRequiresPublishing" />
 


### PR DESCRIPTION
I believe this will fix https://github.com/dotnet/sdk/issues/46790, but see the discussion in that issue. Not sure yet if this is the best approach.