### PR TITLE
Add ExcludeFromCodeCoverage to template for MSTest, NUnit, XUnit

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/MSTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/MSTestSettings.cs
@@ -1,1 +1,4 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]
+﻿using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/MSTestSettings.fs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/MSTestSettings.fs
@@ -1,6 +1,8 @@
 ﻿module MSTestSettings
 
+open System.Diagnostics.CodeAnalysis
 open Microsoft.VisualStudio.TestTools.UnitTesting
 
+[<assembly: ExcludeFromCodeCoverage>]
 [<assembly: Parallelize(Scope = ExecutionScope.MethodLevel)>]
 do()

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/MSTestSettings.vb
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/MSTestSettings.vb
@@ -1,3 +1,5 @@
-﻿Imports Microsoft.VisualStudio.TestTools.UnitTesting
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
+<Assembly: ExcludeFromCodeCoverage>
 <Assembly: Parallelize(Scope:=ExecutionScope.MethodLevel)>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-CSharp/NUnitTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-CSharp/NUnitTestSettings.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="UnitTest1.fs"/>
+    <Compile Include="NUnitTestSettings.fs"/>
     <Compile Include="Program.fs"/>
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-FSharp/NUnitTestSettings.fs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-FSharp/NUnitTestSettings.fs
@@ -1,0 +1,6 @@
+module NUnitTestSettings
+
+open System.Diagnostics.CodeAnalysis
+
+[<assembly: ExcludeFromCodeCoverage>]
+do()

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-VisualBasic/NUnitTestSettings.vb
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/NUnit-VisualBasic/NUnitTestSettings.vb
@@ -1,0 +1,3 @@
+Imports System.Diagnostics.CodeAnalysis
+
+<Assembly: ExcludeFromCodeCoverage>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/MSTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/MSTestSettings.cs
@@ -1,1 +1,4 @@
-﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]
+﻿using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-NUnit-CSharp/NUnitTestSettings.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-NUnit-CSharp/NUnitTestSettings.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-CSharp/XUnitSettings.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-CSharp/XUnitSettings.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="Tests.fs" />
+    <Compile Include="XUnitSettings.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-FSharp/XUnitSettings.fs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-FSharp/XUnitSettings.fs
@@ -1,0 +1,6 @@
+module XUnitSettings
+
+open System.Diagnostics.CodeAnalysis
+
+[<assembly: ExcludeFromCodeCoverage>]
+do()

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-VisualBasic/XUnitSettings.vb
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/XUnit-VisualBasic/XUnitSettings.vb
@@ -1,0 +1,3 @@
+Imports System.Diagnostics.CodeAnalysis
+
+<Assembly: ExcludeFromCodeCoverage>


### PR DESCRIPTION
This PR is operating under the principle that "defaults matter".

By default, code coverage tools calculate code coverage for all loaded assemblies, including the test assemblies themselves. This tends to artificially inflate the code coverage %, as the test code is included in the calculation. This behavior is often surprising to devs.

There's a mild consensus that test code shouldn't be included in % calculations (see https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations and https://softwareengineering.stackexchange.com/questions/309015/when-does-it-make-sense-to-include-test-code-in-coverage as examples), and among devs that are calculating %, the prevailing method to do that appears to be setting `[ExcludeFromCodeCoverage]` on the test assembly (see https://github.com/search?q=%22assembly%3A+ExcludeFromCodeCoverage%22+language%3AC%23&type=code for some hits).

For this change I added the assembly attribute to our templates for MSTest, NUnit, and XUnit to the settings file (adding it for the other projects). This strikes a good balance of leading devs towards the [Pit of Success](https://ricomariani.medium.com/the-pit-of-success-cfefc6cb64c8), while letting them remove it if they disagree, similar to what we do for parallelism in MSTest.