### PR TITLE
Fix version badge moniker for linux-musl-*

### DIFF
--- a/src/Installer/redist-installer/targets/Badge.targets
+++ b/src/Installer/redist-installer/targets/Badge.targets
@@ -2,10 +2,9 @@
 
   <Target Name="GenerateVersionBadge" BeforeTargets="AfterBuild">
     <PropertyGroup>
-      <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(Rid)' == 'linux-musl-x64'">linux_musl_x64</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(IslinuxPortable)' == 'true'">linux_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true'">all_linux_distros_native_installer</VersionBadgeMoniker>
+      <!-- Replace '-' with '_' for os names like 'linux-musl' -->
+      <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(Architecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(IsLinuxPortable)' == 'true'">linux_$(Architecture)</VersionBadgeMoniker>
 
       <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <VersionSvgTemplate>$(MSBuildThisFileDirectory)..\version_badge.svg</VersionSvgTemplate>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4919

The badge for linux-musl-arm and linux-musl-arm64 isn't produced correctly. See https://github.com/dotnet/sdk/blob/main/documentation/package-table.md and https://github.com/dotnet/dotnet/blob/main/docs/builds-table.md

The previous condition only worked for linux-musl-x64 but not for linux-musl-arm64 and linux-musl-arm that we are also building.

Also remove a dead property