### PR TITLE
Remove the `xliff-tasks` VMR mapping

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -174,16 +174,6 @@
             "defaultRemote": "https://github.com/dotnet/xdt"
         },
         {
-            // TODO: Remove the xliff-tasks mapping once the synchronization flags it as unused
-            // We no longer synchronize it but we can't remove it yet until
-            // it disappears from all of the Version.Details.xml files.
-            // https://github.com/dotnet/source-build/issues/4359
-            "name": "xliff-tasks",
-            "defaultRemote": "https://github.com/dotnet/xliff-tasks",
-            "ignoreDefaults": true,
-            "exclude": [ "**/*" ]
-        },
-        {
             "name": "winforms",
             "defaultRemote": "https://github.com/dotnet/winforms",
             "exclude": [


### PR DESCRIPTION
It was only kept there because it was referenced in `Version.Details.xml` of one of the repos

https://github.com/dotnet/source-build/issues/4359