### PR TITLE
Do not show VS workloads from an old version Fixes #47794

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/WorkloadInfoHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Workloads.Workload.List
 #if !DOT_NET_BUILD_FROM_SOURCE
             if (OperatingSystem.IsWindows())
             {
-                VisualStudioWorkloads.GetInstalledWorkloads(WorkloadResolver, installedWorkloads);
+                VisualStudioWorkloads.GetInstalledWorkloads(WorkloadResolver, installedWorkloads, _currentSdkFeatureBand);
             }
 #endif
             return installedWorkloads;


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47794

I ported the changes over to main for actual testing, hence this being targeted at 9.0.3xx but mentioning a 10.0- feature band.

Without the change:
```
Workload version: 10.0.100-manifests.7ab2c471

Installed Workload Id      Manifest Version                                 Installation Source
-----------------------------------------------------------------------------------------------
android                    35.99.0-preview.1.140/10.0.100-preview.1         VS 17.14.35824.293
aspire                     8.2.2/8.0.100                                    VS 17.14.35824.293
ios                        18.2.10322-net10-p1/10.0.100-preview.1           VS 17.14.35824.293
maccatalyst                18.2.10322-net10-p1/10.0.100-preview.1           VS 17.14.35824.293
macos                      15.2.10322-net10-p1/10.0.100-preview.1           VS 17.14.35824.293
maui-windows               10.0.0-preview.1.25122.6/10.0.100-preview.1      VS 17.14.35824.293
tvos                       18.2.10322-net10-p1/10.0.100-preview.1           VS 17.14.35824.293
wasm-tools                 10.0.0-preview.4.25170.5/10.0.100-preview.4      VS 17.14.35824.293
wasm-tools-net6            10.0.0-preview.4.25170.5/10.0.100-preview.4      VS 17.14.35824.293
wasm-tools-net7            10.0.0-preview.4.25170.5/10.0.100-preview.4      VS 17.14.35824.293
wasm-tools-net8            10.0.0-preview.4.25170.5/10.0.100-preview.4      VS 17.14.35824.293

Use `dotnet workload search` to find additional workloads to install.
```

With the change:
```
Installed Workload Id      Manifest Version      Installation Source
--------------------------------------------------------------------

Use `dotnet workload search` to find additional workloads to install.
```

(I hadn't installed any workloads at that point, so empty is correct.)

I then installed wasm-tools and ran it again and got this result:

```
Installed Workload Id      Manifest Version                                 Installation Source
-----------------------------------------------------------------------------------------------
wasm-tools                 10.0.0-preview.3.25167.9/10.0.100-preview.3      SDK 10.0.100

Use `dotnet workload search` to find additional workloads to install.
```

/cc: @danroth27 