### PR TITLE
Don't restore crossgen packs on unsupported envs

### DIFF
--- a/src/Installer/redist-installer/Directory.Build.targets
+++ b/src/Installer/redist-installer/Directory.Build.targets
@@ -14,7 +14,9 @@
   <Import Project="targets\BundledManifests.targets" />
   <Import Project="targets\BundledDotnetTools.targets" />
   <Import Project="targets\GenerateBundledVersions.targets" />
-  <Import Project="targets\Crossgen.targets" />
+  <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
+  <Import Project="targets\Crossgen.targets"
+          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'" />
   <Import Project="targets\GenerateLayout.targets" />
   <Import Project="targets\GenerateArchives.targets" Condition="'$(PackInstaller)' != 'false'"/>
   <Import Project="targets\GenerateMSIs.targets" />

--- a/src/Installer/redist-installer/targets/Crossgen.targets
+++ b/src/Installer/redist-installer/targets/Crossgen.targets
@@ -12,9 +12,7 @@
     <PackageDownload Include="$(RuntimeNETCrossgenPackageName)" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
   </ItemGroup>
 
-  <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
-  <Target Name="CrossgenLayout"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'">
+  <Target Name="CrossgenLayout">
     <PropertyGroup>
       <CrossgenPath>$(NuGetPackageRoot)$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <CreateCrossgenSymbols Condition="'$(CreateCrossgenSymbols)' == ''">true</CreateCrossgenSymbols>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/sdk/commit/8ab5945fe6630c8b8a205066595fe4e1180de705
Fixes https://github.com/dotnet/sdk/issues/46943