### PR TITLE
Add Logger and MSBuild --verbosity option to dotnet test

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Cli
         public const string DLLExtension = ".dll";
 
         public const string MTPTarget = "_MTPBuild";
+
+        public const string TestTraceLoggingEnvVar = "DOTNET_CLI_TEST_TRACEFILE";
     }
 
     internal static class TestStates

--- a/src/Cli/dotnet/commands/dotnet-test/Logger.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Logger.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Tools.Test
 
             try
             {
-                string message = $"[dotnet test - {DateTimeOffset.UtcNow.ToString(format: "MM/dd/yyyy HH:mm:ss.fff")}]{messageLog()}";
+                string message = $"[dotnet test - {DateTimeOffset.UtcNow:MM/dd/yyyy HH:mm:ss.fff}]{messageLog()}";
 
                 lock (_lock)
                 {
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Test
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[dotnet test - {DateTimeOffset.UtcNow}]{ex}");
+                Console.WriteLine($"[dotnet test - {DateTimeOffset.UtcNow:MM/dd/yyyy HH:mm:ss.fff}]{ex}");
             }
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-test/Logger.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Logger.cs
@@ -3,19 +3,19 @@
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    internal class TestingPlatformTrace
+    internal class Logger
     {
         public static bool TraceEnabled { get; private set; }
         private static readonly string _traceFilePath;
         private static readonly object _lock = new();
 
-        static TestingPlatformTrace()
+        static Logger()
         {
-            _traceFilePath = Environment.GetEnvironmentVariable("DOTNET_CLI_TESTING_PLATFORM_TRACEFILE");
+            _traceFilePath = Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_TRACEFILE");
             TraceEnabled = !string.IsNullOrEmpty(_traceFilePath);
         }
 
-        public static void Write(Func<string> messageLog)
+        public static void LogTrace(Func<string> messageLog)
         {
             if (!TraceEnabled)
             {

--- a/src/Cli/dotnet/commands/dotnet-test/Logger.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Logger.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli;
+
 namespace Microsoft.DotNet.Tools.Test
 {
     internal static class Logger
@@ -11,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         static Logger()
         {
-            _traceFilePath = Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_TRACEFILE");
+            _traceFilePath = Environment.GetEnvironmentVariable(CliConstants.TestTraceLoggingEnvVar);
             TraceEnabled = !string.IsNullOrEmpty(_traceFilePath);
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -135,19 +135,19 @@ namespace Microsoft.DotNet.Cli
 
         private void LogProjectProperties(IEnumerable<Module> modules)
         {
-            if (!TestingPlatformTrace.TraceEnabled)
+            if (!Logger.TraceEnabled)
             {
                 return;
             }
 
             foreach (var module in modules)
             {
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.ProjectFullPath}: {module.ProjectFullPath}");
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.IsTestProject}: {module.IsTestProject}");
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.IsTestingPlatformApplication}: {module.IsTestingPlatformApplication}");
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.TargetFramework}: {module.TargetFramework}");
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.TargetPath}: {module.TargetPath}");
-                TestingPlatformTrace.Write(() => $"{ProjectProperties.RunSettingsFilePath}: {module.RunSettingsFilePath}");
+                Logger.LogTrace(() => $"{ProjectProperties.ProjectFullPath}: {module.ProjectFullPath}");
+                Logger.LogTrace(() => $"{ProjectProperties.IsTestProject}: {module.IsTestProject}");
+                Logger.LogTrace(() => $"{ProjectProperties.IsTestingPlatformApplication}: {module.IsTestingPlatformApplication}");
+                Logger.LogTrace(() => $"{ProjectProperties.TargetFramework}: {module.TargetFramework}");
+                Logger.LogTrace(() => $"{ProjectProperties.TargetPath}: {module.TargetPath}");
+                Logger.LogTrace(() => $"{ProjectProperties.RunSettingsFilePath}: {module.RunSettingsFilePath}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -135,23 +135,19 @@ namespace Microsoft.DotNet.Cli
 
         private void LogProjectProperties(IEnumerable<Module> modules)
         {
-            if (!VSTestTrace.TraceEnabled)
+            if (!TestingPlatformTrace.TraceEnabled)
             {
                 return;
             }
 
             foreach (var module in modules)
             {
-                Console.WriteLine();
-
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.ProjectFullPath}: {module.ProjectFullPath}");
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.IsTestProject}: {module.IsTestProject}");
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.IsTestingPlatformApplication}: {module.IsTestingPlatformApplication}");
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.TargetFramework}: {module.TargetFramework}");
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.TargetPath}: {module.TargetPath}");
-                VSTestTrace.SafeWriteTrace(() => $"{ProjectProperties.RunSettingsFilePath}: {module.RunSettingsFilePath}");
-
-                Console.WriteLine();
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.ProjectFullPath}: {module.ProjectFullPath}");
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.IsTestProject}: {module.IsTestProject}");
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.IsTestingPlatformApplication}: {module.IsTestingPlatformApplication}");
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.TargetFramework}: {module.TargetFramework}");
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.TargetPath}: {module.TargetPath}");
+                TestingPlatformTrace.Write(() => $"{ProjectProperties.RunSettingsFilePath}: {module.RunSettingsFilePath}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
@@ -69,6 +69,7 @@ namespace Microsoft.DotNet.Cli
                 buildProperties,
                 parseResult.GetValue(CommonOptions.NoRestoreOption),
                 parseResult.GetValue(TestingPlatformOptions.NoBuildOption),
+                parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
                 degreeOfParallelism,
                 unmatchedTokens,
                 msbuildArgs);
@@ -109,6 +110,11 @@ namespace Microsoft.DotNet.Cli
         private static bool BuildOrRestoreProjectOrSolution(string filePath, BuildOptions buildOptions)
         {
             List<string> msbuildArgs = [.. buildOptions.MSBuildArgs];
+
+            if (buildOptions.Verbosity is null)
+            {
+                msbuildArgs.Add($"-verbosity:quiet");
+            }
 
             msbuildArgs.Add(filePath);
             msbuildArgs.Add($"-target:{CliConstants.MTPTarget}");

--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -9,5 +9,5 @@ namespace Microsoft.DotNet.Cli
 
     internal record BuildProperties(string Configuration, string RuntimeIdentifier, string TargetFramework);
 
-    internal record BuildOptions(PathOptions PathOptions, BuildProperties BuildProperties, bool HasNoRestore, bool HasNoBuild, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
+    internal record BuildOptions(PathOptions PathOptions, BuildProperties BuildProperties, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
 }

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplicationEventHandlers.cs
@@ -31,11 +31,11 @@ namespace Microsoft.DotNet.Cli
             _executions[testApplication] = appInfo;
             _output.AssemblyRunStarted(appInfo.ModulePath, appInfo.TargetFramework, appInfo.Architecture, appInfo.ExecutionId);
 
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
             foreach (var property in args.Handshake.Properties)
             {
-                VSTestTrace.SafeWriteTrace(() => $"{GetHandshakePropertyName(property.Key)}: {property.Value}");
+                TestingPlatformTrace.Write(() => $"{GetHandshakePropertyName(property.Key)}: {property.Value}");
             }
         }
 
@@ -65,12 +65,12 @@ namespace Microsoft.DotNet.Cli
                         test.Uid);
             }
 
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
-            VSTestTrace.SafeWriteTrace(() => $"DiscoveredTests Execution Id: {args.ExecutionId}");
+            TestingPlatformTrace.Write(() => $"DiscoveredTests Execution Id: {args.ExecutionId}");
             foreach (var discoveredTestMessage in args.DiscoveredTests)
             {
-                VSTestTrace.SafeWriteTrace(() => $"DiscoveredTest: {discoveredTestMessage.Uid}, {discoveredTestMessage.DisplayName}");
+                TestingPlatformTrace.Write(() => $"DiscoveredTest: {discoveredTestMessage.Uid}, {discoveredTestMessage.DisplayName}");
             }
         }
 
@@ -108,20 +108,20 @@ namespace Microsoft.DotNet.Cli
                     errorOutput: null);
             }
 
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
-            VSTestTrace.SafeWriteTrace(() => $"TestResults Execution Id: {args.ExecutionId}");
+            TestingPlatformTrace.Write(() => $"TestResults Execution Id: {args.ExecutionId}");
 
             foreach (SuccessfulTestResult successfulTestResult in args.SuccessfulTestResults)
             {
-                VSTestTrace.SafeWriteTrace(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
+                TestingPlatformTrace.Write(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
                 $"{successfulTestResult.State}, {successfulTestResult.Duration}, {successfulTestResult.Reason}, {successfulTestResult.StandardOutput}," +
                 $"{successfulTestResult.ErrorOutput}, {successfulTestResult.SessionUid}");
             }
 
             foreach (FailedTestResult failedTestResult in args.FailedTestResults)
             {
-                VSTestTrace.SafeWriteTrace(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
+                TestingPlatformTrace.Write(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
                 $"{failedTestResult.State}, {failedTestResult.Duration}, {failedTestResult.Reason}, {string.Join(", ", failedTestResult.Exceptions?.Select(e => $"{e.ErrorMessage}, {e.ErrorType}, {e.StackTrace}"))}" +
                 $"{failedTestResult.StandardOutput}, {failedTestResult.ErrorOutput}, {failedTestResult.SessionUid}");
             }
@@ -140,13 +140,13 @@ namespace Microsoft.DotNet.Cli
                     artifact.TestDisplayName, artifact.FullPath);
             }
 
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
-            VSTestTrace.SafeWriteTrace(() => $"FileArtifactMessages Execution Id: {args.ExecutionId}");
+            TestingPlatformTrace.Write(() => $"FileArtifactMessages Execution Id: {args.ExecutionId}");
 
             foreach (FileArtifact fileArtifactMessage in args.FileArtifacts)
             {
-                VSTestTrace.SafeWriteTrace(() => $"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
+                TestingPlatformTrace.Write(() => $"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
                 $"{fileArtifactMessage.Description}, {fileArtifactMessage.TestUid}, {fileArtifactMessage.TestDisplayName}, " +
                 $"{fileArtifactMessage.SessionUid}");
             }
@@ -154,17 +154,17 @@ namespace Microsoft.DotNet.Cli
 
         public void OnSessionEventReceived(object sender, SessionEventArgs args)
         {
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
             var sessionEvent = args.SessionEvent;
-            VSTestTrace.SafeWriteTrace(() => $"TestSessionEvent: {sessionEvent.SessionType}, {sessionEvent.SessionUid}, {sessionEvent.ExecutionId}");
+            TestingPlatformTrace.Write(() => $"TestSessionEvent: {sessionEvent.SessionType}, {sessionEvent.SessionUid}, {sessionEvent.ExecutionId}");
         }
 
         public void OnErrorReceived(object sender, ErrorEventArgs args)
         {
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
-            VSTestTrace.SafeWriteTrace(() => args.ErrorMessage);
+            TestingPlatformTrace.Write(() => args.ErrorMessage);
         }
 
         public void OnTestProcessExited(object sender, TestProcessExitEventArgs args)
@@ -180,21 +180,21 @@ namespace Microsoft.DotNet.Cli
                 _output.AssemblyRunCompleted(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
             }
 
-            if (!VSTestTrace.TraceEnabled) return;
+            if (!TestingPlatformTrace.TraceEnabled) return;
 
             if (args.ExitCode != ExitCode.Success)
             {
-                VSTestTrace.SafeWriteTrace(() => $"Test Process exited with non-zero exit code: {args.ExitCode}");
+                TestingPlatformTrace.Write(() => $"Test Process exited with non-zero exit code: {args.ExitCode}");
             }
 
             if (args.OutputData.Count > 0)
             {
-                VSTestTrace.SafeWriteTrace(() => $"Output Data: {string.Join("\n", args.OutputData)}");
+                TestingPlatformTrace.Write(() => $"Output Data: {string.Join("\n", args.OutputData)}");
             }
 
             if (args.ErrorData.Count > 0)
             {
-                VSTestTrace.SafeWriteTrace(() => $"Error Data: {string.Join("\n", args.ErrorData)}");
+                TestingPlatformTrace.Write(() => $"Error Data: {string.Join("\n", args.ErrorData)}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplicationEventHandlers.cs
@@ -31,11 +31,11 @@ namespace Microsoft.DotNet.Cli
             _executions[testApplication] = appInfo;
             _output.AssemblyRunStarted(appInfo.ModulePath, appInfo.TargetFramework, appInfo.Architecture, appInfo.ExecutionId);
 
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
             foreach (var property in args.Handshake.Properties)
             {
-                TestingPlatformTrace.Write(() => $"{GetHandshakePropertyName(property.Key)}: {property.Value}");
+                Logger.LogTrace(() => $"{GetHandshakePropertyName(property.Key)}: {property.Value}");
             }
         }
 
@@ -65,12 +65,12 @@ namespace Microsoft.DotNet.Cli
                         test.Uid);
             }
 
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
-            TestingPlatformTrace.Write(() => $"DiscoveredTests Execution Id: {args.ExecutionId}");
+            Logger.LogTrace(() => $"DiscoveredTests Execution Id: {args.ExecutionId}");
             foreach (var discoveredTestMessage in args.DiscoveredTests)
             {
-                TestingPlatformTrace.Write(() => $"DiscoveredTest: {discoveredTestMessage.Uid}, {discoveredTestMessage.DisplayName}");
+                Logger.LogTrace(() => $"DiscoveredTest: {discoveredTestMessage.Uid}, {discoveredTestMessage.DisplayName}");
             }
         }
 
@@ -108,20 +108,20 @@ namespace Microsoft.DotNet.Cli
                     errorOutput: null);
             }
 
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
-            TestingPlatformTrace.Write(() => $"TestResults Execution Id: {args.ExecutionId}");
+            Logger.LogTrace(() => $"TestResults Execution Id: {args.ExecutionId}");
 
             foreach (SuccessfulTestResult successfulTestResult in args.SuccessfulTestResults)
             {
-                TestingPlatformTrace.Write(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
+                Logger.LogTrace(() => $"SuccessfulTestResult: {successfulTestResult.Uid}, {successfulTestResult.DisplayName}, " +
                 $"{successfulTestResult.State}, {successfulTestResult.Duration}, {successfulTestResult.Reason}, {successfulTestResult.StandardOutput}," +
                 $"{successfulTestResult.ErrorOutput}, {successfulTestResult.SessionUid}");
             }
 
             foreach (FailedTestResult failedTestResult in args.FailedTestResults)
             {
-                TestingPlatformTrace.Write(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
+                Logger.LogTrace(() => $"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
                 $"{failedTestResult.State}, {failedTestResult.Duration}, {failedTestResult.Reason}, {string.Join(", ", failedTestResult.Exceptions?.Select(e => $"{e.ErrorMessage}, {e.ErrorType}, {e.StackTrace}"))}" +
                 $"{failedTestResult.StandardOutput}, {failedTestResult.ErrorOutput}, {failedTestResult.SessionUid}");
             }
@@ -140,13 +140,13 @@ namespace Microsoft.DotNet.Cli
                     artifact.TestDisplayName, artifact.FullPath);
             }
 
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
-            TestingPlatformTrace.Write(() => $"FileArtifactMessages Execution Id: {args.ExecutionId}");
+            Logger.LogTrace(() => $"FileArtifactMessages Execution Id: {args.ExecutionId}");
 
             foreach (FileArtifact fileArtifactMessage in args.FileArtifacts)
             {
-                TestingPlatformTrace.Write(() => $"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
+                Logger.LogTrace(() => $"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
                 $"{fileArtifactMessage.Description}, {fileArtifactMessage.TestUid}, {fileArtifactMessage.TestDisplayName}, " +
                 $"{fileArtifactMessage.SessionUid}");
             }
@@ -154,17 +154,17 @@ namespace Microsoft.DotNet.Cli
 
         public void OnSessionEventReceived(object sender, SessionEventArgs args)
         {
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
             var sessionEvent = args.SessionEvent;
-            TestingPlatformTrace.Write(() => $"TestSessionEvent: {sessionEvent.SessionType}, {sessionEvent.SessionUid}, {sessionEvent.ExecutionId}");
+            Logger.LogTrace(() => $"TestSessionEvent: {sessionEvent.SessionType}, {sessionEvent.SessionUid}, {sessionEvent.ExecutionId}");
         }
 
         public void OnErrorReceived(object sender, ErrorEventArgs args)
         {
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
-            TestingPlatformTrace.Write(() => args.ErrorMessage);
+            Logger.LogTrace(() => args.ErrorMessage);
         }
 
         public void OnTestProcessExited(object sender, TestProcessExitEventArgs args)
@@ -180,21 +180,21 @@ namespace Microsoft.DotNet.Cli
                 _output.AssemblyRunCompleted(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
             }
 
-            if (!TestingPlatformTrace.TraceEnabled) return;
+            if (!Logger.TraceEnabled) return;
 
             if (args.ExitCode != ExitCode.Success)
             {
-                TestingPlatformTrace.Write(() => $"Test Process exited with non-zero exit code: {args.ExitCode}");
+                Logger.LogTrace(() => $"Test Process exited with non-zero exit code: {args.ExitCode}");
             }
 
             if (args.OutputData.Count > 0)
             {
-                TestingPlatformTrace.Write(() => $"Output Data: {string.Join("\n", args.OutputData)}");
+                Logger.LogTrace(() => $"Output Data: {string.Join("\n", args.OutputData)}");
             }
 
             if (args.ErrorData.Count > 0)
             {
-                TestingPlatformTrace.Write(() => $"Error Data: {string.Join("\n", args.ErrorData)}");
+                Logger.LogTrace(() => $"Error Data: {string.Join("\n", args.ErrorData)}");
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -231,6 +231,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(TestingPlatformOptions.FrameworkOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);
             command.Options.Add(CommonOptions.RuntimeOption);
+            command.Options.Add(CommonOptions.VerbosityOption);
             command.Options.Add(CommonOptions.NoRestoreOption);
             command.Options.Add(TestingPlatformOptions.NoBuildOption);
             command.Options.Add(TestingPlatformOptions.NoAnsiOption);

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli
             // If no matches were found, we simply return
             if (!testModulePaths.Any())
             {
-                VSTestTrace.SafeWriteTrace(() => $"No test modules found for the given test module pattern: {testModules} with root directory: {rootDirectory}");
+                TestingPlatformTrace.Write(() => $"No test modules found for the given test module pattern: {testModules} with root directory: {rootDirectory}");
                 return false;
             }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
             // If no matches were found, we simply return
             if (!testModulePaths.Any())
             {
-                TestingPlatformTrace.Write(() => $"No test modules found for the given test module pattern: {testModules} with root directory: {rootDirectory}");
+                Logger.LogTrace(() => $"No test modules found for the given test module pattern: {testModules} with root directory: {rootDirectory}");
                 return false;
             }
 

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Cli
     internal sealed class TestModulesFilterHandler
     {
         private readonly List<string> _args;
-
         private readonly TestApplicationActionQueue _actionQueue;
 
         public TestModulesFilterHandler(List<string> args, TestApplicationActionQueue actionQueue)

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    internal class TestingPlatformTrace
+    internal static class TestingPlatformTrace
     {
         public static bool TraceEnabled { get; private set; }
         private static readonly string _traceFilePath;

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DotNet.Tools.Test
     {
         public static bool TraceEnabled { get; private set; }
         private static readonly string _traceFilePath;
+        private static readonly object _lock = new();
 
         static TestingPlatformTrace()
         {
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 string message = $"[dotnet test - {DateTimeOffset.UtcNow.ToString(format: "MM/dd/yyyy HH:mm:ss.fff")}]{messageLog()}";
 
-                lock (_traceFilePath)
+                lock (_lock)
                 {
                     using StreamWriter logFile = File.AppendText(_traceFilePath);
                     logFile.WriteLine(message);

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Test
+{
+    internal class TestingPlatformTrace
+    {
+        public static bool TraceEnabled { get; private set; }
+        private static readonly string _traceFilePath;
+
+        static TestingPlatformTrace()
+        {
+            _traceFilePath = Environment.GetEnvironmentVariable("DOTNET_CLI_TESTING_PLATFORM_TRACEFILE");
+            TraceEnabled = !string.IsNullOrEmpty(_traceFilePath);
+        }
+
+        public static void Write(Func<string> messageLog)
+        {
+            if (!TraceEnabled)
+            {
+                return;
+            }
+
+            try
+            {
+                string message = $"[dotnet test - {DateTimeOffset.UtcNow.ToString(format: "MM/dd/yyyy HH:mm:ss.fff")}]{messageLog()}";
+
+                lock (_traceFilePath)
+                {
+                    using StreamWriter logFile = File.AppendText(_traceFilePath);
+                    logFile.WriteLine(message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[dotnet test - {DateTimeOffset.UtcNow}]{ex}");
+            }
+        }
+    }
+}

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -500,5 +500,24 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCode.GenericFailure);
         }
 
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
+        public void RunWithTraceFileLogging_ShouldReturnExitCodeGenericFailure(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
+
+            string traceFile = "logs.txt";
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnvironmentVariable(CliConstants.TestTraceLoggingEnvVar, traceFile)
+                                    .WithEnableTestingPlatform()
+                                    .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
+
+            Assert.True(File.Exists(Path.Combine(testInstance.Path, traceFile)), "Trace file should exist after test execution.");
+
+            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+        }
+
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `dotnet-test` command in the CLI, focusing on improving trace logging and adding verbosity options.

### Trace Logging Improvements:
* Replaced `VSTestTrace` with `TestingPlatformTrace` in multiple files to standardize trace logging. (`src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs`, `src/Cli/dotnet/commands/dotnet-test/TestApplicationEventHandlers.cs`, `src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs`) [[1]](diffhunk://#diff-d09dff37dec2091ac10348e8908259990c9e6dbcd5707f166e94f1c32b1e44c2L138-R150) [[2]](diffhunk://#diff-2bfa12d8dba32275f7fce2416b4092c9366541dcb74150e2586db46683f94304L34-R38) [[3]](diffhunk://#diff-2bfa12d8dba32275f7fce2416b4092c9366541dcb74150e2586db46683f94304L68-R73) [[4]](diffhunk://#diff-2bfa12d8dba32275f7fce2416b4092c9366541dcb74150e2586db46683f94304L111-R124) [[5]](diffhunk://#diff-2bfa12d8dba32275f7fce2416b4092c9366541dcb74150e2586db46683f94304L143-R167) [[6]](diffhunk://#diff-2bfa12d8dba32275f7fce2416b4092c9366541dcb74150e2586db46683f94304L183-R197) [[7]](diffhunk://#diff-123b99caa16abc2fdbc519119665ca4ad830168ef586697dee5831eecd446a87L47-R46)
* Added a new `TestingPlatformTrace` class to handle trace logging. (`src/Cli/dotnet/commands/dotnet-test/TestingPlatformTrace.cs`)

### Verbosity Options:
* Added verbosity option handling to `BuildOptions` and related methods to allow setting verbosity levels during builds. (`src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs`, `src/Cli/dotnet/commands/dotnet-test/Options.cs`) [[1]](diffhunk://#diff-750583b9174273b35d6402b8e0a89b207ecfd941d69158c76210be14961923f0R72) [[2]](diffhunk://#diff-750583b9174273b35d6402b8e0a89b207ecfd941d69158c76210be14961923f0R114-R118) [[3]](diffhunk://#diff-06b2f34cdc31f95ab0b81f621aedb53f6973df21e8b66b14569d43dcc0dd6b85L12-R12)
* Included the verbosity option in the testing platform CLI command options. (`src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs`)

These changes enhance the trace logging capabilities and provide more control over the verbosity of build outputs, improving the overall debugging and user experience.

Relates to https://github.com/dotnet/sdk/issues/45927
