### PR TITLE
Remove unnecessary 32bit arm architecture checks in the Windows build

### DIFF
--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -39,7 +39,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SkipBuildingInstallers Condition="'$(OS)' == 'Windows_NT' and '$(Architecture)' == 'arm'">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition="'$(PgoInstrument)' == 'true'">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition="

--- a/src/Layout/redist-installer/targets/BundledManifests.targets
+++ b/src/Layout/redist-installer/targets/BundledManifests.targets
@@ -43,7 +43,7 @@
     </PackageDownload>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' != 'arm' ">
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PackageDownload Include="@(BundledManifests->'%(MsiNupkgId)')">
       <Version>[%(Version)]</Version>
     </PackageDownload>
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <Target Name="ValidateBundledManifestSigning"
-          Condition="'$(OS)' == 'Windows_NT' and '$(Architecture)' != 'arm'"
+          Condition="'$(OS)' == 'Windows_NT' "
           BeforeTargets="GenerateWorkloadManifestsWxs">
     <PropertyGroup>
       <SignCheckExe>$(PkgMicrosoft_DotNet_SignCheck)\tools\Microsoft.DotNet.SignCheck.exe</SignCheckExe>

--- a/src/Layout/redist-installer/targets/BundledTemplates.targets
+++ b/src/Layout/redist-installer/targets/BundledTemplates.targets
@@ -74,7 +74,7 @@
           DestinationFiles="$(RedistInstallerLayoutPath)templates\$(CurrentTemplateInstallPath)\$([System.String]::Copy('%(Filename)%(Extension)').ToLowerInvariant())" />
   </Target>
 
-  <Target Name="LayoutTemplatesForMSI" DependsOnTargets="CalculateTemplatesVersions;GetRepoTemplates" Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
+  <Target Name="LayoutTemplatesForMSI" DependsOnTargets="CalculateTemplatesVersions;GetRepoTemplates" Condition="$(ProductMonikerRid.StartsWith('win'))">
     <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
           DestinationFolder="$(BaseOutputPath)$(Configuration)\templates-%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)\templates\%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)" />
 

--- a/src/Layout/redist-installer/targets/RestoreLayout.targets
+++ b/src/Layout/redist-installer/targets/RestoreLayout.targets
@@ -71,7 +71,6 @@
     <WinFormsAndWpfSharedFxRootUrl>$(PublicBaseURL)WindowsDesktop/$(WindowsDesktopBlobVersion)</WinFormsAndWpfSharedFxRootUrl>
     <SdkRootUrl>$(PublicBaseURL)Sdk/$(FullNugetVersion)</SdkRootUrl>
 
-    <IncludeWpfAndWinForms Condition="'$(IncludeWpfAndWinForms)' == '' AND '$(Architecture)' == 'arm'">false</IncludeWpfAndWinForms>
     <IncludeWpfAndWinForms Condition="'$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT'">true</IncludeWpfAndWinForms>
     <IncludeWpfAndWinForms Condition="'$(IncludeWpfAndWinForms)' == ''">false</IncludeWpfAndWinForms>
   </PropertyGroup>


### PR DESCRIPTION
We only build for arm64 on Windows since .NET 5.