### PR TITLE
Add installer tests project

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Installer.Tests;
+
+public static class Config
+{
+    public static string AssetsDirectory { get; } = GetRuntimeConfig(AssetsDirectorySwitch);
+    const string AssetsDirectorySwitch = RuntimeConfigSwitchPrefix + nameof(AssetsDirectory);
+
+    public static string PackagesDirectory { get; } = GetRuntimeConfig(PackagesDirectorySwitch);
+    const string PackagesDirectorySwitch = RuntimeConfigSwitchPrefix + nameof(PackagesDirectory);
+
+    public static string ScenarioTestsNuGetConfigPath { get; } = GetRuntimeConfig(ScenarioTestsNuGetConfigSwitch);
+    const string ScenarioTestsNuGetConfigSwitch = RuntimeConfigSwitchPrefix + nameof(ScenarioTestsNuGetConfigPath);
+
+    public static string Architecture { get; } = GetRuntimeConfig(ArchitectureSwitch);
+    const string ArchitectureSwitch = RuntimeConfigSwitchPrefix + nameof(Architecture);
+
+    public static bool TestRpmPackages { get; } = TryGetRuntimeConfig(TestRpmPackagesSwitch, out bool value) ? value : false;
+    const string TestRpmPackagesSwitch = RuntimeConfigSwitchPrefix + nameof(TestRpmPackages);
+
+    public static bool TestDebPackages { get; } = TryGetRuntimeConfig(TestDebPackagesSwitch, out bool value) ? value : false;
+    const string TestDebPackagesSwitch = RuntimeConfigSwitchPrefix + nameof(TestDebPackages);
+
+    public const string RuntimeConfigSwitchPrefix = "Microsoft.DotNet.Installer.Tests.";
+
+    public static string GetRuntimeConfig(string key)
+    {
+        return TryGetRuntimeConfig(key, out string? value) ? value : throw new InvalidOperationException($"Runtime config setting '{key}' must be specified");
+    }
+
+    public static bool TryGetRuntimeConfig(string key, out bool value)
+    {
+        string? rawValue = (string?)AppContext.GetData(key);
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            value = default!;
+            return false;
+        }
+        value = bool.Parse(rawValue);
+        return true;
+    }
+
+    public static bool TryGetRuntimeConfig(string key, [NotNullWhen(true)] out string? value)
+    {
+        value = (string?)AppContext.GetData(key);
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -29,6 +29,9 @@ public static class Config
     public static bool TestDebPackages { get; } = TryGetRuntimeConfig(TestDebPackagesSwitch, out bool value) ? value : false;
     const string TestDebPackagesSwitch = RuntimeConfigSwitchPrefix + nameof(TestDebPackages);
 
+    public static bool KeepDockerImages { get; } = TryGetRuntimeConfig(KeepDockerImagesSwitch, out bool value) ? value : false;
+    const string KeepDockerImagesSwitch = RuntimeConfigSwitchPrefix + nameof(KeepDockerImages);
+
     public const string RuntimeConfigSwitchPrefix = "Microsoft.DotNet.Installer.Tests.";
 
     public static string GetRuntimeConfig(string key)

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Installer.Tests;
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/DockerHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/DockerHelper.cs
@@ -1,0 +1,270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Installer.Tests;
+
+public class DockerHelper
+{
+    public static string DockerOS => GetDockerOS();
+    public static string DockerArchitecture => GetDockerArch();
+    public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
+    public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
+    public static string TestArtifactsDir { get; } = Path.Combine(Directory.GetCurrentDirectory(), "TestAppArtifacts");
+
+    private ITestOutputHelper OutputHelper { get; set; }
+
+    public DockerHelper(ITestOutputHelper outputHelper)
+    {
+        OutputHelper = outputHelper;
+    }
+
+    public void Build(
+        string tag,
+        string? dockerfile = null,
+        string? target = null,
+        string contextDir = ".",
+        bool pull = false,
+        string? platform = null,
+        params string[] buildArgs)
+    {
+        string buildArgsOption = string.Empty;
+        if (buildArgs != null)
+        {
+            foreach (string arg in buildArgs)
+            {
+                buildArgsOption += $" --build-arg {arg}";
+            }
+        }
+
+        string platformOption = string.Empty;
+        if (platform is not null)
+        {
+            platformOption = $" --platform {platform}";
+        }
+
+        string targetArg = target == null ? string.Empty : $" --target {target}";
+        string dockerfileArg = dockerfile == null ? string.Empty : $" -f {dockerfile}";
+        string pullArg = pull ? " --pull" : string.Empty;
+
+        ExecuteWithLogging($"build -t {tag}{targetArg}{buildArgsOption}{dockerfileArg}{pullArg}{platformOption} {contextDir}");
+    }
+
+
+    public static bool ContainerExists(string name) => ResourceExists("container", $"-f \"name={name}\"");
+
+    public static bool ContainerIsRunning(string name) => Execute($"inspect --format=\"{{{{.State.Running}}}}\" {name}") == "true";
+
+    public void Copy(string src, string dest) => ExecuteWithLogging($"cp {src} {dest}");
+
+    public void DeleteContainer(string container, bool captureLogs = false)
+    {
+        if (ContainerExists(container))
+        {
+            if (captureLogs)
+            {
+                ExecuteWithLogging($"logs {container}", ignoreErrors: true);
+            }
+
+            // If a container is already stopped, running `docker stop` again has no adverse effects.
+            // This prevents some issues where containers could fail to be forcibly removed while they're running.
+            // e.g. https://github.com/dotnet/dotnet-docker/issues/5127
+            StopContainer(container);
+
+            ExecuteWithLogging($"container rm -f {container}");
+        }
+    }
+
+    public void DeleteImage(string tag)
+    {
+        if (ImageExists(tag))
+        {
+            ExecuteWithLogging($"image rm -f {tag}");
+        }
+    }
+
+    private void StopContainer(string container)
+    {
+        if (ContainerExists(container))
+        {
+            ExecuteWithLogging($"stop {container}", autoRetry: true);
+        }
+    }
+
+    private static string Execute(
+        string args, bool ignoreErrors = false, bool autoRetry = false, ITestOutputHelper? outputHelper = null)
+    {
+        (Process Process, string StdOut, string StdErr) result;
+        if (autoRetry)
+        {
+            result = ExecuteWithRetry(args, outputHelper!, ExecuteProcess);
+        }
+        else
+        {
+            result = ExecuteProcess(args, outputHelper!);
+        }
+
+        if (!ignoreErrors && result.Process.ExitCode != 0)
+        {
+            ProcessStartInfo startInfo = result.Process.StartInfo;
+            string msg = $"Failed to execute {startInfo.FileName} {startInfo.Arguments}" +
+                $"{Environment.NewLine}Exit code: {result.Process.ExitCode}" +
+                $"{Environment.NewLine}Standard Error: {result.StdErr}";
+            throw new InvalidOperationException(msg);
+        }
+
+        return result.StdOut;
+    }
+
+    private static (Process Process, string StdOut, string StdErr) ExecuteProcess(
+        string args, ITestOutputHelper outputHelper) => ExecuteProcess("docker", args, outputHelper);
+
+    private string ExecuteWithLogging(string args, bool ignoreErrors = false, bool autoRetry = false)
+    {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.Start();
+
+        OutputHelper.WriteLine($"Executing: docker {args}");
+        string result = Execute(args, outputHelper: OutputHelper, ignoreErrors: ignoreErrors, autoRetry: autoRetry);
+
+        stopwatch.Stop();
+        OutputHelper.WriteLine($"Execution Elapsed Time: {stopwatch.Elapsed}");
+
+        return result;
+    }
+
+    private static (Process Process, string StdOut, string StdErr) ExecuteWithRetry(
+        string args,
+        ITestOutputHelper outputHelper,
+        Func<string, ITestOutputHelper, (Process Process, string StdOut, string StdErr)> executor)
+    {
+        const int maxRetries = 5;
+        const int waitFactor = 5;
+
+        int retryCount = 0;
+
+        (Process Process, string StdOut, string StdErr) result = executor(args, outputHelper);
+        while (result.Process.ExitCode != 0)
+        {
+            retryCount++;
+            if (retryCount >= maxRetries)
+            {
+                break;
+            }
+
+            int waitTime = Convert.ToInt32(Math.Pow(waitFactor, retryCount - 1));
+            if (outputHelper != null)
+            {
+                outputHelper.WriteLine($"Retry {retryCount}/{maxRetries}, retrying in {waitTime} seconds...");
+            }
+
+            Thread.Sleep(waitTime * 1000);
+            result = executor(args, outputHelper!);
+        }
+
+        return result;
+    }
+
+    private static (Process Process, string StdOut, string StdErr) ExecuteProcess(
+    string fileName, string args, ITestOutputHelper outputHelper)
+    {
+        Process process = new Process
+        {
+            EnableRaisingEvents = true,
+            StartInfo =
+            {
+                FileName = fileName,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            }
+        };
+
+        StringBuilder stdOutput = new StringBuilder();
+        process.OutputDataReceived += new DataReceivedEventHandler((sender, e) => stdOutput.AppendLine(e.Data));
+
+        StringBuilder stdError = new StringBuilder();
+        process.ErrorDataReceived += new DataReceivedEventHandler((sender, e) => stdError.AppendLine(e.Data));
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        string output = stdOutput.ToString().Trim();
+        if (outputHelper != null && !string.IsNullOrWhiteSpace(output))
+        {
+            outputHelper.WriteLine(output);
+        }
+
+        string error = stdError.ToString().Trim();
+        if (outputHelper != null && !string.IsNullOrWhiteSpace(error))
+        {
+            outputHelper.WriteLine(error);
+        }
+
+        return (process, output, error);
+    }
+
+    private static string GetDockerOS() => Execute("version -f \"{{ .Server.Os }}\"");
+    private static string GetDockerArch() => Execute("version -f \"{{ .Server.Arch }}\"");
+
+    public string GetImageUser(string image) => ExecuteWithLogging($"inspect -f \"{{{{ .Config.User }}}}\" {image}");
+
+    public IDictionary<string, string> GetEnvironmentVariables(string image)
+    {
+        string envVarsStr = ExecuteWithLogging($"inspect -f \"{{{{json .Config.Env }}}}\" {image}");
+        JArray? envVarsArray = (JArray?)JsonConvert.DeserializeObject(envVarsStr);
+        return envVarsArray!
+            .ToDictionary(
+                item => item.ToString().Split('=')[0],
+                item => item.ToString().Split('=')[1]);
+    }
+
+    public static bool ImageExists(string tag) => ResourceExists("image", tag);
+
+    private static bool ResourceExists(string type, string filterArg)
+    {
+        string output = Execute($"{type} ls -a -q {filterArg}", true);
+        return output != "";
+    }
+
+    public string Run(
+        string image,
+        string name,
+        string? command = null,
+        string? workdir = null,
+        string? optionalRunArgs = null,
+        bool detach = false,
+        string? runAsUser = null,
+        bool skipAutoCleanup = false,
+        bool useMountedDockerSocket = false,
+        bool silenceOutput = false,
+        bool tty = true)
+    {
+        string cleanupArg = skipAutoCleanup ? string.Empty : " --rm";
+        string detachArg = detach ? " -d" : string.Empty;
+        string ttyArg = detach && tty ? " -t" : string.Empty;
+        string userArg = runAsUser != null ? $" -u {runAsUser}" : string.Empty;
+        string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
+        string mountedDockerSocketArg = useMountedDockerSocket ? " -v /var/run/docker.sock:/var/run/docker.sock" : string.Empty;
+        if (silenceOutput)
+        {
+            return Execute(
+                $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{ttyArg}{mountedDockerSocketArg} {optionalRunArgs} {image} {command}");
+        }
+        return ExecuteWithLogging(
+            $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{ttyArg}{mountedDockerSocketArg} {optionalRunArgs} {image} {command}", ignoreErrors: true);
+    }
+}

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/DockerHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/DockerHelper.cs
@@ -9,8 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Installer.Tests;
@@ -221,16 +219,6 @@ public class DockerHelper
     private static string GetDockerArch() => Execute("version -f \"{{ .Server.Arch }}\"");
 
     public string GetImageUser(string image) => ExecuteWithLogging($"inspect -f \"{{{{ .Config.User }}}}\" {image}");
-
-    public IDictionary<string, string> GetEnvironmentVariables(string image)
-    {
-        string envVarsStr = ExecuteWithLogging($"inspect -f \"{{{{json .Config.Env }}}}\" {image}");
-        JArray? envVarsArray = (JArray?)JsonConvert.DeserializeObject(envVarsStr);
-        return envVarsArray!
-            .ToDictionary(
-                item => item.ToString().Split('=')[0],
-                item => item.ToString().Split('=')[1]);
-    }
 
     public static bool ImageExists(string tag) => ResourceExists("image", tag);
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -27,6 +27,8 @@ public class LinuxInstallerTests : IDisposable
 
     private const string NetStandard21RpmPackage = @"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm";
     private const string NetStandard21DebPackage = @"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.deb";
+    private const string RuntimeDepsRepo = "mcr.microsoft.com/dotnet/nightly/runtime-deps";
+    private const string RuntimeDepsVersion = "10.0-preview";
 
     public static bool IncludeRpmTests => Config.TestRpmPackages;
     public static bool IncludeDebTests => Config.TestDebPackages;
@@ -64,14 +66,14 @@ public class LinuxInstallerTests : IDisposable
     }
 
     [ConditionalTheory(typeof(LinuxInstallerTests), nameof(IncludeRpmTests))]
-    [InlineData("mcr.microsoft.com/dotnet/nightly/runtime-deps", "10.0-preview-azurelinux3.0")]
+    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-azurelinux3.0")]
     public void RpmTest(string repo, string tag)
     {
         DistroTest($"{repo}:{tag}", PackageType.Rpm);
     }
 
     [ConditionalTheory(typeof(LinuxInstallerTests), nameof(IncludeDebTests))]
-    [InlineData("mcr.microsoft.com/dotnet/nightly/runtime-deps", "10.0-preview-trixie-slim")]
+    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-trixie-slim")]
     public void DebTest(string repo, string tag)
     {
         DistroTest($"{repo}:{tag}", PackageType.Deb);
@@ -206,7 +208,10 @@ public class LinuxInstallerTests : IDisposable
         }
         finally
         {
-            _dockerHelper.DeleteImage(tag);
+            if (!Config.KeepDockerImages)
+            {
+                _dockerHelper.DeleteImage(tag);
+            }
         }
     }
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -28,12 +28,12 @@ public class LinuxInstallerTests : IDisposable
 
     private readonly string[] RpmDistroImages =
     [
-        "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40"
+        "mcr.microsoft.com/dotnet/runtime-deps:9.0-azurelinux3.0"
     ];
 
     private readonly string[] DebDistroImages =
     [
-        "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04"
+        "mcr.microsoft.com/dotnet/runtime-deps:9.0-bookworm-slim"
     ];
 
     private const string NetStandard21RpmPackage = @"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm";
@@ -327,20 +327,8 @@ public class LinuxInstallerTests : IDisposable
         string matchPattern = "dotnet-runtime-deps-*.deb";
         if (distroType == DistroType.Rpm)
         {
-            string depsId = "fedora";
-            if (baseImage.Contains("fedora"))
-            {
-                depsId = "fedora";
-            }
-            else if (baseImage.Contains("centos"))
-            {
-                depsId = "centos";
-            }
-            else if (baseImage.Contains("rhel"))
-            {
-                depsId = "rhel";
-            }
-            else if (baseImage.Contains("opensuse"))
+            string? depsId = null;
+            if (baseImage.Contains("opensuse"))
             {
                 depsId = "opensuse";
             }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -1,0 +1,386 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.Intrinsics.Arm;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Microsoft.DotNet.Installer.Tests;
+
+public class LinuxInstallerTests : IDisposable
+{
+    private readonly DockerHelper _dockerHelper;
+    private readonly string _tmpDir;
+    private readonly string _contextDir;
+
+    private readonly string[] RpmDistroImages =
+    [
+        "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40"
+    ];
+
+    private readonly string[] DebDistroImages =
+    [
+        "mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04"
+    ];
+
+    private const string NetStandard21RpmPackage = @"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm";
+    private const string NetStandard21DebPackage = @"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.deb";
+
+    private enum DistroType
+    {
+        Rpm,
+        Deb
+    }
+
+    private ITestOutputHelper OutputHelper { get; set; }
+
+    public LinuxInstallerTests(ITestOutputHelper outputHelper)
+    {
+        OutputHelper = outputHelper;
+        _dockerHelper = new DockerHelper(OutputHelper);
+
+        _tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tmpDir);
+        _contextDir = Path.Combine(_tmpDir, Path.GetRandomFileName());
+        Directory.CreateDirectory(_contextDir);
+
+        InitializeContext();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tmpDir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    [Fact]
+    public void RunScenarioTestsForAllDistros()
+    {
+        if (Config.TestRpmPackages)
+        {
+            TestAllDistros(DistroType.Rpm);
+        }
+
+
+        if (Config.TestDebPackages)
+        {
+            TestAllDistros(DistroType.Deb);
+        }
+    }
+
+    private void TestAllDistros(DistroType distroType)
+    {
+        foreach (string image in (distroType == DistroType.Rpm ? RpmDistroImages : DebDistroImages))
+        {
+            try
+            {
+                OutputHelper.WriteLine($"Begin testing distro: {image}");
+                DistroTest(image, distroType);
+                OutputHelper.WriteLine($"Finished testing distro: {image}");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Test failed for {image}: {ex}");
+            }
+        }
+    }
+
+    private void InitializeContext()
+    {
+        // For rpm enumerate RPM packages, excluding those that contain ".cm." in the name
+        List<string> rpmPackages = Directory.GetFiles(Config.AssetsDirectory, "*.rpm", SearchOption.AllDirectories)
+            .Where(p => !Path.GetFileName(p).Contains("-cm.") && !Path.GetFileName(p).EndsWith("azl.rpm"))
+            .ToList();
+
+        foreach (string rpmPackage in rpmPackages)
+        {
+            File.Copy(rpmPackage, Path.Combine(_contextDir, Path.GetFileName(rpmPackage)));
+        }
+
+        // Copy all DEB packages as well
+        foreach (string debPackage in Directory.GetFiles(Config.AssetsDirectory, "*.deb", SearchOption.AllDirectories))
+        {
+            File.Copy(debPackage, Path.Combine(_contextDir, Path.GetFileName(debPackage)));
+        }
+
+        // Download NetStandard 2.1 packages
+        DownloadFileAsync(NetStandard21RpmPackage, Path.Combine(_contextDir, Path.GetFileName(NetStandard21RpmPackage))).Wait();
+        DownloadFileAsync(NetStandard21DebPackage, Path.Combine(_contextDir, Path.GetFileName(NetStandard21DebPackage))).Wait();
+
+        // Copy nuget packages
+        string nugetPackagesDir = Path.Combine(_contextDir, "packages");
+        Directory.CreateDirectory(nugetPackagesDir);
+        foreach (string package in Directory.GetFiles(Config.PackagesDirectory, "*.nupkg", SearchOption.AllDirectories))
+        {
+            File.Copy(package, Path.Combine(nugetPackagesDir, Path.GetFileName(package)));
+        }
+
+        // Copy and update NuGet.config from scenario-tests repo
+        string newNuGetConfig = Path.Combine(_contextDir, "NuGet.config");
+        File.Copy(Config.ScenarioTestsNuGetConfigPath, newNuGetConfig);
+        InsertLocalPackagesPathToNuGetConfig(newNuGetConfig, "/packages");
+
+        // Find the scenario-tests package and unpack it to the context dir, subfolder "scenario-tests"
+        string? scenarioTestsPackage = Directory.GetFiles(nugetPackagesDir, "Microsoft.DotNet.ScenarioTests.SdkTemplateTests*.nupkg", SearchOption.AllDirectories).FirstOrDefault();
+        if (scenarioTestsPackage == null)
+        {
+            Assert.Fail("Scenario tests package not found");
+        }
+
+        ZipFile.ExtractToDirectory(scenarioTestsPackage, Path.Combine(_contextDir, "scenario-tests"));
+    }
+
+    private void InsertLocalPackagesPathToNuGetConfig(string nuGetConfig, string localPackagesPath)
+    {
+        XDocument doc = XDocument.Load(nuGetConfig);
+        if (doc.Root != null)
+        {
+            XElement? packageSourcesElement = doc.Root.Element("packageSources");
+            if (packageSourcesElement != null)
+            {
+                XElement? clearElement = packageSourcesElement.Element("clear");
+                if (clearElement != null)
+                {
+                    XElement newAddElement = new XElement("add",
+                    new XAttribute("key", "local-packages"),
+                        new XAttribute("value", localPackagesPath));
+
+                    clearElement.AddAfterSelf(newAddElement);
+                }
+            }
+
+            doc.Save(nuGetConfig);
+        }
+    }
+
+    private void DistroTest(string baseImage, DistroType distroType)
+    {
+        // Order of installation is important as we do not want to use "--nodeps"
+        // We install in correct order, so package dependencies are present.
+
+        // Prepare the package list in correct install order
+        List<string> packageList =
+        [
+            // Deps package should be installed first
+            Path.GetFileName(GetMatchingDepsPackage(baseImage, distroType))
+        ];
+
+        // Add all other packages in correct install order
+        AddPackage(packageList, "dotnet-host-", distroType);
+        AddPackage(packageList, "dotnet-hostfxr-", distroType);
+        AddPackage(packageList, "dotnet-runtime-", distroType);
+        AddPackage(packageList, "dotnet-targeting-pack-", distroType);
+        AddPackage(packageList, "aspnetcore-runtime-", distroType);
+        AddPackage(packageList, "aspnetcore-targeting-pack-", distroType);
+        AddPackage(packageList, "dotnet-apphost-pack-", distroType);
+        if (Config.Architecture == "x64")
+        {
+            // netstandard package exists for x64 only
+            AddPackage(packageList, "netstandard-targeting-pack-", distroType);
+        }
+        AddPackage(packageList, "dotnet-sdk-", distroType);
+
+        string dockerfile = GenerateDockerfile(packageList, baseImage, distroType);
+
+        string tag = $"test-{Path.GetRandomFileName()}";
+        string output = "";
+
+        try
+        {
+            // Build docker image and run the tests
+            _dockerHelper.Build(tag, dockerfile: dockerfile, contextDir: _contextDir);
+            output = _dockerHelper.Run(tag, tag);
+
+            int testResultsSummaryIndex = output.IndexOf("Tests run: ");
+            if (testResultsSummaryIndex >= 0)
+            {
+                string testResultsSummary = output[testResultsSummaryIndex..];
+                Assert.False(AnyTestFailures(testResultsSummary), testResultsSummary);
+            }
+            else
+            {
+                Assert.Fail("Test summary not found");
+            }
+        }
+        catch (Exception e)
+        {
+            if (string.IsNullOrEmpty(output))
+            {
+                output = e.Message;
+            }
+            Assert.Fail($"Build failed: {output}");
+        }
+        finally
+        {
+            _dockerHelper.DeleteImage(tag);
+        }
+    }
+
+    private string GenerateDockerfile(List<string> rpmPackageList, string baseImage, DistroType distroType)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine("FROM " + baseImage);
+        sb.AppendLine("");
+        sb.AppendLine("# Copy NuGet.config");
+        sb.AppendLine($"COPY NuGet.config .");
+
+        sb.AppendLine("");
+        sb.AppendLine("# Copy scenario-tests content");
+        sb.AppendLine($"COPY scenario-tests scenario-tests");
+
+        sb.AppendLine("");
+        sb.AppendLine("# Copy nuget packages");
+        sb.AppendLine($"COPY packages packages");
+
+        sb.AppendLine("");
+        sb.AppendLine("# Copy RPM packages");
+        foreach (string package in rpmPackageList)
+        {
+            sb.AppendLine($"COPY {package} {package}");
+        }
+        sb.AppendLine("");
+        sb.AppendLine("# Install RPM packages and Microsoft.DotNet.ScenarioTests.SdkTemplateTests tool");
+        sb.Append("RUN");
+
+        // TODO: remove --force-all when aspnet package versioning issue have been resolved - https://github.com/dotnet/source-build/issues/4895
+        string packageInstallationCommand = distroType == DistroType.Deb ? "dpkg -i --force-all" : "rpm -i";
+        bool useAndOperator = false;
+        foreach (string package in rpmPackageList)
+        {
+            sb.AppendLine(" \\");
+            sb.Append($"    {(useAndOperator ? "&&" : "")} {packageInstallationCommand} {package}");
+            useAndOperator = true;
+        }
+        sb.AppendLine("");
+
+        // Set environment for nuget.config
+        sb.AppendLine("");
+        sb.AppendLine("# Set custom nuget.config");
+        sb.AppendLine("ENV RestoreConfigFile=/NuGet.config");
+
+        // Find scenario-tests binary in context/scenario-tests
+        string? scenarioTestsBinary = Directory.GetFiles(Path.Combine(_contextDir, "scenario-tests"), "Microsoft.DotNet.ScenarioTests.SdkTemplateTests.dll", SearchOption.AllDirectories).FirstOrDefault();
+        if (scenarioTestsBinary == null)
+        {
+            throw new Exception("Scenario tests binary not found");
+        }
+        scenarioTestsBinary = scenarioTestsBinary.Replace(_contextDir, "").Replace("\\", "/");
+
+        // Set entry point
+        sb.AppendLine("");
+        sb.AppendLine($"ENTRYPOINT [ \"dotnet\", \"{scenarioTestsBinary}\", \"--dotnet-root\", \"/usr/share/dotnet\" ]");
+
+        string dockerfile = Path.Combine(_contextDir, Path.GetRandomFileName());
+        File.WriteAllText(dockerfile, sb.ToString());
+        return dockerfile;
+    }
+
+    private bool AnyTestFailures(string testResultSummary)
+    {
+        var parts = testResultSummary.Split(',')
+         .Select(part => part.Split(':').Select(p => p.Trim()).ToArray())
+         .Where(p => p.Length == 2)
+         .ToDictionary(p => p[0], p => int.Parse(p[1]));
+
+        return parts["Errors"] > 0 || parts["Failures"] > 0;
+    }
+
+    private void AddPackage(List<string> packageList, string prefix, DistroType distroType)
+    {
+        packageList.Add(Path.GetFileName(GetContentPackage(prefix, distroType)));
+    }
+
+    private string GetContentPackage(string prefix, DistroType distroType)
+    {
+        string matchPattern = DistroType.Deb == distroType ? "*.deb" : "*.rpm";
+        string[] rpmFiles = Directory.GetFiles(_contextDir, prefix + matchPattern, SearchOption.AllDirectories)
+            .Where(p => !Path.GetFileName(p).Contains("dotnet-runtime-deps-"))
+            .ToArray();
+        if (rpmFiles.Length == 0)
+        {
+            throw new Exception($"RPM package with prefix '{prefix}' not found");
+        }
+
+        return rpmFiles.OrderByDescending(f => f).First();
+    }
+
+    private string GetMatchingDepsPackage(string baseImage, DistroType distroType)
+    {
+        string matchPattern = "dotnet-runtime-deps-*.deb";
+        if (distroType == DistroType.Rpm)
+        {
+            string depsId = "fedora";
+            if (baseImage.Contains("fedora"))
+            {
+                depsId = "fedora";
+            }
+            else if (baseImage.Contains("centos"))
+            {
+                depsId = "centos";
+            }
+            else if (baseImage.Contains("rhel"))
+            {
+                depsId = "rhel";
+            }
+            else if (baseImage.Contains("opensuse"))
+            {
+                depsId = "opensuse";
+            }
+            else if (baseImage.Contains("sles"))
+            {
+                depsId = "sles";
+            }
+            else if (baseImage.Contains("azurelinux"))
+            {
+                depsId = "azl";
+            }
+            else
+            {
+                throw new Exception($"Unknown distro: {baseImage}");
+            }
+
+            matchPattern = $"dotnet-runtime-deps-*{depsId}*.rpm";
+        }
+
+        string[] files = Directory.GetFiles(_contextDir, matchPattern, SearchOption.AllDirectories);
+        if (files.Length == 0)
+        {
+            throw new Exception($"Did not find the DEPS package.");
+        }
+
+        return files.OrderByDescending(f => f).First();
+    }
+
+    private static async Task DownloadFileAsync(string url, string filePath)
+    {
+        using (HttpClient client = new HttpClient())
+        {
+            HttpResponseMessage response = await client.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                await response.Content.CopyToAsync(fileStream);
+            }
+        }
+    }
+}
+

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -154,7 +154,7 @@ public class LinuxInstallerTests : IDisposable
                 if (clearElement != null)
                 {
                     XElement newAddElement = new XElement("add",
-                    new XAttribute("key", "local-packages"),
+                        new XAttribute("key", "local-packages"),
                         new XAttribute("value", localPackagesPath));
 
                     clearElement.AddAfterSelf(newAddElement);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -32,6 +32,9 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TestDebPackages">
         <Value>$(TestDebPackages)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).KeepDockerImages">
+        <Value>$(KeepDockerImages)</Value>
+      </RuntimeHostConfigurationOption>
     </ItemGroup>
   </Target>
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -6,6 +6,10 @@
     <VSTestCLIRunSettings>$(VSTestCLIRunSettings);RunConfiguration.DotNetHostPath=$(DotnetTool)</VSTestCLIRunSettings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+  </ItemGroup>
+
   <Target Name="SetRuntimeConfigOptions"
           BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
     <ItemGroup>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <VSTestLogger>console%3bverbosity=normal;trx%3bverbosity=diagnostic%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+    <VSTestCLIRunSettings>$(VSTestCLIRunSettings);RunConfiguration.DotNetHostPath=$(DotnetTool)</VSTestCLIRunSettings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <Target Name="SetRuntimeConfigOptions"
+          BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
+    <ItemGroup>
+      <!-- General configs -->
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).AssetsDirectory">
+        <Value>$(ArtifactsAssetsDir)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).PackagesDirectory">
+        <Value>$(ArtifactsPackagesDir)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).ScenarioTestsNuGetConfigPath">
+        <Value>$(RepoRoot)src\scenario-tests\NuGet.config</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).Architecture">
+        <Value>$(HostArchitecture)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TestRpmPackages">
+        <Value>$(TestRpmPackages)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TestDebPackages">
+        <Value>$(TestDebPackages)</Value>
+      </RuntimeHostConfigurationOption>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -6,10 +6,6 @@
     <VSTestCLIRunSettings>$(VSTestCLIRunSettings);RunConfiguration.DotNetHostPath=$(DotnetTool)</VSTestCLIRunSettings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" />
-  </ItemGroup>
-
   <Target Name="SetRuntimeConfigOptions"
           BeforeTargets="_GenerateRuntimeConfigurationFilesInputCache">
     <ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/109848

This PR introduces test project for installer tests. It does not hook it up to build infra. There will be another PR soon that will introduce a job/step in `VMR Validation` stage that will run installer tests for both x64 and arm64 installers.

Originally the plan was to run these tests as part of the mainline build job, but we are running that job as cross-build on x64 host, which precludes us from testing arm64 installers.

Some notes about the PR contents:
- There is one RPM and one Debian test platform - this can be expanded as needed
- Debian installation uses `--force-all` to work around issues in https://github.com/dotnet/source-build/issues/4895 - the fix is in PR and this will be removed in the near future. I opted not to include that fix as a patch, but that is a possibility
- Consumers can specify if they want to test just Deb or Rpm or both
- `DockerHelper.cs` was borrowed from dotnet-docker repo: https://github.com/dotnet/dotnet-docker/blob/main/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs. I have removed many unused methods
- Only Linux installer tests are being added today, Windows and MacOS installers will be considered in the future