### PR TITLE
Allow container targets to be loaded in more scenarios, even if the targets will be skipped

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets
@@ -64,5 +64,5 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\Containers\build\Microsoft.NET.Build.Containers.props')" />
 
   <Import Project="$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets"
-    Condition="$(_IsNotSetContainersTargetsDir) AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets') AND '$(TargetFramework)' != ''" />
+    Condition="$(_IsNotSetContainersTargetsDir) AND Exists('$(_ContainersTargetsDir)Microsoft.NET.Build.Containers.targets')" />
 </Project>


### PR DESCRIPTION
# Description

When publishing a solution with `dotnet publish /t:PublishContainer` when the solution contains at least one multi-targeted project, container publish fails because the `PublishContainer` target isn't loaded when targeting multiple TFMs.

This is an artifact of our original single-TFM nature that isn't apparent when publishing single projects and really only shows up when publishing at the solution level. We need to enable this target to be called in a multi-TFM context even if the target itself doesn't support multi-TFM publishing. This is safe because the SDK itself blocks multi-TFM publishing of a project (you get NETSDK1129 errors), we just need to not block _libraries_ and other non-exe-projects from being able to be built at the solution level.

## Impact
Almost completely blocking for any solution-level container publish - the only workaround is making a stub `PublishContainer` Target in the library projects, which is very gnarly and likely will shoot us in the foot later on.

## Risk

**Medium** - this fixes library-style projects from breaking in this scenario, but without the NETSDK1129 error you'd end up in a weird state. We probably need to go back and add multi-TFM detection and processing inside the PublishContainer target itself to be safest, but that's an even larger change.

## Testing
* manual testing against a reproducing setup
* added to the existing automated tests for solution-level publish