### PR TITLE
Remove publishing opt-out for nuget assets

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ManifestAssets/JoinVerticalsAssetSelector.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ManifestAssets/JoinVerticalsAssetSelector.cs
@@ -45,9 +45,6 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.ManifestAssets
                 // - this can be removed after this issue is resolved: https://github.com/dotnet/source-build/issues/4892
                 StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.AssetId, "Microsoft.Diagnostics.NETCore.Client") ||
                 StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.AssetId, "Microsoft.NET.Sdk.Aspire.Manifest-8.0.100") ||
-                // Skip all Nuget packaged as they are missing UB version suffix +100 patch version
-                // - this can be removed after this issue is resolved: https://github.com/dotnet/source-build/issues/4894
-                StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.Asset.RepoOrigin, "nuget-client") ||
                 // Skip productVersion.txt files from all repos except sdk
                 // - this can be removed after this issue is resolved: https://github.com/dotnet/source-build/issues/4596
                 (assetVerticalMatch.AssetId.Contains("/productVersion.txt", StringComparison.OrdinalIgnoreCase) && (assetVerticalMatch.Asset.RepoOrigin != "sdk"));


### PR DESCRIPTION
NuGet assets now produce a properly build-varying version in official builds.