### PR TITLE
Improve baselining

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -12,11 +12,60 @@
   {
     "issueType": "AssemblyVersionMismatch",
     "descriptionMatch": ".resources.dll",
+    "allowRevisionOnlyVariance": true,
     "justification": "Resource dlls get per-build versioning but this doesn't matter."
   },
   {
     "issueType": "MissingShipping",
     "descriptionMatch": "Aspire.*",
     "justification": "Aspire to be removed from the VMR. Also .NET does not ship these packages."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Microsoft\\.CodeAnalysis.*\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "CodeAnalysis dlls vary build to build with patch number."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Microsoft\\.Build\\.CodeAnalysis.*\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "CodeAnalysis dlls vary build to build with patch number."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Microsoft\\.Build.*\\.CodeAnalysis\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "CodeAnalysis dlls vary build to build with patch number."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Metrics.*\\.exe",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Analyzers vary build to build"
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Microsoft\\.NET\\..*\\.Tasks\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Allow build-build patch variance"
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "NuGet\\..*\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Nuget DLLs vary build to build."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "Microsoft\\.DotNet\\..*\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Arcade binaries vary build to build."
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "descriptionMatch": "analyzers/dotnet/.*\\.dll",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Analyzers vary build to build"
   }
 ]

--- a/src/SourceBuild/content/eng/tools/BuildComparer/IssueType.cs
+++ b/src/SourceBuild/content/eng/tools/BuildComparer/IssueType.cs
@@ -25,4 +25,7 @@ public enum IssueType
     AssemblyVersionMismatch,
     MissingPackageContent,
     ExtraPackageContent,
+    PackageMetadataDifference,
+    PackageTFMs,
+    PackageDependencies,
 }

--- a/src/SourceBuild/content/eng/tools/BuildComparer/Program.cs
+++ b/src/SourceBuild/content/eng/tools/BuildComparer/Program.cs
@@ -408,7 +408,7 @@ public class Program
     /// <param name="mapping">Asset mapping to compare lists for</param>
     /// <param name="diffPackageReader">Diff (VMR) package reader</param>
     /// <param name="basePackageReader">Baseline (old build) package reader</param>
-    private async void ComparePackageFileLists(AssetMapping mapping, PackageArchiveReader diffPackageReader, PackageArchiveReader basePackageReader)
+    private async Task ComparePackageFileLists(AssetMapping mapping, PackageArchiveReader diffPackageReader, PackageArchiveReader basePackageReader)
     {
         IEnumerable<string> baselineFiles = (await basePackageReader.GetFilesAsync(CancellationToken.None));
         IEnumerable<string> testFiles = (await diffPackageReader.GetFilesAsync(CancellationToken.None));


### PR DESCRIPTION
- Add baseline entries for some typical cases
- Add an option for the baseline entry to specify that assembly versions can vary by revision number. This allow for a generic match on file named with a specific check that major.minor.patch are the same
- Fix up some comments
- Add some more summary info