### PR TITLE
Avoid hardcoded path to VMR orchestrator package layout

### DIFF
--- a/src/Installer/redist-installer/Directory.Build.props
+++ b/src/Installer/redist-installer/Directory.Build.props
@@ -38,6 +38,9 @@
        $(Rid.StartsWith('linux-musl'))
       )">true</SkipBuildingInstallers>
 
+    <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
+    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
+
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
     <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'true' AND !$(Rid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>
     <HighEntropyVA>true</HighEntropyVA>

--- a/src/Installer/redist-installer/Directory.Build.targets
+++ b/src/Installer/redist-installer/Directory.Build.targets
@@ -25,7 +25,7 @@
   <Import Project="targets\GenerateBundledVersions.targets" />
   <Import Project="targets\Crossgen.targets" />
   <Import Project="targets\GenerateLayout.targets" />
-  <Import Project="targets\Badge.targets" />
+  <Import Project="targets\Badge.targets" Condition="'$(PgoInstrument)' != 'true'" />
   <Import Project="targets\GenerateArchives.targets" />
 
   <!-- Installers -->

--- a/src/Installer/redist-installer/redist-installer.proj
+++ b/src/Installer/redist-installer/redist-installer.proj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
-    <!-- DotNetBuildOrchestrator is (currently) needed in order to obtain NuGet packages from the runtime build. -->
-    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$(DotNetBuildOrchestrator)' == 'true'">true</BundleNativeAotCompiler>
     <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 

--- a/src/Installer/redist-installer/targets/Badge.targets
+++ b/src/Installer/redist-installer/targets/Badge.targets
@@ -1,13 +1,16 @@
 <Project>
 
-  <PropertyGroup>
-    <VersionSvgTemplate>$(RepoRoot)src\Installer\redist-installer\version_badge.svg</VersionSvgTemplate>
-  </PropertyGroup>
+  <Target Name="GenerateVersionBadge" BeforeTargets="AfterBuild">
+    <PropertyGroup>
+      <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(Rid)' == 'linux-musl-x64'">linux_musl_x64</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(IslinuxPortable)' == 'true'">linux_$(Architecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true'">all_linux_distros_native_installer</VersionBadgeMoniker>
 
-  <Target Name="GenerateVersionBadge"
-          Condition="'$(PgoInstrument)' != 'true'"
-          DependsOnTargets="SetBadgeProps"
-          BeforeTargets="AfterBuild">
+      <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
+      <VersionSvgTemplate>$(MSBuildThisFileDirectory)..\version_badge.svg</VersionSvgTemplate>
+    </PropertyGroup>
+
     <Message Text="$(VersionBadge)" />
 
     <ReplaceFileContents
@@ -15,18 +18,6 @@
       DestinationFiles="$(VersionBadge)"
       ReplacementPatterns="ver_number"
       ReplacementStrings="$(Version)" />
-  </Target>
-
-  <Target Name="SetBadgeProps">
-    <PropertyGroup>
-      <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition=" '$(Rid)' == 'linux-musl-x64' ">linux_musl_x64</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition=" '$(IslinuxPortable)' == 'true' ">linux_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition=" '$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true' ">all_linux_distros_native_installer</VersionBadgeMoniker>
-
-      <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
-      <CoherentBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_coherent_badge.svg</CoherentBadge>
-    </PropertyGroup>
   </Target>
 
 </Project>

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -362,7 +362,7 @@
     </ItemGroup>
 
     <!-- BundledLayoutPackage with SkipExtractPackage=true metadata -->
-    <ItemGroup>
+    <ItemGroup Condition="'@(BundledLayoutPackage->AnyHaveMetadataValue('SkipExtractPackage', 'true'))' == 'true'">
       <BundledUncompressedLayoutPackage Include="@(BundledLayoutPackage->WithMetadataValue('SkipExtractPackage', 'true'))" />
       <BundledUncompressedLayoutPackageFile Include="$(NuGetPackageRoot)\%(BundledUncompressedLayoutPackage.LoweredPackageName)\%(BundledUncompressedLayoutPackage.PackageVersion)\%(BundledUncompressedLayoutPackage.LoweredPackageName).%(BundledUncompressedLayoutPackage.PackageVersion).nupkg"
                                             DestinationPath="$(RedistLayoutPath)%(BundledUncompressedLayoutPackage.RelativeLayoutPath)\%(BundledUncompressedLayoutPackage.PackageName).%(BundledUncompressedLayoutPackage.PackageVersion).nupkg" />

--- a/src/Installer/redist-installer/targets/GenerateLayout.targets
+++ b/src/Installer/redist-installer/targets/GenerateLayout.targets
@@ -75,54 +75,63 @@
 
   <!-- BEGIN: Bundled layout packages -->
   <ItemGroup>
-    <BundledLayoutPackage Include="MicrosoftNetCoreAppTargetingPackNupkg">
-      <PackageName>Microsoft.NETCore.App.Ref</PackageName>
-      <PackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.NETCore.App.Ref"
+      PackageName="Microsoft.NETCore.App.Ref"
+      PackageVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftNetStandardTargetingPackNupkg">
-      <PackageName>NETStandard.Library.Ref</PackageName>
-      <PackageVersion>$(NETStandardLibraryRefPackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="NETStandard.Library.Ref"
+      PackageName="NETStandard.Library.Ref"
+      PackageVersion="$(NETStandardLibraryRefPackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftAspNetCoreAppTargetingPackNupkg">
-      <PackageName>Microsoft.AspNetCore.App.Ref</PackageName>
-      <PackageVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.AspNetCore.App.Ref"
+      PackageName="Microsoft.AspNetCore.App.Ref"
+      PackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftNetCoreAppHostPackNupkg">
-      <PackageName>Microsoft.NETCore.App.Host.$(SharedFrameworkRid)</PackageName>
-      <PackageVersion>$(MicrosoftNETCoreAppHostPackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.NETCore.App.Host.$(SharedFrameworkRid)"
+      PackageName="Microsoft.NETCore.App.Host.$(SharedFrameworkRid)"
+      PackageVersion="$(MicrosoftNETCoreAppHostPackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftNetCoreAppRuntimePackNupkg" Condition="'$(BundleRuntimePacks)' == 'true'">
-      <PackageName>Microsoft.NETCore.App.Runtime.$(SharedFrameworkRid)</PackageName>
-      <PackageVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.NETCore.App.Runtime.$(SharedFrameworkRid)"
+      PackageName="Microsoft.NETCore.App.Runtime.$(SharedFrameworkRid)"
+      Condition="'$(BundleRuntimePacks)' == 'true'"
+      PackageVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftAspNetCoreAppRuntimePackNupkg" Condition="'$(BundleRuntimePacks)' == 'true'">
-      <PackageName>Microsoft.AspNetCore.App.Runtime.$(SharedFrameworkRid)</PackageName>
-      <PackageVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.AspNetCore.App.Runtime.$(SharedFrameworkRid)"
+      PackageName="Microsoft.AspNetCore.App.Runtime.$(SharedFrameworkRid)"
+      Condition="'$(BundleRuntimePacks)' == 'true'"
+      PackageVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftDotNetILCompilerPackNupkg" Condition="'$(BundleNativeAotCompiler)' == 'true'">
-      <PackageName>runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler</PackageName>
-      <PackageVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="Microsoft.WindowsDesktop.App.Ref"
+      PackageName="Microsoft.WindowsDesktop.App.Ref"
+      Condition="'$(IncludeWpfAndWinForms)' != 'false'"
+      PackageVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
-    <BundledLayoutPackage Include="MicrosoftWindowsDesktopAppTargetingPackNupkg"
-                          Condition="'$(IncludeWpfAndWinForms)' != 'false'">
-      <PackageName>Microsoft.WindowsDesktop.App.Ref</PackageName>
-      <PackageVersion>$(MicrosoftWindowsDesktopAppRefPackageVersion)</PackageVersion>
-      <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-    </BundledLayoutPackage>
+    <BundledLayoutPackage Include="runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler"
+      Condition="'$(BundleNativeAotCompiler)' == 'true'"
+      PackageName="runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler"
+      PackageVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
+
+    <BundledLayoutPackage Include="Microsoft.DotNet.ILCompiler"
+      Condition="'$(BundleNativeAotCompiler)' == 'true'"
+      PackageName="Microsoft.DotNet.ILCompiler"
+      PackageVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+      RelativeLayoutPath="library-packs"
+      SkipExtractPackage="true" />
+
+    <BundledLayoutPackage Include="Microsoft.NET.ILLink.Tasks"
+      Condition="'$(BundleNativeAotCompiler)' == 'true'"
+      PackageName="Microsoft.NET.ILLink.Tasks"
+      PackageVersion="$(MicrosoftNETILLinkTasksPackageVersion)"
+      RelativeLayoutPath="library-packs"
+      SkipExtractPackage="true" />
   </ItemGroup>
   <!-- END: Bundled layout packages -->
 
@@ -330,42 +339,39 @@
         <LoweredPackageName>$([MSBuild]::ValueOrDefault('%(BundledLayoutPackage.PackageName)', '').ToLowerInvariant())</LoweredPackageName>
       </BundledLayoutPackage>
 
-      <BundledLayoutPackageDownloadFiles Include="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\**\*.*">
+      <!-- Remove files from the root of the package, as these are either files NuGet writes, or not necessary -->
+      <BundledLayoutPackageDownloadFiles Include="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\**\*.*"
+                                         Exclude="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\*.*"
+                                         Condition="%(BundledLayoutPackage.SkipExtractPackage) != 'true'">
         <RelativeLayoutPath>%(BundledLayoutPackage.RelativeLayoutPath)</RelativeLayoutPath>
         <LayoutPackageDescription>%(BundledLayoutPackage.Identity)</LayoutPackageDescription>
       </BundledLayoutPackageDownloadFiles>
-
-      <!-- Remove files from the root of the package, as these are either files NuGet writes, or not necessary -->
-      <BundledLayoutPackageDownloadFiles Remove="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\*.*" />
 
       <!-- Set destination path in layout -->
       <BundledLayoutPackageDownloadFiles>
         <DestinationPath>%(BundledLayoutPackageDownloadFiles.RecursiveDir)%(BundledLayoutPackageDownloadFiles.Filename)%(BundledLayoutPackageDownloadFiles.Extension)</DestinationPath>
       </BundledLayoutPackageDownloadFiles>
       <BundledLayoutPackageDownloadFiles>
-        <DestinationPath>$(RedistLayoutPath)/%(BundledLayoutPackageDownloadFiles.RelativeLayoutPath)/%(BundledLayoutPackageDownloadFiles.DestinationPath)</DestinationPath>
+        <DestinationPath>$(RedistLayoutPath)%(BundledLayoutPackageDownloadFiles.RelativeLayoutPath)/%(BundledLayoutPackageDownloadFiles.DestinationPath)</DestinationPath>
       </BundledLayoutPackageDownloadFiles>
       <BundledLayoutPackageDownloadFiles>
         <DestinationPath>$([MSBuild]::NormalizePath(%(BundledLayoutPackageDownloadFiles.DestinationPath)))</DestinationPath>
       </BundledLayoutPackageDownloadFiles>
 
-      <!-- Creating a new item here isn't strictly necessary, but makes it easier to see what's going on in the .binlog,
-           since the metadata updates don't show up there -->
       <BundledLayoutPackageDownloadFilesWithDestination Include="@(BundledLayoutPackageDownloadFiles)" />
+    </ItemGroup>
+
+    <!-- BundledLayoutPackage with SkipExtractPackage=true metadata -->
+    <ItemGroup>
+      <BundledUncompressedLayoutPackage Include="@(BundledLayoutPackage->WithMetadataValue('SkipExtractPackage', 'true'))" />
+      <BundledUncompressedLayoutPackageFile Include="$(NuGetPackageRoot)\%(BundledUncompressedLayoutPackage.LoweredPackageName)\%(BundledUncompressedLayoutPackage.PackageVersion)\%(BundledUncompressedLayoutPackage.LoweredPackageName).%(BundledUncompressedLayoutPackage.PackageVersion).nupkg"
+                                            DestinationPath="$(RedistLayoutPath)%(BundledUncompressedLayoutPackage.RelativeLayoutPath)\%(BundledUncompressedLayoutPackage.PackageName).%(BundledUncompressedLayoutPackage.PackageVersion).nupkg" />
+      
+      <BundledLayoutPackageDownloadFilesWithDestination Include="@(BundledUncompressedLayoutPackageFile)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(BundledLayoutPackageDownloadFilesWithDestination)"
           DestinationFiles="@(BundledLayoutPackageDownloadFilesWithDestination->'%(DestinationPath)')"
-          SkipUnchangedFiles="true" />
-
-    <ItemGroup>
-      <BundledLayoutLibraryPackage Include="$(SourceBuiltShippingPackagesDir)/../runtime/Microsoft.DotNet.ILCompiler.$(MicrosoftNETCoreAppRuntimePackageVersion).nupkg;
-                                            $(SourceBuiltShippingPackagesDir)/../runtime/Microsoft.NET.ILLink.Tasks.$(MicrosoftNETILLinkTasksPackageVersion).nupkg"
-                                  Condition="'$(BundleNativeAotCompiler)' == 'true'" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(BundledLayoutLibraryPackage)"
-          DestinationFolder="$(RedistLayoutPath)/library-packs"
           SkipUnchangedFiles="true" />
 
     <!-- https://github.com/dotnet/msbuild/issues/5881#issuecomment-802492423 -->

--- a/src/Installer/redist-installer/version_badge.svg
+++ b/src/Installer/redist-installer/version_badge.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="20">
     <mask id="a">
-        <rect width="200" height="20" rx="0" fill="#fff" />
+        <rect width="240" height="20" rx="0" fill="#fff" />
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h52v20H0z" />
-        <path fill="#007ec6" d="M52 0h148v20H52z" />
-        <path fill="url(#b)" d="M0 0h150v20H0z" />
+        <path fill="#007ec6" d="M52 0h188v20H52z" />
+        <path fill="url(#b)" d="M0 0h190v20H0z" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="26" y="15" fill="#010101" fill-opacity=".3">version</text>
         <text x="26" y="14">version</text>
-        <text x="125" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
-        <text x="125" y="14">ver_number</text>
+        <text x="145" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
+        <text x="145" y="14">ver_number</text>
     </g>
 </svg>

--- a/src/SourceBuild/content/README.md
+++ b/src/SourceBuild/content/README.md
@@ -20,6 +20,13 @@ Similarly, VMR's `main` branch will follow `main` branches of product repositori
 More in-depth documentation about the VMR can be found in [VMR Design And Operation](src/arcade/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#layout).
 See also [dotnet/source-build](https://github.com/dotnet/source-build) for more information about our whole-product source-build.
 
+
+## Installing the SDK
+
+You can download the .NET SDK either as an installer (MSI, PKG) or as an archive (zip, tar.gz). The .NET SDK contains both the .NET runtimes and CLI tools.
+
+- [**Latest builds table**](docs/builds-table.md)
+
 ## Goals
 
 - The main purpose of the [dotnet/dotnet](https://github.com/dotnet/dotnet) repository is to have all source code necessary to build the .NET product available in one repository and identified by a single commit.

--- a/src/SourceBuild/content/docs/builds-table.md
+++ b/src/SourceBuild/content/docs/builds-table.md
@@ -1,0 +1,101 @@
+### Supported Platforms
+
+
+--------------------------------------------------------------------------------------
+| Platform | main<br>(10.0.x&nbsp;Runtime) |
+| :--------- | :----------: |
+| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] |
+| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] |
+| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] |
+| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] |
+| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] |
+| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] |
+| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] |
+| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] |
+
+Reference notes:
+> **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
+> * [Host, Host FX Resolver, and Shared Framework](https://github.com/dotnet/runtime/blob/main/docs/project/dogfooding.md#nightly-builds-table)
+> * [ASP.NET Core Shared Framework](https://github.com/aspnet/AspNetCore/blob/main/docs/DailyBuilds.md)
+
+[win-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_x64_Release_version_badge.svg?no-cache
+[win-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-x64.txt
+[win-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.zip.sha
+
+[win-x86-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_x86_Release_version_badge.svg?no-cache
+[win-x86-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-x86.txt
+[win-x86-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.zip.sha
+
+[osx-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/osx_x64_Release_version_badge.svg?no-cache
+[osx-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-osx-x64.txt
+[osx-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+
+[osx-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/osx_arm64_Release_version_badge.svg?no-cache
+[osx-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+
+[linux-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_x64_Release_version_badge.svg?no-cache
+[linux-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-x64.tar.gz.sha
+
+[linux-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_arm_Release_version_badge.svg?no-cache
+[linux-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-arm.txt
+[linux-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm.tar.gz.sha
+
+[linux-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_arm64_Release_version_badge.svg?no-cache
+[linux-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+
+[rhel-6-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/rhel.6_x64_Release_version_badge.svg?no-cache
+[rhel-6-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+
+[linux-musl-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_x64_Release_version_badge.svg?no-cache
+[linux-musl-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+
+[linux-musl-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_arm_Release_version_badge.svg?no-cache
+[linux-musl-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+
+[linux-musl-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
+[linux-musl-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+
+[win-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_arm_Release_version_badge.svg?no-cache
+[win-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-arm.txt
+[win-arm-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm.zip.sha
+
+[win-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_arm64_Release_version_badge.svg?no-cache
+[win-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-arm64.txt
+[win-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.zip.sha


### PR DESCRIPTION
Correctly implement BundleNativeAotCompiler by restoring the packs via PackageDownload instead of hardcoding the path to the VMR orchestrator layout.

@tmds follow-up on https://github.com/dotnet/sdk/commit/f3ebfb5ccb1ca3b072cee5b8f52a9e1087b2ad11