### PR TITLE
Revert changes to NativeAot test due to runtime update

### DIFF
--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -39,25 +39,7 @@ namespace Microsoft.NET.Publish.Tests
             {
                 testProject.AdditionalProperties["StripSymbols"] = "true";
             }
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
-
-            string[] ignoredPatterns = null;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                ignoredPatterns = new string[]
-                {
-                    // Both these exclusions can be removed once the min tested version is .NET 10 and the min supported
-                    // XCode version is XCode 16.
-
-                    // -ld_classic option is required to workaround bugs in XCode 15 and .NET 9 and older runtimes.
-                    // See https://github.com/dotnet/runtime/issues/97745 for details.
-                    "ld: warning: -ld_classic is deprecated and will be removed in a future release",
-                    // These warnings show up when dotnet/runtime compiled using Apple clang 15+ is used
-                    // with classic linker (either Apple clang 14 or clang 15+ with -ld_classic).
-                    "ld: warning: __LD,__compact_unwind entries for",
-                };
-            }
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
             publishCommand
@@ -66,7 +48,7 @@ namespace Microsoft.NET.Publish.Tests
                 .And.NotHaveStdOutContaining("IL2026")
                 .And.NotHaveStdErrContaining("NETSDK1179")
                 .And.NotHaveStdErrContaining("warning")
-                .And.NotHaveStdOutContaining("warning", ignoredPatterns);
+                .And.NotHaveStdOutContaining("warning");
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
             var rid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];


### PR DESCRIPTION
Referring to the previous [comment](https://github.com/dotnet/sdk/pull/46661#issuecomment-2654511267), I reverted the previous changes.