### PR TITLE
Enable building sdk tests in the VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
 
-    <!-- Tests are only building on Windows - https://github.com/dotnet/source-build/issues/4882 -->
-    <DotNetBuildTestsOptOut Condition="'$(OS)' != 'Windows_NT'">true</DotNetBuildTestsOptOut>
-
     <BuildArgs Condition="'$(TargetOS)' == 'windows'">$(BuildArgs) -nativeToolsOnMachine</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:PackageProjectUrl=https://github.com/dotnet/sdk</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:PortableRid=$(PortableRid)</BuildArgs>


### PR DESCRIPTION
The underlying issue is now closed.