### PR TITLE
Change property used for after-publish target

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.props
@@ -11,9 +11,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <_AfterSdkPublishDependsOn Condition="'$(_IsAspNetCoreProject)' == 'true'">AfterPublish</_AfterSdkPublishDependsOn>
-    <_AfterSdkPublishDependsOn Condition="'$(_IsAspNetCoreProject)' != 'true'">Publish</_AfterSdkPublishDependsOn>
+  <PropertyGroup Condition="'$(_AfterSdkPublishDependsOn)' == ''">
+    <_AfterSdkPublishDependsOn Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">AfterPublish</_AfterSdkPublishDependsOn>
+    <_AfterSdkPublishDependsOn Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'">Publish</_AfterSdkPublishDependsOn>
   </PropertyGroup>
 
   <Target Name="AfterSdkPublish" AfterTargets="$(_AfterSdkPublishDependsOn)"></Target>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -150,11 +150,14 @@ namespace Microsoft.NET.Publish.Tests
                 .Pass();
         }
 
-        [Fact]
-        public void Target_after_AfterSdkPublish_executes()
+        [Theory]
+        [InlineData("Microsoft.NET.Sdk")]
+        [InlineData("Microsoft.NET.Sdk.Web")]
+        public void Target_after_AfterSdkPublish_executes(string sdk)
         {
             var projectChanges = (XDocument doc) =>
             {
+                doc.Root.SetAttributeValue("Sdk", sdk);
                 var ns = doc.Root.Name.Namespace;
                 var target = new XElement("Target");
                 target.ReplaceAttributes(new XAttribute[] { new XAttribute("Name", "AfterAfterSdkPublish"), new XAttribute("AfterTargets", "AfterSdkPublish") });


### PR DESCRIPTION
This is based on feedback [here](https://github.com/dotnet/sdk/pull/36850#issuecomment-2676884372) and [here](https://github.com/dotnet/sdk/issues/26710#issuecomment-2676891024).

It seems that the property used for this for web-based projects is typically set in a target, which means it isn't available at evaulation time. This changes the property used to determine if a project is web-based to one set by importing the web sdk.

Although I think it should not be used in almost any case, it also adds the option of specifying that the target should run after a specified target. If a new project type comes up that has an AfterAfterPublish, for instance, and we want to run this after that, this makes it easy to support that.