### PR TITLE
Fix global properties not propagating in new dotnet test for MTP

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -9,5 +9,5 @@ namespace Microsoft.DotNet.Cli
 
     internal record BuildProperties(string Configuration, string RuntimeIdentifier, string TargetFramework);
 
-    internal record BuildOptions(PathOptions PathOptions, BuildProperties BuildProperties, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
+    internal record BuildOptions(PathOptions PathOptions, BuildProperties BuildProperties, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, string[] UserSpecifiedProperties, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
 }

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -234,6 +234,7 @@ namespace Microsoft.DotNet.Cli
             command.Options.Add(TestingPlatformOptions.TestModulesRootDirectoryOption);
             command.Options.Add(TestingPlatformOptions.MaxParallelTestModulesOption);
             command.Options.Add(CommonOptions.ArchitectureOption);
+            command.Options.Add(CommonOptions.PropertiesOption);
             command.Options.Add(TestingPlatformOptions.ConfigurationOption);
             command.Options.Add(TestingPlatformOptions.FrameworkOption);
             command.Options.Add(CommonOptions.OperatingSystemOption);

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/OtherTestProject/OtherTestProject.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication Condition="'$(PROPERTY_TO_ENABLE_MTP)' != ''">true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/OtherTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/OtherTestProject/Program.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test1",
+			DisplayName = "Test1",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProject/Program.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+		
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<LangVersion>latest</LangVersion>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication Condition="'$(PROPERTY_TO_ENABLE_MTP)' != ''">true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProjectWithConditionOnGlobalProperty.sln
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/TestProjectWithConditionOnGlobalProperty.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35505.181
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{D2E321F2-3513-99DE-C37E-6D48D15F404D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherTestProject", "OtherTestProject/OtherTestProject.csproj", "{6171FC1F-E2F2-4F66-A8DE-EC4765081661}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6171FC1F-E2F2-4F66-A8DE-EC4765081661}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6171FC1F-E2F2-4F66-A8DE-EC4765081661}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6171FC1F-E2F2-4F66-A8DE-EC4765081661}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6171FC1F-E2F2-4F66-A8DE-EC4765081661}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3D7914D1-7D03-4FFB-8D0F-7FFA6B6BA6A0}
+	EndGlobalSection
+EndGlobal

--- a/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/dotnet.config
+++ b/test/TestAssets/TestProjects/TestProjectWithConditionOnGlobalProperty/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test:runner]
+name= "Microsoft.Testing.Platform"


### PR DESCRIPTION
Related to #45927

- Adds `CommonOptions.PropertiesOption` (i.e, `-p`/`--property`/etc) as a command line option for the new dotnet test experience.
- Capture those user-specified properties to `BuildOptions`
- Ensure those properties propagate correctly and are taken into consideration in `GetGlobalProperties`
- Cleanup `GetPropertyTokens` as it's now not "unmatched token".