### PR TITLE
Ensure container generation uniformly reports outputs to MSBuild

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -107,9 +107,11 @@ internal sealed class ImageBuilder
         _baseImageConfig.AddLayer(l);
     }
 
-    internal void AddBaseImageDigestLabel()
+    internal (string name, string value) AddBaseImageDigestLabel()
     {
-        AddLabel("org.opencontainers.image.base.digest", _baseImageManifest.GetDigest());
+        var label = ("org.opencontainers.image.base.digest", _baseImageManifest.GetDigest());
+        AddLabel(label.Item1, label.Item2);
+        return label;
     }
 
     /// <summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -261,6 +261,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get 
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedDigestLabel.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedDigestLabel.set -> void
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.set -> void

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -94,6 +94,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get 
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedDigestLabel.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedDigestLabel.set -> void
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolName.get -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateCommandLineCommands() -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateFullPathToTool() -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -192,6 +192,9 @@ partial class CreateNewImage
     [Output]
     public ITaskItem[] GeneratedContainerNames { get; set; }
 
+    [Output]
+    public ITaskItem? GeneratedDigestLabel { get; set; }
+
     public CreateNewImage()
     {
         ContainerizeDirectory = "";
@@ -227,6 +230,7 @@ partial class CreateNewImage
         GeneratedArchiveOutputPath = "";
         GeneratedContainerMediaType = "";
         GeneratedContainerNames = Array.Empty<ITaskItem>();
+        GeneratedDigestLabel = null;
 
         GenerateLabels = false;
         GenerateDigestLabel = false;

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -240,7 +240,7 @@
   </Target>
 
   <Target Name="_PublishSingleContainer"
-          Returns="@(GeneratedContainers)">
+          Returns="@(GeneratedContainer)">
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
       <DotNetHostDirectory>$(NetCoreRoot)</DotNetHostDirectory>
       <DotNetHostFileName>dotnet</DotNetHostFileName>
@@ -287,23 +287,23 @@
     </CreateNewImage>
 
     <ItemGroup>
-      <GeneratedContainers Include="GeneratedContainer">
+      <GeneratedContainer Include="GeneratedContainer">
         <Manifest>$(GeneratedContainerManifest)</Manifest>
         <Configuration>$(GeneratedContainerConfiguration)</Configuration>
         <ManifestDigest>$(GeneratedContainerDigest)</ManifestDigest>
         <ManifestMediaType>$(GeneratedContainerMediaType)</ManifestMediaType>
-      </GeneratedContainers>
+      </GeneratedContainer>
     </ItemGroup>
   </Target>
 
-  <Target Name="_PublishMultiArchContainers" DependsOnTargets="$(PublishContainerDependsOn)" >
+  <Target Name="_PublishMultiArchContainers" DependsOnTargets="$(PublishContainerDependsOn)" Returns="@(GeneratedContainer)" >
     <PropertyGroup>
       <!--We want to skip publishing individual images in case of multi-arch tarball publishing or local daemon (only docker) publishing because all images are published in one tarball.-->
       <!--We don't want to skip publishing individual images in case of remote registry because the individual images should be available in the registry before image index is pushed.-->
       <!--We don't want to skip publishing individual images in case of local daemon podman because podman loads multi-arch tarball differently - only individual image for the current platform.-->
       <_SkipContainerPublishing>false</_SkipContainerPublishing>
       <_SkipContainerPublishing Condition="$(ContainerArchiveOutputPath) != '' or ( $(ContainerRegistry) == '' and ( $(LocalRegistry) == '' or $(LocalRegistry) == 'Docker' ) )">true</_SkipContainerPublishing>
-    
+
       <!--We want to skip CreateImageIndex task in case of local daemon podman because it is not supported.-->
       <_SkipCreateImageIndex>false</_SkipCreateImageIndex>
       <_SkipCreateImageIndex Condition="$(ContainerArchiveOutputPath) == '' and $(ContainerRegistry) == '' and $(LocalRegistry) == 'Podman'">true</_SkipCreateImageIndex>
@@ -346,11 +346,11 @@
         Projects="@(_InnerBuild)"
         Targets="Publish;_ParseItemsForPublishingSingleContainer;_PublishSingleContainer"
         BuildInParallel="true">
-        <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainers" />
+        <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />
     </MSBuild>
 
     <CreateImageIndex Condition="'$(_SkipCreateImageIndex)' == 'false' "
-                      GeneratedContainers="@(GeneratedContainers)"
+                      GeneratedContainers="@(GeneratedContainer)"
                       LocalRegistry="$(LocalRegistry)"
                       OutputRegistry="$(ContainerRegistry)"
                       ArchiveOutputPath="$(ContainerArchiveOutputPath)"
@@ -403,7 +403,9 @@
 
   <Target Name="PublishContainer"
   DependsOnTargets="$(PublishContainerDependsOn)"
-  Condition="'$(IsPublishable)' == 'true' AND '$(EnableSdkContainerSupport)' == 'true'">
+  Condition="'$(IsPublishable)' == 'true' AND '$(EnableSdkContainerSupport)' == 'true'"
+  Returns="@(GeneratedContainer)"
+  >
     <PropertyGroup>
       <_IsMultiTFMBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</_IsMultiTFMBuild>
       <!-- we are multi-RID if:
@@ -418,8 +420,12 @@
     </PropertyGroup>
 
     <!-- Call _PublishMultiArchContainers if we are in a multi-rid build, and call _PublishSingleContainer if we are in a single-RID build -->
-    <CallTarget Condition="'$(_IsMultiRIDBuild)' == 'true' " Targets="_PublishMultiArchContainers" />
-    <CallTarget Condition="'$(_IsSingleRIDBuild)' == 'true' " Targets="_PublishSingleContainer" />
+    <CallTarget Condition="'$(_IsMultiRIDBuild)' == 'true' " Targets="_PublishMultiArchContainers">
+      <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />
+    </CallTarget>
+    <CallTarget Condition="'$(_IsSingleRIDBuild)' == 'true' " Targets="_PublishSingleContainer">
+      <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />
+    </CallTarget>
 
     <Error Condition="'$(_IsMultiTFMBuild)' == 'true'" Code="CONTAINERS0666" Text="Containers cannot be published for multiple TargetFrameworks at this time. Please specify a TargetFramework." />
   </Target>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -284,6 +284,7 @@
       <Output TaskParameter="GeneratedArchiveOutputPath" PropertyName="GeneratedArchiveOutputPath" />
       <Output TaskParameter="GeneratedContainerMediaType" PropertyName="GeneratedContainerMediaType" />
       <Output TaskParameter="GeneratedContainerNames" ItemName="GeneratedContainerName" />
+      <Output TaskParameter="GeneratedDigestLabel" ItemName="ContainerLabel" />
     </CreateNewImage>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/622.

Adds Returns to the single- and multi-arch container Targets so that regardless of how many containers are created consumers can get the whole list.

Adds an output of the generated container base image digest Label to the CreateNewImage Task so that the `ContainerLabel` itemgroup is updated after the Task is completed.