### PR TITLE
Move branding information to targets file

### DIFF
--- a/src/Installer/redist-installer/Directory.Build.props
+++ b/src/Installer/redist-installer/Directory.Build.props
@@ -3,19 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <SdkBrandName>Microsoft .NET SDK $(Version)</SdkBrandName>
-    <ToolsetBrandName>Microsoft .NET Toolset $(Version)</ToolsetBrandName>
-    <SharedFrameworkBrandName>Microsoft .NET Runtime $(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkBrandName>
-    <NetCoreAppTargetingPackBrandName>Microsoft .NET Targeting Pack $(MicrosoftNETCoreAppRefPackageVersion)</NetCoreAppTargetingPackBrandName>
-    <NetStandardTargetingPackBrandName>Microsoft .NET Standard 2.1 Targeting Pack $(NETStandardLibraryRefPackageVersion)</NetStandardTargetingPackBrandName>
-    <NetCoreAppHostPackBrandName>Microsoft .NET AppHost Pack $(MicrosoftNETCoreAppHostHostPackageVersion)</NetCoreAppHostPackBrandName>
-    <SharedHostBrandName>Microsoft .NET Host $(SharedHostVersion)</SharedHostBrandName>
-    <HostFxrBrandName>Microsoft .NET Host FX Resolver $(HostFxrVersion)</HostFxrBrandName>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
-    <SharedFrameworkNugetName>$(SharedFrameworkName)</SharedFrameworkNugetName>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <OSName Condition="'$(OSName)' == '' AND $(Rid) != ''">$(Rid.Substring(0, $(Rid.LastIndexOf('-'))))</OSName>
     <OSName Condition="'$(OSName)' == ''">$(HostOSName)</OSName>
     <PortableOSName Condition=" '$(PortableOSName)' == '' ">$(OSName)</PortableOSName>

--- a/src/Installer/redist-installer/Directory.Build.targets
+++ b/src/Installer/redist-installer/Directory.Build.targets
@@ -3,6 +3,19 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <SdkBrandName>Microsoft .NET SDK $(Version)</SdkBrandName>
+    <ToolsetBrandName>Microsoft .NET Toolset $(Version)</ToolsetBrandName>
+    <SharedFrameworkBrandName>Microsoft .NET Runtime $(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkBrandName>
+    <NetCoreAppTargetingPackBrandName>Microsoft .NET Targeting Pack $(MicrosoftNETCoreAppRefPackageVersion)</NetCoreAppTargetingPackBrandName>
+    <NetStandardTargetingPackBrandName>Microsoft .NET Standard 2.1 Targeting Pack $(NETStandardLibraryRefPackageVersion)</NetStandardTargetingPackBrandName>
+    <NetCoreAppHostPackBrandName>Microsoft .NET AppHost Pack $(MicrosoftNETCoreAppHostHostPackageVersion)</NetCoreAppHostPackBrandName>
+    <SharedHostBrandName>Microsoft .NET Host $(SharedHostVersion)</SharedHostBrandName>
+    <HostFxrBrandName>Microsoft .NET Host FX Resolver $(HostFxrVersion)</HostFxrBrandName>
+    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
+    <SharedFrameworkNugetName>$(SharedFrameworkName)</SharedFrameworkNugetName>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <RedistLayoutPath>$(OutputPath)dotnet\</RedistLayoutPath>
     <SdkInternalLayoutPath>$(OutputPath)i\</SdkInternalLayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47080

The Version property defined by Arcade is only available in .targets files. Move all the branding properties to D.B.targets.