### PR TITLE
Don't reference windowsdesktop from sdk when building source-only

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -61,7 +61,7 @@
     <RepositoryReference Include="symreader" />
     <RepositoryReference Include="templating" />
     <RepositoryReference Include="vstest" />
-    <RepositoryReference Include="windowsdesktop" Condition="'$(TargetOS)' == 'windows'" />
+    <RepositoryReference Include="windowsdesktop" Condition="'$(TargetOS)' == 'windows' and '$(DotNetBuildSourceOnly)' != 'true'" />
     <RepositoryReference Include="xdt" />
   </ItemGroup>
 


### PR DESCRIPTION
... and generating the graph on Windows. I converted our VMR repo dependencies to a mermaid graph when building source-only and the windows UI stack was showing up. That's because the condition doesn't include source-only. Add the condition for correctness.