### PR TITLE
Don't run the GetProducedPackages target early when previous build pass dependencies are referenced

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -390,7 +390,7 @@
       <_DependentProjectCurrentBuildPass Include="@(_DependentProject->WithMetadataValue('DotNetBuildPass', '$(DotNetBuildPass)'))" />
 
       <_DependentProjectToSkip Include="@(_DependentProject)" Exclude="@(_DependentProjectCurrentBuildPass)" />
-      <_DependentProjectToSkip Include="@(_DependentProject)" AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
+      <_DependentProjectToSkip AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
 
       <_DependentProject Remove="@(_DependentProject)" />
       <_DependentProject Include="@(_DependentProjectCurrentBuildPass)" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -390,6 +390,7 @@
       <_DependentProjectCurrentBuildPass Include="@(_DependentProject->WithMetadataValue('DotNetBuildPass', '$(DotNetBuildPass)'))" />
 
       <_DependentProjectToSkip Include="@(_DependentProject)" Exclude="@(_DependentProjectCurrentBuildPass)" />
+      <_DependentProjectToSkip Include="@(_DependentProject)" AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
 
       <_DependentProject Remove="@(_DependentProject)" />
       <_DependentProject Include="@(_DependentProjectCurrentBuildPass)" />
@@ -553,7 +554,26 @@
     </Touch>
   </Target>
 
+  <Target Name="GetProducedPackagesFromDependentVerticals"
+          Condition="'$(IsUtilityProject)' != 'true'"
+          Returns="@(ProducedPackageFromDependentVertical)">
+    <!-- Add manifests from dependent verticals. -->
+    <ItemGroup>
+      <RepoAssetManifestFromDependentVertical Include="$(ArtifactsAssetManifestsDir)*.xml" Exclude="$(MergedAssetManifestOutputPath)" />
+    </ItemGroup>
+
+    <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifestFromDependentVertical)" RepoOrigin="$(RepositoryName)">
+      <Output TaskParameter="KnownPackages" ItemName="ProducedPackageFromDependentVertical" />
+      <Output TaskParameter="KnownBlobs" ItemName="ProducedAssetFromDependentVertical" />
+    </GetKnownArtifactsFromAssetManifests>
+
+    <ItemGroup>
+      <ProducedPackageFromDependentVertical ReferenceOnly="$([MSBuild]::ValueOrDefault('$(ReferenceOnlyRepoArtifacts)', 'false'))" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="GetProducedPackages"
+          DependsOnTargets="GetProducedPackagesFromDependentVerticals"
           Condition="'$(IsUtilityProject)' != 'true'"
           Returns="@(ProducedPackage);@(ProducedPackageFromDependentVertical)">
     <ItemGroup>
@@ -588,19 +608,8 @@
       <BinPlaceFile Include="@(ProducedAsset->'$(ArtifactsAssetsDir)%(Identity)')" Condition="'%(Visibility)' != 'Vertical'"/>
     </ItemGroup>
 
-    <!-- Add manifests from dependent verticals. -->
-    <ItemGroup>
-      <RepoAssetManifestFromDependentVertical Include="$(ArtifactsAssetManifestsDir)*.xml" Exclude="$(MergedAssetManifestOutputPath)" />
-    </ItemGroup>
-
-    <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifestFromDependentVertical)" RepoOrigin="$(RepositoryName)">
-      <Output TaskParameter="KnownPackages" ItemName="ProducedPackageFromDependentVertical" />
-      <Output TaskParameter="KnownBlobs" ItemName="ProducedAssetFromDependentVertical" />
-    </GetKnownArtifactsFromAssetManifests>
-
     <ItemGroup>
       <ProducedPackage ReferenceOnly="$([MSBuild]::ValueOrDefault('$(ReferenceOnlyRepoArtifacts)', 'false'))" />
-      <ProducedPackageFromDependentVertical ReferenceOnly="$([MSBuild]::ValueOrDefault('$(ReferenceOnlyRepoArtifacts)', 'false'))" />
     </ItemGroup>
   </Target>
 
@@ -712,7 +721,12 @@
     </Touch>
   </Target>
 
-  <Target Name="DiscoverToolPackageVersions" DependsOnTargets="GetProducedPackages">
+  <PropertyGroup>
+    <_DiscoverToolPackageVersionsDependsOn>GetProducedPackages</_DiscoverToolPackageVersionsDependsOn>
+    <_DiscoverToolPackageVersionsDependsOn Condition="'$(GetDependentVerticalAssetsOnly)' == 'true'">GetProducedPackagesFromDependentVerticals</_DiscoverToolPackageVersionsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DiscoverToolPackageVersions" DependsOnTargets="$(_DiscoverToolPackageVersionsDependsOn)">
     <JoinItems Left="@(ProducedPackage);@(ProducedPackageFromDependentVertical)"
                Right="@(BuiltSdkPackage)"
                LeftMetadata="*">

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -24,4 +24,9 @@
     <RepositoryReference Include="sdk" DotNetBuildPass="2" />
   </ItemGroup>
 
+  <!-- Build the ASP.NET Core hosting bundle -->
+  <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and '$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'x64'">
+    <RepositoryReference Include="aspnetcore" DotNetBuildPass="2" />
+  </ItemGroup>
+
 </Project>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -65,10 +65,6 @@
     <RepositoryReference Include="source-build-reference-packages" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and '$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'x64'">
-    <RepositoryReference Include="aspnetcore" DotNetBuildPass="2" />
-  </ItemGroup>
-
   <!--
     If we have authentication, keep the templating internal feed (if one exists) to acquire the
     text-only prebuilt. The source-build repo as a whole should depend on the same internal feed as


### PR DESCRIPTION
When getting produced packages from dependencies that we aren't building, make sure to only look at dependent verticals. Otherwise we may run the "GetProducedPackages" target before we run the "Build" target.