### PR TITLE
Remove duplicate nuget packages from asset manifests baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_arm.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_arm.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_Alpine_arm">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-musl-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-musl-arm" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -45,23 +44,6 @@
   <Package Id="Microsoft.NETCore.App.Host.linux-musl-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.linux-musl-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-musl-arm.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-arm.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -77,28 +59,10 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-linux-musl-arm.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-musl-arm.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-musl-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-musl-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-musl-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-musl-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_arm64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_arm64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_Alpine_arm64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-musl-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-musl-arm64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -51,23 +50,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.AOT.linux-musl-arm64.Cross.wasi-wasm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.linux-musl-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-arm64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -83,7 +65,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-linux-musl-arm64.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-musl-arm64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-musl-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-musl-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-musl-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.linux-musl-arm64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -94,23 +75,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.linux-musl-arm64.Cross.wasi-wasm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-musl-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-arm64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_x64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_Alpine_x64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_Alpine_x64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-musl-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-musl-x64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -52,23 +51,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.linux-musl-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-musl-x64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -84,7 +66,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-linux-musl-x64.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-musl-x64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.linux-musl-x64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -96,23 +77,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-musl-x64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_arm.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_arm.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_arm">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-arm" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -46,23 +45,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.linux-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.linux-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-arm.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-arm.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-arm.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -78,29 +60,11 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-linux-arm.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-arm.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_arm64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_arm64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_arm64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-arm64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -52,23 +51,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.linux-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.linux-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-arm64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-arm64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -96,7 +78,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-linux-arm64.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-arm64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.linux-arm64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -108,23 +89,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-arm64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_x64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/AzureLinux_x64_Cross_x64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="AzureLinux_x64_Cross_x64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.linux-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.linux-x64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -52,23 +51,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.linux-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.linux-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -96,7 +78,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-x64.rpm.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.linux-x64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -108,23 +89,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.linux-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-x64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-x64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.linux-x64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/OSX_arm64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/OSX_arm64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="OSX_arm64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.osx-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.osx-arm64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -60,23 +59,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.osx-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.osx-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.osx-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.osx-arm64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.osx-arm64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -92,7 +74,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-osx-arm64.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.osx-arm64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.osx-arm64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -112,23 +93,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.osx-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-arm64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-arm64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/OSX_x64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/OSX_x64.xml
@@ -1,7 +1,6 @@
 <Build PublishingVersion="3" Name="dotnet-dotnet" BuildId="20250306.10" Branch="refs/heads/rid-specific-publish" Commit="5abbbba42e04d26068d1ff5f24de662e682b851e" AzureDevOpsAccount="dnceng" AzureDevOpsBranch="refs/heads/rid-specific-publish" AzureDevOpsBuildDefinitionId="1330" AzureDevOpsBuildId="2656964" AzureDevOpsBuildNumber="20250306.10" AzureDevOpsProject="internal" AzureDevOpsRepository="https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" InitialAssetsLocation="https://dev.azure.com/dnceng/internal/_apis/build/builds/2656964/artifacts" IsReleaseOnlyPackageVersion="false" IsStable="false" VerticalName="OSX_x64">
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.osx-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.osx-x64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -60,23 +59,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.Mono.osx-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.osx-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.osx-x64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.osx-x64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -92,7 +74,6 @@
   <Blob Id="aspnetcore/Runtime/10.0.0-preview.3.25156.110/aspnetcore-targeting-pack-10.0.0-preview.3.25156.110-osx-x64.tar.gz.sha512" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//Microsoft.CodeAnalysis.LanguageServer.osx-x64.4.14.0-3.25156.110.symbols.nupkg" RepoOrigin="roslyn" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -112,23 +93,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.osx-x64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-x64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-x64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.osx-x64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/Windows_arm64.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/Windows_arm64.xml
@@ -2,7 +2,6 @@
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.ANCMSymbols.win-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.win-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.win-arm64" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -53,23 +52,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.win-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.win-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.WindowsDesktop.App.Runtime.win-arm64" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.win-arm64.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.win-arm64.Microsoft.DotNet.Wpf.GitHub" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="wpf" Visibility="External" />
   <Package Id="runtime.win-arm64.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -105,7 +87,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//runtime.win-arm64.Microsoft.DotNet.Wpf.GitHub.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="wpf" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.ANCMSymbols.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.android-arm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -117,23 +98,6 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.WindowsDesktop.App.Runtime.win-arm64.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-arm64.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-arm64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-arm64.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/Windows_x86.xml
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Tests/assets/JoinVerticalsTests/manifests/verticals/Windows_x86.xml
@@ -2,7 +2,6 @@
   <Package Id="Microsoft.Arcade.Common" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.AspNetCore.ANCMSymbols.win-x86" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Package Id="Microsoft.AspNetCore.App.Runtime.win-x86" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Package Id="Microsoft.Build.NuGetSdkResolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="Microsoft.Cci.Extensions" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
   <Package Id="Microsoft.CodeAnalysis.LanguageServer.win-x86" Version="4.14.0-3.25156.110" CouldBeStable="false" RepoOrigin="roslyn" Visibility="External" />
   <Package Id="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25156.110" NonShipping="true" RepoOrigin="arcade" Visibility="Internal" />
@@ -48,23 +47,6 @@
   <Package Id="Microsoft.NETCore.App.Runtime.NativeAOT.win-x86" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.NETCore.App.Runtime.win-x86" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="Microsoft.WindowsDesktop.App.Runtime.win-x86" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Console" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Build.Tasks.Pack" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.CommandLine.XPlat" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Commands" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Common" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Configuration" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Credentials" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.DependencyResolver.Core" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Frameworks" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.LibraryModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.PackageManagement" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Packaging" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.ProjectModel" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Protocol" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Resolver" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
-  <Package Id="NuGet.Versioning" Version="6.14.0-preview.1.32767" CouldBeStable="false" RepoOrigin="nuget-client" Visibility="External" />
   <Package Id="runtime.win-x86.Microsoft.DotNet.ILCompiler" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Package Id="runtime.win-x86.Microsoft.DotNet.Wpf.GitHub" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" NonShipping="true" RepoOrigin="wpf" Visibility="External" />
   <Package Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="10.0.0-preview.3.25156.110" CouldBeStable="false" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
@@ -100,30 +82,12 @@
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10//runtime.win-x86.Microsoft.DotNet.Wpf.GitHub.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="wpf" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.ANCMSymbols.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.AspNetCore.App.Runtime.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="aspnetcore" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.Build.NuGetSdkResolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Crossgen2.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Host.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.Mono.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" NonShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.NativeAOT.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.NETCore.App.Runtime.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/Microsoft.WindowsDesktop.App.Runtime.win-x86.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="windowsdesktop" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Console.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Build.Tasks.Pack.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.CommandLine.XPlat.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Commands.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Common.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Configuration.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Credentials.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.DependencyResolver.Core.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Frameworks.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.LibraryModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.PackageManagement.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Packaging.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.ProjectModel.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Protocol.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Resolver.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
-  <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/NuGet.Versioning.6.14.0-preview.1.32767.symbols.nupkg" RepoOrigin="nuget-client" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-x86.Microsoft.DotNet.ILCompiler.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-x86.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />
   <Blob Id="assets/symbols/dotnet-dotnet/20250306.10/runtime.win-x86.Microsoft.NETCore.ILAsm.10.0.0-preview.3.25156.110.symbols.nupkg" DotNetReleaseShipping="true" RepoOrigin="runtime" Visibility="External" />


### PR DESCRIPTION
Should fix the test failures we're seeing