### PR TITLE
Remove incorrect text from --blame-hang docs

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -267,7 +267,7 @@ Implies --blame.</value>
     <value>The type of crash dump to be collected. Supported values are full (default) and mini. Implies --blame-crash.</value>
   </data>
   <data name="CmdBlameHangDescription" xml:space="preserve">
-    <value>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</value>
+    <value>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</value>
   </data>
   <data name="CmdBlameHangDumpTypeDescription" xml:space="preserve">
     <value>The type of crash dump to be collected. The supported values are full (default), mini, and none. When 'none' is used then test host is terminated on timeout, but no dump is collected. Implies --blame-hang.</value>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -88,8 +88,8 @@ Implikuje --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Spustí testy v režimu blame a umožní shromažďování výpisů stavu systému při zablokování, když test překročí stanovený časový limit. Tato možnost představuje přepínač --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Spustí testy v režimu blame a umožní shromažďování výpisů stavu systému při zablokování, když test překročí stanovený časový limit.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -88,8 +88,8 @@ Impliziert „--blame“.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Hiermit werden Tests im Modus "Verantwortung zuweisen" ausgeführt, und es wird die Erfassung eines Blockadeabbilds aktiviert, wenn der Test länger als angegeben dauert. Impliziert "--blame-hang".</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Hiermit werden Tests im Modus "Verantwortung zuweisen" ausgeführt, und es wird die Erfassung eines Blockadeabbilds aktiviert, wenn der Test länger als angegeben dauert.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -90,8 +90,8 @@ Implica --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Ejecuta las pruebas en el modo de culpa y habilita la recopilación del volcado de bloqueo cuando la prueba supera el tiempo de espera especificado. Implica --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Ejecuta las pruebas en el modo de culpa y habilita la recopilación del volcado de bloqueo cuando la prueba supera el tiempo de espera especificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -88,8 +88,8 @@ Implique --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Exécutez les tests en mode blame (responsabilité) et activez la collecte des données de vidage sur blocage quand le test dépasse le délai d'expiration spécifié. Implique --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Exécutez les tests en mode blame (responsabilité) et activez la collecte des données de vidage sur blocage quand le test dépasse le délai d'expiration spécifié.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -88,8 +88,8 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Esegue i test in modalità di segnalazione errore e abilita la raccolta del dump di blocco quando il test supera il timeout specificato. Implica --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Esegue i test in modalità di segnalazione errore e abilita la raccolta del dump di blocco quando il test supera il timeout specificato.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -88,8 +88,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">変更履歴モードでテストを実行し、テストが指定のタイムアウトを超えたときにハング ダンプを収集するのを可能にします。--blame-hang を暗黙的に指定します。</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">変更履歴モードでテストを実行し、テストが指定のタイムアウトを超えたときにハング ダンプを収集するのを可能にします。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -88,8 +88,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">테스트를 원인 모드로 실행하고 테스트가 지정된 시간 제한을 초과하는 경우 중단 덤프 수집을 사용하도록 설정합니다. --blame-hang을 의미합니다.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">테스트를 원인 모드로 실행하고 테스트가 지정된 시간 제한을 초과하는 경우 중단 덤프 수집을 사용하도록 설정합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -88,8 +88,8 @@ Implies --blame.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Uruchamia testy w trybie blame i włącza zbieranie zrzutów w stanie zawieszenia, gdy test przekroczy podany limit czasu. Implikuje użycie parametru --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Uruchamia testy w trybie blame i włącza zbieranie zrzutów w stanie zawieszenia, gdy test przekroczy podany limit czasu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -88,8 +88,8 @@ Implica --culpa.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Executar os testes no modo blame e habilitar a coleta de despejo de memória quando o teste exceder o tempo limite determinado. Implica --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Executar os testes no modo blame e habilitar a coleta de despejo de memória quando o teste exceder o tempo limite determinado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -88,8 +88,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Выполнение тестов в режиме обвинения и включение сбора дампа зависания при превышении заданного времени ожидания для теста. Подразумевается использование параметра --blame-hang.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Выполнение тестов в режиме обвинения и включение сбора дампа зависания при превышении заданного времени ожидания для теста.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -88,8 +88,8 @@ Araçlar buradan indirilebilir: https://docs.microsoft.com/sysinternals/download
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">Testleri blame modunda çalıştırır ve test, verilen zaman aşımını süresini aştığında yanıt vermemeye başlama bilgi dökümünün toplanmasını sağlar. --blame-hang anlamına gelir.</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">Testleri blame modunda çalıştırır ve test, verilen zaman aşımını süresini aştığında yanıt vermemeye başlama bilgi dökümünün toplanmasını sağlar.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -88,8 +88,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">在追责模式下运行测试，并允许在测试超过给定超时时长时收集挂起转储。Implies --blame-hang。</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">在追责模式下运行测试，并允许在测试超过给定超时时长时收集挂起转储。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -88,8 +88,8 @@ Implies --blame.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDescription">
-        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout. Implies --blame-hang.</source>
-        <target state="translated">當測試超過指定的逾時時，請在改動者模式中執行測試，並啟用收集停止回應傾印。Implies --blame-hang。</target>
+        <source>Run the tests in blame mode and enables collecting hang dump when test exceeds the given timeout.</source>
+        <target state="translated">當測試超過指定的逾時時，請在改動者模式中執行測試，並啟用收集停止回應傾印。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdBlameHangDumpTypeDescription">


### PR DESCRIPTION
Assuming that `Implies --blame-hang.` should not be included in the docs for the `--blame-hang` argument (as it is redundant!), then this PR removes that text.

Fixes #46929