### PR TITLE
Don't exclude *.app and *.dmg in .gitignore template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -424,9 +424,6 @@ autom4te.cache/
 tarballs/
 test-results/
 
-# Mac bundle stuff
-*.dmg
-
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General
 .DS_Store

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -426,9 +426,6 @@ test-results/
 
 # Mac bundle stuff
 *.dmg
-*.app
-# but not .app/ directories, which are common
-!*.app/
 
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -427,6 +427,8 @@ test-results/
 # Mac bundle stuff
 *.dmg
 *.app
+# but not .app/ directories, which are common
+!*.app/
 
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -424,9 +424,6 @@ autom4te.cache/
 tarballs/
 test-results/
 
-# Mac bundle stuff
-*.dmg
-
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General
 .DS_Store

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -426,9 +426,6 @@ test-results/
 
 # Mac bundle stuff
 *.dmg
-*.app
-# but not .app/ directories, which are common
-!*.app/
 
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General

--- a/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.Tests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -427,6 +427,8 @@ test-results/
 # Mac bundle stuff
 *.dmg
 *.app
+# but not .app/ directories, which are common
+!*.app/
 
 # content below from: https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 # General


### PR DESCRIPTION
The `.gitignore` excludes `*.app` to exclude Mac bundles, but that _also_ ignores any directory that ends in ".app". That's somewhat common; I see 1.6k hits for this pattern in the dotnet org alone: https://github.com/search?q=path%3A.app%2F+org%3Adotnet&type=code.

To address this, I'm suggesting we remove the exclude for .app. That then leads to the question of why `*.dmg` is specifically excluded. `git blame` provides no rationale. However, there's no known case where a mac dev would create a .dmg outside of an output folder, and output folders are already excluded correctly. Thus, I'm removing `*.dmg` as well.

## Repro steps

1. mkdir repro && cd repro && git init .
2. dotnet new gitignore
3. dotnet new console -o Service.App

## Expected results

These files are untracked and can be `git add`-ed
- Service.App/Program.cs
- Service.App/Service.App.csproj

## Actual results

These files are ignored 