### PR TITLE
[Github Actions] Remove Branch Lockdown Labels on Branding Merge

### DIFF
--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -16,11 +16,12 @@ jobs:
         -   name: Checkout repository
             uses: actions/checkout@v2
 
-        # flagged user-visible change: replaced shell script with JS to check <VersionFeature>user-visible change: replaced shell script with JS to check <VersionFeature>
-        -   name: PR's only change is <VersionFeature> in eng/Versions.propsly change is <VersionFeature> in eng/Versions.props
+        -   name: PR's only change is <VersionFeature> in eng/Versions.props
             uses: actions/github-script@v4
             with:
                 script: |
+                    const otherChangesMessage = "❌ Changes in eng/Versions.props other than <VersionFeature> found";
+                    const onlyVersionFeatureMessage = "✅ PR's only change is <VersionFeature> in eng/Versions.props";
                     const prNumber = context.payload.pull_request.number;
                     const { data: files } = await github.pulls.listFiles({
                         owner: context.repo.owner,
@@ -29,7 +30,7 @@ jobs:
                     });
                     // If files other than eng/Versions.props are changed, output message and exit
                     if (files.some(file => file.filename !== "eng/Versions.props")) {
-                        console.log("❌ Changes in eng/Versions.props other than <VersionFeature> found");
+                        console.log(otherChangesMessage);
                         core.exportVariable("only_version_feature_changed", "false");
                         return;
                     }
@@ -38,16 +39,16 @@ jobs:
                     const patchLines = versionsPropsFile.patch.split("\n").filter(l => l.startsWith("+") || l.startsWith("-"));
                     for (const line of patchLines) {
                         if (!line.includes("<VersionFeature>")) {
-                            console.log("❌ Changes in eng/Versions.props other than <VersionFeature> found");
+                            console.log(otherChangesMessage);
                             core.exportVariable("only_version_feature_changed", "false");
                             return;
                         }
                     }
-                    console.log("✅ PR's only change is <VersionFeature> in eng/Versions.props");
+                    console.log(onlyVersionFeatureMessage);
                     core.exportVariable("only_version_feature_changed", "true");
 
         -   name: Remove Branch Lockdown label from other PRs targeting this branch
-            if: steps.PR_has_Branding_label.outputs.has_branding_label == 'true' && steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'
+            if: steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'
             uses: actions/github-script@v4
             with:
                 script: |

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -13,6 +13,8 @@ jobs:
         if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'Branding')
         runs-on: ubuntu-latest
         steps:
+        -   name: Checkout repository
+            uses: actions/checkout@v2
         -   name: PR's only change is <VersionFeature> in eng/Versions.props
             run: |
                 git fetch --depth=2

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -21,8 +21,10 @@ jobs:
                 has_changes_without_version_feature=$(echo "$changes_without_version_feature" | wc -l)
                 if [ "$has_changes_without_version_feature" -eq 0 ]; then
                     echo "only_version_feature_changed=true" >> $GITHUB_ENV
+                    echo "✅ Only change in eng/Versions.props is <VersionFeature>"
                 else
                     echo "only_version_feature_changed=false" >> $GITHUB_ENV
+                    echo "❌ Changes in eng/Versions.props other than <VersionFeature> found"
 
         -   name: Remove Branch Lockdown label from other PRs targeting this branch
             if: steps.PR_has_Branding_label.outputs.has_branding_label == 'true' && steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -1,0 +1,50 @@
+name: Remove Lockdown Label from PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+    actions: write
+    issues: write
+
+jobs:
+    remove-labels:
+        if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'Branding')
+        runs-on: ubuntu-latest
+        steps:
+        -   name: PR's only change is <VersionFeature> in eng/Versions.props
+            run: |
+                git fetch --depth=2
+                changes=$(git diff HEAD^ HEAD -- eng/Versions.props | grep '^[-+]')
+                changes_without_version_feature=$(echo "$changes" | grep -v '<VersionFeature>')
+                has_changes_without_version_feature=$(echo "$changes_without_version_feature" | wc -l)
+                if [ "$has_changes_without_version_feature" -eq 0 ]; then
+                    echo "only_version_feature_changed=true" >> $GITHUB_ENV
+                else
+                    echo "only_version_feature_changed=false" >> $GITHUB_ENV
+
+        -   name: Remove Branch Lockdown label from other PRs targeting this branch
+            if: steps.PR_has_Branding_label.outputs.has_branding_label == 'true' && steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'
+            uses: actions/github-script@v4
+            with:
+                script: |
+                    const prs = await github.pulls.list({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        state: 'open',
+                        base: github.event.pull_request.base.ref,
+                        per_page: 300
+                    });
+                    const filtered_prs = prs.data
+                        .filter(pr => pr.number !== github.context.payload.pull_request.number)
+                        .filter(pr => pr.labels.map(label => label.name).includes('Branch Lockdown'));
+                    for (const pr of filtered_prs) {
+                        await github.issues.removeLabel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: pr.number,
+                            name: 'Branch Lockdown'
+                        });
+                        console.log(`Removed Branch Lockdown label from PR #${pr.number}`);
+                    }

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -17,6 +17,7 @@ jobs:
             uses: actions/checkout@v2
 
         -   name: PR's only change is <VersionFeature> in eng/Versions.props
+            id: only_version_feature_changed
             uses: actions/github-script@v4
             with:
                 script: |
@@ -25,7 +26,7 @@ jobs:
                     const prNumber = context.payload.pull_request.number;
                     const { data: files } = await github.pulls.listFiles({
                         owner: context.repo.owner,
-                        repo: context.repo.repo,    repo: context.repo.repo,
+                        repo: context.repo.repo,
                         pull_number: prNumber
                     });
                     // If files other than eng/Versions.props are changed, output message and exit
@@ -48,7 +49,7 @@ jobs:
                     core.exportVariable("only_version_feature_changed", "true");
 
         -   name: Remove Branch Lockdown label from other PRs targeting this branch
-            if: steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'
+            if: steps.only_version_feature_changed.outputs.only_version_feature_changed == 'true'
             uses: actions/github-script@v4
             with:
                 script: |

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -15,18 +15,36 @@ jobs:
         steps:
         -   name: Checkout repository
             uses: actions/checkout@v2
-        -   name: PR's only change is <VersionFeature> in eng/Versions.props
-            run: |
-                git fetch --depth=2
-                changes=$(git diff HEAD^ HEAD -- eng/Versions.props | grep '^[-+]')
-                changes_without_version_feature=$(echo "$changes" | grep -v '<VersionFeature>')
-                has_changes_without_version_feature=$(echo "$changes_without_version_feature" | wc -l)
-                if [ "$has_changes_without_version_feature" -eq 0 ]; then
-                    echo "only_version_feature_changed=true" >> $GITHUB_ENV
-                    echo "✅ Only change in eng/Versions.props is <VersionFeature>"
-                else
-                    echo "only_version_feature_changed=false" >> $GITHUB_ENV
-                    echo "❌ Changes in eng/Versions.props other than <VersionFeature> found"
+
+        # flagged user-visible change: replaced shell script with JS to check <VersionFeature>user-visible change: replaced shell script with JS to check <VersionFeature>
+        -   name: PR's only change is <VersionFeature> in eng/Versions.propsly change is <VersionFeature> in eng/Versions.props
+            uses: actions/github-script@v4
+            with:
+                script: |
+                    const prNumber = context.payload.pull_request.number;
+                    const { data: files } = await github.pulls.listFiles({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,    repo: context.repo.repo,
+                        pull_number: prNumber
+                    });
+                    // If files other than eng/Versions.props are changed, output message and exit
+                    if (files.any(file => file.filename !== "eng/Versions.props")) {
+                        console.log("❌ Changes in eng/Versions.props other than <VersionFeature> found");
+                        core.exportVariable("only_version_feature_changed", "false");
+                        return;
+                    }
+                    // Iterate through the patch of eng/Versions.props to check for changes other than <VersionFeature>
+                    const versionsPropsFile = files.find(file => file.filename === "eng/Versions.props");
+                    const patchLines = versionsPropsFile.patch.split("\n").filter(l => l.startsWith("+") || l.startsWith("-"));
+                    for (const line of patchLines) {
+                        if (!line.includes("<VersionFeature>")) {
+                            console.log("❌ Changes in eng/Versions.props other than <VersionFeature> found");
+                            core.exportVariable("only_version_feature_changed", "false");
+                            return;
+                        }
+                    }
+                    console.log("✅ PR's only change is <VersionFeature> in eng/Versions.props");
+                    core.exportVariable("only_version_feature_changed", "true");
 
         -   name: Remove Branch Lockdown label from other PRs targeting this branch
             if: steps.PR_has_Branding_label.outputs.has_branding_label == 'true' && steps.PR_only_change_is_VersionFeature_in_eng_Versions_props.outputs.only_version_feature_changed == 'true'

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -28,7 +28,7 @@ jobs:
                         pull_number: prNumber
                     });
                     // If files other than eng/Versions.props are changed, output message and exit
-                    if (files.any(file => file.filename !== "eng/Versions.props")) {
+                    if (files.some(file => file.filename !== "eng/Versions.props")) {
                         console.log("❌ Changes in eng/Versions.props other than <VersionFeature> found");
                         core.exportVariable("only_version_feature_changed", "false");
                         return;

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     actions: write
-    issues: write
+    pull-requests: write
 
 jobs:
     remove-labels:


### PR DESCRIPTION
It would be really useful if `Branch Lockdown` labels were automatically removed once branding prs check in, as that would automate some blocking points for codeflow.

The job only runs on PR's labeled `Branding`
When the PR gets merged, it will check the file differences to make sure it is a proper branding PR
If it is, it will remove the `Branch Lockdown` labels from other PRs targeting the same branch