### PR TITLE
Fix GenerateLayout target dependencies when skipping crossgen

### DIFF
--- a/src/Installer/redist-installer/Directory.Build.targets
+++ b/src/Installer/redist-installer/Directory.Build.targets
@@ -14,9 +14,7 @@
   <Import Project="targets\BundledManifests.targets" />
   <Import Project="targets\BundledDotnetTools.targets" />
   <Import Project="targets\GenerateBundledVersions.targets" />
-  <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
-  <Import Project="targets\Crossgen.targets"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'" />
+  <Import Project="targets\Crossgen.targets" />
   <Import Project="targets\GenerateLayout.targets" />
   <Import Project="targets\GenerateArchives.targets" Condition="'$(PackInstaller)' != 'false'"/>
   <Import Project="targets\GenerateMSIs.targets" />

--- a/src/Installer/redist-installer/targets/Crossgen.targets
+++ b/src/Installer/redist-installer/targets/Crossgen.targets
@@ -1,6 +1,9 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
+    <IsCrossgenSupported Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'">true</IsCrossgenSupported>
+
     <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
     <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
 
@@ -8,11 +11,11 @@
   </PropertyGroup>
 
   <!-- Download the runtime package with the crossgen executable in it -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(IsCrossgenSupported)' == 'true'">
     <PackageDownload Include="$(RuntimeNETCrossgenPackageName)" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
   </ItemGroup>
 
-  <Target Name="CrossgenLayout">
+  <Target Name="CrossgenLayout" Condition="'$(IsCrossgenSupported)' == 'true'">
     <PropertyGroup>
       <CrossgenPath>$(NuGetPackageRoot)$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <CreateCrossgenSymbols Condition="'$(CreateCrossgenSymbols)' == ''">true</CreateCrossgenSymbols>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4904

The Crossgen.targets file must be imported because the `GenerateLayout` target depends on the `CrossgenLayout` target in it.