### PR TITLE
Revert "Use pipeline artifacts for final artifacts"

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -921,9 +921,9 @@ stages:
           artifact: AssetManifests
           displayName: Publish Merged Manifest
           sbomEnabled: false
-        - output: pipelineArtifact
-          path: $(Build.ArtifactStagingDirectory)/artifacts/assets
-          artifact: BlobArtifacts
+        - output: buildArtifacts
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/assets
+          ArtifactName: BlobArtifacts
           displayName: Publish Blob Artifacts
           sbomEnabled: false
         - output: pipelineArtifact
@@ -965,7 +965,7 @@ stages:
           artifactName: PackageArtifacts
           continueOnError: true
           OS: Windows_NT
-    
+
     - job: ValidateSigning_Mac
       displayName: Validate Signing - Mac
       pool: ${{ parameters.pool_Mac }}


### PR DESCRIPTION
This reverts part of commit 15e448cb4df1ae08ebadf624580f95fa27a21a65.

Unfortunately, the final push to BAR will attempt to generate the merged manifest to put in BlobArtifacts. Meaning that if we use pipeline artifacts for it, we can't upload to BAR, it will fail. Switch back to build artifacts for blobArtifacts. leave for pipeline and asset manifests.