### PR TITLE
Throw error on PublishContainer when EnableSdkContainerSupport is not true

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -405,7 +405,7 @@
 
   <Target Name="PublishContainer"
   DependsOnTargets="$(PublishContainerDependsOn)"
-  Condition="'$(IsPublishable)' == 'true' AND '$(EnableSdkContainerSupport)' == 'true'">
+  Condition="'$(IsPublishable)' == 'true'">
     <PropertyGroup>
       <_IsMultiTFMBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</_IsMultiTFMBuild>
       <!-- we are multi-RID if:
@@ -424,6 +424,7 @@
     <CallTarget Condition="'$(_IsSingleRIDBuild)' == 'true' " Targets="_PublishSingleContainer" />
 
     <Error Condition="'$(_IsMultiTFMBuild)' == 'true'" Code="CONTAINERS0666" Text="Containers cannot be published for multiple TargetFrameworks at this time. Please specify a TargetFramework." />
+    <Error Condition="'$(EnableSdkContainerSupport)' != 'true'" Code="CONTAINERS0667" Text="Publishing to container requires EnableSdkContainerSupport be set to true." />
   </Target>
 
 </Project>


### PR DESCRIPTION
Currently, the `PublishContainer` `Target` is skipped if `EnableSdkContainerSupport` is not `true`. In some cases this leads to confusing behavior, wherein the publish to container appears successful, with no indication otherwise beyond the lack of an image. In the case of the Microsoft-recommended community tool Aspirate, this is especially problematic as it results in the emitting of deployments that point to non-existent images.

This PR attempts to remedy this by updating `Microsoft.NET.Build.Containers.targets` to throw a new error, `CONTAINERS0667`, in the event of publishing to container when `EnableSdkContainerSupport` is not `true`.