### PR TITLE
Wait for file change when process exits

### DIFF
--- a/src/BuiltInTools/dotnet-watch/EnvironmentVariables.cs
+++ b/src/BuiltInTools/dotnet-watch/EnvironmentVariables.cs
@@ -28,7 +28,7 @@ internal static class EnvironmentVariables
     public static bool IsPollingEnabled => ReadBool("DOTNET_USE_POLLING_FILE_WATCHER");
     public static bool SuppressEmojis => ReadBool("DOTNET_WATCH_SUPPRESS_EMOJIS");
     public static bool RestartOnRudeEdit => ReadBool("DOTNET_WATCH_RESTART_ON_RUDE_EDIT");
-    public static TimeSpan ProcessCleanupTimeout => ReadTimeSpan("DOTNET_WATCH_PROCESS_CLEANUP_TIMEOUT_MS");
+    public static TimeSpan ProcessCleanupTimeout => ReadTimeSpan("DOTNET_WATCH_PROCESS_CLEANUP_TIMEOUT_MS", defaultValue: TimeSpan.FromSeconds(5));
 
     public static string SdkRootDirectory =>
 #if DEBUG
@@ -51,6 +51,6 @@ internal static class EnvironmentVariables
     private static bool ReadBool(string variableName)
         => Environment.GetEnvironmentVariable(variableName) is var value && (value == "1" || bool.TryParse(value, out var boolValue) && boolValue);
 
-    private static TimeSpan ReadTimeSpan(string variableName)
-        => Environment.GetEnvironmentVariable(variableName) is var value && long.TryParse(value, out var intValue) && intValue >= 0 ? TimeSpan.FromMilliseconds(intValue) : TimeSpan.FromSeconds(5);
+    private static TimeSpan ReadTimeSpan(string variableName, TimeSpan defaultValue)
+        => Environment.GetEnvironmentVariable(variableName) is var value && long.TryParse(value, out var intValue) && intValue >= 0 ? TimeSpan.FromMilliseconds(intValue) : defaultValue;
 }

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.Build.Graph;
 using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Watch
 {
@@ -218,8 +219,11 @@ namespace Microsoft.DotNet.Watch
                         }
                         catch (OperationCanceledException)
                         {
+                            // Ctrl+C, forced restart, or process exited.
                             Debug.Assert(iterationCancellationToken.IsCancellationRequested);
-                            waitForFileChangeBeforeRestarting = false;
+
+                            // Will wait for a file change if process exited.
+                            waitForFileChangeBeforeRestarting = true;
                             break;
                         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47425.

There are two code paths that may be executed when process exists ,depending on exact timing of task cancellation.
One of the code paths was incorrectly not waiting for a file update before restarting the app.