### PR TITLE
Unified-build lite pipeline

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -456,6 +456,33 @@ stages:
         targetOS: iossimulator
         targetArchitecture: arm64
 
+    ### Additional jobs for internal lite builds ###
+    - ${{ if and(in(parameters.scope, 'lite'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+
+        - template: ../jobs/vmr-build.yml
+          parameters:
+            buildName: ${{ format('{0}_Ubuntu_BuildTests', variables.ubuntuName) }}
+            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+            vmrBranch: ${{ variables.VmrBranch }}
+            pool: ${{ parameters.pool_Linux }}
+            container:
+              name: ${{ variables.ubuntuContainerName }}
+              image: ${{ variables.ubuntuContainerImage }}
+            targetOS: linux
+            targetArchitecture: x64
+            extraProperties: /p:DotNetBuildTests=true
+
+        - template: ../jobs/vmr-build.yml
+          parameters:
+            buildName: Windows_BuildTests
+            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+            vmrBranch: ${{ variables.VmrBranch }}
+            sign: ${{ variables.signEnabled }}
+            pool: ${{ parameters.pool_Windows }}
+            targetOS: windows
+            targetArchitecture: x64
+            extraProperties: /p:DotNetBuildTests=true
+
     ### Additional jobs for full build ###
     - ${{ if in(parameters.scope, 'full') }}:
 

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -28,6 +28,10 @@
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1330
 #   - PR: lite build
 #   - CI: release/*, internal/release/* and main only, every batched commit, full build
+#
+# - dotnet-unified-build-lite (internal)
+#   https://dev.azure.com/dnceng/internal/_build?definitionId=1330
+#   - Runs lite build and additional legs for building tests
 
 parameters:
 - name: desiredSigning
@@ -46,6 +50,9 @@ variables:
 
 - name: isSourceOnlyBuildLite
   value: ${{ contains(variables['Build.DefinitionName'], '-source-build-lite') }}
+
+- name: isUnifiedBuildLite
+  value: ${{ contains(variables['Build.DefinitionName'], '-unified-build-lite') }}
 
 - name: isScheduleTrigger
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
@@ -158,7 +165,7 @@ extends:
           scope: lite
         ${{ elseif and(eq(variables.isPRTrigger, 'true'), eq(variables.isSourceOnlyBuild, 'true')) }}:
           scope: ultralite
-        ${{ elseif and(eq(variables.isPRTrigger, 'true'), ne(variables.isSourceOnlyBuild, 'true')) }}:
+        ${{ elseif and(or(eq(variables.isPRTrigger, 'true'), eq(variables.isUnifiedBuildLite, 'true')), ne(variables.isSourceOnlyBuild, 'true')) }}:
           scope: lite
         ${{ else }}:
           scope: full


### PR DESCRIPTION
Validation of vmr changes does not always require running all unified-build legs. Having a `lite` pipeline could help improve throughput, and save build resources. This also enable us to validate legs that build tests, as those are now only enabled in public CI or PR.

## Some concerns

Duplication of jobs for building tests - we already have them in Validation block right above - https://github.com/dotnet/sdk/blob/d833ffb8016b3937b6c13db926fc1acbac254dd7/eng/pipelines/templates/stages/vmr-build.yml#L354-L387

Perhaps I should just update that condition to include internal/lite scenario and update the comment.

Not sure if both Linux and Windows jobs for building tests would be required, or just one of them.