### PR TITLE
Don't run the VMR Final Join in public rolling/scheduled builds

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -898,7 +898,7 @@ stages:
             - AzureLinux_x64_Cross_Alpine_arm
 
 ### FINAL JOIN ###
-- ${{ if and(parameters.isBuiltFromVmr, not(parameters.isSourceOnlyBuild), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(parameters.isBuiltFromVmr, not(parameters.isSourceOnlyBuild), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: VMR_Final_Join
     displayName: VMR Final Join
     dependsOn: VMR_Vertical_Build


### PR DESCRIPTION
Fixes failures in the dotnet-unified-build (public) scheduled builds, i.e. https://dev.azure.com/dnceng-public/public/_build/results?buildId=963114&view=results