### PR TITLE
`dotnet package list` command should restore first

### DIFF
--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "dotnet": {
-      "commandName": "Project",
-      "commandLineArgs": "package list --project N:/trash/p7/p7.sln --format json"
+      "commandName": "Project"
     }
   }
 }

--- a/src/Cli/dotnet/Properties/launchSettings.json
+++ b/src/Cli/dotnet/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "dotnet": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "package list --project N:/trash/p7/p7.sln --format json"
     }
   }
 }

--- a/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(PackageListCommandParser.InteractiveOption);
             command.Options.Add(PackageListCommandParser.FormatOption);
             command.Options.Add(PackageListCommandParser.OutputVersionOption);
+            command.Options.Add(PackageListCommandParser.NoRestore);
 
             command.SetAction((parseResult) => new ListPackageReferencesCommand(parseResult).Execute());
 

--- a/src/Cli/dotnet/commands/dotnet-package/list/ListPackageReferencesCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/list/ListPackageReferencesCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Package.List
             _fileOrDirectory = GetAbsolutePath(Directory.GetCurrentDirectory(),
                 parseResult.HasOption(PackageCommandParser.ProjectOption) ?
                 parseResult.GetValue(PackageCommandParser.ProjectOption) :
-                parseResult.GetValue(ListCommandParser.SlnOrProjectArgument));
+                parseResult.GetValue(ListCommandParser.SlnOrProjectArgument) ?? "");
         }
 
         private static string GetAbsolutePath(string currentDirectory, string relativePath)
@@ -32,17 +32,17 @@ namespace Microsoft.DotNet.Tools.Package.List
 
         public override int Execute()
         {
-            string projectFile = _parseResult.GetValue(PackageCommandParser.ProjectOption);
+            string projectFile = GetProjectOrSolution();
             bool noRestore = _parseResult.HasOption(PackageListCommandParser.NoRestore);
             int restoreExitCode = 0;
 
-            if (!noRestore)
+            if (!noRestore )
             {
                 restoreExitCode = RunRestore(projectFile);
             }
 
             return restoreExitCode == 0
-                ? NuGetCommand.Run(TransformArgs())
+                ? NuGetCommand.Run(TransformArgs(projectFile))
                 : restoreExitCode;
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tools.Package.List
             }
         }
 
-        private string[] TransformArgs()
+        private string[] TransformArgs(string projectOrSolution)
         {
             var args = new List<string>
             {
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tools.Package.List
                 "list",
             };
 
-            args.Add(GetProjectOrSolution());
+            args.Add(projectOrSolution);
 
             args.AddRange(_parseResult.OptionValuesToBeForwarded(PackageListCommandParser.GetCommand()));
 

--- a/src/Cli/dotnet/commands/dotnet-package/list/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-package/list/LocalizableStrings.resx
@@ -174,4 +174,11 @@
   <data name="CmdOutputVersionDescription" xml:space="preserve">
     <value>Specifies the version of machine-readable output. Requires the '--format json' option.</value>
   </data>
+  <data name="CmdNoRestoreDescription" xml:space="preserve">
+    <value>Do not restore before running the command.</value>
+  </data>
+  <data name="Error_restore" xml:space="preserve">
+    <value>Restore failed. Please try running `dotnet restore`.</value>
+    <comment>do not translate `dotnet restore`</comment>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-package/list/PackageListCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/list/PackageListCommandParser.cs
@@ -78,6 +78,12 @@ namespace Microsoft.DotNet.Cli
             Arity = ArgumentArity.Zero
         }.ForwardAs("--interactive");
 
+        public static readonly CliOption NoRestore = new CliOption<bool>("--no-restore")
+        {
+            Description = LocalizableStrings.CmdNoRestoreDescription,
+            Arity = ArgumentArity.Zero
+        };
+
         public static readonly CliOption VerbosityOption = new ForwardedOption<VerbosityOptions>("--verbosity", "-v")
         {
             Description = CommonLocalizableStrings.VerbosityOptionDescription,
@@ -119,6 +125,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(InteractiveOption);
             command.Options.Add(FormatOption);
             command.Options.Add(OutputVersionOption);
+            command.Options.Add(NoRestore);
             command.Options.Add(PackageCommandParser.ProjectOption);
 
             command.SetAction((parseResult) => new ListPackageReferencesCommand(parseResult).Execute());

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Zvolí architekturu, pro kterou se mají zobrazit balíčky. Pokud chcete určit více architektur, zadejte tento přepínač vícekrát.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Vypíše balíčky, které mají novější verze. Nedá se kombinovat s možností --deprecated ani --vulnerable.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Vypíše balíčky, které mají známá ohrožení zabezpečení. Nedá se kombinovat s možností --deprecated ani --outdated.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Wählt ein Framework für die Anzeige der zugehörigen Pakete aus. Für mehrere Frameworks verwenden Sie die Option mehrmals.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Listet Pakete mit neueren Versionen auf. Kann nicht mit den Optionen "--deprecated" oder "--vulnerable" kombiniert werden.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Listet Pakete auf, die bekannte Sicherheitsrisiken aufweisen. Kann nicht mit den Optionen "--deprecated" oder "--outdated" kombiniert werden.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Elige un marco para mostrar sus paquetes. Utilice la opción varias veces para marcos múltiples.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Muestra los paquetes que tienen versiones más recientes. No se puede combinar con las opciones '--deprecated" o "--vulnerable".</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Muestra los paquetes que tienen vulnerabilidades conocidas. No se puede combinar con las opciones "--outdated" o "--deprecated".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Choisit un framework pour afficher ses packages. Utilisez l'option plusieurs fois selon le nombre de frameworks.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Liste les packages qui ont versions plus récentes. Impossible à combiner avec les options '--deprecated' ou '--vulnerable'.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Liste les packages qui ont vulnérabilités. Impossible à combiner avec les options '--deprecated' ou '--outdated'.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Consente di scegliere un framework per mostrarne i pacchetti. Usare l'opzione più volte in caso di framework multipli.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Elenca i pacchetti con versioni più recenti. Non può essere combinato con l'opzione '--deprecated' o '--vulnerable'.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Elenca i pacchetti che presentano vulnerabilità note. Non può essere combinato con l'opzione '--deprecated' o '--outdated'.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">パッケージを表示するフレームワークを選択します。複数のフレームワークに対してはこのオプションを複数回使用します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">新しいバージョンのパッケージを一覧表示します。'--deprecated' または '--vulnerable' オプションと組み合わせることはできません。</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">既知の脆弱性を持つパッケージを一覧表示します。'--deprecated' または '--outdated' オプションと組み合わせることはできません。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">프레임워크를 선택하여 패키지를 표시합니다. 여러 프레임워크의 경우 옵션을 여러 번 사용합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">최신 버전이 포함된 패키지를 나열합니다. '--deprecated' 또는 '--vulnerable' 옵션과 함께 사용할 수 없습니다.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">알려진 취약성이 있는 패키지를 나열합니다. '--deprecated' 또는 '--outdated' 옵션과 함께 사용할 수 없습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Wybiera strukturę, aby wyświetlić jej pakiety. W przypadku wielu struktur użyj tej opcji wielokrotnie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Wyświetla pakiety, które mają nowszą wersję. Nie można łączyć z opcją „--deprecated” ani „--vulnerable”.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Wyświetla pakiety ze znanymi lukami w zabezpieczeniach. Nie można łączyć z opcją „--deprecated” ani „--outdated”.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Escolhe uma estrutura para mostrar seus pacotes. Use a opção várias vezes para várias estruturas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Lista os pacotes que têm versões mais recentes. Não pode ser combinado com a opção '--deprecated' nem com a opção '--vulnerable'.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Lista os pacotes que têm vulnerabilidades conhecidas. Não pode ser combinado com a opção '--deprecated' nem com a opção '--outdated'.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Выбирает платформу, список пакетов для которой необходимо отобразить. Для нескольких платформ укажите этот параметр несколько раз.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Возвращает список пакетов, у которых есть более новые версии. Не может использоваться с параметрами "--deprecated" или "--vulnerable".</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Возвращает список пакетов, у которых есть известные уязвимости. Не может использоваться с параметрами "--deprecated" или "--outdated".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Paketlerini görüntülemek için bir çerçeve seçin. Birden fazla çerçeve için seçeneği birden fazla kez kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Daha yeni sürümlere sahip paketleri listeler. '--deprecated' veya '--vulnerable' seçenekleriyle birleştirilemez.</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">Bilinen güvenlik açıklarına sahip paketleri listeler. '--deprecated' veya '--outdated' seçenekleriyle birleştirilemez.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">选择一个框架来显示其包。对多个框架多次使用该选项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出具有较新版本的包。不能与 "--deprecated" 或 "--vulnerable" 选项结合使用。</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">列出具有已知漏洞的包。不能与 "--deprecated" 或 "--outdated" 选项结合使用。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-package/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">選擇架構以顯示其套件。若有多個架構，則重複使用該選項。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Do not restore before running the command.</source>
+        <target state="new">Do not restore before running the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出有更新版本的套件。無法與 '--deprecated' 或 '--vulnerable' 選項一併使用。</target>
@@ -46,6 +51,11 @@
         <source>Lists packages that have known vulnerabilities. Cannot be combined with '--deprecated' or '--outdated' options.</source>
         <target state="translated">列出有已知弱點的套件。無法與 '--deprecated' 或 '--outdated' 選項一併使用。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error_restore">
+        <source>Restore failed. Please try running `dotnet restore`.</source>
+        <target state="new">Restore failed. Please try running `dotnet restore`.</target>
+        <note>do not translate `dotnet restore`</note>
       </trans-unit>
       <trans-unit id="NoProjectsOrSolutions">
         <source>A project or solution file could not be found in {0}. Specify a project or solution file to use.</source>

--- a/test/Microsoft.NET.TestFramework/Commands/ListPackageCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/ListPackageCommand.cs
@@ -16,12 +16,13 @@ namespace Microsoft.NET.TestFramework.Commands
         public override CommandResult Execute(IEnumerable<string> args)
         {
             List<string> newArgs = new();
+            newArgs.Add("package");
             newArgs.Add("list");
             if (!string.IsNullOrEmpty(_projectName))
             {
+                newArgs.Add("--project");
                 newArgs.Add(_projectName);
             }
-            newArgs.Add("package");
             newArgs.AddRange(args);
 
             return base.Execute(newArgs);

--- a/test/Microsoft.NET.TestFramework/Commands/PackageListCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/PackageListCommand.cs
@@ -5,30 +5,28 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.NET.TestFramework.Commands
 {
-    public class ListPackageCommand : DotnetCommand
+    public class PackageListCommand : DotnetCommand
     {
         private string? _projectName = null;
 
-        public ListPackageCommand(ITestOutputHelper log, params string[] args) : base(log, args)
+        public PackageListCommand(ITestOutputHelper log, params string[] args) : base(log, args)
         {
         }
 
         public override CommandResult Execute(IEnumerable<string> args)
         {
-            List<string> newArgs = new();
-            newArgs.Add("list");
+            List<string> newArgs = ["package", "list"];
             if (!string.IsNullOrEmpty(_projectName))
             {
+                newArgs.Add("--project");
                 newArgs.Add(_projectName);
             }
-            newArgs.Add("package");
             newArgs.AddRange(args);
 
             return base.Execute(newArgs);
         }
 
-
-        public ListPackageCommand WithProject(string projectName)
+        public PackageListCommand WithProject(string projectName)
         {
             _projectName = projectName;
             return this;

--- a/test/dotnet-completions.Tests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet-completions.Tests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1080,7 +1080,7 @@ _testhost_package_list() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="--verbosity --outdated --deprecated --vulnerable --framework --include-transitive --include-prerelease --highest-patch --highest-minor --config --source --interactive --format --output-version --project --help" 
+    opts="--verbosity --outdated --deprecated --vulnerable --framework --include-transitive --include-prerelease --highest-patch --highest-minor --config --source --interactive --format --output-version --no-restore --project --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )

--- a/test/dotnet-completions.Tests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet-completions.Tests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -635,6 +635,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--format', '--format', [CompletionResultType]::ParameterName, "Specifies the output format type for the list packages command.")
                 [CompletionResult]::new('--output-version', '--output-version', [CompletionResultType]::ParameterName, "Specifies the version of machine-readable output. Requires the `'--format json`' option.")
+                [CompletionResult]::new('--no-restore', '--no-restore', [CompletionResultType]::ParameterName, "Do not restore before running the command.")
                 [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "--project")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")

--- a/test/dotnet-completions.Tests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet-completions.Tests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -629,6 +629,7 @@ _testhost() {
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--format=[Specifies the output format type for the list packages command.]: :((console\:"console" json\:"json" ))' \
                                             '--output-version=[Specifies the version of machine-readable output. Requires the '\''--format json'\'' option.]: : ' \
+                                            '--no-restore[Do not restore before running the command.]' \
                                             '--project=[]: : ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute("--verbosity", "quiet")
+                .Execute("--verbosity", "quiet", "--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
             new ListPackageCommand(Log)
                 .WithProject("App.sln")
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Fail()
                 .And.HaveStdErr();
@@ -194,7 +194,7 @@ class Program
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -202,7 +202,7 @@ class Program
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute(args: "--include-transitive")
+                .Execute(args: ["--include-transitive", "--no-restore"])
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -303,7 +303,13 @@ class Program
         }
 
         [Theory]
+        [InlineData(false, "--no-restore")]
         [InlineData(false, "--vulnerable")]
+        [InlineData(false, "--no-restore", "--include-transitive")]
+        [InlineData(false, "--no-restore", "--include-prerelease")]
+        [InlineData(false, "--no-restore", "--deprecated")]
+        [InlineData(false, "--no-restore", "--outdated")]
+        [InlineData(false, "--no-restore", "--vulnerable")]
         [InlineData(false, "--vulnerable", "--include-transitive")]
         [InlineData(false, "--vulnerable", "--include-prerelease")]
         [InlineData(false, "--deprecated", "--highest-minor")]

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -139,10 +139,28 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
 
             new ListPackageCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Fail()
                 .And.HaveStdErr();
+        }
+
+        [Fact]
+        public void RestoresAndLists()
+        {
+            var testAsset = "NewtonSoftDependentProject";
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset(testAsset)
+                .WithSource()
+                .Path;
+
+            new PackageListCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdOut()
+                .And.HaveStdOutContaining("NewtonSoft.Json");
         }
 
         [Fact]

--- a/test/dotnet-package-list.Tests/GivenDotnetPackageList.cs
+++ b/test/dotnet-package-list.Tests/GivenDotnetPackageList.cs
@@ -6,11 +6,11 @@
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Package.List;
 
-namespace Microsoft.DotNet.Cli.List.Package.Tests
+namespace Microsoft.DotNet.Cli.Package.List.Tests
 {
-    public class GivenDotnetListPackage : SdkTest
+    public class GivenDotnetPackageList : SdkTest
     {
-        public GivenDotnetListPackage(ITestOutputHelper output) : base(output)
+        public GivenDotnetPackageList(ITestOutputHelper output) : base(output)
         {
         }
 
@@ -29,9 +29,9 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute("--verbosity", "quiet")
+                .Execute("--verbosity", "quiet", "--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -61,9 +61,9 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -86,9 +86,9 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -118,10 +118,10 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithProject("App.sln")
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -137,9 +137,9 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .WithSource()
                 .Path;
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Fail()
                 .And.HaveStdErr();
@@ -192,17 +192,17 @@ class Program
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute()
+                .Execute("--no-restore")
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
                 .And.NotHaveStdOutContaining("System.IO.FileSystem");
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
-                .Execute(args: "--include-transitive")
+                .Execute(args: ["--include-transitive", "--no-restore"])
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
@@ -236,7 +236,7 @@ class Program
 
             if (shouldntInclude == null)
             {
-                new ListPackageCommand(Log)
+                new PackageListCommand(Log)
                     .WithWorkingDirectory(projectDirectory)
                     .Execute(args.Split(' ', options: StringSplitOptions.RemoveEmptyEntries))
                     .Should()
@@ -246,7 +246,7 @@ class Program
             }
             else
             {
-                new ListPackageCommand(Log)
+                new PackageListCommand(Log)
                     .WithWorkingDirectory(projectDirectory)
                     .Execute(args.Split(' ', options: StringSplitOptions.RemoveEmptyEntries))
                     .Should()
@@ -272,7 +272,7 @@ class Program
                 .Should()
                 .Pass();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
                 .Execute("--framework", "invalid")
                 .Should()
@@ -294,7 +294,7 @@ class Program
                 .Pass()
                 .And.NotHaveStdErr();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
                 .Execute()
                 .Should()
@@ -303,7 +303,13 @@ class Program
         }
 
         [Theory]
+        [InlineData(false, "--no-restore")]
         [InlineData(false, "--vulnerable")]
+        [InlineData(false, "--no-restore", "--include-transitive")]
+        [InlineData(false, "--no-restore", "--include-prerelease")]
+        [InlineData(false, "--no-restore", "--deprecated")]
+        [InlineData(false, "--no-restore", "--outdated")]
+        [InlineData(false, "--no-restore", "--vulnerable")]
         [InlineData(false, "--vulnerable", "--include-transitive")]
         [InlineData(false, "--vulnerable", "--include-prerelease")]
         [InlineData(false, "--deprecated", "--highest-minor")]
@@ -324,7 +330,7 @@ class Program
         [InlineData(true, "--deprecated", "--outdated")]
         public void ItEnforcesOptionRules(bool throws, params string[] options)
         {
-            var parseResult = Parser.Instance.Parse($"dotnet list package {string.Join(' ', options)}");
+            var parseResult = Parser.Instance.Parse($"dotnet package list {string.Join(' ', options)}");
             Action checkRules = () => ListPackageReferencesCommand.EnforceOptionRules(parseResult);
 
             if (throws)
@@ -352,7 +358,7 @@ class Program
                 .Should()
                 .Pass();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithWorkingDirectory(projectDirectory)
                 .Execute()
                 .Should()
@@ -374,7 +380,7 @@ class Program
                 .Should()
                 .Pass();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithProject("TestAppSimple.csproj")
                 .WithWorkingDirectory(projectDirectory)
                 .Execute()
@@ -397,7 +403,7 @@ class Program
                 .Should()
                 .Pass();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithProject("App.sln")
                 .WithWorkingDirectory(projectDirectory)
                 .Execute()
@@ -424,7 +430,7 @@ class Program
                 .Should()
                 .Pass();
 
-            new ListPackageCommand(Log)
+            new PackageListCommand(Log)
                 .WithProject("../App.sln")
                 .WithWorkingDirectory(subFolderPath)
                 .Execute()

--- a/test/dotnet-package-list.Tests/GivenDotnetPackageList.cs
+++ b/test/dotnet-package-list.Tests/GivenDotnetPackageList.cs
@@ -145,6 +145,25 @@ namespace Microsoft.DotNet.Cli.Package.List.Tests
                 .And.HaveStdErr();
         }
 
+
+        [Fact]
+        public void RestoresAndLists()
+        {
+            var testAsset = "NewtonSoftDependentProject";
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset(testAsset)
+                .WithSource()
+                .Path;
+
+            new PackageListCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdOut()
+                .And.HaveStdOutContaining("NewtonSoft.Json");
+        }
+
         [Fact]
         public void ItListsTransitivePackage()
         {

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\dotnet-list-reference.Tests\**\*.cs" LinkBase="dotnet-list-reference" />
     <Compile Include="..\dotnet-nuget.UnitTests\**\*.cs" LinkBase="dotnet-nuget" />
     <Compile Include="..\dotnet-pack.Tests\**\*.cs" LinkBase="dotnet-pack" />
+    <Compile Include="..\dotnet-package-list.Tests\**\*.cs" LinkBase="dotnet-package-list" />
     <Compile Include="..\dotnet-publish.Tests\**\*.cs" LinkBase="dotnet-publish" />
     <Compile Include="..\dotnet-remove-package.Tests\**\*.cs" LinkBase="dotnet-remove-package" />
     <Compile Include="..\dotnet-remove-reference.Tests\**\*.cs" LinkBase="dotnet-remove-reference" />


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/13406

## Description

This PR
* Adds implicit restore to `dotnet package list` command or `dotnet list package` (https://github.com/dotnet/sdk/pull/45384)

