### PR TITLE
Simplify reused artifact download for VMR builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -335,7 +335,7 @@ jobs:
           inputs:
             artifactName: ${{ reuseBuildArtifacts }}_Artifacts
             targetPath: $(sourcesPath)/artifacts/
-            displayName: Download Previous Build (${{ reuseBuildArtifacts }})
+          displayName: Download Previous Build (${{ reuseBuildArtifacts }})
 
   - ${{ if eq(parameters.withPreviousSDK, 'true') }}:
     - script: |

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -331,16 +331,11 @@ jobs:
             TargetFolder: $(sourcesPath)/prereqs/packages/archive/
 
       - ${{ else }}:
-        - download: current
-          artifact: ${{ reuseBuildArtifacts }}_Artifacts
-          displayName: Download Previous Build (${{ reuseBuildArtifacts }})
-
-        - task: CopyFiles@2
-          displayName: Copy Previous Build (${{ reuseBuildArtifacts }})
+        - task: DownloadPipelineArtifact@2
           inputs:
-            SourceFolder: $(Pipeline.Workspace)/${{ reuseBuildArtifacts }}_Artifacts/
-            OverWrite: false
-            TargetFolder: $(sourcesPath)/artifacts/
+            artifactName: ${{ reuseBuildArtifacts }}_Artifacts
+            targetPath: $(sourcesPath)/artifacts/
+            displayName: Download Previous Build (${{ reuseBuildArtifacts }})
 
   - ${{ if eq(parameters.withPreviousSDK, 'true') }}:
     - script: |


### PR DESCRIPTION
Instead of downloading and then copying all of the assets from previous builds, just directly download them to the correct folder.