### PR TITLE
NuGetPackageDownloader: Stop verifying the package signature on Mac and queue off of the environment on Linux

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _sourceRepositories = new();
             // If windows or env variable is set, verify signatures
             _verifySignatures = verifySignatures && (OperatingSystem.IsWindows() ? true 
-                : string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.TrueString, StringComparison.OrdinalIgnoreCase) ?? OperatingSystem.IsLinux());
+                : string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.FalseString, StringComparison.OrdinalIgnoreCase) ?  false : OperatingSystem.IsLinux());
 
             _cacheSettings = new SourceCacheContext
             {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -38,6 +38,10 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
         private readonly Dictionary<PackageSource, SourceRepository> _sourceRepositories;
         private readonly bool _shouldUsePackageSourceMapping;
 
+        /// <summary>
+        /// If true, the package downloader will verify the signatures of the packages it downloads.
+        /// Temporarily disabled for macOS and Linux. 
+        /// </summary>
         private readonly bool _verifySignatures;
         private readonly VerbosityOptions _verbosityOptions;
         private readonly string _currentWorkingDirectory;
@@ -65,7 +69,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _restoreActionConfig = restoreActionConfig ?? new RestoreActionConfig();
             _retryTimer = timer;
             _sourceRepositories = new();
-            _verifySignatures = OperatingSystem.IsWindows() && verifySignatures; // TODO: Check
+            _verifySignatures = OperatingSystem.IsWindows() && verifySignatures; // This is temporarily disabled for macOS and Linux.
 
             _cacheSettings = new SourceCacheContext
             {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _restoreActionConfig = restoreActionConfig ?? new RestoreActionConfig();
             _retryTimer = timer;
             _sourceRepositories = new();
-            _verifySignatures = verifySignatures;
+            _verifySignatures = OperatingSystem.IsWindows() && verifySignatures; // TODO: Check
 
             _cacheSettings = new SourceCacheContext
             {
@@ -131,7 +131,6 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             }
 
             await VerifySigning(nupkgPath, repository);
-            
             return nupkgPath;
         }
 

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -69,7 +69,9 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _restoreActionConfig = restoreActionConfig ?? new RestoreActionConfig();
             _retryTimer = timer;
             _sourceRepositories = new();
-            _verifySignatures = OperatingSystem.IsWindows() && verifySignatures; // This is temporarily disabled for macOS and Linux.
+            // If windows or env variable is set, verify signatures
+            _verifySignatures = verifySignatures
+                && (OperatingSystem.IsWindows() || string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.TrueString, StringComparison.OrdinalIgnoreCase));
 
             _cacheSettings = new SourceCacheContext
             {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _sourceRepositories = new();
             // If windows or env variable is set, verify signatures
             _verifySignatures = verifySignatures && (OperatingSystem.IsWindows() ? true 
-                : string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.FalseString, StringComparison.OrdinalIgnoreCase) ?  false : OperatingSystem.IsLinux());
+                : bool.TryParse(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), out var shouldVerifySignature) ? shouldVerifySignature : OperatingSystem.IsLinux());
 
             _cacheSettings = new SourceCacheContext
             {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -70,8 +70,8 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
             _retryTimer = timer;
             _sourceRepositories = new();
             // If windows or env variable is set, verify signatures
-            _verifySignatures = verifySignatures
-                && (OperatingSystem.IsWindows() || string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+            _verifySignatures = verifySignatures && (OperatingSystem.IsWindows() ? true 
+                : string.Equals(Environment.GetEnvironmentVariable(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification), bool.TrueString, StringComparison.OrdinalIgnoreCase) ?? OperatingSystem.IsLinux());
 
             _cacheSettings = new SourceCacheContext
             {

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -133,6 +133,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                     string.Format("Downloading {0} version {1} failed", packageId,
                         packageVersion.ToNormalizedString()));
             }
+
             // Delete file if verification fails
             try
             {
@@ -143,6 +144,7 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                 File.Delete(nupkgPath);
                 throw;
             }
+
             return nupkgPath;
         }
 

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -133,8 +133,16 @@ namespace Microsoft.DotNet.Cli.NuGetPackageDownloader
                     string.Format("Downloading {0} version {1} failed", packageId,
                         packageVersion.ToNormalizedString()));
             }
-
-            await VerifySigning(nupkgPath, repository);
+            // Delete file if verification fails
+            try
+            {
+                await VerifySigning(nupkgPath, repository);
+            }
+            catch (NuGetPackageInstallerException)
+            {
+                File.Delete(nupkgPath);
+                throw;
+            }
             return nupkgPath;
         }
 


### PR DESCRIPTION
Fixes #46857 
**Customer Scenario**
dotnet tool install/restore is checking the package signature on Mac with 9.0.200. However, we shouldn't be doing that as macos doesn't fully support the signature store that nuget uses to verify signatures. This is already disabled for nuget restore.

**Fix**
Match the logic NuGet uses where we are always on for windows, default off for Mac, default on for Linux, and honor the env variable to override the values.

**Justification**
There are half a dozen customer comments on the linked issues saying they are blocked in 9.0.200.