### PR TITLE
Fix branch trigger for CI builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -5,7 +5,7 @@ trigger:
   branches:
     include:
     - main
-    - release/9.0.3xx
+    - release/10.0.1xx-*
     - internal/release/*
     - exp/*
 


### PR DESCRIPTION
Originally committed via https://github.com/dotnet/sdk/commit/2bd57358496aab562494e96c962be87098a80439 but never got forward ported into main

cc @marcpopMSFT 