### PR TITLE
[10.0.1xx-preview3] Update winforms cloaking paths

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -188,10 +188,10 @@
             "defaultRemote": "https://github.com/dotnet/winforms",
             "exclude": [
                 // Non-OSS license - https://github.com/dotnet/source-build/issues/3772
-                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.cs",
-                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.ico",
-                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.resx",
-                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/LICENSE.txt"
+                "src/test/integration/DesignSurface/**/*.cs",
+                "src/test/integration/DesignSurface/**/*.ico",
+                "src/test/integration/DesignSurface/**/*.resx",
+                "src/test/integration/DesignSurface/THIRD-PARTY-NOTICE.txt"
             ]
         },
         {


### PR DESCRIPTION
Updating the cloaking paths for the winforms repo due to the file moves in https://github.com/dotnet/winforms/pull/13073.