### PR TITLE
`dotnet sln remove` smart project matching

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -145,7 +145,7 @@
     <value>PROJECT_PATH</value>
   </data>
   <data name="RemoveProjectPathArgumentDescription" xml:space="preserve">
-    <value>The paths to the projects to remove from the solution.</value>
+    <value>The project paths or names to remove from the solution.</value>
   </data>
   <data name="RemoveAppFullName" xml:space="preserve">
     <value>Remove one or more projects from a solution file.</value>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Cesty k projektům, které se mají z řešení odebrat</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Cesty k projektům, které se mají z řešení odebrat</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Die Pfade zu den Projekten, die aus der Projektmappe entfernt werden sollen.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Die Pfade zu den Projekten, die aus der Projektmappe entfernt werden sollen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Rutas de acceso a los proyectos que se van a quitar de la solución.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Rutas de acceso a los proyectos que se van a quitar de la solución.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Chemins aux projets à supprimer de la solution.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Chemins aux projets à supprimer de la solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Percorsi dei progetti da rimuovere dalla soluzione.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Percorsi dei progetti da rimuovere dalla soluzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">ソリューションから削除するプロジェクトへのパス。</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">ソリューションから削除するプロジェクトへのパス。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">솔루션에서 제거할 프로젝트의 경로입니다.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">솔루션에서 제거할 프로젝트의 경로입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Ścieżki do projektów, które mają zostać usunięte z rozwiązania.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Ścieżki do projektów, które mają zostać usunięte z rozwiązania.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Os caminhos dos projetos para remover da solução.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Os caminhos dos projetos para remover da solução.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Пути к проектам, которые необходимо удалить из решения.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Пути к проектам, которые необходимо удалить из решения.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">Çözümden kaldırılacak projelerin yolları.</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">Çözümden kaldırılacak projelerin yolları.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">要从解决方案中移除的项目的路径。</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">要从解决方案中移除的项目的路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -103,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveProjectPathArgumentDescription">
-        <source>The paths to the projects to remove from the solution.</source>
-        <target state="translated">要從解決方案中移除的專案路徑。</target>
+        <source>The project paths or names to remove from the solution.</source>
+        <target state="needs-review-translation">要從解決方案中移除的專案路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectsHeader">

--- a/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnRemove.cs
@@ -19,7 +19,7 @@ Usage:
 
 Arguments:
   <SLN_FILE>        The solution file to operate on. If not specified, the command will search the current directory for one. [default: {PathUtility.EnsureTrailingSlash(defaultVal)}]
-  <PROJECT_PATH>    The paths to the projects to remove from the solution.
+  <PROJECT_PATH>    The project paths or names to remove from the solution.
 
 Options:
   -?, -h, --help    Show command line help.";


### PR DESCRIPTION
Fixes #47111

```bash
dotnet solution remove baz
```

This would find a .csproj file named baz.csproj in the solution, independent of the path to the project. If there is a conflict (aka, multiple baz.csproj files), it would error. Otherwise, it would do the smart thing, find the project defined as foo/bar/baz/baz.csproj and remove it.