### PR TITLE
Avoid intermediate FullNugetVersion file

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -29,7 +29,7 @@
 
   <Target Name="GetNonStableProductVersion">
     <!-- Retrieve the non-stable product version. -->
-    <MSBuild Projects="$(RepoRoot)src/Installer/redist-installer/redist-installer.csproj"
+    <MSBuild Projects="$(RepoRoot)src/Installer/redist-installer/redist-installer.proj"
              Targets="ReturnProductVersion">
       <Output TaskParameter="TargetOutputs" PropertyName="NonStableProductVersion" />
     </MSBuild>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -26,4 +26,23 @@
   <ItemGroup>
     <Artifact Update="$(ArtifactsShippingPackagesDir)dotnet-sdk-pgo-*" Visibility="External" />
   </ItemGroup>
+
+  <Target Name="GetNonStableProductVersion">
+    <!-- Retrieve the non-stable product version. -->
+    <MSBuild Projects="$(RepoRoot)src/Layout/redist/redist.csproj"
+             Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NonStableProductVersion" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="AddRelativeBlobPathToBlobArtifacts"
+          DependsOnTargets="GetNonStableProductVersion"
+          BeforeTargets="PublishToAzureDevOpsArtifacts"
+          AfterTargets="GenerateChecksumsFromArtifacts">
+    <ItemGroup>
+      <Artifact Condition="'%(Artifact.PublishFlatContainer)' == 'true' and '%(Artifact.RelativeBlobPath)' == ''"
+                RelativeBlobPath="Sdk/$(NonStableProductVersion)/%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -19,7 +19,7 @@
   <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
     <Artifact Include="$(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg;
                        $(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg"
-              PublishFlatContainer="false" />
+              Kind="Package" />
   </ItemGroup>
 
   <!-- The PGO sdk should always have External visibility, even if someone changes the default artifact visibility -->
@@ -40,7 +40,7 @@
           BeforeTargets="PublishToAzureDevOpsArtifacts"
           AfterTargets="GenerateChecksumsFromArtifacts">
     <ItemGroup>
-      <Artifact Condition="'%(Artifact.PublishFlatContainer)' == 'true' and '%(Artifact.RelativeBlobPath)' == ''"
+      <Artifact Condition="'%(Artifact.Kind)' == 'Blob' and '%(Artifact.RelativeBlobPath)' == ''"
                 RelativeBlobPath="Sdk/$(NonStableProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -29,7 +29,7 @@
 
   <Target Name="GetNonStableProductVersion">
     <!-- Retrieve the non-stable product version. -->
-    <MSBuild Projects="$(RepoRoot)src/Layout/redist/redist.csproj"
+    <MSBuild Projects="$(RepoRoot)src/Installer/redist-installer/redist-installer.csproj"
              Targets="ReturnProductVersion">
       <Output TaskParameter="TargetOutputs" PropertyName="NonStableProductVersion" />
     </MSBuild>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -84,7 +84,7 @@
     <Artifact Include="$(ArtifactsPackagesDir)**\VS.Tools.*.nupkg;
                        $(ArtifactsPackagesDir)**\VS.Redist.*.nupkg"
               IsShipping="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping'))"
-              PublishFlatContainer="false" />
+              Kind="Package" />
   </ItemGroup>
 
   <!-- Only publish this file from win-x64 so that we don't end up with duplicates. -->
@@ -114,7 +114,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="@(SdkArtifact)">
+    <Artifact Include="@(SdkArtifact)" Kind="Blob">
       <ChecksumPath Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip')) != 'true'">%(FullPath).sha512</ChecksumPath>
     </Artifact>
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <RelativeBlobPathParent>Sdk/$([System.IO.File]::ReadAllText('$(ArtifactsTmpDir)FullNugetVersion.version').Trim())</RelativeBlobPathParent>
     <PublishBinariesAndBadge Condition="'$(PublishBinariesAndBadge)' == ''">true</PublishBinariesAndBadge>
   </PropertyGroup>
 
@@ -115,8 +114,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="@(SdkArtifact)"
-              RelativeBlobPath="$(RelativeBlobPathParent)/%(Filename)%(Extension)">
+    <Artifact Include="@(SdkArtifact)">
       <ChecksumPath Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip')) != 'true'">%(FullPath).sha512</ChecksumPath>
     </Artifact>
   </ItemGroup>

--- a/src/Installer/redist-installer/Directory.Build.targets
+++ b/src/Installer/redist-installer/Directory.Build.targets
@@ -28,14 +28,6 @@
     <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
   </PropertyGroup>
 
-  <!-- This is a hack to make the full nuget version available during the publishing step -->
-  <Target Name="GenerateFullNugetVersionFile"
-          BeforeTargets="Build">
-    <WriteLinesToFile File="$(ArtifactsTmpDir)FullNugetVersion.version"
-                      Lines="$(FullNugetVersion)"
-                      Overwrite="true" />
-  </Target>
-
   <Import Project="$(RepoRoot)src\Tasks\sdk-tasks\sdk-tasks.InTree.targets" />
 
   <Import Project="targets\RestoreLayout.targets" />

--- a/src/Installer/redist-installer/redist-installer.proj
+++ b/src/Installer/redist-installer/redist-installer.proj
@@ -20,4 +20,6 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" />
   </ItemGroup>
 
+  <Target Name="ReturnProductVersion" Returns="$(FullNugetVersion)" />
+
 </Project>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -103,4 +103,6 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ReturnProductVersion" Returns="$(FullNugetVersion)" />
+
 </Project>

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -103,6 +103,4 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ReturnProductVersion" Returns="$(FullNugetVersion)" />
-
 </Project>


### PR DESCRIPTION
Use the same mechanism as in aspnetcore, windowsdesktop and runtime to retrieve the non stable product version in Publishing.props and update the Artifact items with that version.

Also remove `IsShipping="true"` from the artifacts as that's the default.