### PR TITLE
[StaticWebAssets] Reduce allocations

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -201,7 +201,7 @@ public class ApplyCompressionNegotiation : Task
     {
         var compressedFingerprint = compressedEndpoint.EndpointProperties.FirstOrDefault(ep => ep.Name == "fingerprint");
         var relatedFingerprint = relatedEndpointCandidate.EndpointProperties.FirstOrDefault(ep => ep.Name == "fingerprint");
-        return string.Equals(compressedFingerprint?.Value, relatedFingerprint?.Value, StringComparison.Ordinal);
+        return string.Equals(compressedFingerprint.Value, relatedFingerprint.Value, StringComparison.Ordinal);
     }
 
     private void ApplyCompressedEndpointHeaders(List<StaticWebAssetEndpointResponseHeader> headers, StaticWebAssetEndpoint compressedEndpoint, string relatedEndpointCandidateRoute)

--- a/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
@@ -43,8 +43,9 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
                 {
                     candidateEndpoint.Route = StaticWebAsset.CombineNormalizedPaths("", asset.BasePath, candidateEndpoint.Route, '/');
 
-                    foreach (var property in candidateEndpoint.EndpointProperties)
+                    for (var i = 0; i < candidateEndpoint.EndpointProperties.Length; i++)
                     {
+                        ref var property = ref candidateEndpoint.EndpointProperties[i];
                         if (string.Equals(property.Name, "label", StringComparison.OrdinalIgnoreCase))
                         {
                             property.Value = StaticWebAsset.CombineNormalizedPaths("", asset.BasePath, property.Value, '/');

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -933,14 +933,15 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 #endif
     }
 
-    internal IEnumerable<StaticWebAssetResolvedRoute> ComputeRoutes()
+    internal void ComputeRoutes(List<StaticWebAssetResolvedRoute> routes)
     {
+        routes.Clear();
         var tokenResolver = StaticWebAssetTokenResolver.Instance;
         var pattern = StaticWebAssetPathPattern.Parse(RelativePath, Identity);
         foreach (var expandedPattern in pattern.ExpandPatternExpression())
         {
             var (path, tokens) = expandedPattern.ReplaceTokens(this, tokenResolver);
-            yield return new StaticWebAssetResolvedRoute(pattern.ComputePatternLabel(), path, tokens);
+            routes.Add(new StaticWebAssetResolvedRoute(pattern.ComputePatternLabel(), path, tokens));
         }
     }
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointProperty.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization.Metadata;
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-public class StaticWebAssetEndpointProperty : IComparable<StaticWebAssetEndpointProperty>, IEquatable<StaticWebAssetEndpointProperty>
+public struct StaticWebAssetEndpointProperty : IComparable<StaticWebAssetEndpointProperty>, IEquatable<StaticWebAssetEndpointProperty>
 {
     private static readonly JsonTypeInfo<StaticWebAssetEndpointProperty[]> _jsonTypeInfo =
         StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointPropertyArray;
@@ -26,15 +26,18 @@ public class StaticWebAssetEndpointProperty : IComparable<StaticWebAssetEndpoint
             responseHeaders ?? [],
             _jsonTypeInfo);
 
-    public int CompareTo(StaticWebAssetEndpointProperty other) => string.Compare(Name, other.Name, StringComparison.Ordinal) switch
+    public int CompareTo(StaticWebAssetEndpointProperty other) => string.CompareOrdinal(Name, other.Name) switch
     {
-        0 => string.Compare(Value, other.Value, StringComparison.Ordinal),
+        0 => string.CompareOrdinal(Value, other.Value),
         int result => result
     };
 
-    public override bool Equals(object obj) => Equals(obj as StaticWebAssetEndpointProperty);
+    public override bool Equals(object obj) => obj is StaticWebAssetEndpointProperty endpointProperty &&
+        Equals(endpointProperty);
 
-    public bool Equals(StaticWebAssetEndpointProperty other) => other is not null && Name == other.Name && Value == other.Value;
+    public bool Equals(StaticWebAssetEndpointProperty other) =>
+       string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+       string.Equals(Value, other.Value, StringComparison.Ordinal);
 
     public override int GetHashCode()
     {

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointResponseHeader.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization.Metadata;
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-public class StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEndpointResponseHeader>, IComparable<StaticWebAssetEndpointResponseHeader>
+public struct StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEndpointResponseHeader>, IComparable<StaticWebAssetEndpointResponseHeader>
 {
     private static readonly JsonTypeInfo<StaticWebAssetEndpointResponseHeader[]> _jsonTypeInfo =
         StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointResponseHeaderArray;
@@ -28,9 +28,11 @@ public class StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEnd
 
     private string GetDebuggerDisplay() => $"{Name}: {Value}";
 
-    public override bool Equals(object obj) => Equals(obj as StaticWebAssetEndpointResponseHeader);
+    public override bool Equals(object obj) => obj is StaticWebAssetEndpointResponseHeader responseHeader &&
+        Equals(responseHeader);
 
-    public bool Equals(StaticWebAssetEndpointResponseHeader other) => string.Equals(Name, other?.Name, StringComparison.Ordinal) && string.Equals(Value, other?.Value, StringComparison.Ordinal);
+    public bool Equals(StaticWebAssetEndpointResponseHeader other) => string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+        string.Equals(Value, other.Value, StringComparison.Ordinal);
 
     public override int GetHashCode()
     {
@@ -44,9 +46,9 @@ public class StaticWebAssetEndpointResponseHeader : IEquatable<StaticWebAssetEnd
 #endif
     }
 
-    public int CompareTo(StaticWebAssetEndpointResponseHeader other) => string.Compare(Name, other?.Name, StringComparison.Ordinal) switch
+    public int CompareTo(StaticWebAssetEndpointResponseHeader other) => string.CompareOrdinal(Name, other.Name) switch
     {
-        0 => string.Compare(Value, other?.Value, StringComparison.Ordinal),
+        0 => string.CompareOrdinal(Value, other.Value),
         int result => result
     };
 }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpointSelector.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization.Metadata;
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointSelector>, IComparable<StaticWebAssetEndpointSelector>
+public struct StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointSelector>, IComparable<StaticWebAssetEndpointSelector>
 {
     private static readonly JsonTypeInfo<StaticWebAssetEndpointSelector[]> _jsonTypeInfo =
         StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointSelectorArray;
@@ -30,18 +30,13 @@ public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointS
 
     public int CompareTo(StaticWebAssetEndpointSelector other)
     {
-        if (other is null)
-        {
-            return 1;
-        }
-
-        var nameComparison = string.Compare(Name, other.Name, StringComparison.Ordinal);
+        var nameComparison = string.CompareOrdinal(Name, other.Name);
         if (nameComparison != 0)
         {
             return nameComparison;
         }
 
-        var valueComparison = string.Compare(Value, other.Value, StringComparison.Ordinal);
+        var valueComparison = string.CompareOrdinal(Value, other.Value);
         if (valueComparison != 0)
         {
             return valueComparison;
@@ -50,9 +45,12 @@ public class StaticWebAssetEndpointSelector : IEquatable<StaticWebAssetEndpointS
         return 0;
     }
 
-    public override bool Equals(object obj) => Equals(obj as StaticWebAssetEndpointSelector);
+    public override bool Equals(object obj) => obj is StaticWebAssetEndpointSelector endpointSelector &&
+        Equals(endpointSelector);
 
-    public bool Equals(StaticWebAssetEndpointSelector other) => other is not null && Name == other.Name && Value == other.Value && Quality == other.Quality;
+    public bool Equals(StaticWebAssetEndpointSelector other) =>
+        string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+        string.Equals(Value, other.Value, StringComparison.Ordinal);
 
     public override int GetHashCode()
     {

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselineFactory.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssetsBaselineFactory.cs
@@ -111,8 +111,9 @@ public partial class StaticWebAssetsBaselineFactory
 
         foreach (var endpoint in manifest.Endpoints)
         {
-            foreach (var header in endpoint.ResponseHeaders)
+            for (var i = 0; i < endpoint.ResponseHeaders.Length; i++)
             {
+                ref var header = ref endpoint.ResponseHeaders[i];
                 switch (header.Name)
                 {
                     case "Content-Length":
@@ -142,8 +143,9 @@ public partial class StaticWebAssetsBaselineFactory
                 }
             }
 
-            foreach (var property in endpoint.EndpointProperties)
+            for (var i = 0; i < endpoint.EndpointProperties.Length; i++)
             {
+                ref var property = ref endpoint.EndpointProperties[i];
                 switch (property.Name)
                 {
                     case "fingerprint":
@@ -160,8 +162,9 @@ public partial class StaticWebAssetsBaselineFactory
                 ReplaceFileName(endpoint.Route);
             }
 
-            foreach (var selector in endpoint.Selectors)
+            for (var i = 0; i < endpoint.Selectors.Length; i++)
             {
+                ref var selector = ref endpoint.Selectors[i];
                 selector.Quality = "__quality__";
             }
 


### PR DESCRIPTION
* Convert complex properties to Structs
* Reuse a list on DefineStaticWebAssetEndpoints
* Create arrays with the correct size on CreateEndpoints instead of using lists