### PR TITLE
Update exit code logic for dotnet test

### DIFF
--- a/src/Cli/dotnet/PathDotnetTest.ps1
+++ b/src/Cli/dotnet/PathDotnetTest.ps1
@@ -1,4 +1,0 @@
-& dotnet build
-Copy-Item C:\Code\sdk\artifacts\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net10.0\Microsoft.NET.Build.Tasks.dll -Destination C:\code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev
-Copy-Item C:\Code\sdk\artifacts\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net10.0\Microsoft.NET.Build.Tasks.dll -Destination C:\Code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev\Sdks\Microsoft.NET.Sdk\tools\net10.0
-Copy-Item C:\code\sdk\artifacts\bin\dotnet\Debug\net10.0\dotnet.dll -Destination  C:\code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev

--- a/src/Cli/dotnet/PathDotnetTest.ps1
+++ b/src/Cli/dotnet/PathDotnetTest.ps1
@@ -1,0 +1,4 @@
+& dotnet build
+Copy-Item C:\Code\sdk\artifacts\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net10.0\Microsoft.NET.Build.Tasks.dll -Destination C:\code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev
+Copy-Item C:\Code\sdk\artifacts\bin\Debug\Sdks\Microsoft.NET.Sdk\tools\net10.0\Microsoft.NET.Build.Tasks.dll -Destination C:\Code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev\Sdks\Microsoft.NET.Sdk\tools\net10.0
+Copy-Item C:\code\sdk\artifacts\bin\dotnet\Debug\net10.0\dotnet.dll -Destination  C:\code\sdk\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev

--- a/src/Cli/dotnet/commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/commands/Test/SolutionAndProjectUtility.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli;
 internal static class SolutionAndProjectUtility
 {
     private static readonly string s_computeRunArgumentsTarget = "ComputeRunArguments";
-    private static readonly Lock s_buildLock = new Lock();
+    private static readonly Lock s_buildLock = new();
 
     public static (bool SolutionOrProjectFileFound, string Message) TryGetProjectOrSolutionFilePath(string directory, out string projectOrSolutionFilePath, out bool isSolution)
     {

--- a/src/Cli/dotnet/commands/Test/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/commands/Test/TestApplicationActionQueue.cs
@@ -41,11 +41,6 @@ internal class TestApplicationActionQueue
     {
         Task.WaitAll([.. _readers]);
 
-        if (_firstExitCode is null)
-        {
-            return _hasFailed ? ExitCode.GenericFailure : ExitCode.Success;
-        }
-
         if (_allSameExitCode && _firstExitCode.HasValue)
         {
             return _firstExitCode.Value;
@@ -56,6 +51,7 @@ internal class TestApplicationActionQueue
 
     public void EnqueueCompleted()
     {
+        //Notify readers that no more data will be written
         _channel.Writer.Complete();
     }
 

--- a/src/Cli/dotnet/commands/Test/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/commands/Test/TestApplicationActionQueue.cs
@@ -41,6 +41,11 @@ internal class TestApplicationActionQueue
     {
         Task.WaitAll([.. _readers]);
 
+        if (_firstExitCode is null)
+        {
+            return _hasFailed ? ExitCode.GenericFailure : ExitCode.Success;
+        }
+
         if (_allSameExitCode && _firstExitCode.HasValue)
         {
             return _firstExitCode.Value;

--- a/src/Cli/dotnet/commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/commands/Test/TestingPlatformCommand.cs
@@ -26,7 +26,7 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
 
     public int Run(ParseResult parseResult)
     {
-        bool hasFailed = false;
+        int exitCode = ExitCode.Success;
         try
         {
             ValidationUtility.ValidateMutuallyExclusiveOptions(parseResult);
@@ -64,7 +64,7 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
             }
 
             _actionQueue.EnqueueCompleted();
-            hasFailed = _actionQueue.WaitAllActions();
+            exitCode = _actionQueue.WaitAllActions();
         }
         finally
         {
@@ -72,7 +72,7 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
             CleanUp();
         }
 
-        return hasFailed ? ExitCode.GenericFailure : ExitCode.Success;
+        return exitCode;
     }
 
     private void PrepareEnvironment(ParseResult parseResult, out TestOptions testOptions, out int degreeOfParallelism)

--- a/test/Microsoft.NET.TestFramework/Constants.cs
+++ b/test/Microsoft.NET.TestFramework/Constants.cs
@@ -11,4 +11,13 @@ namespace Microsoft.NET.TestFramework
         public const string Failed = "failed";
         public const string Passed = "passed";
     }
+
+    internal static class ExitCode
+    {
+        public const int Success = 0;
+        public const int GenericFailure = 1;
+        public const int AtLeastOneTestFailed = 2;
+        public const int ZeroTests = 8;
+        public const int MinimumExpectedTestsPolicyViolation = 9;
+    }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -31,7 +32,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .Should().Contain("Discovered 0 tests.");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -54,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Discovered 0 tests.*", result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -75,7 +76,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Discovered 1 tests.*", result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Discovered 3 tests.*", result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -119,7 +120,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 2 tests", ["TestMethod1", "TestMethod3"]), result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -139,7 +140,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Cli.Utils;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -29,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -56,7 +57,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Assert.Matches(otherTestProjectPattern, result.StdOut);
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [Fact]
@@ -86,7 +87,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 2");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
 
@@ -118,7 +119,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 0");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -59,7 +60,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.NotContain("Expected to find --arg-from-my-target");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -85,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -110,7 +111,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 2");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -140,7 +141,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -160,7 +161,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -180,7 +181,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain(Tools.Test.LocalizableStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -200,7 +201,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain(Tools.Test.LocalizableStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -220,7 +221,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Should().Contain(Tools.Test.LocalizableStrings.CmdMultipleProjectOrSolutionFilesErrorDescription);
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -245,7 +246,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 0");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -273,7 +274,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 0");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -47,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 2");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -93,7 +94,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 3");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -121,7 +122,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 3");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -157,7 +158,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 0");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithArtifacts.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithArtifacts.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Cli.Utils;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -75,7 +76,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 0");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "exec", addVersionAndArchPattern: false));
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -48,7 +49,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -85,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -104,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdInvalidProjectFileExtensionErrorDescription, invalidProjectPath));
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -123,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdInvalidSolutionFileExtensionErrorDescription, invalidSolutionPath));
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -146,7 +147,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.StdErr.Should().Contain(Tools.Test.LocalizableStrings.CmdMultipleBuildPathOptionsErrorDescription);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -167,7 +168,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.StdErr.Should().Contain(Tools.Test.LocalizableStrings.CmdMultipleBuildPathOptionsErrorDescription);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -187,7 +188,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             string fullProjectPath = $"{testInstance.TestRoot}{Path.DirectorySeparatorChar}{testProjectPath}";
             result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdNonExistentFileErrorDescription, fullProjectPath));
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -207,7 +208,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             string fullSolutionPath = $"{testInstance.TestRoot}{Path.DirectorySeparatorChar}{solutionPath}";
             result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdNonExistentFileErrorDescription, fullSolutionPath));
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -225,7 +226,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                              TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             result.StdOut.Should().Contain(string.Format(Tools.Test.LocalizableStrings.CmdNonExistentDirectoryErrorDescription, directoryPath));
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -245,7 +246,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, configuration, runtime: runtime), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -264,7 +265,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, configuration, runtime: runtime), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -283,7 +284,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             CommonOptions.ArchitectureOption.Name, arch,
                                             TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -302,7 +303,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, configuration, runtime: runtime), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -323,7 +324,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, configuration, runtime: runtime), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -350,7 +351,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Assert that the bin folder hasn't been modified
             Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -367,7 +368,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.True(File.Exists(string.Format("{0}{1}{2}", testInstance.TestRoot, Path.DirectorySeparatorChar, CliConstants.BinLogFileName)));
             Assert.True(File.Exists(string.Format("{0}{1}{2}", testInstance.TestRoot, Path.DirectorySeparatorChar, "msbuild-dotnet-test.binlog")));
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -393,7 +394,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                   .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -418,7 +419,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                   .And.Contain("skipped: 2");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -445,7 +446,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                  .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCode.Success);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -492,7 +493,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             // This should fail because OtherTestProject is not built with the previous .NET version
             // Therefore, the build error will prevent the tests from running
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
 
@@ -531,7 +532,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                  .And.Contain("skipped: 2");
             }
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -549,7 +550,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.True(File.Exists(Path.Combine(testInstance.Path, traceFile)), "Trace file should exist after test execution.");
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -567,7 +568,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.True(File.Exists(Path.Combine(testInstance.Path, traceFile)), "Trace file should exist after test execution.");
 
-            result.ExitCode.Should().Be(ExitCode.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestsRunsWithDifferentCultures.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestsRunsWithDifferentCultures.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
 namespace Microsoft.DotNet.Cli.Test.Tests;
 
@@ -23,6 +24,6 @@ public class GivenDotnetTestsRunsWithDifferentCultures : SdkTest
                                 .WithCulture(locale)
                                 .Execute();
 
-        result.ExitCode.Should().Be(ExitCode.Success);
+        result.ExitCode.Should().Be(ExitCodes.Success);
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `TestApplicationActionQueue` and `TestingPlatformCommand` classes, as well as updates to test exit codes across multiple test files. The primary goal of these changes is to improve the handling of test application exit codes and to ensure consistency in exit code usage across the codebase.

Key changes include:

### Improvements to `TestApplicationActionQueue`:

* Refactored the constructor to initialize `_channel`, `_readers`, `_hasFailed`, `_firstExitCode`, and `_allSameExitCode` fields.
* Modified the `WaitAllActions` method to return an exit code instead of a boolean value, ensuring consistent exit code handling.

### Updates to `TestingPlatformCommand`:

* Replaced the `hasFailed` boolean variable with an `exitCode` integer variable to align with the new exit code handling in `TestApplicationActionQueue`. [[1]](diffhunk://#diff-08a3b3fc25c750adf5767d156560cdca69ddf0d9a24702befdc7c5c5d59cac0dL29-R29) [[2]](diffhunk://#diff-08a3b3fc25c750adf5767d156560cdca69ddf0d9a24702befdc7c5c5d59cac0dL67-R75)

### Introduction of `ExitCode` constants:

* Added a new `ExitCode` class to the `TestingConstants` file, defining various exit codes such as `Success`, `GenericFailure`, `AtLeastOneTestFailed`, `ZeroTests`, and `MinimumExpectedTestsPolicyViolation`.

### Test file updates:

* Updated multiple test files to use the new `ExitCodes` constants instead of the old `ExitCode` values. This ensures consistency and readability across the test suite. [[1]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77R5) [[2]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L34-R35) [[3]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L57-R58) [[4]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L78-R79) [[5]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L100-R101) [[6]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L122-R123) [[7]](diffhunk://#diff-7e9305afa686438b6324410a73c66415cce91b3a647099e8e46e2006e1b94c77L142-R143) [[8]](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664R6) [[9]](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664L32-R33) [[10]](diffhunk://#diff-652cd84fa48ff955c9ca3e70c7ca4a8c10f17eb67e53c16afe9bf122d728b664L59-R60) [[11]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5R5) [[12]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5L47-R48) [[13]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5L89-R90) [[14]](diffhunk://#diff-65a7ba541f688798c2ae7f74cd9d55af424a691910c8cf0647f2aa22ecd130c5L121-R122) [[15]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298R5) [[16]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L36-R37) [[17]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L62-R63) [[18]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L88-R89) [[19]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L113-R114) [[20]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L143-R144) [[21]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L163-R164) [[22]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L183-R184) [[23]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L203-R204) [[24]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L223-R224) [[25]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L248-R249) [[26]](diffhunk://#diff-45db39b74f3224fc348535ecbff7c7dbf5662f17ff42d63a0303d72f22407298L276-R277)

Relates to https://github.com/dotnet/sdk/issues/45927
Fixes https://github.com/dotnet/sdk/issues/47550