### PR TITLE
[StaticWebAssets] Make all the properties in StaticWebAssetEndpoint lazy

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -21,7 +21,7 @@ public class ApplyCompressionNegotiation : Task
 
     public override bool Execute()
     {
-        var assetsById = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity);
+        var assetsById = StaticWebAsset.ToAssetDictionary(CandidateAssets);
 
         var endpointsByAsset = CandidateEndpoints.Select(StaticWebAssetEndpoint.FromTaskItem)
             .GroupBy(e => e.AssetFile)

--- a/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
+++ b/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
@@ -25,7 +25,7 @@ public class CollectStaticWebAssetsToCopy : Task
         var normalizedOutputPath = StaticWebAsset.NormalizeContentRootPath(Path.GetFullPath(OutputPath));
         try
         {
-            foreach (var asset in Assets.Select(StaticWebAsset.FromTaskItem))
+            foreach (var asset in StaticWebAsset.FromTaskItemGroup(Assets))
             {
                 string fileOutputPath = null;
                 if (!(asset.IsDiscovered() || asset.IsComputed()))

--- a/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
@@ -29,7 +29,7 @@ public class DiscoverPrecompressedAssets : Task
             return true;
         }
 
-        var candidates = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray();
+        var candidates = StaticWebAsset.FromTaskItemGroup(CandidateAssets);
         var assetsToUpdate = new List<ITaskItem>();
 
         var candidatesByIdentity = candidates.ToDictionary(asset => asset.Identity, OSPath.PathComparer);

--- a/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
@@ -54,8 +54,8 @@ public class ResolveCompressedAssets : Task
             return true;
         }
 
-        var candidates = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray();
-        var explicitAssets = ExplicitAssets?.Select(StaticWebAsset.FromTaskItem).ToArray() ?? [];
+        var candidates = StaticWebAsset.FromTaskItemGroup(CandidateAssets).ToArray();
+        var explicitAssets = ExplicitAssets == null ? [] : StaticWebAsset.FromTaskItemGroup(ExplicitAssets);
         var existingCompressionFormatsByAssetItemSpec = CollectCompressedAssets(candidates);
 
         var includePatterns = SplitPattern(IncludePatterns);

--- a/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
@@ -20,7 +20,7 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
 
     public override bool Execute()
     {
-        var assets = Assets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity, a => a);
+        var assets = StaticWebAsset.ToAssetDictionary(Assets);
         var candidateEndpoints = StaticWebAssetEndpoint.FromItemGroup(CandidateEndpoints);
 
         var endpoints = new List<StaticWebAssetEndpoint>();

--- a/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
@@ -27,7 +27,7 @@ public class ComputeStaticWebAssetsTargetPaths : Task
         try
         {
             Log.LogMessage(MessageImportance.Low, "Using path prefix '{0}'", PathPrefix);
-            AssetsWithTargetPath = new TaskItem[Assets.Length];
+            AssetsWithTargetPath = new ITaskItem[Assets.Length];
 
             for (var i = 0; i < Assets.Length; i++)
             {

--- a/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1376,7 +1376,10 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         return metadataName switch
         {
+            // These two are special and aren't "Real metadata"
             "FullPath" => Identity ?? "",
+            nameof(Identity) => Identity ?? "",
+            // These are common metadata
             nameof(SourceId) => SourceId ?? "",
             nameof(SourceType) => SourceType ?? "",
             nameof(ContentRoot) => ContentRoot ?? "",

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -51,27 +51,27 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     public StaticWebAsset(StaticWebAsset asset)
     {
-        _identity = asset._identity;
-        _sourceType = asset._sourceType;
-        _sourceId = asset._sourceId;
-        _contentRoot = asset._contentRoot;
-        _basePath = asset._basePath;
-        _relativePath = asset._relativePath;
-        _assetKind = asset._assetKind;
-        _assetMode = asset._assetMode;
-        _assetRole = asset._assetRole;
-        _assetMergeBehavior = asset._assetMergeBehavior;
-        _assetMergeSource = asset._assetMergeSource;
-        _relatedAsset = asset._relatedAsset;
-        _assetTraitName = asset._assetTraitName;
-        _assetTraitValue = asset._assetTraitValue;
-        _copyToOutputDirectory = asset._copyToOutputDirectory;
-        _copyToPublishDirectory = asset._copyToPublishDirectory;
-        _originalItemSpec = asset._originalItemSpec;
-        _fileLength = asset._fileLength;
-        _lastWriteTime = asset._lastWriteTime;
-        _fingerprint = asset._fingerprint;
-        _integrity = asset._integrity;
+        _identity = asset.Identity;
+        _sourceType = asset.SourceType;
+        _sourceId = asset.SourceId;
+        _contentRoot = asset.ContentRoot;
+        _basePath = asset.BasePath;
+        _relativePath = asset.RelativePath;
+        _assetKind = asset.AssetKind;
+        _assetMode = asset.AssetMode;
+        _assetRole = asset.AssetRole;
+        _assetMergeBehavior = asset.AssetMergeBehavior;
+        _assetMergeSource = asset.AssetMergeSource;
+        _relatedAsset = asset.RelatedAsset;
+        _assetTraitName = asset.AssetTraitName;
+        _assetTraitValue = asset.AssetTraitValue;
+        _copyToOutputDirectory = asset.CopyToOutputDirectory;
+        _copyToPublishDirectory = asset.CopyToPublishDirectory;
+        _originalItemSpec = asset.OriginalItemSpec;
+        _fileLength = asset.FileLength;
+        _lastWriteTime = asset.LastWriteTime;
+        _fingerprint = asset.Fingerprint;
+        _integrity = asset.Integrity;
     }
 
     private string GetMetadata(string name) => _originalItem?.GetMetadata(name);

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1376,7 +1376,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         return metadataName switch
         {
-            nameof(Identity) => Identity ?? "",
+            "FullPath" => Identity ?? "",
             nameof(SourceId) => SourceId ?? "",
             nameof(SourceType) => SourceType ?? "",
             nameof(ContentRoot) => ContentRoot ?? "",

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -86,7 +86,8 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         set
         {
             _modified = true;
-            _identity = Path.GetFullPath(value);
+            // Note, this is the same ItemSpec does in new TaskItem
+            _identity = FixFilePath(value);
         }
     }
 
@@ -1263,7 +1264,14 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     #region ITaskItem2 implementation
 
     string ITaskItem2.EvaluatedIncludeEscaped { get => Identity; set => Identity = value; }
-    string ITaskItem.ItemSpec { get => Identity; set => Identity = value; }
+
+    string ITaskItem.ItemSpec {
+        get => Identity;
+        set => Identity = value;
+    }
+
+    // This mimics the implementation from
+    private static string FixFilePath(string value) => string.IsNullOrEmpty(value) || Path.DirectorySeparatorChar == '\\' ? value : value.Replace('\\', '/');
 
     private static readonly string[] _defaultPropertyNames = [
         nameof(SourceId),

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -86,7 +86,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         set
         {
             _modified = true;
-            _identity = value;
+            _identity = Path.GetFullPath(value);
         }
     }
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -86,7 +86,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         set
         {
             _modified = true;
-            _identity = Path.GetFullPath(value);
+            _identity = value;
         }
     }
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1319,6 +1319,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         return metadataName switch
         {
+            nameof(Identity) => Identity ?? "",
             nameof(SourceId) => SourceId ?? "",
             nameof(SourceType) => SourceType ?? "",
             nameof(ContentRoot) => ContentRoot ?? "",
@@ -1455,6 +1456,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     string ITaskItem.GetMetadata(string metadataName) => metadataName switch
     {
         "FullPath" => Identity ?? "",
+        nameof(Identity) => Identity ?? "",
         nameof(SourceId) => SourceId ?? "",
         nameof(SourceType) => SourceType ?? "",
         nameof(ContentRoot) => ContentRoot ?? "",

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -21,74 +21,290 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 {
     public const string DateTimeAssetFormat = "ddd, dd MMM yyyy HH:mm:ss 'GMT'";
 
+    private bool _modified;
+    private ITaskItem _originalItem;
+    private string _identity;
+    private string _sourceId;
+    private string _sourceType;
+    private string _contentRoot;
+    private string _basePath;
+    private string _relativePath;
+    private string _assetKind;
+    private string _assetMode;
+    private string _assetRole;
+    private string _assetMergeBehavior;
+    private string _assetMergeSource;
+    private string _relatedAsset;
+    private string _assetTraitName;
+    private string _assetTraitValue;
+    private string _fingerprint;
+    private string _integrity;
+    private string _copyToOutputDirectory;
+    private string _copyToPublishDirectory;
+    private string _originalItemSpec;
+    private long _fileLength = -1;
+    private DateTimeOffset _lastWriteTime = DateTimeOffset.MinValue;
+
     public StaticWebAsset()
     {
     }
 
     public StaticWebAsset(StaticWebAsset asset)
     {
-        Identity = asset.Identity;
-        SourceType = asset.SourceType;
-        SourceId = asset.SourceId;
-        ContentRoot = asset.ContentRoot;
-        BasePath = asset.BasePath;
-        RelativePath = asset.RelativePath;
-        AssetKind = asset.AssetKind;
-        AssetMode = asset.AssetMode;
-        AssetRole = asset.AssetRole;
-        AssetMergeBehavior = asset.AssetMergeBehavior;
-        AssetMergeSource = asset.AssetMergeSource;
-        RelatedAsset = asset.RelatedAsset;
-        AssetTraitName = asset.AssetTraitName;
-        AssetTraitValue = asset.AssetTraitValue;
-        CopyToOutputDirectory = asset.CopyToOutputDirectory;
-        CopyToPublishDirectory = asset.CopyToPublishDirectory;
-        OriginalItemSpec = asset.OriginalItemSpec;
-        FileLength = asset.FileLength;
-        LastWriteTime = asset.LastWriteTime;
+        _identity = asset._identity;
+        _sourceType = asset._sourceType;
+        _sourceId = asset._sourceId;
+        _contentRoot = asset._contentRoot;
+        _basePath = asset._basePath;
+        _relativePath = asset._relativePath;
+        _assetKind = asset._assetKind;
+        _assetMode = asset._assetMode;
+        _assetRole = asset._assetRole;
+        _assetMergeBehavior = asset._assetMergeBehavior;
+        _assetMergeSource = asset._assetMergeSource;
+        _relatedAsset = asset._relatedAsset;
+        _assetTraitName = asset._assetTraitName;
+        _assetTraitValue = asset._assetTraitValue;
+        _copyToOutputDirectory = asset._copyToOutputDirectory;
+        _copyToPublishDirectory = asset._copyToPublishDirectory;
+        _originalItemSpec = asset._originalItemSpec;
+        _fileLength = asset._fileLength;
+        _lastWriteTime = asset._lastWriteTime;
+        _fingerprint = asset._fingerprint;
+        _integrity = asset._integrity;
     }
 
-    public string Identity { get; set; }
+    private string GetMetadata(string name) => _originalItem?.GetMetadata(name);
 
-    public string SourceId { get; set; }
+    public string Identity
+    {
+        get => _identity ??= GetMetadata("FullPath");
+        set
+        {
+            _modified = true;
+            _identity = value;
+        }
+    }
 
-    public string SourceType { get; set; }
+    public string SourceId
+    {
+        get => _sourceId ??= GetMetadata(nameof(SourceId));
+        set
+        {
+            _modified = true;
+            _sourceId = value;
+        }
+    }
 
-    public string ContentRoot { get; set; }
+    public string SourceType
+    {
+        get => _sourceType ??= GetMetadata(nameof(SourceType));
+        set
+        {
+            _modified = true;
+            _sourceType = value;
+        }
+    }
 
-    public string BasePath { get; set; }
+    public string ContentRoot
+    {
+        get => _contentRoot ??= GetMetadata(nameof(ContentRoot));
+        set
+        {
+            _modified = true;
+            _contentRoot = value;
+        }
+    }
 
-    public string RelativePath { get; set; }
+    public string BasePath
+    {
+        get => _basePath ??= GetMetadata(nameof(BasePath));
+        set
+        {
+            _modified = true;
+            _basePath = value;
+        }
+    }
 
-    public string AssetKind { get; set; }
+    public string RelativePath
+    {
+        get => _relativePath ??= GetMetadata(nameof(RelativePath));
+        set
+        {
+            _modified = true;
+            _relativePath = value;
+        }
+    }
 
-    public string AssetMode { get; set; }
+    public string AssetKind
+    {
+        get => _assetKind ??= GetMetadata(nameof(AssetKind));
+        set
+        {
+            _modified = true;
+            _assetKind = value;
+        }
+    }
 
-    public string AssetRole { get; set; }
+    public string AssetMode
+    {
+        get => _assetMode ??= GetMetadata(nameof(AssetMode));
+        set
+        {
+            _modified = true;
+            _assetMode = value;
+        }
+    }
 
-    public string AssetMergeBehavior { get; set; }
+    public string AssetRole
+    {
+        get => _assetRole ??= GetMetadata(nameof(AssetRole));
+        set
+        {
+            _modified = true;
+            _assetRole = value;
+        }
+    }
 
-    public string AssetMergeSource { get; set; }
+    public string AssetMergeBehavior
+    {
+        get => _assetMergeBehavior ??= GetMetadata(nameof(AssetMergeBehavior));
+        set
+        {
+            _modified = true;
+            _assetMergeBehavior = value;
+        }
+    }
 
-    public string RelatedAsset { get; set; }
+    public string AssetMergeSource
+    {
+        get => _assetMergeSource ??= GetMetadata(nameof(AssetMergeSource));
+        set
+        {
+            _modified = true;
+            _assetMergeSource = value;
+        }
+    }
 
-    public string AssetTraitName { get; set; }
+    public string RelatedAsset
+    {
+        get => _relatedAsset ??= GetMetadata(nameof(RelatedAsset));
+        set
+        {
+            _modified = true;
+            _relatedAsset = value;
+        }
+    }
 
-    public string AssetTraitValue { get; set; }
+    public string AssetTraitName
+    {
+        get => _assetTraitName ??= GetMetadata(nameof(AssetTraitName));
+        set
+        {
+            _modified = true;
+            _assetTraitName = value;
+        }
+    }
 
-    public string Fingerprint { get; set; }
+    public string AssetTraitValue
+    {
+        get => _assetTraitValue ??= GetMetadata(nameof(AssetTraitValue));
+        set
+        {
+            _modified = true;
+            _assetTraitValue = value;
+        }
+    }
 
-    public string Integrity { get; set; }
+    public string Fingerprint
+    {
+        get => _fingerprint ??= GetMetadata(nameof(Fingerprint));
+        set
+        {
+            _modified = true;
+            _fingerprint = value;
+        }
+    }
 
-    public string CopyToOutputDirectory { get; set; }
+    public string Integrity
+    {
+        get => _integrity ??= GetMetadata(nameof(Integrity));
+        set
+        {
+            _modified = true;
+            _integrity = value;
+        }
+    }
 
-    public string CopyToPublishDirectory { get; set; }
+    public string CopyToOutputDirectory
+    {
+        get => _copyToOutputDirectory ??= GetMetadata(nameof(CopyToOutputDirectory));
+        set
+        {
+            _modified = true;
+            _copyToOutputDirectory = value;
+        }
+    }
 
-    public string OriginalItemSpec { get; set; }
+    public string CopyToPublishDirectory
+    {
+        get => _copyToPublishDirectory ??= GetMetadata(nameof(CopyToPublishDirectory));
+        set
+        {
+            _modified = true;
+            _copyToPublishDirectory = value;
+        }
+    }
 
-    public long FileLength { get; set; } = -1;
+    public string OriginalItemSpec
+    {
+        get => _originalItemSpec ??= GetMetadata(nameof(OriginalItemSpec));
+        set
+        {
+            _modified = true;
+            _originalItemSpec = value;
+        }
+    }
 
-    public DateTimeOffset LastWriteTime { get; set; } = DateTimeOffset.MinValue;
+    public long FileLength
+    {
+        get
+        {
+            if (_fileLength < 0)
+            {
+                var fileLengthString = GetMetadata(nameof(FileLength));
+                _fileLength = !string.IsNullOrEmpty(fileLengthString) && long.TryParse(fileLengthString, out var fileLength)
+                    ? fileLength
+                    : -1;
+            }
+            return _fileLength;
+        }
+        set
+        {
+            _modified = true;
+            _fileLength = value;
+        }
+    }
+
+    public DateTimeOffset LastWriteTime
+    {
+        get
+        {
+            if (_lastWriteTime == DateTimeOffset.MinValue)
+            {
+                var lastWriteTimeString = GetMetadata(nameof(LastWriteTime));
+                _lastWriteTime = !string.IsNullOrEmpty(lastWriteTimeString) && DateTimeOffset.TryParse(lastWriteTimeString, out var lastWriteTime)
+                    ? lastWriteTime
+                    : DateTimeOffset.MinValue;
+            }
+            return _lastWriteTime;
+        }
+        set
+        {
+            _modified = true;
+            _lastWriteTime = value;
+        }
+    }
 
     public static StaticWebAsset FromTaskItem(ITaskItem item)
     {
@@ -196,12 +412,14 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         return result;
     }
 
-    private static StaticWebAsset FromTaskItemCore(ITaskItem item) =>
-        new()
+    private static StaticWebAsset FromTaskItemCore(ITaskItem item)
+    {
+        return new()
         {
             // Register the identity as the full path since assets might have come
             // from packages and other sources and the identity (which is typically
             // just the relative path from the project) is not enough to locate them.
+            _originalItem = item,
             Identity = item.GetMetadata("FullPath"),
             SourceType = item.GetMetadata(nameof(SourceType)),
             SourceId = item.GetMetadata(nameof(SourceId)),
@@ -226,6 +444,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
             LastWriteTime = item.GetMetadata("LastWriteTime") is string lastWriteTimeString &&
                 DateTimeOffset.TryParse(lastWriteTimeString, out var lastWriteTime) ? lastWriteTime : DateTimeOffset.MinValue
         };
+    }
 
     public void ApplyDefaults()
     {
@@ -301,6 +520,11 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     public ITaskItem ToTaskItem()
     {
+        if (_originalItem != null && !_modified)
+        {
+            return _originalItem;
+        }
+
         var result = new TaskItem(Identity);
         result.SetMetadata(nameof(SourceType), SourceType);
         result.SetMetadata(nameof(SourceId), SourceId);
@@ -320,8 +544,8 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         result.SetMetadata(nameof(CopyToOutputDirectory), CopyToOutputDirectory);
         result.SetMetadata(nameof(CopyToPublishDirectory), CopyToPublishDirectory);
         result.SetMetadata(nameof(OriginalItemSpec), OriginalItemSpec);
-        result.SetMetadata("FileLength", FileLength.ToString(CultureInfo.InvariantCulture));
-        result.SetMetadata("LastWriteTime", LastWriteTime.ToString(DateTimeAssetFormat, CultureInfo.InvariantCulture));
+        result.SetMetadata(nameof(FileLength), FileLength.ToString(CultureInfo.InvariantCulture));
+        result.SetMetadata(nameof(LastWriteTime), LastWriteTime.ToString(DateTimeAssetFormat, CultureInfo.InvariantCulture));
         return result;
     }
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -86,8 +86,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         set
         {
             _modified = true;
-            // Note, this is the same ItemSpec does in new TaskItem
-            _identity = FixFilePath(value);
+            _identity = Path.GetFullPath(value);
         }
     }
 
@@ -1264,14 +1263,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     #region ITaskItem2 implementation
 
     string ITaskItem2.EvaluatedIncludeEscaped { get => Identity; set => Identity = value; }
-
-    string ITaskItem.ItemSpec {
-        get => Identity;
-        set => Identity = value;
-    }
-
-    // This mimics the implementation from
-    private static string FixFilePath(string value) => string.IsNullOrEmpty(value) || Path.DirectorySeparatorChar == '\\' ? value : value.Replace('\\', '/');
+    string ITaskItem.ItemSpec { get => Identity; set => Identity = value; }
 
     private static readonly string[] _defaultPropertyNames = [
         nameof(SourceId),

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1262,13 +1262,158 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     // For that reason, and since we control inside the tasks how this is used, we can safely ignore the pieces that MSBuild won't call.
     #region ITaskItem2 implementation
 
-    string ITaskItem2.EvaluatedIncludeEscaped { get => Identity; set => throw new NotImplementedException(); }
-    string ITaskItem.ItemSpec { get => Identity; set => throw new NotImplementedException(); }
-    ICollection ITaskItem.MetadataNames => throw new NotImplementedException();
-    int ITaskItem.MetadataCount => throw new NotImplementedException();
+    string ITaskItem2.EvaluatedIncludeEscaped { get => Identity; set => Identity = value; }
+    string ITaskItem.ItemSpec { get => Identity; set => Identity = value; }
 
-    string ITaskItem2.GetMetadataValueEscaped(string metadataName) => throw new NotImplementedException();
-    void ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) => throw new NotImplementedException();
+    private static readonly string[] _defaultPropertyNames = [
+        nameof(SourceId),
+        nameof(SourceType),
+        nameof(ContentRoot),
+        nameof(BasePath),
+        nameof(RelativePath),
+        nameof(AssetKind),
+        nameof(AssetMode),
+        nameof(AssetRole),
+        nameof(AssetMergeBehavior),
+        nameof(AssetMergeSource),
+        nameof(RelatedAsset),
+        nameof(AssetTraitName),
+        nameof(AssetTraitValue),
+        nameof(Fingerprint),
+        nameof(Integrity),
+        nameof(CopyToOutputDirectory),
+        nameof(CopyToPublishDirectory),
+        nameof(OriginalItemSpec),
+        nameof(FileLength),
+        nameof(LastWriteTime)
+    ];
+
+    ICollection ITaskItem.MetadataNames
+    {
+        get
+        {
+            if (_additionalCustomMetadata == null)
+            {
+                return _defaultPropertyNames;
+            }
+            else
+            {
+
+            }
+            var result = new List<string>(_defaultPropertyNames.Length + _additionalCustomMetadata.Count);
+            result.AddRange(_defaultPropertyNames);
+
+            if (_additionalCustomMetadata != null)
+            {
+                foreach (var kvp in _additionalCustomMetadata)
+                {
+                    result.Add(kvp.Key);
+                }
+            }
+            return result;
+        }
+    }
+
+    int ITaskItem.MetadataCount => _defaultPropertyNames.Length + _additionalCustomMetadata?.Count ?? 0;
+    string ITaskItem2.GetMetadataValueEscaped(string metadataName)
+    {
+        return metadataName switch
+        {
+            nameof(SourceId) => SourceId ?? "",
+            nameof(SourceType) => SourceType ?? "",
+            nameof(ContentRoot) => ContentRoot ?? "",
+            nameof(BasePath) => BasePath ?? "",
+            nameof(RelativePath) => RelativePath ?? "",
+            nameof(AssetKind) => AssetKind ?? "",
+            nameof(AssetMode) => AssetMode ?? "",
+            nameof(AssetRole) => AssetRole ?? "",
+            nameof(AssetMergeBehavior) => AssetMergeBehavior ?? "",
+            nameof(AssetMergeSource) => AssetMergeSource ?? "",
+            nameof(RelatedAsset) => RelatedAsset ?? "",
+            nameof(AssetTraitName) => AssetTraitName ?? "",
+            nameof(AssetTraitValue) => AssetTraitValue ?? "",
+            nameof(Fingerprint) => Fingerprint ?? "",
+            nameof(Integrity) => Integrity ?? "",
+            nameof(CopyToOutputDirectory) => CopyToOutputDirectory ?? "",
+            nameof(CopyToPublishDirectory) => CopyToPublishDirectory ?? "",
+            nameof(OriginalItemSpec) => OriginalItemSpec ?? "",
+            nameof(FileLength) => FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "",
+            nameof(LastWriteTime) => LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "",
+            _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? value : "",
+        };
+    }
+
+    void ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue)
+    {
+        switch (metadataName)
+        {
+            case nameof(SourceId):
+                SourceId = metadataValue;
+                break;
+            case nameof(SourceType):
+                SourceType = metadataValue;
+                break;
+            case nameof(ContentRoot):
+                ContentRoot = metadataValue;
+                break;
+            case nameof(BasePath):
+                BasePath = metadataValue;
+                break;
+            case nameof(RelativePath):
+                RelativePath = metadataValue;
+                break;
+            case nameof(AssetKind):
+                AssetKind = metadataValue;
+                break;
+            case nameof(AssetMode):
+                AssetMode = metadataValue;
+                break;
+            case nameof(AssetRole):
+                AssetRole = metadataValue;
+                break;
+            case nameof(AssetMergeBehavior):
+                AssetMergeBehavior = metadataValue;
+                break;
+            case nameof(AssetMergeSource):
+                AssetMergeSource = metadataValue;
+                break;
+            case nameof(RelatedAsset):
+                RelatedAsset = metadataValue;
+                break;
+            case nameof(AssetTraitName):
+                AssetTraitName = metadataValue;
+                break;
+            case nameof(AssetTraitValue):
+                AssetTraitValue = metadataValue;
+                break;
+            case nameof(Fingerprint):
+                Fingerprint = metadataValue;
+                break;
+            case nameof(Integrity):
+                Integrity = metadataValue;
+                break;
+            case nameof(CopyToOutputDirectory):
+                CopyToOutputDirectory = metadataValue;
+                break;
+            case nameof(CopyToPublishDirectory):
+                CopyToPublishDirectory = metadataValue;
+                break;
+            case nameof(OriginalItemSpec):
+                OriginalItemSpec = metadataValue;
+                break;
+            case nameof(FileLength):
+                FileLength = long.Parse(metadataValue, System.Globalization.CultureInfo.InvariantCulture);
+                break;
+            case nameof(LastWriteTime):
+                LastWriteTime = DateTimeOffset.Parse(metadataValue, System.Globalization.CultureInfo.InvariantCulture);
+                break;
+            default:
+                _additionalCustomMetadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _additionalCustomMetadata[metadataName] = metadataValue;
+                _modified = true;
+                break;
+        }
+    }
 
     IDictionary ITaskItem2.CloneCustomMetadataEscaped()
     {
@@ -1327,8 +1472,8 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         nameof(CopyToOutputDirectory) => CopyToOutputDirectory ?? "",
         nameof(CopyToPublishDirectory) => CopyToPublishDirectory ?? "",
         nameof(OriginalItemSpec) => OriginalItemSpec ?? "",
-        nameof(FileLength) => FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        nameof(LastWriteTime) => LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture),
+        nameof(FileLength) => FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "",
+        nameof(LastWriteTime) => LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "",
         _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? value : ""
     };
 
@@ -1386,6 +1531,15 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
                 break;
             case nameof(CopyToPublishDirectory):
                 CopyToPublishDirectory = metadataValue;
+                break;
+            case nameof(OriginalItemSpec):
+                OriginalItemSpec = metadataValue;
+                break;
+            case nameof(FileLength):
+                FileLength = long.Parse(metadataValue, System.Globalization.CultureInfo.InvariantCulture);
+                break;
+            case nameof(LastWriteTime):
+                LastWriteTime = DateTimeOffset.Parse(metadataValue, System.Globalization.CultureInfo.InvariantCulture);
                 break;
             default:
                 _additionalCustomMetadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1339,12 +1339,13 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
             nameof(OriginalItemSpec) => OriginalItemSpec ?? "",
             nameof(FileLength) => FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "",
             nameof(LastWriteTime) => LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "",
-            _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? value : "",
+            _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? (value ?? "") : "",
         };
     }
 
     void ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue)
     {
+        metadataValue ??= "";
         switch (metadataName)
         {
             case nameof(SourceId):
@@ -1419,26 +1420,26 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         var result = new Dictionary<string, string>
         {
-            { nameof(SourceId), SourceId },
-            { nameof(SourceType), SourceType },
-            { nameof(ContentRoot), ContentRoot },
-            { nameof(BasePath), BasePath },
-            { nameof(RelativePath), RelativePath },
-            { nameof(AssetKind), AssetKind },
-            { nameof(AssetMode), AssetMode },
-            { nameof(AssetRole), AssetRole },
-            { nameof(AssetMergeBehavior), AssetMergeBehavior },
-            { nameof(AssetMergeSource), AssetMergeSource },
-            { nameof(RelatedAsset), RelatedAsset },
-            { nameof(AssetTraitName), AssetTraitName },
-            { nameof(AssetTraitValue), AssetTraitValue },
-            { nameof(Fingerprint), Fingerprint },
-            { nameof(Integrity), Integrity },
-            { nameof(CopyToOutputDirectory), CopyToOutputDirectory },
-            { nameof(CopyToPublishDirectory), CopyToPublishDirectory },
-            { nameof(OriginalItemSpec), OriginalItemSpec },
-            { nameof(FileLength), FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) },
-            { nameof(LastWriteTime), LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) }
+            { nameof(SourceId), SourceId ?? "" },
+            { nameof(SourceType), SourceType  ?? "" },
+            { nameof(ContentRoot), ContentRoot  ?? "" },
+            { nameof(BasePath), BasePath  ?? "" },
+            { nameof(RelativePath), RelativePath  ?? "" },
+            { nameof(AssetKind), AssetKind  ?? "" },
+            { nameof(AssetMode), AssetMode  ?? "" },
+            { nameof(AssetRole), AssetRole  ?? "" },
+            { nameof(AssetMergeBehavior), AssetMergeBehavior  ?? "" },
+            { nameof(AssetMergeSource), AssetMergeSource  ?? "" },
+            { nameof(RelatedAsset), RelatedAsset  ?? "" },
+            { nameof(AssetTraitName), AssetTraitName  ?? "" },
+            { nameof(AssetTraitValue), AssetTraitValue  ?? "" },
+            { nameof(Fingerprint), Fingerprint  ?? "" },
+            { nameof(Integrity), Integrity  ?? "" },
+            { nameof(CopyToOutputDirectory), CopyToOutputDirectory  ?? "" },
+            { nameof(CopyToPublishDirectory), CopyToPublishDirectory  ?? "" },
+            { nameof(OriginalItemSpec), OriginalItemSpec  ?? "" },
+            { nameof(FileLength), FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "" },
+            { nameof(LastWriteTime), LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "" }
         };
         if (_additionalCustomMetadata != null)
         {
@@ -1474,11 +1475,12 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         nameof(OriginalItemSpec) => OriginalItemSpec ?? "",
         nameof(FileLength) => FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "",
         nameof(LastWriteTime) => LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "",
-        _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? value : ""
+        _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? (value ?? "") : ""
     };
 
     void ITaskItem.SetMetadata(string metadataName, string metadataValue)
     {
+        metadataValue ??= "";
         switch (metadataName)
         {
             case nameof(SourceId):
@@ -1556,31 +1558,31 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     void ITaskItem.CopyMetadataTo(ITaskItem destinationItem)
     {
-        destinationItem.SetMetadata(nameof(SourceId), SourceId);
-        destinationItem.SetMetadata(nameof(SourceType), SourceType);
-        destinationItem.SetMetadata(nameof(ContentRoot), ContentRoot);
-        destinationItem.SetMetadata(nameof(BasePath), BasePath);
-        destinationItem.SetMetadata(nameof(RelativePath), RelativePath);
-        destinationItem.SetMetadata(nameof(AssetKind), AssetKind);
-        destinationItem.SetMetadata(nameof(AssetMode), AssetMode);
-        destinationItem.SetMetadata(nameof(AssetRole), AssetRole);
-        destinationItem.SetMetadata(nameof(AssetMergeBehavior), AssetMergeBehavior);
-        destinationItem.SetMetadata(nameof(AssetMergeSource), AssetMergeSource);
-        destinationItem.SetMetadata(nameof(RelatedAsset), RelatedAsset);
-        destinationItem.SetMetadata(nameof(AssetTraitName), AssetTraitName);
-        destinationItem.SetMetadata(nameof(AssetTraitValue), AssetTraitValue);
-        destinationItem.SetMetadata(nameof(Fingerprint), Fingerprint);
-        destinationItem.SetMetadata(nameof(Integrity), Integrity);
-        destinationItem.SetMetadata(nameof(CopyToOutputDirectory), CopyToOutputDirectory);
-        destinationItem.SetMetadata(nameof(CopyToPublishDirectory), CopyToPublishDirectory);
-        destinationItem.SetMetadata(nameof(OriginalItemSpec), OriginalItemSpec);
-        destinationItem.SetMetadata(nameof(FileLength), FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        destinationItem.SetMetadata(nameof(LastWriteTime), LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture));
+        destinationItem.SetMetadata(nameof(SourceId), SourceId ?? "");
+        destinationItem.SetMetadata(nameof(SourceType), SourceType ?? "");
+        destinationItem.SetMetadata(nameof(ContentRoot), ContentRoot ?? "");
+        destinationItem.SetMetadata(nameof(BasePath), BasePath ?? "");
+        destinationItem.SetMetadata(nameof(RelativePath), RelativePath ?? "");
+        destinationItem.SetMetadata(nameof(AssetKind), AssetKind ?? "");
+        destinationItem.SetMetadata(nameof(AssetMode), AssetMode ?? "");
+        destinationItem.SetMetadata(nameof(AssetRole), AssetRole ?? "");
+        destinationItem.SetMetadata(nameof(AssetMergeBehavior), AssetMergeBehavior ?? "");
+        destinationItem.SetMetadata(nameof(AssetMergeSource), AssetMergeSource ?? "");
+        destinationItem.SetMetadata(nameof(RelatedAsset), RelatedAsset ?? "");
+        destinationItem.SetMetadata(nameof(AssetTraitName), AssetTraitName ?? "");
+        destinationItem.SetMetadata(nameof(AssetTraitValue), AssetTraitValue ?? "");
+        destinationItem.SetMetadata(nameof(Fingerprint), Fingerprint ?? "");
+        destinationItem.SetMetadata(nameof(Integrity), Integrity ?? "");
+        destinationItem.SetMetadata(nameof(CopyToOutputDirectory), CopyToOutputDirectory ?? "");
+        destinationItem.SetMetadata(nameof(CopyToPublishDirectory), CopyToPublishDirectory ?? "");
+        destinationItem.SetMetadata(nameof(OriginalItemSpec), OriginalItemSpec ?? "");
+        destinationItem.SetMetadata(nameof(FileLength), FileLength.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "");
+        destinationItem.SetMetadata(nameof(LastWriteTime), LastWriteTime.ToString(DateTimeAssetFormat, System.Globalization.CultureInfo.InvariantCulture) ?? "");
         if (_additionalCustomMetadata != null)
         {
             foreach (var kvp in _additionalCustomMetadata)
             {
-                destinationItem.SetMetadata(kvp.Key, kvp.Value);
+                destinationItem.SetMetadata(kvp.Key, kvp.Value ?? "");
             }
         }
     }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -78,7 +78,11 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     public string Identity
     {
-        get => _identity ??= GetOriginalItemMetadata("FullPath");
+        get
+        {
+            return _identity ??= GetOriginalItemMetadata("FullPath");
+        }
+
         set
         {
             _modified = true;
@@ -1270,7 +1274,6 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         var result = new Dictionary<string, string>
         {
-            { nameof(Identity), Identity },
             { nameof(SourceId), SourceId },
             { nameof(SourceType), SourceType },
             { nameof(ContentRoot), ContentRoot },
@@ -1305,7 +1308,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     string ITaskItem.GetMetadata(string metadataName) => metadataName switch
     {
-        nameof(Identity) => Identity ?? "",
+        "FullPath" => Identity ?? "",
         nameof(SourceId) => SourceId ?? "",
         nameof(SourceType) => SourceType ?? "",
         nameof(ContentRoot) => ContentRoot ?? "",
@@ -1333,9 +1336,6 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     {
         switch (metadataName)
         {
-            case nameof(Identity):
-                Identity = metadataValue;
-                break;
             case nameof(SourceId):
                 SourceId = metadataValue;
                 break;
@@ -1402,7 +1402,6 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     void ITaskItem.CopyMetadataTo(ITaskItem destinationItem)
     {
-        destinationItem.SetMetadata(nameof(Identity), Identity);
         destinationItem.SetMetadata(nameof(SourceId), SourceId);
         destinationItem.SetMetadata(nameof(SourceType), SourceType);
         destinationItem.SetMetadata(nameof(ContentRoot), ContentRoot);

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -80,6 +80,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
 
         set
         {
+            Array.Sort(value);
             _selectors = value;
             _selectorsModified = true;
             _modified = true;
@@ -105,6 +106,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         }
         set
         {
+            Array.Sort(value);
             _responseHeaders = value;
             _responseHeadersModified = true;
             _modified = true;
@@ -130,6 +132,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         }
         set
         {
+            Array.Sort(value);
             _endpointProperties = value;
             _endpointPropertiesModified = true;
             _modified = true;
@@ -144,9 +147,6 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         for (var i = 0; i < endpoints.Length; i++)
         {
             result[i] = FromTaskItem(endpoints[i]);
-            Array.Sort(result[i].ResponseHeaders);
-            Array.Sort(result[i].Selectors);
-            Array.Sort(result[i].EndpointProperties);
         }
 
         Array.Sort(result, (a, b) => (a.Route, b.Route) switch

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -21,8 +21,11 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
     private string _route;
     private bool _modified;
     private string _selectorsString;
+    private bool _selectorsModified;
     private string _responseHeadersString;
+    private bool _responseHeadersModified;
     private string _endpointPropertiesString;
+    private bool _endpointPropertiesModified;
 
     // Route as it should be registered in the routing table.
     public string Route
@@ -77,6 +80,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         set
         {
             _selectors = value;
+            _selectorsModified = true;
             _modified = true;
         }
     }
@@ -101,6 +105,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         set
         {
             _responseHeaders = value;
+            _responseHeadersModified = true;
             _modified = true;
         }
     }
@@ -125,6 +130,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         set
         {
             _endpointProperties = value;
+            _endpointPropertiesModified = true;
             _modified = true;
         }
     }
@@ -192,9 +198,32 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
 
         var item = new TaskItem(Route);
         item.SetMetadata(nameof(AssetFile), AssetFile);
-        item.SetMetadata(nameof(Selectors), StaticWebAssetEndpointSelector.ToMetadataValue(Selectors));
-        item.SetMetadata(nameof(ResponseHeaders), StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders));
-        item.SetMetadata(nameof(EndpointProperties), StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties));
+        if(!_selectorsModified)
+        {
+            item.SetMetadata(nameof(Selectors), SelectorsString);
+        }
+        else
+        {
+            item.SetMetadata(nameof(Selectors), StaticWebAssetEndpointSelector.ToMetadataValue(Selectors));
+        }
+
+        if (!_responseHeadersModified)
+        {
+            item.SetMetadata(nameof(ResponseHeaders), ResponseHeadersString);
+        }
+        else
+        {
+            item.SetMetadata(nameof(ResponseHeaders), StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders));
+        }
+
+        if (!_endpointPropertiesModified)
+        {
+            item.SetMetadata(nameof(EndpointProperties), EndpointPropertiesString);
+        }
+        else
+        {
+            item.SetMetadata(nameof(EndpointProperties), StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties));
+        }
         return item;
     }
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -468,7 +468,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
 
     IDictionary ITaskItem2.CloneCustomMetadataEscaped()
     {
-        var result = new Dictionary<string, string>
+        var result = new Dictionary<string, string>(((ITaskItem)this).MetadataCount)
         {
             { nameof(AssetFile), AssetFile ?? "" },
             { nameof(Selectors), !_selectorsModified ? SelectorsString ?? "" : StaticWebAssetEndpointSelector.ToMetadataValue(Selectors) },
@@ -487,50 +487,11 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         return result;
     }
 
-    string ITaskItem.GetMetadata(string metadataName) => metadataName switch
-    {
-        nameof(AssetFile) => AssetFile ?? "",
-        nameof(Selectors) => !_selectorsModified ? SelectorsString ?? "" : StaticWebAssetEndpointSelector.ToMetadataValue(Selectors),
-        nameof(ResponseHeaders) => !_responseHeadersModified ? ResponseHeadersString ?? "" : StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders),
-        nameof(EndpointProperties) => !_endpointPropertiesModified ? EndpointPropertiesString ?? "" : StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties),
-        _ => _additionalCustomMetadata?.TryGetValue(metadataName, out var value) == true ? (value ?? "") : ""
-    };
+    string ITaskItem.GetMetadata(string metadataName) => ((ITaskItem2)this).GetMetadataValueEscaped(metadataName);
 
-    void ITaskItem.SetMetadata(string metadataName, string metadataValue)
-    {
-        metadataValue ??= "";
-        switch (metadataName)
-        {
-            case nameof(AssetFile):
-                AssetFile = metadataValue;
-                break;
-            case nameof(Selectors):
-                _selectorsString = metadataValue;
-                _selectors = null;  // Force re-evaluation
-                _selectorsModified = false;
-                break;
-            case nameof(ResponseHeaders):
-                _responseHeadersString = metadataValue;
-                _responseHeaders = null;  // Force re-evaluation
-                _responseHeadersModified = false;
-                break;
-            case nameof(EndpointProperties):
-                _endpointPropertiesString = metadataValue;
-                _endpointProperties = null;  // Force re-evaluation
-                _endpointPropertiesModified = false;
-                break;
-            default:
-                _additionalCustomMetadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                _additionalCustomMetadata[metadataName] = metadataValue;
-                break;
-        }
-        _modified = true;
-    }
+    void ITaskItem.SetMetadata(string metadataName, string metadataValue) => ((ITaskItem2)this).SetMetadataValueLiteral(metadataName, metadataValue);
 
-    void ITaskItem.RemoveMetadata(string metadataName)
-    {
-        _additionalCustomMetadata?.Remove(metadataName);
-    }
+    void ITaskItem.RemoveMetadata(string metadataName) => _additionalCustomMetadata?.Remove(metadataName);
 
     void ITaskItem.CopyMetadataTo(ITaskItem destinationItem)
     {

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, IComparable<StaticWebAssetEndpoint>
 {
     private ITaskItem _originalItem;
-    private StaticWebAssetEndpointProperty[] _endpointProperties = [];
-    private StaticWebAssetEndpointResponseHeader[] _responseHeaders = [];
-    private StaticWebAssetEndpointSelector[] _selectors = [];
+    private StaticWebAssetEndpointProperty[] _endpointProperties;
+    private StaticWebAssetEndpointResponseHeader[] _responseHeaders;
+    private StaticWebAssetEndpointSelector[] _selectors;
     private string _assetFile;
     private string _route;
     private bool _modified;

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
@@ -41,7 +41,7 @@ public partial class DefineStaticWebAssets : Task
         var patternMetadata = new[] { nameof(FingerprintPattern.Pattern), nameof(FingerprintPattern.Expression) };
         var fingerprintPatternsHash = HashingUtils.ComputeHash(memoryStream, FingerprintPatterns ?? [], patternMetadata);
 
-        var propertyOverridesHash = HashingUtils.ComputeHash(memoryStream, PropertyOverrides, nameof(ITaskItem.GetMetadata));
+        var propertyOverridesHash = HashingUtils.ComputeHash(memoryStream, PropertyOverrides);
 
 #if NET9_0_OR_GREATER
         Span<string> candidateAssetMetadata = [

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
@@ -41,7 +41,7 @@ public partial class DefineStaticWebAssets : Task
         var patternMetadata = new[] { nameof(FingerprintPattern.Pattern), nameof(FingerprintPattern.Expression) };
         var fingerprintPatternsHash = HashingUtils.ComputeHash(memoryStream, FingerprintPatterns ?? [], patternMetadata);
 
-        var propertyOverridesHash = HashingUtils.ComputeHash(memoryStream, PropertyOverrides);
+        var propertyOverridesHash = HashingUtils.ComputeHash(memoryStream, PropertyOverrides ?? []);
 
 #if NET9_0_OR_GREATER
         Span<string> candidateAssetMetadata = [

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -25,7 +25,7 @@ public partial class DefineStaticWebAssets : Task
     [Required]
     public ITaskItem[] CandidateAssets { get; set; }
 
-    public ITaskItem[] PropertyOverrides { get; set; }
+    public string[] PropertyOverrides { get; set; }
 
     public string SourceId { get; set; }
 
@@ -73,8 +73,11 @@ public partial class DefineStaticWebAssets : Task
 
     public Func<string, string, (FileInfo file, long fileLength, DateTimeOffset lastWriteTimeUtc)> TestResolveFileDetails { get; set; }
 
+    private HashSet<string> _overrides;
+
     public override bool Execute()
     {
+        _overrides = new HashSet<string>(PropertyOverrides ?? [], StringComparer.OrdinalIgnoreCase);
         var assetsCache = GetOrCreateAssetsCache();
 
         if (assetsCache.IsUpToDate())
@@ -356,7 +359,7 @@ public partial class DefineStaticWebAssets : Task
 
     private string ComputePropertyValue(ITaskItem element, string metadataName, string propertyValue, bool isRequired = true)
     {
-        if (PropertyOverrides != null && PropertyOverrides.Any(a => string.Equals(a.ItemSpec, metadataName, StringComparison.OrdinalIgnoreCase)))
+        if (_overrides.Contains(metadataName))
         {
             return propertyValue;
         }

--- a/src/StaticWebAssetsSdk/Tasks/FilterStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/FilterStaticWebAssetEndpoints.cs
@@ -32,7 +32,7 @@ public class FilterStaticWebAssetEndpoints : Task
     public override bool Execute()
     {
         var filterCriteria = (Filters ?? []).Select(FilterCriteria.FromTaskItem).ToArray();
-        var assetFiles = (Assets ?? []).ToDictionary(a => a.ItemSpec, StaticWebAsset.FromTaskItem);
+        var assetFiles = Assets != null ? StaticWebAsset.ToAssetDictionary(Assets) : [];
         var endpoints = StaticWebAssetEndpoint.FromItemGroup(Endpoints ?? []);
         var endpointFoundMatchingAsset = new Dictionary<string, StaticWebAsset>();
 

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -37,7 +37,8 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
         try
         {
             // Get the list of the asset that need to be part of the manifest (this is similar to GenerateStaticWebAssetsDevelopmentManifest)
-            var manifestAssets = ComputeManifestAssets(Assets.Select(StaticWebAsset.FromTaskItem), ManifestType)
+            var assets = StaticWebAsset.FromTaskItemGroup(Assets);
+            var manifestAssets = ComputeManifestAssets(assets, ManifestType)
                 .ToDictionary(a => a.ResolvedAsset.Identity, a => a, OSPath.PathComparer);
 
             // Filter out the endpoints to those that point to the assets that are part of the manifest

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
@@ -25,7 +25,7 @@ public class GenerateStaticWebAssetEndpointsPropsFile : Task
     public override bool Execute()
     {
         var endpoints = StaticWebAssetEndpoint.FromItemGroup(StaticWebAssetEndpoints);
-        var assets = StaticWebAssets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity, a => a);
+        var assets = StaticWebAsset.ToAssetDictionary(StaticWebAssets);
         if (!ValidateArguments(endpoints, assets))
         {
             return false;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsDevelopmentManifest.cs
@@ -49,7 +49,7 @@ public class GenerateStaticWebAssetsDevelopmentManifest : Task
             }
 
             var manifest = ComputeDevelopmentManifest(
-                Assets.Select(StaticWebAsset.FromTaskItem),
+                StaticWebAsset.FromTaskItemGroup(Assets),
                 DiscoveryPatterns.Select(StaticWebAssetsDiscoveryPattern.FromTaskItem));
 
             PersistManifest(manifest);

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -44,7 +44,8 @@ public class GenerateStaticWebAssetsManifest : Task
     {
         try
         {
-            var assets = Assets.OrderBy(a => a.GetMetadata("FullPath")).Select(StaticWebAsset.FromTaskItem).ToArray();
+            var assets = StaticWebAsset.FromTaskItemGroup(Assets, validate: true);
+            Array.Sort(assets, (l, r) => string.CompareOrdinal(l.Identity, r.Identity));
 
             var endpoints = FilterPublishEndpointsIfNeeded(assets)
                 .OrderBy(a => a.Route)

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -91,7 +91,7 @@ public class GenerateStaticWebAssetsManifest : Task
         return !Log.HasLoggedErrors;
     }
 
-    private IEnumerable<StaticWebAssetEndpoint> FilterPublishEndpointsIfNeeded(IEnumerable<StaticWebAsset> assets)
+    private IEnumerable<StaticWebAssetEndpoint> FilterPublishEndpointsIfNeeded(StaticWebAsset[] assets)
     {
         // Only include endpoints for assets that are going to be available in production. We do the filtering
         // inside the manifest because its cumbersome to do it in MSBuild directly.

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -47,17 +47,19 @@ public class GenerateStaticWebAssetsManifest : Task
             var assets = StaticWebAsset.FromTaskItemGroup(Assets, validate: true);
             Array.Sort(assets, (l, r) => string.CompareOrdinal(l.Identity, r.Identity));
 
-            var endpoints = FilterPublishEndpointsIfNeeded(assets)
-                .OrderBy(a => a.Route)
-                .ThenBy(a => a.AssetFile)
-                .ToArray();
+            var endpoints = FilterPublishEndpointsIfNeeded(assets);
+            Array.Sort(endpoints, (l, r) => string.CompareOrdinal(l.Route, r.Route) switch
+            {
+                0 => string.CompareOrdinal(l.AssetFile, r.AssetFile),
+                int result => result,
+            });
 
             Log.LogMessage(MessageImportance.Low, "Generating manifest for '{0}' assets and '{1}' endpoints", assets.Length, endpoints.Length);
 
-            var assetsByTargetPath = assets.GroupBy(a => a.ComputeTargetPath("", '/'), StringComparer.OrdinalIgnoreCase);
+            var assetsByTargetPath = GroupAssetsByTargetPath(assets);
             foreach (var group in assetsByTargetPath)
             {
-                if (!StaticWebAsset.ValidateAssetGroup(group.Key, [.. group], out var reason))
+                if (!StaticWebAsset.ValidateAssetGroup(group.Key, group.Value, out var reason))
                 {
                     Log.LogError(reason);
                     return false;
@@ -91,7 +93,7 @@ public class GenerateStaticWebAssetsManifest : Task
         return !Log.HasLoggedErrors;
     }
 
-    private IEnumerable<StaticWebAssetEndpoint> FilterPublishEndpointsIfNeeded(StaticWebAsset[] assets)
+    private StaticWebAssetEndpoint[] FilterPublishEndpointsIfNeeded(StaticWebAsset[] assets)
     {
         // Only include endpoints for assets that are going to be available in production. We do the filtering
         // inside the manifest because its cumbersome to do it in MSBuild directly.
@@ -113,10 +115,10 @@ public class GenerateStaticWebAssetsManifest : Task
                 }
             }
 
-            return filteredEndpoints;
+            return [.. filteredEndpoints];
         }
 
-        return Endpoints.Select(StaticWebAssetEndpoint.FromTaskItem);
+        return StaticWebAssetEndpoint.FromItemGroup(Endpoints);
     }
 
     private void PersistManifest(StaticWebAssetsManifest manifest)
@@ -148,5 +150,37 @@ public class GenerateStaticWebAssetsManifest : Task
         {
             Log.LogMessage(MessageImportance.Low, $"Skipping manifest updated because manifest version '{manifest.Hash}' has not changed.");
         }
+    }
+
+    private static Dictionary<string, (StaticWebAsset First, StaticWebAsset Second, List<StaticWebAsset> Other)> GroupAssetsByTargetPath(StaticWebAsset[] assets)
+    {
+        var result = new Dictionary<string, (StaticWebAsset First, StaticWebAsset Second, List<StaticWebAsset> Other)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var asset in assets)
+        {
+            var targetPath = asset.ComputeTargetPath("", '/');
+
+            if (result.TryGetValue(targetPath, out var existing))
+            {
+                if (existing.Second == null)
+                {
+                    // We have first but not second
+                    result[targetPath] = (existing.First, asset, null);
+                }
+                else
+                {
+                    // We already have first and second, add to rest
+                    existing.Other ??= [];
+                    existing.Other.Add(asset);
+                }
+            }
+            else
+            {
+                // First asset with this path
+                result.Add(targetPath, (asset, null, null));
+            }
+        }
+
+        return result;
     }
 }

--- a/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
+++ b/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
@@ -25,7 +25,7 @@ public class MergeConfigurationProperties : Task
     {
         try
         {
-            ProjectConfigurations = new TaskItem[CandidateConfigurations.Length];
+            ProjectConfigurations = new ITaskItem[CandidateConfigurations.Length];
 
             for (var i = 0; i < CandidateConfigurations.Length; i++)
             {

--- a/src/StaticWebAssetsSdk/Tasks/MergeStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/MergeStaticWebAssets.cs
@@ -27,7 +27,8 @@ public class MergeStaticWebAssets : Task
     public override bool Execute()
     {
 
-        var assets = CandidateAssets.OrderBy(a => a.GetMetadata("FullPath")).Select(StaticWebAsset.FromTaskItem);
+        var assets = StaticWebAsset.FromTaskItemGroup(CandidateAssets);
+        Array.Sort(assets, (a, b) => string.CompareOrdinal(a.Identity, b.Identity));
 
         var assetsByTargetPath = assets
             .GroupBy(a => a.ComputeTargetPath("", '/'), StringComparer.OrdinalIgnoreCase)

--- a/src/StaticWebAssetsSdk/Tasks/ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs
@@ -26,7 +26,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssets : Task
     public override bool Execute()
     {
         var candidateEndpoints = StaticWebAssetEndpoint.FromItemGroup(CandidateEndpoints);
-        var candidateAssets = CandidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray();
+        var candidateAssets = StaticWebAsset.FromTaskItemGroup(CandidateAssets);
         var resolvedEndpoints = new List<StaticWebAssetEndpoint>();
 
         var endpointsByAsset = candidateEndpoints.GroupBy(e => e.AssetFile, OSPath.PathComparer)

--- a/src/StaticWebAssetsSdk/Tasks/ResolveStaticWebAssetEndpointRoutes.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ResolveStaticWebAssetEndpointRoutes.cs
@@ -18,7 +18,7 @@ public class ResolveStaticWebAssetEndpointRoutes : Task
     public override bool Execute()
     {
         var endpoints = StaticWebAssetEndpoint.FromItemGroup(Endpoints);
-        var assets = Assets.Select(StaticWebAsset.FromTaskItem).ToDictionary(a => a.Identity, a => a);
+        var assets = StaticWebAsset.ToAssetDictionary(Assets);
 
         foreach (var endpoint in endpoints)
         {

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsTest.cs
@@ -103,7 +103,7 @@ public class ComputeEndpointsForReferenceStaticWebAssetsTest
         return result.ToTaskItem();
     }
 
-    private static TaskItem CreateCandidateEndpoint(string route, string assetFile)
+    private static ITaskItem CreateCandidateEndpoint(string route, string assetFile)
     {
         return new StaticWebAssetEndpoint
         {

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -49,8 +49,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
-                Patterns = new[] { CreatePatternCandidate(Path.Combine("MyPackage","wwwroot"), "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "MyPackage") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Patterns = new[] { CreatePatternCandidate("MyPackage\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "MyPackage") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
             };
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new[] { CreatePatternCandidate("Other\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "Other") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -103,8 +103,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All")
+                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -134,9 +134,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All"),
-                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Publish", "All")
+                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All"),
+                    CreateCandidate("wwwroot\\candidate.publish.js", "MyPackage", "Discovered", "candidate.js", "Publish", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = manifestKind,
                 ProjectMode = "Default"
@@ -192,7 +192,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -270,7 +270,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -296,7 +296,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Project", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Project", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -322,7 +322,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Package", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Package", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new[] { CreatePatternCandidate("MyPackage\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "MyPackage") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new[] { CreatePatternCandidate("Other\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "Other") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -103,8 +103,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.other.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -134,9 +134,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All"),
-                    CreateCandidate("wwwroot\\candidate.publish.js", "MyPackage", "Discovered", "candidate.js", "Publish", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.other.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.publish.js"), "MyPackage", "Discovered", "candidate.js", "Publish", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = manifestKind,
                 ProjectMode = "Default"
@@ -192,7 +192,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -270,7 +270,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -296,7 +296,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Project", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Project", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -322,7 +322,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Package", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Package", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -49,8 +49,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
-                Patterns = new[] { CreatePatternCandidate("MyPackage\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "MyPackage") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Patterns = new[] { CreatePatternCandidate(Path.Combine("MyPackage","wwwroot"), "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "MyPackage") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
             };
@@ -75,7 +75,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All") },
                 Patterns = new[] { CreatePatternCandidate("Other\\wwwroot", "base", Directory.GetCurrentDirectory(), "wwwroot\\**", "Other") },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -103,8 +103,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -134,9 +134,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All"),
-                    CreateCandidate("wwwroot\\candidate.publish.js", "MyPackage", "Discovered", "candidate.js", "Publish", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "Publish", "All")
                 },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
@@ -166,7 +166,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", assetKind, "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = manifestKind,
                 ProjectMode = "Default"
@@ -192,7 +192,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -218,7 +218,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Default"
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "CurrentProject") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -270,7 +270,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "Reference") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Default",
                 ProjectMode = "Root"
@@ -296,7 +296,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Project", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Project", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -322,7 +322,7 @@ namespace Microsoft.NET.Sdk.Razor.Tests
             {
                 BuildEngine = buildEngine.Object,
                 Source = "MyPackage",
-                Assets = new[] { CreateCandidate("wwwroot\\candidate.js", "Other", "Package", "candidate.js", "All", "All") },
+                Assets = new[] { CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "Other", "Package", "candidate.js", "All", "All") },
                 Patterns = new ITaskItem[] { },
                 AssetKind = "Build",
                 ProjectMode = "Default"

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeStaticWebAssetsForCurrentProjectTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeStaticWebAssetsForCurrentProjectTest.cs
@@ -51,8 +51,8 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.other.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All")
                 },
                 AssetKind = "Build",
                 ProjectMode = "Default"
@@ -81,9 +81,9 @@ namespace Microsoft.NET.Sdk.Razor.Tests
                 Source = "MyPackage",
                 Assets = new[]
                 {
-                    CreateCandidate("wwwroot\\candidate.js", "MyPackage", "Discovered", "candidate.js", "All", "All"),
-                    CreateCandidate("wwwroot\\candidate.other.js", "MyPackage", "Discovered", "candidate.js", "Build", "All"),
-                    CreateCandidate("wwwroot\\candidate.publish.js", "MyPackage", "Discovered", "candidate.js", "Publish", "All")
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.other.js"), "MyPackage", "Discovered", "candidate.js", "Build", "All"),
+                    CreateCandidate(Path.Combine("wwwroot", "candidate.publish.js"), "MyPackage", "Discovered", "candidate.js", "Publish", "All")
                 },
                 AssetKind = "Build",
                 ProjectMode = "Default"

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -208,7 +208,7 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
         return result.ToTaskItem();
     }
 
-    private static TaskItem CreateStaticWebAssetEndpoint(
+    private static ITaskItem CreateStaticWebAssetEndpoint(
         string route,
         string assetFile,
         StaticWebAssetEndpointResponseHeader[] responseHeaders = null,

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest.cs
@@ -36,7 +36,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
             )
         ];
 
-        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        var endpoints = CreateEndpoints(candidateAssets.Select(a => StaticWebAsset.FromTaskItem(a)).ToArray());
 
         var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
         {
@@ -79,7 +79,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
             )
         ];
 
-        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        var endpoints = CreateEndpoints(candidateAssets.Select(a => StaticWebAsset.FromTaskItem(a)).ToArray());
         endpoints = endpoints.Where(e => !e.Route.Contains("asdf1234")).ToArray();
 
         var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
@@ -119,7 +119,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
             )
         ];
 
-        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        var endpoints = CreateEndpoints(candidateAssets.Select(a => StaticWebAsset.FromTaskItem(a)).ToArray());
 
         var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
         {
@@ -162,7 +162,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
             )
         ];
 
-        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        var endpoints = CreateEndpoints(candidateAssets.Select(a => StaticWebAsset.FromTaskItem(a)).ToArray());
 
         var resolvedEndpoints = new ResolveFingerprintedStaticWebAssetEndpointsForAssets
         {
@@ -205,7 +205,7 @@ public class ResolveFingerprintedStaticWebAssetEndpointsForAssetsTest
             )
         ];
 
-        var endpoints = CreateEndpoints(candidateAssets.Select(StaticWebAsset.FromTaskItem).ToArray());
+        var endpoints = CreateEndpoints(candidateAssets.Select(a => StaticWebAsset.FromTaskItem(a)).ToArray());
         endpoints = endpoints.Where(e => !e.Route.Contains("asdf1234")).ToArray();
         endpoints[0].AssetFile = Path.GetFullPath("other.js");
 


### PR DESCRIPTION
* Avoid accessing the properties until needed.
* Reuse the original Task Item if it wasn't modified.
* Avoid deserializing expensive properties unless needed.
* Sort endpoint headers/properties/selectors on write.

Another ~800ms cut

```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.44

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.34

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.40

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.93

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.62

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.54

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.19

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.37

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.50

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.23

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.72

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.33

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.04

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.29

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.29

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.06

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.41

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.62

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.86

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.29
```