### PR TITLE
Update builds table in VMR and SDK

### DIFF
--- a/documentation/package-table.md
+++ b/documentation/package-table.md
@@ -6,7 +6,7 @@
 | **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-10.0.1XX-preview2]][win-x64-version-10.0.1XX-preview2]<br>[Installer][win-x64-installer-10.0.1XX-preview2] - [Checksum][win-x64-installer-checksum-10.0.1XX-preview2]<br>[zip][win-x64-zip-10.0.1XX-preview2] - [Checksum][win-x64-zip-checksum-10.0.1XX-preview2] | [![][win-x64-badge-9.0.3XX]][win-x64-version-9.0.3XX]<br>[Installer][win-x64-installer-9.0.3XX] - [Checksum][win-x64-installer-checksum-9.0.3XX]<br>[zip][win-x64-zip-9.0.3XX] - [Checksum][win-x64-zip-checksum-9.0.3XX] |
 | **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-10.0.1XX-preview2]][win-x86-version-10.0.1XX-preview2]<br>[Installer][win-x86-installer-10.0.1XX-preview2] - [Checksum][win-x86-installer-checksum-10.0.1XX-preview2]<br>[zip][win-x86-zip-10.0.1XX-preview2] - [Checksum][win-x86-zip-checksum-10.0.1XX-preview2] | [![][win-x86-badge-9.0.3XX]][win-x86-version-9.0.3XX]<br>[Installer][win-x86-installer-9.0.3XX] - [Checksum][win-x86-installer-checksum-9.0.3XX]<br>[zip][win-x86-zip-9.0.3XX] - [Checksum][win-x86-zip-checksum-9.0.3XX] |
 | **Windows arm** | **N/A** | **N/A** | **N/A** |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-10.0.1XX-preview2]][win-arm64-version-10.0.1XX-preview2]<br>[Installer][win-arm64-installer-10.0.1XX-preview2] - [Checksum][win-arm64-installer-checksum-10.0.1XX-preview2]<br>[zip][win-arm64-zip-10.0.1XX-preview2] | [![][win-arm64-badge-9.0.3XX]][win-arm64-version-9.0.3XX]<br>[Installer][win-arm64-installer-9.0.3XX] - [Checksum][win-arm64-installer-checksum-9.0.3XX]<br>[zip][win-arm64-zip-9.0.3XX] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] - [Checksum][win-arm64-zip-checksum-main] | [![][win-arm64-badge-10.0.1XX-preview2]][win-arm64-version-10.0.1XX-preview2]<br>[Installer][win-arm64-installer-10.0.1XX-preview2] - [Checksum][win-arm64-installer-checksum-10.0.1XX-preview2]<br>[zip][win-arm64-zip-10.0.1XX-preview2] | [![][win-arm64-badge-9.0.3XX]][win-arm64-version-9.0.3XX]<br>[Installer][win-arm64-installer-9.0.3XX] - [Checksum][win-arm64-installer-checksum-9.0.3XX]<br>[zip][win-arm64-zip-9.0.3XX] |
 | **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-10.0.1XX-preview2]][osx-x64-version-10.0.1XX-preview2]<br>[Installer][osx-x64-installer-10.0.1XX-preview2] - [Checksum][osx-x64-installer-checksum-10.0.1XX-preview2]<br>[tar.gz][osx-x64-targz-10.0.1XX-preview2] - [Checksum][osx-x64-targz-checksum-10.0.1XX-preview2] | [![][osx-x64-badge-9.0.3XX]][osx-x64-version-9.0.3XX]<br>[Installer][osx-x64-installer-9.0.3XX] - [Checksum][osx-x64-installer-checksum-9.0.3XX]<br>[tar.gz][osx-x64-targz-9.0.3XX] - [Checksum][osx-x64-targz-checksum-9.0.3XX] |
 | **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-10.0.1XX-preview2]][osx-arm64-version-10.0.1XX-preview2]<br>[Installer][osx-arm64-installer-10.0.1XX-preview2] - [Checksum][osx-arm64-installer-checksum-10.0.1XX-preview2]<br>[tar.gz][osx-arm64-targz-10.0.1XX-preview2] - [Checksum][osx-arm64-targz-checksum-10.0.1XX-preview2] | [![][osx-arm64-badge-9.0.3XX]][osx-arm64-version-9.0.3XX]<br>[Installer][osx-arm64-installer-9.0.3XX] - [Checksum][osx-arm64-installer-checksum-9.0.3XX]<br>[tar.gz][osx-arm64-targz-9.0.3XX] - [Checksum][osx-arm64-targz-checksum-9.0.3XX] |
 | **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-10.0.1XX-preview2]][linux-version-10.0.1XX-preview2]<br>[DEB Installer][linux-DEB-installer-10.0.1XX-preview2] - [Checksum][linux-DEB-installer-checksum-10.0.1XX-preview2]<br>[RPM Installer][linux-RPM-installer-10.0.1XX-preview2] - [Checksum][linux-RPM-installer-checksum-10.0.1XX-preview2]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-10.0.1XX-preview2] - [Checksum][linux-targz-checksum-10.0.1XX-preview2] | [![][linux-badge-9.0.3XX]][linux-version-9.0.3XX]<br>[DEB Installer][linux-DEB-installer-9.0.3XX] - [Checksum][linux-DEB-installer-checksum-9.0.3XX]<br>[RPM Installer][linux-RPM-installer-9.0.3XX] - [Checksum][linux-RPM-installer-checksum-9.0.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-9.0.3XX] - [Checksum][linux-targz-checksum-9.0.3XX] |
@@ -25,236 +25,236 @@ Reference notes:
 [win-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-win-x64.txt
 [win-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.exe.sha512
 [win-x64-zip-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x64.zip.sha512
 
 [win-x64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-win-x64.txt
 [win-x64-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.exe.sha512
 [win-x64-zip-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x64.zip.sha512
 
 [win-x64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-win-x64.txt
 [win-x64-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.exe.sha512
 [win-x64-zip-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x64.zip.sha512
 
 [win-x86-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-win-x86.txt
 [win-x86-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.exe.sha512
 [win-x86-zip-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-x86.zip.sha512
 
 [win-x86-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-win-x86.txt
 [win-x86-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.exe.sha512
 [win-x86-zip-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-x86.zip.sha512
 
 [win-x86-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-win-x86.txt
 [win-x86-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.exe.sha512
 [win-x86-zip-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-x86.zip.sha512
 
 [osx-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-osx-x64.txt
 [osx-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha512
 [osx-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha512
 
 [osx-x64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-osx-x64.txt
 [osx-x64-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.sha512
 [osx-x64-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha512
 
 [osx-x64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-osx-x64.txt
 [osx-x64-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.pkg.sha512
 [osx-x64-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha512
 
 [osx-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-osx-arm64.txt
 [osx-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha512
 [osx-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha512
 
 [osx-arm64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-osx-arm64.txt
 [osx-arm64-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.sha512
 [osx-arm64-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha512
 
 [osx-arm64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-osx-arm64.txt
 [osx-arm64-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.sha512
 [osx-arm64-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha512
 
 [linux-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-x64.txt
 [linux-DEB-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.deb.sha
+[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.deb.sha512
 [linux-RPM-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.rpm.sha
+[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-x64.rpm.sha512
 [linux-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
 [linux-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-x64.txt
 [linux-DEB-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.deb.sha
+[linux-DEB-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.deb.sha512
 [linux-RPM-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.rpm.sha
+[linux-RPM-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-x64.rpm.sha512
 [linux-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
 [linux-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-x64.txt
 [linux-DEB-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.deb.sha
+[linux-DEB-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.deb.sha512
 [linux-RPM-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.rpm.sha
+[linux-RPM-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-x64.rpm.sha512
 [linux-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
 [linux-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-arm.txt
 [linux-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
 [linux-arm-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-arm.txt
 [linux-arm-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
 [linux-arm-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-arm.txt
 [linux-arm-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
 [linux-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-arm64.txt
 [linux-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
 [linux-arm64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-arm64.txt
 [linux-arm64-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
 [linux-arm64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-arm64.txt
 [linux-arm64-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
 [rhel-6-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
 [rhel-6-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
 
 [rhel-6-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/rhel.6_x64_Release_version_badge.svg?no-cache
 [rhel-6-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
 
 [rhel-6-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
 [rhel-6-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
 
 [linux-musl-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-musl-x64.txt
 [linux-musl-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
 [linux-musl-x64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-musl-x64.txt
 [linux-musl-x64-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
 [linux-musl-x64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-musl-x64.txt
 [linux-musl-x64-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
 [linux-musl-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
 [linux-musl-arm-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
 [linux-musl-arm-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
 [linux-musl-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-linux-musl-arm64.txt
 [linux-musl-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
 [linux-musl-arm64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-linux-musl-arm64.txt
 [linux-musl-arm64-targz-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-targz-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
 [linux-musl-arm64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-linux-musl-arm64.txt
 [linux-musl-arm64-targz-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-targz-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
 [win-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/win_arm_Release_version_badge.svg?no-cache
 [win-arm-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-win-arm.txt
 [win-arm-zip-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm.zip.sha512
 
 [win-arm-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/win_arm_Release_version_badge.svg?no-cache
 [win-arm-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-win-arm.txt
 [win-arm-zip-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm.zip.sha512
 
 [win-arm-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/win_arm_Release_version_badge.svg?no-cache
 [win-arm-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-win-arm.txt
 [win-arm-zip-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm.zip.sha512
 
 [win-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx/daily/productCommit-win-arm64.txt
 [win-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha512
 [win-arm64-zip-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha512
 
 [win-arm64-badge-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/productCommit-win-arm64.txt
 [win-arm64-installer-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-installer-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.exe.sha512
 [win-arm64-zip-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-zip-checksum-10.0.1XX-preview2]: https://aka.ms/dotnet/10.0.1xx-preview2/daily/dotnet-sdk-win-arm64.zip.sha512
 
 [win-arm64-badge-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/productCommit-win-arm64.txt
 [win-arm64-installer-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-installer-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.exe.sha512
 [win-arm64-zip-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-zip-checksum-9.0.3XX]: https://aka.ms/dotnet/9.0.3xx/daily/dotnet-sdk-win-arm64.zip.sha512

--- a/src/SourceBuild/content/docs/builds-table.md
+++ b/src/SourceBuild/content/docs/builds-table.md
@@ -6,7 +6,7 @@
 | :--------- | :----------: |
 | **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] |
 | **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] - [Checksum][win-arm64-zip-checksum-main] |
 | **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] |
 | **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] |
 | **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] |
@@ -24,78 +24,73 @@ Reference notes:
 [win-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-x64.txt
 [win-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.exe.sha512
 [win-x64-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x64.zip.sha512
 
 [win-x86-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-x86.txt
 [win-x86-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.exe.sha512
 [win-x86-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-x86.zip.sha512
 
 [osx-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-osx-x64.txt
 [osx-x64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.sha512
 [osx-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha512
 
 [osx-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-osx-arm64.txt
 [osx-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.sha512
 [osx-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha512
 
 [linux-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-x64.txt
 [linux-DEB-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.deb.sha
+[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.deb.sha512
 [linux-RPM-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.rpm.sha
+[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-x64.rpm.sha512
 [linux-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
 [linux-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-arm.txt
 [linux-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
 [linux-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-arm64.txt
 [linux-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
 [rhel-6-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/rhel.6_x64_Release_version_badge.svg?no-cache
 [rhel-6-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha512
 
 [linux-musl-x64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-x64.txt
 [linux-musl-x64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
 [linux-musl-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
 [linux-musl-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-linux-musl-arm64.txt
 [linux-musl-arm64-targz-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
-
-[win-arm-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_arm_Release_version_badge.svg?no-cache
-[win-arm-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-arm.txt
-[win-arm-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm.zip.sha
+[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
 [win-arm64-badge-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/productCommit-win-arm64.txt
 [win-arm64-installer-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.exe.sha512
 [win-arm64-zip-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/10.0.1xx-ub/daily/dotnet-sdk-win-arm64.zip.sha512


### PR DESCRIPTION
- Checksums got renamed from .sha to .sha512
- Add the missing win-arm64 checksum entry
- Remove win-arm links from VMR builds-table.md