### PR TITLE
[wasm] Remove explicit WasmBootConfigFileName from tests

### DIFF
--- a/test/Microsoft.NET.TestFramework/AspNetSdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/AspNetSdkTest.cs
@@ -57,15 +57,6 @@ namespace Microsoft.NET.TestFramework
                         targetFrameworks.Value = targetFrameworks.Value.Replace("$(AspNetTestTfm)", overrideTfm ?? DefaultTfm);
                         targetFrameworks.AddAfterSelf(new XElement("StaticWebAssetsFingerprintContent", "false"));
                     }
-
-                    if (project.Root != null)
-                    {
-                        var itemGroup = new XElement("PropertyGroup");
-                        itemGroup.SetAttributeValue("Condition", "'$(TargetFramework)' == 'net10.0'");
-                        var fingerprintAssets = new XElement("WasmBootConfigFileName", WasmBootConfigFileName);
-                        itemGroup.Add(fingerprintAssets);
-                        project.Root.Add(itemGroup);
-                    }
                 });
 
             foreach (string assetPath in Directory.EnumerateFiles(Path.Combine(_testAssetsManager.TestAssetsRoot, "WasmOverride")))


### PR DESCRIPTION
The change to have dotnet.boot.js as a default boot config flown from runtime to sdk. We can remove the explicit configuration from all tests.

Contributes to https://github.com/dotnet/aspnetcore/issues/59456