### PR TITLE
Use PackageDownload in Crossgen.targets

### DIFF
--- a/src/Installer/redist-installer/Directory.Build.props
+++ b/src/Installer/redist-installer/Directory.Build.props
@@ -46,8 +46,19 @@
       )">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition="'$(SkipBuildingInstallers)' == ''">false</SkipBuildingInstallers>
 
-    <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'True' AND !$(Rid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>
+    <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
+    <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'true' AND !$(Rid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>
     <HighEntropyVA>true</HighEntropyVA>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NetRuntimeRid Condition="'$(NetRuntimeRid)' == ''">$(HostRid)</NetRuntimeRid>
+    <NetRuntimeRid Condition=" ('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd' or '$(OSName)' == 'illumos' or '$(OSName)' == 'solaris') and '$(DotNetBuildSourceOnly)' != 'true' ">$(OSName)-$(Architecture)</NetRuntimeRid>
+    <NetRuntimeRid Condition="'$(DotNetBuild)' != 'true' and $(NetRuntimeRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</NetRuntimeRid>
+
+    <SharedFrameworkRid>$(NetRuntimeRid)</SharedFrameworkRid>
+    <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
+    <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
   </PropertyGroup>
 
 </Project>

--- a/src/Installer/redist-installer/targets/Crossgen.targets
+++ b/src/Installer/redist-installer/targets/Crossgen.targets
@@ -1,10 +1,21 @@
 <Project>
 
+  <PropertyGroup>
+    <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
+    <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
+
+    <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(Crossgen2Rid)</RuntimeNETCrossgenPackageName>
+  </PropertyGroup>
+
+  <!-- Download the runtime package with the crossgen executable in it -->
+  <ItemGroup>
+    <PackageDownload Include="$(RuntimeNETCrossgenPackageName)" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
+  </ItemGroup>
+
   <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
   <Target Name="CrossgenLayout"
           Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'">
     <PropertyGroup>
-      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(Crossgen2Rid)</RuntimeNETCrossgenPackageName>
       <CrossgenPath>$(NuGetPackageRoot)$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <CreateCrossgenSymbols Condition="'$(CreateCrossgenSymbols)' == ''">true</CreateCrossgenSymbols>
       <!-- When ingesting stable pgo instrumented binaries, the shared framework will be a non-stable version,
@@ -12,19 +23,6 @@
       <SharedFrameworkNameVersionPath Condition=" '$(PgoInstrument)' != 'true' ">$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
       <SharedFrameworkNameVersionPath Condition=" '$(PgoInstrument)' == 'true' ">$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(VSRedistCommonNetCoreTargetingPackx64100PackageVersion)</SharedFrameworkNameVersionPath>
     </PropertyGroup>
-
-    <!-- Download the runtime package with the crossgen executable in it -->
-    <ItemGroup>
-      <CrossGenDownloadPackageProject Include="$(MSBuildThisFileDirectory)..\projects\DownloadPackage.csproj">
-        <Properties>
-          PackageToRestore=$(RuntimeNETCrossgenPackageName);
-          PackageVersionToRestore=$(MicrosoftNETCoreAppRuntimePackageVersion);
-          TargetFramework=$(TargetFramework)
-        </Properties>
-      </CrossGenDownloadPackageProject>
-    </ItemGroup>
-
-    <MSBuild Projects="@(CrossGenDownloadPackageProject)" />
 
     <!-- This PropertyGroup contains the paths to the various SDK tooling that should be
          cross-genned. This tooling multi-targets, and we only want to cross-gen the .NET Core

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -32,10 +32,6 @@
       <!-- MSBuild removes the '//' slashes when passing PublicBaseURL from the outer to the inner build. -->
       <PublicBaseURL Condition="$(PublicBaseURL.StartsWith('file:')) and '$(OS)' != 'Windows_NT'">$([System.Text.RegularExpressions.Regex]::Replace('$(PublicBaseURL)', '%28file:\/{1,}%29%28.+%29', 'file:///%242'))</PublicBaseURL>
 
-      <NetRuntimeRid Condition="'$(NetRuntimeRid)' == ''">$(HostRid)</NetRuntimeRid>
-      <NetRuntimeRid Condition=" ('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd' or '$(OSName)' == 'illumos' or '$(OSName)' == 'solaris') and '$(DotNetBuildSourceOnly)' != 'true' ">$(OSName)-$(Architecture)</NetRuntimeRid>
-      <NetRuntimeRid Condition="'$(DotNetBuild)' != 'true' and $(NetRuntimeRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</NetRuntimeRid>
-
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>
 
@@ -68,16 +64,9 @@
       <DownloadedNetStandardTargetingPackInstallerFileName Condition="'$(SharedFrameworkInstallerFileRid)' == 'osx-arm64'">netstandard-targeting-pack-$(NETStandardLibraryRefPackageVersion)-osx-x64$(InstallerExtension)</DownloadedNetStandardTargetingPackInstallerFileName>
       <NetStandardTargetingPackTargetFramework>netstandard$(NETStandardLibraryRefPackageVersion.Split('.')[0])$(NETStandardLibraryRefPackageVersion.Split('.')[1])</NetStandardTargetingPackTargetFramework>
 
-      <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
-      <SharedFrameworkRid>$(NetRuntimeRid)</SharedFrameworkRid>
-      <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
-      <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
       <CombinedFrameworkHostArchiveFileName Condition=" '$(PgoInstrument)' != 'true' ">dotnet-runtime-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
       <CombinedFrameworkHostArchiveFileName Condition=" '$(PgoInstrument)' == 'true' ">dotnet-runtime$(PgoTerm)-$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
       <WinFormsAndWpfSharedFxArchiveFileName>windowsdesktop-runtime-$(MicrosoftWindowsDesktopAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>
-
-      <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
-      <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
 
       <AspNetCoreInstallerRid Condition="'$(AspNetCoreInstallerRid)' == ''">$(SharedFrameworkRid)</AspNetCoreInstallerRid>
       <AspNetCoreArchiveRid>$(AspNetCoreInstallerRid)</AspNetCoreArchiveRid>


### PR DESCRIPTION
Use PackageDownload to restore dependencies up-front as part of the NuGet restore target.