### PR TITLE
Rename VSMSBuildExtensions and VSTemplateLocator and move under src/Layout

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -5,8 +5,8 @@
   <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and
                         '$(OS)' == 'Windows_NT' and
                         '$(Architecture)' == 'x64'">
-    <ProjectToBuild Include="$(RepoRoot)src\VSMSBuildExtensions\VSMSBuildExtensions.proj" DotNetBuildPass="2" />
-    <ProjectToBuild Include="$(RepoRoot)src\VSTemplateLocator\VSTemplateLocator.proj" DotNetBuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)src\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj" DotNetBuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)src\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj" DotNetBuildPass="2" />
   </ItemGroup>
 
   <!-- For product build, build the sdk bundle in the second build pass on windows as

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -5,8 +5,8 @@
   <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and
                         '$(OS)' == 'Windows_NT' and
                         '$(Architecture)' == 'x64'">
-    <ProjectToBuild Include="$(RepoRoot)src\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj" DotNetBuildPass="2" />
-    <ProjectToBuild Include="$(RepoRoot)src\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj" DotNetBuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj" DotNetBuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj" DotNetBuildPass="2" />
   </ItemGroup>
 
   <!-- For product build, build the sdk bundle in the second build pass on windows as

--- a/sdk.sln
+++ b/sdk.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.31903.286
@@ -491,7 +491,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "redist-installer", "src\Ins
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sdk", "src\Installer\pkg\dotnet-sdk.proj", "{8D6A9984-118D-4415-A8FA-AB1F26CF5C44}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VS.Redist.Common.Net.Core.SDK.VSTemplateLocator", "src\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj", "{0CBA5FB8-71A3-457A-89F3-E52B9602164A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VS.Redist.Common.Net.Core.SDK.VSTemplateLocator", "src\Layout\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj", "{0CBA5FB8-71A3-457A-89F3-E52B9602164A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sdk-tasks.Tests", "test\sdk-tasks.Tests\sdk-tasks.Tests.csproj", "{21C21975-84C1-4A24-8E21-F7EC790A4584}"
 EndProject

--- a/sdk.sln
+++ b/sdk.sln
@@ -491,7 +491,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "redist-installer", "src\Ins
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-sdk", "src\Installer\pkg\dotnet-sdk.proj", "{8D6A9984-118D-4415-A8FA-AB1F26CF5C44}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSTemplateLocator", "src\VSTemplateLocator\VSTemplateLocator.proj", "{0CBA5FB8-71A3-457A-89F3-E52B9602164A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VS.Redist.Common.Net.Core.SDK.VSTemplateLocator", "src\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj", "{0CBA5FB8-71A3-457A-89F3-E52B9602164A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sdk-tasks.Tests", "test\sdk-tasks.Tests\sdk-tasks.Tests.csproj", "{21C21975-84C1-4A24-8E21-F7EC790A4584}"
 EndProject
@@ -503,7 +503,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Sdk.Compilers
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebTools.AspireService.Tests", "test\Microsoft.WebTools.AspireService.Tests\Microsoft.WebTools.AspireService.Tests.csproj", "{1F0B4B3C-DC88-4740-B04F-1707102E9930}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSMSBuildExtensions", "src\VSMSBuildExtensions\VSMSBuildExtensions.proj", "{D9617F63-15F4-4CA2-8ECF-728A94B45D82}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VS.Redist.Common.Net.Core.SDK.MSBuildExtensions", "src\Layout\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj", "{D9617F63-15F4-4CA2-8ECF-728A94B45D82}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DotNet.HotReload.Agent", "src\BuiltInTools\HotReloadAgent\Microsoft.DotNet.HotReload.Agent.shproj", "{418B10BD-CA42-49F3-8F4A-D8CC90C8A17D}"
 EndProject

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj
@@ -10,7 +10,6 @@
                            '$(Architecture)' == 'x64' and
                            '$(PgoInstrument)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
-    <PackageId>VS.Redist.Common.Net.Core.SDK.MSBuildExtensions</PackageId>
     <PackageDescription>MSBuild extensions bundled with .NET Core SDK for internal Visual Studio build consumption</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj
@@ -10,7 +10,6 @@
                            '$(Architecture)' == 'x64' and
                            '$(PgoInstrument)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
-    <PackageId>VS.Redist.Common.Net.Core.SDK.VSTemplateLocator</PackageId>
     <PackageDescription>MSBuild extensions bundled with .NET Core SDK for internal Visual Studio build consumption</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>


### PR DESCRIPTION
Move the VS related packages under src/Layout so that they can share properties with the other Layout projects to avoid hardcodes. src/Layout will be the home for all the VS transport packages. https://github.com/dotnet/sdk/pull/47499 is related.