### PR TITLE
Suppress welcome message with get* builds Fixes #38444

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Configurer
         private readonly IFileSentinel _toolPathSentinel;
         private readonly IEnvironmentPath _pathAdder;
         private readonly Dictionary<string, double> _performanceMeasurements;
+        private readonly bool _skipFirstTimeUseCheck;
 
         public DotnetFirstTimeUseConfigurer(
             IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel,
@@ -25,7 +26,8 @@ namespace Microsoft.DotNet.Configurer
             DotnetFirstRunConfiguration dotnetFirstRunConfiguration,
             IReporter reporter,
             IEnvironmentPath pathAdder,
-            Dictionary<string, double> performanceMeasurements = null)
+            Dictionary<string, double> performanceMeasurements = null,
+            bool skipFirstTimeUseCheck = false)
         {
             _firstTimeUseNoticeSentinel = firstTimeUseNoticeSentinel;
             _aspNetCertificateSentinel = aspNetCertificateSentinel;
@@ -35,6 +37,7 @@ namespace Microsoft.DotNet.Configurer
             _reporter = reporter;
             _pathAdder = pathAdder ?? throw new ArgumentNullException(nameof(pathAdder));
             _performanceMeasurements ??= performanceMeasurements;
+            _skipFirstTimeUseCheck = skipFirstTimeUseCheck;
         }
 
         public void Configure()
@@ -48,7 +51,7 @@ namespace Microsoft.DotNet.Configurer
                 }
             }
 
-            var isFirstTimeUse = !_firstTimeUseNoticeSentinel.Exists();
+            var isFirstTimeUse = !_skipFirstTimeUseCheck && !_firstTimeUseNoticeSentinel.Exists();
             var canShowFirstUseMessages = isFirstTimeUse && !_dotnetFirstRunConfiguration.NoLogo;
             if (isFirstTimeUse)
             {

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -194,6 +194,11 @@ namespace Microsoft.DotNet.Cli
                         nologo: nologo,
                         skipWorkloadIntegrityCheck: skipWorkloadIntegrityCheck);
 
+                    var getStarOptionPassed = parseResult.CommandResult.Tokens.Any(t =>
+                        t.Value.Contains("getProperty", StringComparison.OrdinalIgnoreCase) ||
+                        t.Value.Contains("getItem", StringComparison.OrdinalIgnoreCase) ||
+                        t.Value.Contains("getTargetResult", StringComparison.OrdinalIgnoreCase));
+
                     ConfigureDotNetForFirstTimeUse(
                         firstTimeUseNoticeSentinel,
                         aspNetCertificateSentinel,
@@ -201,7 +206,8 @@ namespace Microsoft.DotNet.Cli
                         isDotnetBeingInvokedFromNativeInstaller,
                         dotnetFirstRunConfiguration,
                         environmentProvider,
-                        performanceData);
+                        performanceData,
+                        skipFirstTimeUseCheck: getStarOptionPassed);
                     PerformanceLogEventSource.Log.FirstTimeConfigurationStop();
                 }
 
@@ -318,9 +324,10 @@ namespace Microsoft.DotNet.Cli
            bool isDotnetBeingInvokedFromNativeInstaller,
            DotnetFirstRunConfiguration dotnetFirstRunConfiguration,
            IEnvironmentProvider environmentProvider,
-           Dictionary<string, double> performanceMeasurements)
+           Dictionary<string, double> performanceMeasurements,
+           bool skipFirstTimeUseCheck)
         {
-            var isFirstTimeUse = !firstTimeUseNoticeSentinel.Exists();
+            var isFirstTimeUse = !firstTimeUseNoticeSentinel.Exists() && !skipFirstTimeUseCheck;
             var environmentPath = EnvironmentPathFactory.CreateEnvironmentPath(isDotnetBeingInvokedFromNativeInstaller, environmentProvider);
             var commandFactory = new DotNetCommandFactory(alwaysRunOutOfProc: true);
             var aspnetCertificateGenerator = new AspNetCoreCertificateGenerator();
@@ -333,7 +340,8 @@ namespace Microsoft.DotNet.Cli
                 dotnetFirstRunConfiguration,
                 reporter,
                 environmentPath,
-                performanceMeasurements);
+                performanceMeasurements,
+                skipFirstTimeUseCheck: skipFirstTimeUseCheck);
 
             dotnetConfigurer.Configure();
 

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -194,10 +194,11 @@ namespace Microsoft.DotNet.Cli
                         nologo: nologo,
                         skipWorkloadIntegrityCheck: skipWorkloadIntegrityCheck);
 
+                    string[] getStarOperators = ["getProperty", "getItem", "getTargetResult"];
+                    char[] switchIndicators = ['-', '/'];
                     var getStarOptionPassed = parseResult.CommandResult.Tokens.Any(t =>
-                        t.Value.Contains("getProperty", StringComparison.OrdinalIgnoreCase) ||
-                        t.Value.Contains("getItem", StringComparison.OrdinalIgnoreCase) ||
-                        t.Value.Contains("getTargetResult", StringComparison.OrdinalIgnoreCase));
+                        getStarOperators.Any(o =>
+                        switchIndicators.Any(i => t.Value.StartsWith(i + o, StringComparison.OrdinalIgnoreCase))));
 
                     ConfigureDotNetForFirstTimeUse(
                         firstTimeUseNoticeSentinel,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/38444

This looks at the parseResult and scans it for any of the get* operators: getProperty, getItem, or getTargetResult. If it finds any of them (via string checks), it defers the first use message for the next operation. As the output from get* operators is often parsed, this dramatically simplifies that parsing.

This is the result when calling `dotnet build -getProperty:TargetFramework` followed by another command that would normally print the welcome message:

![image](https://github.com/user-attachments/assets/526a7829-486b-427e-a6d8-baef4ae4b624)


Notice that the welcome message is still shown (and continues below the screenshot) but does not appear in the part often parsed.