### PR TITLE
Skip CanIgnoreTemplateGroupsWithConstraints

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
@@ -441,6 +441,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Linux, "https://github.com/dotnet/sdk/issues/46212")]
         public void CanIgnoreTemplateGroupsWithConstraints()
         {
             MockTemplateInfo template1 = new MockTemplateInfo("foo1", identity: "foo.1")


### PR DESCRIPTION
This test has been failing flakily with fairly high regularity, but I've almost always seen it fail on linux. Skipping on just linux for now