### PR TITLE
Fix runtimeIdentifier for macOS PR jobs

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -75,11 +75,14 @@ parameters:
   ### MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild
+    runtimeIdentifier: osx-x64
   - categoryName: TemplateEngine
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.Tests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
+    runtimeIdentifier: osx-x64
   - categoryName: AoT
     runAoTTests: true
+    runtimeIdentifier: osx-x64
 
 jobs:
 ### ONELOCBUILD ###


### PR DESCRIPTION
I noticed that the macOS jobs incorrectly use a linux runtime identifier.