### PR TITLE
Add --configfile option to dotnet nuget push command

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -94,6 +94,7 @@ namespace Microsoft.DotNet.Cli
             pushCommand.Options.Add(new CliOption<bool>("--no-service-endpoint"));
             pushCommand.Options.Add(new CliOption<bool>("--interactive"));
             pushCommand.Options.Add(new CliOption<bool>("--skip-duplicate"));
+            pushCommand.Options.Add(new CliOption<string>("--configfile"));
 
             pushCommand.SetAction(NuGetCommand.Run);
 

--- a/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.DotNet.Tests.Commands
         {
             var expected = new[] {
                 "--api-key",
+                "--configfile",
                 "--disable-buffering",
                 "--force-english-output",
                 "--help",


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4879

NuGet is adding the option --configfile to the command dotnet nuget push. This PR adds the option to the command and updates the autocomplete tests.