### PR TITLE
 [release/8.0.1xx] NugetConfigWriter: Update CDN tests 

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeHaveAPackageReferenceWithAliases.cs
@@ -39,7 +39,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var packagesPaths = packageReferences.Select(e => Path.GetDirectoryName(e.NupkgPath));
-            List<string> sources = new List<string>() { NuGetConfigWriter.DotnetCoreBlobFeed };
+            List<string> sources = new();
             sources.AddRange(packagesPaths);
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.SourceFiles[$"{testProject.Name}.cs"] = ClassLibAandBUsage;
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            List<string> sources = new List<string>() { NuGetConfigWriter.DotnetCoreBlobFeed, Path.GetDirectoryName(packageReferenceA.NupkgPath), Path.GetDirectoryName(packageReferenceB.NupkgPath) };
+            List<string> sources = new List<string>() { Path.GetDirectoryName(packageReferenceA.NupkgPath), Path.GetDirectoryName(packageReferenceB.NupkgPath) };
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
             var buildCommand = new BuildCommand(testAsset);
@@ -120,7 +120,7 @@ namespace Microsoft.NET.Build.Tests
             testProject.SourceFiles[$"{testProject.Name}.cs"] = ClassLibAandBUsage;
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
-            List<string> sources = new List<string>() { NuGetConfigWriter.DotnetCoreBlobFeed, Path.GetDirectoryName(packageReferenceA.NupkgPath) };
+            List<string> sources = new List<string>() { Path.GetDirectoryName(packageReferenceA.NupkgPath) };
             NuGetConfigWriter.Write(testAsset.TestRoot, sources);
 
             var buildCommand = new BuildCommand(testAsset);

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -133,7 +133,7 @@ namespace Microsoft.NET.Build.Tests
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject, testIdentifier);
 
-            NuGetConfigWriter.Write(testAsset.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
+            NuGetConfigWriter.Write(testAsset.TestRoot);
 
             var buildCommand = new BuildCommand(testAsset);
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -86,7 +86,7 @@ class Program
 
             var toolProjectInstance = _testAssetsManager.CreateTestProject(toolProject, callingMethod, identifier: toolProject.Name);
 
-            NuGetConfigWriter.Write(toolProjectInstance.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
+            NuGetConfigWriter.Write(toolProjectInstance.TestRoot);
 
             // Workaround https://github.com/dotnet/cli/issues/9701
             var useBundledNETCoreAppPackage = "/p:UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion=true";
@@ -118,7 +118,7 @@ class Program
                         new XAttribute("Version", "1.0.0")));
                 });
 
-            List<string> sources = new List<string>() { NuGetConfigWriter.DotnetCoreBlobFeed };
+            List<string> sources = new();
             sources.Add(nupkgPath);
 
             NuGetConfigWriter.Write(toolReferencerInstance.TestRoot, sources);

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -120,36 +120,6 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [Fact]
-        public void store_nativeonlyassets()
-        {
-            TestAsset simpleDependenciesAsset = _testAssetsManager
-                .CopyTestAsset("UnmanagedStore")
-                .WithSource();
-
-            var storeCommand = new ComposeStoreCommand(Log, simpleDependenciesAsset.TestRoot);
-
-            var OutputFolder = Path.Combine(simpleDependenciesAsset.TestRoot, "outdir");
-            var WorkingDir = Path.Combine(simpleDependenciesAsset.TestRoot, "w");
-
-            NuGetConfigWriter.Write(simpleDependenciesAsset.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
-
-            storeCommand
-                .Execute($"/p:RuntimeIdentifier={_runtimeRid}", $"/p:TargetFramework={_tfm}", $"/p:ComposeWorkingDir={WorkingDir}", $"/p:ComposeDir={OutputFolder}", $"/p:DoNotDecorateComposeDir=true")
-                .Should()
-                .Pass();
-
-            DirectoryInfo storeDirectory = new DirectoryInfo(OutputFolder);
-
-            List<string> files_on_disk = new List<string> {
-               "artifact.xml",
-               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/{_libPrefix}coredistools{FileConstants.DynamicLibSuffix}",
-               $"runtime.{_runtimeRid}.microsoft.netcore.coredistools/1.0.1-prerelease-00001/runtimes/{_runtimeRid}/native/coredistools.h"
-               };
-
-            storeDirectory.Should().OnlyHaveFiles(files_on_disk);
-        }
-
-        [Fact]
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Restore.Tests
                         new XAttribute("Include", obsoletePackageId)));
                 });
 
-            NuGetConfigWriter.Write(toolProjectInstance.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed);
+            NuGetConfigWriter.Write(toolProjectInstance.TestRoot);
 
             RestoreCommand restoreCommand = toolProjectInstance.GetRestoreCommand(Log, toolProject.Name);
             restoreCommand.Execute("/v:n").Should()

--- a/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
+++ b/src/Tests/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NET.Restore.Tests
 
             DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
             DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
-            NuGetConfigWriter.Write(toolReferenceProjectInstance.TestRoot, NuGetConfigWriter.DotnetCoreBlobFeed, nupkgPath);
+            NuGetConfigWriter.Write(toolReferenceProjectInstance.TestRoot, nupkgPath);
 
             RestoreCommand restoreCommand =
                 toolReferenceProjectInstance.GetRestoreCommand(log: Log, relativePath: toolReferenceProject.Name);

--- a/src/Tests/Microsoft.NET.TestFramework/NuGetConfigWriter.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/NuGetConfigWriter.cs
@@ -5,7 +5,6 @@ namespace Microsoft.NET.TestFramework
 {
     public static class NuGetConfigWriter
     {
-        public static readonly string DotnetCoreBlobFeed = "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json";
         public static readonly string AspNetCoreDevFeed = "https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json";
 
         public static void Write(string folder, params string[] nugetSources)


### PR DESCRIPTION
Backports removal of DotnetCoreBlobFeed tests (see https://github.com/dotnet/sdk/pull/45420)