### PR TITLE
[release/9.0.3xx] add a flag to let users opt into serial builds of inner-RID containers

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -347,7 +347,7 @@
     <MSBuild
         Projects="@(_InnerBuild)"
         Targets="Publish;_ParseItemsForPublishingSingleContainer;_PublishSingleContainer"
-        BuildInParallel="true">
+        BuildInParallel="$([MSBuild]::ValueOrDefault('$(ContainerPublishInParallel)', 'true'))">
         <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainers" />
     </MSBuild>
 


### PR DESCRIPTION
Manual backport of #47455 to release/9.0.3xx so this makes it into the next major release.