### PR TITLE
Add HttpResults to the ImplicitUsings of ASP.NET Core projects so TypedResults/Results<T1,T2> don't need an explicit using

### DIFF
--- a/src/WebSdk/Web/Targets/Sdk.Server.props
+++ b/src/WebSdk/Web/Targets/Sdk.Server.props
@@ -66,6 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Using Include="Microsoft.AspNetCore.Builder" />
     <Using Include="Microsoft.AspNetCore.Hosting" />
     <Using Include="Microsoft.AspNetCore.Http" />
+    <Using Include="Microsoft.AspNetCore.Http.HttpResults" />
     <Using Include="Microsoft.AspNetCore.Routing" />
     <Using Include="Microsoft.Extensions.Configuration" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_WebApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateGlobalUsings_WebApp.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NET.Build.Tests
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.AspNetCore.Http;
+global using Microsoft.AspNetCore.HttpResults;
 global using Microsoft.AspNetCore.Routing;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
This issue is related to https://github.com/dotnet/aspnetcore/pull/60337, in which we enrich the `webapiaot` template with OpenAPI by default, which can be disabled with `--no-openapi`. In order to write endpoints with correct OpenAPI metadata, `TypedResults` and `Results<T1,T2>` are used, which are part of the `Microsoft.AspNetCore.Http.HttpResults` namespace.

The build of the mentioned PR failed because the usings for the mentioned types were not available. While researching this, I found out that this is because `ImplicitUsings` for ASP.NET Core projects doesn't add these types.

There are 2 options:

- Require every (new) project to add the `HttpResults` namespace with an explicit using
  - And to every file when endpoints are later on separated by files and `TypedResults` are used.
- Add `Microsoft.AspNetCore.Http.HttpResults` to the list of usings that should be globally added when `ImplicitUsings` is enabled, which is what this PR does. This prevents a bit of "`using` pollution", and is therefore (in my opinion) the preferred approach