### PR TITLE
Don't scan src dirs for project.assets.json files

### DIFF
--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -27,7 +27,6 @@
           Condition="'$(ReportSbrpUsage)' == 'true'">
     <ItemGroup>
       <ProjectAssetsJsonFile Include="$(ArtifactsDir)**/project.assets.json" />
-      <ProjectAssetsJsonFile Include="$(SrcDir)**/project.assets.json" />
     </ItemGroup>
 
     <WriteSbrpUsageReport SbrpRepoSrcPath="$(SbrpRepoSrcDir)"

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -27,6 +27,7 @@
           Condition="'$(ReportSbrpUsage)' == 'true'">
     <ItemGroup>
       <ProjectAssetsJsonFile Include="$(ArtifactsDir)**/project.assets.json" />
+      <ProjectAssetsJsonFile Include="$(SrcDir)**/artifacts/**/project.assets.json" />
     </ItemGroup>
 
     <WriteSbrpUsageReport SbrpRepoSrcPath="$(SbrpRepoSrcDir)"


### PR DESCRIPTION
Tweak dirs to scan for project.assets.json files to only look in artifacts directories.

This is causing incorrect usage data to be reported from a [single checked in project.asset.json file](https://github.com/dotnet/dotnet/blob/main/src/nuget-client/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/compiler/resources/project.assets.json)