### PR TITLE
Fix SDKBundleVersion calculation

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateMSIs.targets
+++ b/src/Installer/redist-installer/targets/GenerateMSIs.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <Target Name="SetupWixProperties">
+  <Target Name="SetupWixProperties" DependsOnTargets="GetAssemblyVersion">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
       <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(MicrosoftSignedWixVersion).zip</WixDownloadUrl>
@@ -54,7 +54,6 @@
 
       <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
       <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
-      <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Previously, redist-installer produced an AssemblyInfo.cs file. That isn't the case anymore as the project now uses the Microsoft.Build.NoTargets SDK as it doesn't need to compile anything. Because of that, the `FileVersion` property doesn't get set automatically anymore.

Define a dependency on the `GetAssemblyVersion` target in the SDK to get the `FileVersion` property set in time. Also remove the fallback which doesn't work anymore:

> -SDKBundleVersion '10.0.100.612008

> `warning CNDL1093 : Invalid Bundle/@Version '10.0.100.612008'. Bundle version has a max value of "65535.65535.65535.65535" and must be all numeric. WorkloadManifests.wxs upgradePolicies.wxs`