### PR TITLE
Update to clarify the first tuesday branding date

### DIFF
--- a/documentation/project-docs/SDK-PR-guide.md
+++ b/documentation/project-docs/SDK-PR-guide.md
@@ -26,8 +26,7 @@ After the minor release locks down, it transitions into servicing / "QB" (Quarte
 ### Servicing releases
 The .NET SDK has monthly servicing releases (e.g.`7.0.100` VS `7.0.101`) aligning with the .NET Runtime servicing releases. These are for top fixes and security updates only to limit risk.
 Any servicing release is open for check-ins from the day the [branding PRs](https://github.com/dotnet/sdk/pulls?q=is%3Apr+branding) are merged (~1st Tuesday of each month) and when code complete is (typically two weeks later).
-The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. We use the `Branch Lockdown` label to mark PRs that should go into the next servicing release but the branch is currently not open. Final signoffs are typically in the last week of each month. We have a workflow that will automatically mark any PR targeting a servicing branch outside of the first to third tuesday window: https://github.com/dotnet/sdk/blob/main/.github/workflows/add-lockdown-label.yml
-
+The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. We use the `Branch Lockdown` label to mark PRs that should go into the next servicing release but the branch is currently not open. Final signoffs are typically in the last week of each month. We have a workflow that will automatically mark any PR targeting a servicing branch outside of the first to third Tuesday window: https://github.com/dotnet/sdk/blob/main/.github/workflows/add-lockdown-label.yml
 ### Schedule
 | Release Type | Frequency    | Lockdown Release  | Branch Open | Lockdown Date (estimate) |
 | -------------|--------------|-------------------|-------------|--------------------------|

--- a/documentation/project-docs/SDK-PR-guide.md
+++ b/documentation/project-docs/SDK-PR-guide.md
@@ -25,15 +25,15 @@ After the minor release locks down, it transitions into servicing / "QB" (Quarte
 
 ### Servicing releases
 The .NET SDK has monthly servicing releases (e.g.`7.0.100` VS `7.0.101`) aligning with the .NET Runtime servicing releases. These are for top fixes and security updates only to limit risk.
-Any servicing release is open for check-ins from the day the [branding PRs](https://github.com/dotnet/sdk/pulls?q=is%3Apr+branding) are merged (~1st of each month) and when code complete is (typically two weeks later).
-The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. We use the `Branch Lockdown` label to mark PRs that should go into the next servicing release but the branch is currently not open. Final signoffs are typically in the last week of each month.
+Any servicing release is open for check-ins from the day the [branding PRs](https://github.com/dotnet/sdk/pulls?q=is%3Apr+branding) are merged (~1st Tuesday of each month) and when code complete is (typically two weeks later).
+The servicing branches are locked from the time of code complete to the next branding in case we need to respin any monthly release. We use the `Branch Lockdown` label to mark PRs that should go into the next servicing release but the branch is currently not open. Final signoffs are typically in the last week of each month. We have a workflow that will automatically mark any PR targeting a servicing branch outside of the first to third tuesday window: https://github.com/dotnet/sdk/blob/main/.github/workflows/add-lockdown-label.yml
 
 ### Schedule
 | Release Type | Frequency    | Lockdown Release  | Branch Open | Lockdown Date (estimate) |
 | -------------|--------------|-------------------|-------------|--------------------------|
 | Major        | Yearly (Nov) | RC2               | ~August     | Mid-September            |
 | Minor        | Quarterly    | Preview 3         | ~Prior release Preview 3 date | End of the month prior to Preview 3 (~7 weeks prior to release) |
-| Servicing    | Monthly      | N/A               | After branding, ~1st of the month | Third Tuesday of prior month (signoff is ~28th of each month) |
+| Servicing    | Monthly      | N/A               | After branding, ~1st Tuesday of the prior month | Third Tuesday of prior month (signoff is ~28th of each month) |
 
 ### Tactics approval
 Even releases that are in lockdown can still take changes as long as they are approved and the final build isn't complete. To bring a change through tactics, mark it with the label `servicing-consider` and update the description to include 5 sections (Description, Customer Impact, Regression?, Risk, Testing). See previously approved bugs for examples by looking for the [servicing-approved](https://github.com/dotnet/sdk/pulls?q=is%3Apr+label%3AServicing-approved+is%3Aclosed) label.


### PR DESCRIPTION
The text previously said the first of the month as that was an estimate at the time. Since then, it's been pretty consistent that we do branding the week before release so the first Tuesday of the month specifically.