### PR TITLE
dotnet test improvements for MTP

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -317,7 +317,7 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</value>
     <comment>{0} - test message state</comment>
   </data>
   <data name="CmdUnsupportedVSTestTestApplicationsDescription" xml:space="preserve">
-    <value>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+    <value>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</value>
   </data>
   <data name="Aborted" xml:space="preserve">

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -1,9 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Concurrent;
+using System.IO;
 using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools.Test;
+using Microsoft.Testing.Platform.OutputDevice;
 using Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 namespace Microsoft.DotNet.Cli
@@ -70,7 +73,7 @@ namespace Microsoft.DotNet.Cli
                 return ExitCode.GenericFailure;
             }
 
-            (IEnumerable<Module> projects, bool restored) = GetProjectsProperties(projectOrSolutionFilePath, isSolution, buildOptions);
+            (IEnumerable<TestModule> projects, bool restored) = GetProjectsProperties(projectOrSolutionFilePath, isSolution, buildOptions);
 
             InitializeTestApplications(projects);
 
@@ -79,28 +82,30 @@ namespace Microsoft.DotNet.Cli
 
         private int RunBuild(string filePath, bool isSolution, BuildOptions buildOptions)
         {
-            (IEnumerable<Module> projects, bool restored) = GetProjectsProperties(filePath, isSolution, buildOptions);
+            (IEnumerable<TestModule> projects, bool restored) = GetProjectsProperties(filePath, isSolution, buildOptions);
 
             InitializeTestApplications(projects);
 
             return restored ? ExitCode.Success : ExitCode.GenericFailure;
         }
 
-        private void InitializeTestApplications(IEnumerable<Module> modules)
+        private void InitializeTestApplications(IEnumerable<TestModule> modules)
         {
-            foreach (Module module in modules)
+            foreach (TestModule module in modules)
             {
-                if (!module.IsTestProject)
+                if (!module.IsTestProject && !module.IsTestingPlatformApplication)
                 {
-                    // Non test projects, like the projects that include production code are skipped over, we won't run them.
-                    return;
+                    // This should never happen. We should only ever create Module if it's a test project.
+                    throw new InvalidOperationException();
                 }
 
                 if (!module.IsTestingPlatformApplication)
                 {
-                    // If one test app has IsTestingPlatformApplication set to false, then we will not run any of the test apps
+                    // If one test app has IsTestingPlatformApplication set to false (VSTest and not MTP), then we will not run any of the test apps
+                    // Note that we still continue the loop here so that we print all projects that are VSTest and not MTP.
                     _areTestingPlatformApplications = false;
-                    return;
+                    _output.WriteMessage(string.Format(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, Path.GetFileName(module.ProjectFullPath)), new SystemConsoleColor { ConsoleColor = ConsoleColor.Red });
+                    continue;
                 }
 
                 var testApp = new TestApplication(module, _args);
@@ -122,9 +127,9 @@ namespace Microsoft.DotNet.Cli
             return true;
         }
 
-        private (IEnumerable<Module> Projects, bool Restored) GetProjectsProperties(string solutionOrProjectFilePath, bool isSolution, BuildOptions buildOptions)
+        private (IEnumerable<TestModule> Projects, bool Restored) GetProjectsProperties(string solutionOrProjectFilePath, bool isSolution, BuildOptions buildOptions)
         {
-            (IEnumerable<Module> projects, bool isBuiltOrRestored) = isSolution ?
+            (IEnumerable<TestModule> projects, bool isBuiltOrRestored) = isSolution ?
                 MSBuildUtility.GetProjectsFromSolution(solutionOrProjectFilePath, buildOptions) :
                 MSBuildUtility.GetProjectsFromProject(solutionOrProjectFilePath, buildOptions);
 
@@ -133,7 +138,7 @@ namespace Microsoft.DotNet.Cli
             return (projects, isBuiltOrRestored);
         }
 
-        private void LogProjectProperties(IEnumerable<Module> modules)
+        private void LogProjectProperties(IEnumerable<TestModule> modules)
         {
             if (!Logger.TraceEnabled)
             {

--- a/src/Cli/dotnet/commands/dotnet-test/Models.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Models.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli
 {
-    internal sealed record Module(string? TargetPath, string? ProjectFullPath, string? TargetFramework, string? RunSettingsFilePath, bool IsTestingPlatformApplication, bool IsTestProject);
+    internal sealed record TestModule(string? TargetPath, string? ProjectFullPath, string? TargetFramework, string? RunSettingsFilePath, bool IsTestingPlatformApplication, bool IsTestProject);
 
     internal sealed record Handshake(Dictionary<byte, string>? Properties);
 

--- a/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
@@ -100,9 +100,9 @@ namespace Microsoft.DotNet.Cli
             return string.IsNullOrEmpty(fileDirectory) ? Directory.GetCurrentDirectory() : fileDirectory;
         }
 
-        public static IEnumerable<Module> GetProjectProperties(string projectFilePath, IDictionary<string, string> globalProperties, ProjectCollection projectCollection)
+        public static IEnumerable<TestModule> GetProjectProperties(string projectFilePath, IDictionary<string, string> globalProperties, ProjectCollection projectCollection)
         {
-            var projects = new List<Module>();
+            var projects = new List<TestModule>();
 
             var globalPropertiesWithoutTargetFramework = new Dictionary<string, string>(globalProperties);
             globalPropertiesWithoutTargetFramework.Remove(ProjectProperties.TargetFramework);
@@ -164,23 +164,22 @@ namespace Microsoft.DotNet.Cli
             return frameworks.Contains(targetFramework);
         }
 
-        private static Module? GetModuleFromProject(Project project)
+        private static TestModule? GetModuleFromProject(Project project)
         {
             _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestProject), out bool isTestProject);
+            _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
 
-            if (!isTestProject)
+            if (!isTestProject && !isTestingPlatformApplication)
             {
                 return null;
             }
-
-            _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
 
             string targetFramework = project.GetPropertyValue(ProjectProperties.TargetFramework);
             string targetPath = project.GetPropertyValue(ProjectProperties.TargetPath);
             string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
             string runSettingsFilePath = project.GetPropertyValue(ProjectProperties.RunSettingsFilePath);
 
-            return new Module(targetPath, PathUtility.FixFilePath(projectFullPath), targetFramework, runSettingsFilePath, isTestingPlatformApplication, isTestProject);
+            return new TestModule(targetPath, PathUtility.FixFilePath(projectFullPath), targetFramework, runSettingsFilePath, isTestingPlatformApplication, isTestProject);
         }
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli
 {
     internal sealed class TestApplication : IDisposable
     {
-        private readonly Module _module;
+        private readonly TestModule _module;
         private readonly List<string> _args;
 
         private readonly List<string> _outputData = [];
@@ -33,9 +33,9 @@ namespace Microsoft.DotNet.Cli
         public event EventHandler<TestProcessExitEventArgs> TestProcessExited;
         public event EventHandler<ExecutionEventArgs> ExecutionIdReceived;
 
-        public Module Module => _module;
+        public TestModule Module => _module;
 
-        public TestApplication(Module module, List<string> args)
+        public TestApplication(TestModule module, List<string> args)
         {
             _module = module;
             _args = args;

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli
 
             foreach (string testModule in testModulePaths)
             {
-                var testApp = new TestApplication(new Module(testModule, null, null, null, true, true), _args);
+                var testApp = new TestApplication(new TestModule(testModule, null, null, null, true, true), _args);
                 // Write the test application to the channel
                 _actionQueue.Enqueue(testApp);
             }

--- a/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestingPlatformCommand.cs
@@ -59,7 +59,6 @@ namespace Microsoft.DotNet.Cli
 
                     if (!_msBuildHandler.EnqueueTestApplications())
                     {
-                        _output.WriteMessage(LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, new SystemConsoleColor { ConsoleColor = ConsoleColor.Red });
                         return ExitCode.GenericFailure;
                     }
                 }

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -361,9 +361,9 @@ Pokud zadaný adresář neexistuje, bude vytvořen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -361,9 +361,9 @@ Das angegebene Verzeichnis wird erstellt, wenn es nicht vorhanden ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -363,9 +363,9 @@ Si no existe, se creará el directorio especificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -361,9 +361,9 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -361,9 +361,9 @@ Se non esiste, la directory specificata verrà creata.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -361,9 +361,9 @@ The specified directory will be created if it does not exist.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -361,9 +361,9 @@ The specified directory will be created if it does not exist.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -361,9 +361,9 @@ Jeśli określony katalog nie istnieje, zostanie utworzony.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -361,9 +361,9 @@ O diretório especificado será criado se ele ainda não existir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -361,9 +361,9 @@ The specified directory will be created if it does not exist.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -361,9 +361,9 @@ Belirtilen dizin yoksa oluşturulur.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -361,9 +361,9 @@ The specified directory will be created if it does not exist.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -361,9 +361,9 @@ The specified directory will be created if it does not exist.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdUnsupportedVSTestTestApplicationsDescription">
-        <source>Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <source>Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</source>
-        <target state="new">Test projects that use both VSTest and Microsoft.Testing.Platform in the same solution are not supported. 
+        <target state="new">Test project '{0}' is using VSTest. When opting-in via dotnet.config, all the test projects are expected to be using Microsoft.Testing.Platform. 
 See https://aka.ms/dotnet-test/mtp for more information.</target>
         <note />
       </trans-unit>

--- a/test/TestAssets/TestProjects/HybridTestRunnerTestProjects/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/HybridTestRunnerTestProjects/OtherTestProject/OtherTestProject.csproj
@@ -6,7 +6,6 @@
 		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
 	</PropertyGroup>
 

--- a/test/TestAssets/TestProjects/MSTestMetaPackageProjectWithMultipleTFMsSolution/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MSTestMetaPackageProjectWithMultipleTFMsSolution/TestProject/TestProject.csproj
@@ -12,7 +12,6 @@
 		<Nullable>enable</Nullable>
 
 		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
 		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
 	</PropertyGroup>
 

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/AnotherTestProject/AnotherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/AnotherTestProject/AnotherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDifferentFailures/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDiscoveredTests/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDiscoveredTests/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDiscoveredTests/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithDiscoveredTests/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectSolution/AnotherTestProject/AnotherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectSolution/AnotherTestProject/AnotherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectSolution/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectSolution/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectSolution/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectSolution/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/AnotherTestProject/AnotherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/AnotherTestProject/AnotherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultipleTestProjectsWithoutSolution/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/ProjectSolutionForMultipleTFMs/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/ProjectSolutionForMultipleTFMs/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/ProjectSolutionForMultipleTFMs/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/ProjectSolutionForMultipleTFMs/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectFileAndSolutionFile/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectFileAndSolutionFile/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectSolution/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectSolution/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectSolutionWithTestsAndArtifacts/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectSolutionWithTestsAndArtifacts/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibrary/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibrary/TestProject/TestProject.csproj
@@ -6,7 +6,6 @@
 		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
 	</PropertyGroup>
 

--- a/test/TestAssets/TestProjects/TestProjectWithDiscoveredTests/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithDiscoveredTests/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsSolution/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsSolution/OtherTestProject/OtherTestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsSolution/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsSolution/TestProject/TestProject.csproj
@@ -7,7 +7,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateProgramFile>false</GenerateProgramFile>
-		<IsTestProject>true</IsTestProject>
 		<LangVersion>latest</LangVersion>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>

--- a/test/TestAssets/TestProjects/TestProjectWithTests/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithTests/TestProject.csproj
@@ -7,7 +7,6 @@
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsTestProject>true</IsTestProject>
 
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
+                result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
             result.ExitCode.Should().Be(ExitCode.GenericFailure);

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription);
+                result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
             result.ExitCode.Should().Be(ExitCode.GenericFailure);


### PR DESCRIPTION
Related to #45927

- The handling of `IsTestProject` and `IsTestingPlatformApplication` was not correct.

    Projects that were setting `IsTestingPlatformApplication` to true but not setting `IsTestProject` were **not** considered, which is wrong.

- Improve error message for having MTP and VSTest together when using the new experience.

- Rename `Module` to `TestModule` for clarity

Fixes https://github.com/microsoft/testfx/issues/5198
Fixes https://github.com/microsoft/testfx/issues/5196