### PR TITLE
Cleanup special handling of command-line options that are now forwarded as global properties

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
@@ -128,14 +128,7 @@ internal static class MSBuildUtility
         {
             foreach (var (key, value) in MSBuildPropertyParser.ParseProperties(property))
             {
-                if (globalProperties.TryGetValue(key, out var existingValues))
-                {
-                    globalProperties[key] = $"{existingValues};{value}";
-                }
-                else
-                {
-                    globalProperties[key] = value;
-                }
+                globalProperties[key] = value;
             }
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildUtility.cs
@@ -62,37 +62,19 @@ internal static class MSBuildUtility
             parseResult.GetValue(TestingPlatformOptions.SolutionOption),
             parseResult.GetValue(TestingPlatformOptions.DirectoryOption));
 
-        BuildProperties buildProperties = new(
-            parseResult.GetValue(TestingPlatformOptions.ConfigurationOption),
-            ResolveRuntimeIdentifier(parseResult),
-            parseResult.GetValue(TestingPlatformOptions.FrameworkOption));
-
         return new BuildOptions(
             pathOptions,
-            buildProperties,
             parseResult.GetValue(CommonOptions.NoRestoreOption),
             parseResult.GetValue(TestingPlatformOptions.NoBuildOption),
             parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
             degreeOfParallelism,
-            parseResult.GetValue(CommonOptions.PropertiesOption),
+            GetGlobalProperties([.. msbuildArgs]),
             unmatchedTokens,
             msbuildArgs);
     }
 
-    private static string ResolveRuntimeIdentifier(ParseResult parseResult)
-    {
-        if (parseResult.HasOption(CommonOptions.RuntimeOption))
-        {
-            return parseResult.GetValue(CommonOptions.RuntimeOption);
-        }
-
-        if (!parseResult.HasOption(CommonOptions.OperatingSystemOption) && !parseResult.HasOption(CommonOptions.ArchitectureOption))
-        {
-            return string.Empty;
-        }
-
-        return CommonOptions.ResolveRidShorthandOptionsToRuntimeIdentifier(parseResult.GetValue(CommonOptions.OperatingSystemOption), parseResult.GetValue(CommonOptions.ArchitectureOption));
-    }
+    private static string[]? GetGlobalProperties(IReadOnlyList<string> args)
+        => new CliConfiguration(new CliCommand("dotnet") { CommonOptions.PropertiesOption }).Parse(args).GetValue(CommonOptions.PropertiesOption);
 
     private static IEnumerable<string> GetBinaryLoggerTokens(IEnumerable<string> args)
     {
@@ -140,8 +122,7 @@ internal static class MSBuildUtility
 
     private static Dictionary<string, string> GetGlobalProperties(BuildOptions buildOptions)
     {
-        var globalProperties = new Dictionary<string, string>();
-        var buildProperties = buildOptions.BuildProperties;
+        var globalProperties = new Dictionary<string, string>(buildOptions.UserSpecifiedProperties.Length);
 
         foreach (var property in buildOptions.UserSpecifiedProperties)
         {
@@ -156,21 +137,6 @@ internal static class MSBuildUtility
                     globalProperties[key] = value;
                 }
             }
-        }
-
-        if (!string.IsNullOrEmpty(buildProperties.Configuration))
-        {
-            globalProperties[CliConstants.Configuration] = buildProperties.Configuration;
-        }
-
-        if (!string.IsNullOrEmpty(buildProperties.RuntimeIdentifier))
-        {
-            globalProperties[CliConstants.RuntimeIdentifier] = buildProperties.RuntimeIdentifier;
-        }
-
-        if (!string.IsNullOrEmpty(buildProperties.TargetFramework))
-        {
-            globalProperties[CliConstants.TargetFramework] = buildProperties.TargetFramework;
         }
 
         return globalProperties;

--- a/src/Cli/dotnet/commands/dotnet-test/Options.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Options.cs
@@ -7,6 +7,4 @@ internal record TestOptions(string Configuration, string Architecture, bool HasF
 
 internal record PathOptions(string ProjectPath, string SolutionPath, string DirectoryPath);
 
-internal record BuildProperties(string Configuration, string RuntimeIdentifier, string TargetFramework);
-
-internal record BuildOptions(PathOptions PathOptions, BuildProperties BuildProperties, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, string[] UserSpecifiedProperties, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
+internal record BuildOptions(PathOptions PathOptions, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, string[] UserSpecifiedProperties, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -398,7 +398,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnableTestingPlatform()
                                     .Execute(TestingPlatformOptions.ProjectOption.Name, "TestProject.csproj",
-                                            TestingPlatformOptions.ConfigurationOption.Name, configuration,
                                             "--property:WarningLevel=2", $"--property:Configuration={configuration}");
 
             if (!TestContext.IsLocalized())

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -398,6 +398,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnableTestingPlatform()
                                     .Execute(TestingPlatformOptions.ProjectOption.Name, "TestProject.csproj",
+                                            TestingPlatformOptions.ConfigurationOption.Name, configuration,
                                             "--property:WarningLevel=2", $"--property:Configuration={configuration}");
 
             if (!TestContext.IsLocalized())


### PR DESCRIPTION
Since https://github.com/dotnet/sdk/pull/47464, I think the special handling for Configuration, RID, and TargetFramework is no longer needed.