### PR TITLE
sln-list: Add format options 

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -189,4 +189,7 @@
   <data name="SerializerNotFound" xml:space="preserve">
     <value>Could not read solution file {0}. Supported files are .sln and .slnx valid solutions.</value>
   </data>
+  <data name="ListOutputFormatOptionDescription" xml:space="preserve">
+    <value>Output format for the list command.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -27,7 +27,7 @@ internal class ListProjectsInSolutionCommand : CommandBase
 
     public override int Execute()
     {
-        string solutionFileFullPath = SlnFileFactory.GetSolutionFileFullPath(_fileOrDirectory, includeSolutionFilterFiles: false);
+        string solutionFileFullPath = SlnFileFactory.GetSolutionFileFullPath(_fileOrDirectory);
         try
         {
             ListAllProjectsAsync(solutionFileFullPath);
@@ -43,7 +43,7 @@ internal class ListProjectsInSolutionCommand : CommandBase
     {
         SolutionModel solution = SlnFileFactory.CreateFromFileOrDirectory(solutionFileFullPath);
         string[] paths = _displaySolutionFolders
-            ? solution.SolutionFolders.Select(folder => Path.GetDirectoryName(folder.Path.TrimStart('/'))).ToArray()
+            ? solution.SolutionFolders.Select(folder => Path.GetDirectoryName(folder.Path.TrimStart('/'))).ToArray() // VS-SolutionPersistence does not return a path object, so there might be issues with forward/backward slashes on different platforms
             : solution.SolutionProjects.Select(project => project.FilePath).ToArray();
         
         if (paths.Length == 0)

--- a/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/Program.cs
@@ -27,7 +27,7 @@ internal class ListProjectsInSolutionCommand : CommandBase
 
     public override int Execute()
     {
-        string solutionFileFullPath = SlnFileFactory.GetSolutionFileFullPath(_fileOrDirectory, includeSolutionFilterFiles: true);
+        string solutionFileFullPath = SlnFileFactory.GetSolutionFileFullPath(_fileOrDirectory, includeSolutionFilterFiles: false);
         try
         {
             ListAllProjectsAsync(solutionFileFullPath);

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListOutputFormat.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListOutputFormat.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli;
+
+public enum SlnListOutputFormat
+{
+    Text,
+    Raw, 
+    Json
+}

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
@@ -17,7 +17,7 @@ public static class SlnListParser
 
     public static readonly CliOption<SlnListOutputFormat> OutputFormatOption = new("--format")
     {
-        Description = "TODO: FORMAT"
+        Description = LocalizableStrings.ListOutputFormatOptionDescription,
     };
 
     private static readonly CliCommand Command = ConstructCommand();

--- a/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/list/SlnListParser.cs
@@ -15,6 +15,11 @@ public static class SlnListParser
         Arity = ArgumentArity.Zero
     };
 
+    public static readonly CliOption<SlnListOutputFormat> OutputFormatOption = new("--format")
+    {
+        Description = "TODO: FORMAT"
+    };
+
     private static readonly CliCommand Command = ConstructCommand();
 
     public static CliCommand GetCommand()
@@ -27,6 +32,7 @@ public static class SlnListParser
         CliCommand command = new("list", LocalizableStrings.ListAppFullName);
 
         command.Options.Add(SolutionFolderOption);
+        command.Options.Add(OutputFormatOption);
         command.SetAction((parseResult) => new ListProjectsInSolutionCommand(parseResult).Execute());
 
         return command;

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Umístěte projekt do kořene řešení, není potřeba vytvářet složku řešení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Zobrazí cesty ke složkám řešení.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Platzieren Sie das Projekt im Stamm der Projektmappe, statt einen Projektmappenordner zu erstellen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Projektmappenordnerpfade anzeigen.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Coloque el proyecto en la raíz de la solución, en lugar de crear una carpeta de soluciones.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Muestra las rutas de acceso de la carpeta de la solución.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Place le projet à la racine de la solution, au lieu de créer un dossier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Afficher les chemins d'accès aux dossiers de solutions.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Inserisce il progetto nella radice della soluzione invece di creare una cartella soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Visualizza i percorsi della cartella della soluzione.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">ソリューション フォルダーを作成するのではなく、プロジェクトをソリューションのルートに配置します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">ソリューション フォルダーのパスを表示します。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">솔루션 폴더를 만드는 대신, 솔루션의 루트에 프로젝트를 배치하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">솔루션 폴더 경로를 표시합니다.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Umieść projekt w katalogu głównym rozwiązania zamiast tworzyć folder rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Wyświetl ścieżki folderów rozwiązania.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Coloque o projeto na raiz da solução, em vez de criar uma pasta da solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Exibir caminhos de pasta da solução.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Поместите проект в корень решения вместо создания папки решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Отображение путей к папке решения.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Bir çözüm klasörü oluşturmak yerine projeyi çözümün köküne yerleştirin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">Çözüm klasörü yollarını görüntüleyin.</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">将项目放在解决方案的根目录下，而不是创建解决方案文件夹。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">显示解决方案文件夹路径。</target>

--- a/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">請將專案放置在解決方案的根目錄中，而非放置於建立解決方案的資料夾中。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListOutputFormatOptionDescription">
+        <source>Output format for the list command.</source>
+        <target state="new">Output format for the list command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListSolutionFoldersArgumentDescription">
         <source>Display solution folder paths.</source>
         <target state="translated">顯示解決方案資料夾路徑。</target>

--- a/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln.Tests/GivenDotnetSlnList.cs
@@ -19,8 +19,9 @@ Arguments:
   <SLN_FILE>    The solution file to operate on. If not specified, the command will search the current directory for one. [default: {PathUtility.EnsureTrailingSlash(defaultVal)}]
 
 Options:
-  --solution-folders  Display solution folder paths.
-  -?, -h, --help    Show command line help.";
+  --solution-folders        Display solution folder paths.
+  --format <Json|Raw|Text>  Output format for the list command.
+  -?, -h, --help            Show command line help.";
 
 
         public GivenDotnetSlnList(ITestOutputHelper log) : base(log)


### PR DESCRIPTION
The current output for `dotnet sln list` might not be easily parseable by other programs. 
This adds the `--format` option (following other commands on the cli) with values:

- `text` (Default): Displays a header and a list of projects/folders.
   ![image](https://github.com/user-attachments/assets/b8598de5-02cf-40e1-88c2-43f341390039)

- `raw`: Displays no header and a list of projects/folders. This can be useful for piping to other commands.
   ![image](https://github.com/user-attachments/assets/ee772829-d193-4b89-8875-f6aee295a1a6)

- `json`: Displays a json array with the projects/folders.
   ![image](https://github.com/user-attachments/assets/2852c27d-77ac-4072-8d94-807b07a3a786)


