### PR TITLE
Remove RunSettingsFilePath support from dotnet test for MTP

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/CliConstants.cs
@@ -41,7 +41,6 @@ internal static class CliConstants
 
     public const string BinLogFileName = "msbuild.binlog";
 
-    public const string TestingPlatformVsTestBridgeRunSettingsFileEnvVar = "TESTINGPLATFORM_VSTESTBRIDGE_RUNSETTINGS_FILE";
     public const string DLLExtension = ".dll";
 
     public const string MTPTarget = "_MTPBuild";
@@ -91,7 +90,6 @@ internal static class ProjectProperties
     internal const string TargetFrameworks = "TargetFrameworks";
     internal const string TargetPath = "TargetPath";
     internal const string ProjectFullPath = "MSBuildProjectFullPath";
-    internal const string RunSettingsFilePath = "RunSettingsFilePath";
     internal const string RunCommand = "RunCommand";
     internal const string RunArguments = "RunArguments";
     internal const string RunWorkingDirectory = "RunWorkingDirectory";

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Models/ModuleMessage.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Models/ModuleMessage.cs
@@ -3,4 +3,4 @@
 
 namespace Microsoft.DotNet.Tools.Test;
 
-internal sealed record ModuleMessage(string? DllOrExePath, string? ProjectPath, string? TargetFramework, string? RunSettingsFilePath, string IsTestingPlatformApplication) : IRequest;
+internal sealed record ModuleMessage(string? DllOrExePath, string? ProjectPath, string? TargetFramework, string IsTestingPlatformApplication) : IRequest;

--- a/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/ModuleMessageSerializer.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/IPC/Serializers/ModuleMessageSerializer.cs
@@ -12,9 +12,8 @@ internal sealed class ModuleMessageSerializer : BaseSerializer, INamedPipeSerial
         string modulePath = ReadString(stream);
         string projectPath = ReadString(stream);
         string targetFramework = ReadString(stream);
-        string runSettingsFilePath = ReadString(stream);
         string isTestingPlatformApplication = ReadString(stream);
-        return new ModuleMessage(modulePath.Trim(), projectPath.Trim(), targetFramework.Trim(), runSettingsFilePath.Trim(), isTestingPlatformApplication.Trim());
+        return new ModuleMessage(modulePath.Trim(), projectPath.Trim(), targetFramework.Trim(), isTestingPlatformApplication.Trim());
     }
 
     public void Serialize(object objectToSerialize, Stream stream)
@@ -22,7 +21,6 @@ internal sealed class ModuleMessageSerializer : BaseSerializer, INamedPipeSerial
         WriteString(stream, ((ModuleMessage)objectToSerialize).DllOrExePath);
         WriteString(stream, ((ModuleMessage)objectToSerialize).ProjectPath);
         WriteString(stream, ((ModuleMessage)objectToSerialize).TargetFramework);
-        WriteString(stream, ((ModuleMessage)objectToSerialize).RunSettingsFilePath);
         WriteString(stream, ((ModuleMessage)objectToSerialize).IsTestingPlatformApplication);
     }
 }

--- a/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/MSBuildHandler.cs
@@ -162,7 +162,6 @@ internal sealed class MSBuildHandler : IDisposable
             logMessageBuilder.AppendLine($"{ProjectProperties.RunCommand}: {module.RunProperties.RunCommand}");
             logMessageBuilder.AppendLine($"{ProjectProperties.RunArguments}: {module.RunProperties.RunArguments}");
             logMessageBuilder.AppendLine($"{ProjectProperties.RunWorkingDirectory}: {module.RunProperties.RunWorkingDirectory}");
-            logMessageBuilder.AppendLine($"{ProjectProperties.RunSettingsFilePath}: {module.RunSettingsFilePath}");
             logMessageBuilder.AppendLine();
         }
 

--- a/src/Cli/dotnet/commands/dotnet-test/Models.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Models.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli;
 
-internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, string? RunSettingsFilePath, bool IsTestingPlatformApplication, bool IsTestProject);
+internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, bool IsTestingPlatformApplication, bool IsTestProject);
 
 internal sealed record Handshake(Dictionary<byte, string>? Properties);
 

--- a/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/SolutionAndProjectUtility.cs
@@ -163,9 +163,8 @@ internal static class SolutionAndProjectUtility
         string targetFramework = project.GetPropertyValue(ProjectProperties.TargetFramework);
         RunProperties runProperties = GetRunProperties(project, loggers);
         string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
-        string runSettingsFilePath = project.GetPropertyValue(ProjectProperties.RunSettingsFilePath);
 
-        return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, runSettingsFilePath, isTestingPlatformApplication, isTestProject);
+        return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, isTestingPlatformApplication, isTestProject);
 
         static RunProperties GetRunProperties(ProjectInstance project, ICollection<ILogger>? loggers)
         {

--- a/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestApplication.cs
@@ -79,8 +79,6 @@ internal sealed class TestApplication : IDisposable
             processStartInfo.WorkingDirectory = _module.RunProperties.RunWorkingDirectory;
         }
 
-        AddRunSettingsFileToEnvironment(processStartInfo);
-
         return processStartInfo;
     }
 
@@ -97,14 +95,6 @@ internal sealed class TestApplication : IDisposable
         // We fallback to dotnet run only when we have a dll and an architecture is specified.
         // TODO: Is this a valid case?
         return BuildArgsWithDotnetRun(testOptions);
-    }
-
-    private void AddRunSettingsFileToEnvironment(ProcessStartInfo processStartInfo)
-    {
-        if (!string.IsNullOrEmpty(_module.RunSettingsFilePath))
-        {
-            processStartInfo.EnvironmentVariables.Add(CliConstants.TestingPlatformVsTestBridgeRunSettingsFileEnvVar, _module.RunSettingsFilePath);
-        }
     }
 
     private static bool IsArchitectureSpecified(TestOptions testOptions)

--- a/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestModulesFilterHandler.cs
@@ -53,7 +53,7 @@ internal sealed class TestModulesFilterHandler
 
         foreach (string testModule in testModulePaths)
         {
-            var testApp = new TestApplication(new TestModule(new RunProperties(testModule, null, null), null, null, null, true, true), buildOptions);
+            var testApp = new TestApplication(new TestModule(new RunProperties(testModule, null, null), null, null, true, true), buildOptions);
             // Write the test application to the channel
             _actionQueue.Enqueue(testApp);
         }


### PR DESCRIPTION
Fixes #47636

Related to #45927

If we want to support that, it should be part of VSTestBridge by hooking into ComputeRunArguments and passing `RunSettingsFilePath` via `--settings` instead of using environment variable.