### PR TITLE
add a flag to let users opt into serial builds of inner-RID containers

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -346,7 +346,7 @@
     <MSBuild
         Projects="@(_InnerBuild)"
         Targets="Publish;_ParseItemsForPublishingSingleContainer;_PublishSingleContainer"
-        BuildInParallel="true">
+        BuildInParallel="$([MSBuild]::ValueOrDefault('$(ContainerPublishInParallel)', 'true'))">
         <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />
     </MSBuild>
 


### PR DESCRIPTION
This adds a workaround for https://github.com/dotnet/sdk-container-builds/issues/625.

It adds a containers-specific flag that lets users publish inner-RID containers in a serial manner.

If merged, we should backport to 9.0.3xx as well (and maybe 8.0.4xx if @MattKotsenas things they'll need it).