### PR TITLE
Avoid downloading unrelated arcade packages in DownloadPackages.csproj

### DIFF
--- a/src/Installer/redist-installer/projects/Directory.Build.props
+++ b/src/Installer/redist-installer/projects/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Installer/redist-installer/projects/Directory.Build.props
+++ b/src/Installer/redist-installer/projects/Directory.Build.props
@@ -1,2 +1,0 @@
-<Project>
-</Project>

--- a/src/Installer/redist-installer/projects/Directory.Build.targets
+++ b/src/Installer/redist-installer/projects/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/Installer/redist-installer/projects/Directory.Build.targets
+++ b/src/Installer/redist-installer/projects/Directory.Build.targets
@@ -1,2 +1,10 @@
 <Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <ItemGroup>
+    <!-- Eliminate any package references injected, since we only want to download a single package. -->
+    <PackageReference Remove="@(PackageReference)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Installer/redist-installer/projects/DownloadPackage.csproj
+++ b/src/Installer/redist-installer/projects/DownloadPackage.csproj
@@ -6,20 +6,12 @@
 -->
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0" DefaultTargets="Restore">
 
-  <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <ResolveAssemblyReferencesSilent>true</ResolveAssemblyReferencesSilent>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Use PackageDownload since we don't need to reference the package. -->
     <!-- See: https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality -->
     <!-- The square brackets for the version constrain restoration to only use that exact version. -->
     <!-- See: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#floating-version-resolutions -->
     <PackageDownload Include="$(PackageToRestore)" Version="[$(PackageVersionToRestore)]" />
-    <!-- Eliminate any package references injected by arcade, since we only want to download a single package. -->
-    <PackageReference Remove="@(PackageReference)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removing the PackageReference doesn't work this way since the arcade targets get imported _after_ the project file. Instead avoid importing arcade targets via empty Directory.Build.props/targets.

We can also remove the properties like GenerateAssemblyInfo=false since they are already set by the NoTargets sdk.