### PR TITLE
[release/9.0.1xx] Update GivenThatWeWantMSBuildToRespectCustomCulture.cs

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantMSBuildToRespectCustomCulture.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantMSBuildToRespectCustomCulture.cs
@@ -27,18 +27,5 @@ namespace Microsoft.NET.Build.Tests
             new FileInfo(Path.Combine(outputDirectory, "test-2", "MSBuildCultureResourceGeneration.resources.dll")).Should().Exist();
         }
 
-        [Theory]
-        [InlineData("net7.0")]
-        [InlineData("net6.0")]
-        public void SupportRespectAlreadyAssignedItemCulture_IsNotSupported_BuildShouldFail(string targetFramework)
-        {
-            var testAsset = _testAssetsManager
-                .CopyTestAsset("MSBuildCultureResourceGeneration", identifier: targetFramework)
-                .WithSource()
-                .WithTargetFramework(targetFramework);
-
-            var buildCommand = new BuildCommand(testAsset);
-            buildCommand.Execute().Should().Fail();
-        }
     }
 }


### PR DESCRIPTION
Manual backport of #47549

> Fixes failing SupportRespectAlreadyAssignedItemCulture_IsNotSupported_BuildShouldFail test by consolidating back with the core only test theory.
> This is causing all PRs in sdk main to fail because of a machine rollout that updated VS to 17.13.x yesterday.
