### PR TITLE
Forward global props to dotnet run

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Test;
-using NuGet.Packaging;
 using LocalizableStrings = Microsoft.DotNet.Tools.Test.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli;
@@ -83,13 +82,10 @@ internal static class SolutionAndProjectUtility
         }
     }
 
-    private static string[] GetSolutionFilePaths(string directory)
-    {
-        string[] solutionFiles = Directory.GetFiles(directory, CliConstants.SolutionExtensionPattern, SearchOption.TopDirectoryOnly);
-        solutionFiles.AddRange(Directory.GetFiles(directory, CliConstants.SolutionXExtensionPattern, SearchOption.TopDirectoryOnly));
-
-        return solutionFiles;
-    }
+    private static string[] GetSolutionFilePaths(string directory) => [
+            .. Directory.GetFiles(directory, CliConstants.SolutionExtensionPattern, SearchOption.TopDirectoryOnly),
+            .. Directory.GetFiles(directory, CliConstants.SolutionXExtensionPattern, SearchOption.TopDirectoryOnly)
+        ];
 
     private static string[] GetSolutionFilterFilePaths(string directory)
     {

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -307,20 +307,11 @@ internal sealed class TestApplication : IDisposable
         builder.Append($" {CommonOptions.NoRestoreOption.Name}");
         builder.Append($" {TestingPlatformOptions.NoBuildOption.Name}");
 
-        // TODO: Instead of passing Architecture and Configuration this way, pass _buildOptions.MSBuildArgs
-        // _buildOptions.MSBuildArgs will include all needed global properties.
-        // TODO: Care to be taken when dealing with -bl.
-        // We will want to adjust the file name here.
-
-        if (!string.IsNullOrEmpty(testOptions.Architecture))
+        foreach (var arg in _buildOptions.MSBuildArgs)
         {
-            builder.Append($" {CommonOptions.ArchitectureOption.Name} {testOptions.Architecture}");
+            builder.Append($" {arg}");
         }
 
-        if (!string.IsNullOrEmpty(testOptions.Configuration))
-        {
-            builder.Append($" {TestingPlatformOptions.ConfigurationOption.Name} {testOptions.Configuration}");
-        }
 
         if (!string.IsNullOrEmpty(_module.TargetFramework))
         {


### PR DESCRIPTION
This pull request includes several changes to the `src/Cli/dotnet/commands/dotnet-test` directory, focusing on code simplification and cleanup. The most important changes include removing an unused import, refactoring a method to use a more concise syntax, and updating the way MSBuild arguments are appended.

Code simplification and cleanup:

* [`src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs`](diffhunk://#diff-02dc8e4e03ee310701a9bce69a494f783e1b2b8c383acff657dac2a711d49118L10): Removed the unused import statement for `NuGet.Packaging`.
* [`src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs`](diffhunk://#diff-02dc8e4e03ee310701a9bce69a494f783e1b2b8c383acff657dac2a711d49118L86-R88): Refactored the `GetSolutionFilePaths` method to use a more concise array initialization syntax.
* [`src/Cli/dotnet/commands/dotnet-test/TestApplication.cs`](diffhunk://#diff-87af23dcd9d529167e3c71f60d8f5077ea0eca3680f5b4a8c959e81a98701baaL310-L323): Updated the `BuildArgsWithDotnetRun` method to append MSBuild arguments using a loop instead of individually checking and appending architecture and configuration options.

Relates to https://github.com/dotnet/sdk/issues/45927
Fixes https://github.com/dotnet/sdk/issues/47635
Fixes https://github.com/dotnet/sdk/issues/47614