### PR TITLE
Force OCI format for inner images when publishing tarballs or to local docker instances

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -304,10 +304,16 @@
       <!--We don't want to skip publishing individual images in case of local daemon podman because podman loads multi-arch tarball differently - only individual image for the current platform.-->
       <_SkipContainerPublishing>false</_SkipContainerPublishing>
       <_SkipContainerPublishing Condition="$(ContainerArchiveOutputPath) != '' or ( $(ContainerRegistry) == '' and ( $(LocalRegistry) == '' or $(LocalRegistry) == 'Docker' ) )">true</_SkipContainerPublishing>
-    
+
       <!--We want to skip CreateImageIndex task in case of local daemon podman because it is not supported.-->
       <_SkipCreateImageIndex>false</_SkipCreateImageIndex>
       <_SkipCreateImageIndex Condition="$(ContainerArchiveOutputPath) == '' and $(ContainerRegistry) == '' and $(LocalRegistry) == 'Podman'">true</_SkipCreateImageIndex>
+
+      <!-- Figure out what format the inner images should be coerced to -->
+      <!-- If a user had an opinion, use that -->
+      <_SingleImageContainerFormat Condition="'$(ContainerImageFormat)' != ''">$(ContainerImageFormat)</_SingleImageContainerFormat>
+      <!-- If we are publishing to local tarball or to local Docker, force OCI to prevent mismatches between inner images and the outer manifest -->
+      <_SingleImageContainerFormat Condition="$(_SkipContainerPublishing) == 'true' ">OCI</_SingleImageContainerFormat>
     </PropertyGroup>
 
     <ItemGroup>
@@ -337,7 +343,8 @@
           ContainerUser=$(ContainerUser);
           ContainerGenerateLabels=$(ContainerGenerateLabels);
           ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest);
-          _SkipContainerPublishing=$(_SkipContainerPublishing)
+          _SkipContainerPublishing=$(_SkipContainerPublishing);
+          ContainerImageFormat=$(_SingleImageContainerFormat)
         "/>
       <_rids Remove ="$(_rids)" />
     </ItemGroup>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1012,7 +1012,7 @@ public class EndToEndTests : IDisposable
             .And.HaveStdOutContaining($"Pushed image '{imageX64}' to registry '{registry}'.")
             .And.HaveStdOutContaining($"Pushed image '{imageArm64}' to registry '{registry}'.")
             .And.HaveStdOutContaining($"Pushed image index '{imageIndex}' to registry '{registry}'.");
-        
+
         // Check that the containers can be run
         // First pull the image from the registry for each platform
         ContainerCli.PullCommand(
@@ -1029,7 +1029,7 @@ public class EndToEndTests : IDisposable
             imageFromRegistry)
             .Execute()
             .Should().Pass();
-        
+
         // Run the containers
         ContainerCli.RunCommand(
             _testOutput,
@@ -1350,5 +1350,46 @@ public class EndToEndTests : IDisposable
             var binary = rid.StartsWith("win", StringComparison.Ordinal) ? $"{appName}.exe" : appName;
             return new[] { $"{workingDir}/{binary}" };
         }
+    }
+
+    [DockerAvailableFact(checkContainerdStoreAvailability: true)]
+    public void EnforcesOciSchemaForMultiRIDTarballOutput()
+    {
+        string imageName = NewImageName();
+        string tag = "1.0";
+
+        // Create new console app
+        DirectoryInfo newProjectDir = CreateNewProject("webapp");
+
+        // Run PublishContainer for multi-arch with ContainerGenerateLabels
+        var publishResult = new DotnetCommand(
+            _testOutput,
+            "publish",
+            "/t:PublishContainer",
+            "/p:RuntimeIdentifiers=\"linux-x64;linux-arm64\"",
+            $"/p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageAspNet}",
+            $"/p:ContainerRepository={imageName}",
+            $"/p:ContainerImageTag={tag}",
+            "/p:EnableSdkContainerSupport=true",
+            "/p:ContainerArchiveOutputPath=archive.tar.gz",
+            "-getProperty:GeneratedImageIndex",
+            "-getItem:GeneratedContainers",
+            "/bl")
+            .WithWorkingDirectory(newProjectDir.FullName)
+            .Execute();
+
+        publishResult.Should().Pass();
+        var jsonDump = JsonDocument.Parse(publishResult.StdOut);
+        var index = JsonDocument.Parse(jsonDump.RootElement.GetProperty("Properties").GetProperty("GeneratedImageIndex").ToString());
+        var containers = jsonDump.RootElement.GetProperty("Items").GetProperty("GeneratedContainers").EnumerateArray().ToArray();
+
+        index.RootElement.GetProperty("mediaType").GetString().Should().Be("application/vnd.oci.image.index.v1+json");
+        containers.Should().HaveCount(2);
+        foreach (var container in containers)
+        {
+            container.GetProperty("ManifestMediaType").GetString().Should().Be("application/vnd.oci.image.manifest.v1+json");
+        }
+        // Cleanup
+        newProjectDir.Delete(true);
     }
 }


### PR DESCRIPTION
## Description

Today it's possible to publish a multi-arch container manifest that is an OCI format, but contains inner images that are Docker format. This is an error - all formats (Docker or OCI) should be unified. Some tools will accept this mismatch, but others will error and force compliance. The MDE team found this as it impacted their migrations to SDK containers.

## Fix

This PR determines if we are in a scenario in the outer-build where we are publishing an OCI manifest wrapper and forces the inner images to be OCI also. There results in exactly one change to the generated inner images: the media type field changes. All other content remains the same.

## Workaround
Users can set `<ContainerImageFormat>OCI</ContainerImageFormat>` today to fix this.

## Risk
**Low** - this is covered by tests and only applies to a single specific erroring scenario.