### PR TITLE
Fix scenario-tests not uploading results to AzDO

### DIFF
--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -48,7 +48,7 @@
 
   <Target Name="SetAzureDevOpsVariableForScenarioTests"
           Condition="'$(ContinuousIntegrationBuild)' == 'true'"
-          BeforeTargets="Test">
+          BeforeTargets="RepoTest">
     <Message Importance="High" Text="##vso[task.setvariable variable=hasScenarioTestResults]true" />
   </Target>
 


### PR DESCRIPTION
This got broken in https://github.com/dotnet/sdk/commit/da7134338432bbecde0b6dd373972b15c01d1f36 when the test execution was moved into the RepoTest target but the target which writes the AzDO variable wasn't updated

Fixes https://github.com/dotnet/source-build/issues/4950