### PR TITLE
Ignore .lutconfig files via .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ cmake/
 # Test results
 **/*.trx
 /TestResults
+
+# Live Unit Testing
+*.lutconfig


### PR DESCRIPTION
When running Live Unit Testing in Visual Studio, a *.lutconfig file is automatically generated at the root folder of the repo. These are for personal use only, no need to have them show up in source control.