### PR TITLE
Check for Muxer path relative to base directory

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -41,10 +41,14 @@ namespace Microsoft.DotNet.Cli.Utils
             string? rootPath = Path.GetDirectoryName(Path.GetDirectoryName(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar)));
             if (rootPath is not null)
             {
-                _muxerPath = Path.Combine(rootPath, $"{MuxerName}{FileNameSuffixes.CurrentPlatform.Exe}");
+                string muxerPathMaybe = Path.Combine(rootPath, $"{MuxerName}{FileNameSuffixes.CurrentPlatform.Exe}");
+                if (File.Exists(muxerPathMaybe))
+                {
+                    _muxerPath = muxerPathMaybe;
+                }
             }
 
-            if (_muxerPath is null || !File.Exists(_muxerPath))
+            if (_muxerPath is null)
             {
                 // Best-effort search for muxer.
                 // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -36,31 +36,42 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public Muxer()
         {
-            // Best-effort search for muxer.
-            // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
-#if NET6_0_OR_GREATER
-            string? processPath = Environment.ProcessPath;
-#else
-            string processPath = Process.GetCurrentProcess().MainModule.FileName;
-#endif
-
-            // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
-            if (processPath is not null && !Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            // Most scenarios are running dotnet.dll as the app
+            // Root directory with muxer should be two above app base: <root>/sdk/<version>
+            string? rootPath = Path.GetDirectoryName(Path.GetDirectoryName(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar)));
+            if (rootPath is not null)
             {
-	            // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
-	            processPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-	            if (processPath is null)
-	            {
-	                // fallback to DOTNET_ROOT which typically holds some dotnet executable
-	                var root = Environment.GetEnvironmentVariable("DOTNET_ROOT");
-	                if (root is not null)
-	                {
-	                    processPath = Path.Combine(root, $"dotnet{Constants.ExeSuffix}");
-	                }
-	            }
+                _muxerPath = Path.Combine(rootPath, $"{MuxerName}{FileNameSuffixes.CurrentPlatform.Exe}");
             }
 
-            _muxerPath = processPath;
+            if (_muxerPath is null || !File.Exists(_muxerPath))
+            {
+                // Best-effort search for muxer.
+                // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
+#if NET6_0_OR_GREATER
+                string? processPath = Environment.ProcessPath;
+#else
+                string processPath = Process.GetCurrentProcess().MainModule.FileName;
+#endif
+
+                // The current process should be dotnet in most normal scenarios except when dotnet.dll is loaded in a custom host like the testhost
+                if (processPath is not null && !Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+                {
+                    // SDK sets DOTNET_HOST_PATH as absolute path to current dotnet executable
+                    processPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+                    if (processPath is null)
+                    {
+                        // fallback to DOTNET_ROOT which typically holds some dotnet executable
+                        var root = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+                        if (root is not null)
+                        {
+                            processPath = Path.Combine(root, $"dotnet{Constants.ExeSuffix}");
+                        }
+                    }
+                }
+
+                _muxerPath = processPath;
+            }
         }
 
         public static string? GetDataFromAppDomain(string propertyName)


### PR DESCRIPTION
When determining the muxer (`dotnet`) path, search relative to the app base directory first. In most scenarios, this should correspond to the `dotnet.dll` directory of `<root>/sdk/<version>` where the `dotnet` executable is under `<root>`. If it doesn't exist, fall back to the existing logic.

With custom SDK search paths in global.json (https://github.com/dotnet/runtime/pull/113512), the running `dotnet` process may not be the same as that corresponding to the running SDK. This updated logic finds the `dotnet` corresponding to the running SDK such that it can be properly propagated to anything launched via SDK commands (for example, `build`).

Part of https://github.com/dotnet/designs/blob/main/proposed/local-sdk-global-json.md.
Contributes to https://github.com/dotnet/sdk/issues/8254

cc @dotnet/appmodel @jaredpar @rainersigwald