### PR TITLE
Remove nuget-client from non-SB VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -45,7 +45,7 @@
     <RepositoryReference Include="emsdk" />
     <RepositoryReference Include="fsharp" />
     <RepositoryReference Include="msbuild" />
-    <!-- nuget-client is not compliant with Unified Build -->
+    <!-- nuget-client is not compliant with Unified Build: https://github.com/dotnet/source-build/issues/4974 -->
     <RepositoryReference Include="nuget-client" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <RepositoryReference Include="razor" />
     <RepositoryReference Include="roslyn-analyzers" />

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -45,7 +45,8 @@
     <RepositoryReference Include="emsdk" />
     <RepositoryReference Include="fsharp" />
     <RepositoryReference Include="msbuild" />
-    <RepositoryReference Include="nuget-client" />
+    <!-- nuget-client is not compliant with Unified Build -->
+    <RepositoryReference Include="nuget-client" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     <RepositoryReference Include="razor" />
     <RepositoryReference Include="roslyn-analyzers" />
     <RepositoryReference Include="roslyn" />


### PR DESCRIPTION
NuGet's localization story is incompatible with the VMR (only works on Windows, uses a separate repository, etc).

To enable us to ship localized NuGet binaries, remove NuGet.Client from the VMR for now and consume through binary flow.