### PR TITLE
dotnet CLI: "Collection initialization can be simplified"

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/DotDefaultPathCorrector.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/DotDefaultPathCorrector.cs
@@ -30,7 +30,7 @@ public static class DotDefaultPathCorrector
             return false;
         }
 
-        IEnumerable<string> paths = existingPath.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        IEnumerable<string> paths = existingPath.Split([';'], StringSplitOptions.RemoveEmptyEntries);
 
         var inCorrectToolsPaths =
             paths.Where(p => p.EndsWith(DotnetToolsSuffix, StringComparison.OrdinalIgnoreCase));

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -7,8 +7,8 @@ namespace Microsoft.DotNet.Cli.Utils;
 
 public class EnvironmentProvider : IEnvironmentProvider
 {
-    private static char[] s_pathSeparator = new char[] { Path.PathSeparator };
-    private static char[] s_quote = new char[] { '"' };
+    private static char[] s_pathSeparator = [Path.PathSeparator];
+    private static char[] s_quote = ['"'];
     private IEnumerable<string>? _searchPaths;
     private readonly Lazy<string> _userHomeDirectory = new(() => Environment.GetEnvironmentVariable("HOME") ?? string.Empty);
     private IEnumerable<string>? _executableExtensions;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -36,10 +36,9 @@ internal class ForwardingAppImplementation
         _depsFile = depsFile;
         _runtimeConfig = runtimeConfig;
         _additionalProbingPath = additionalProbingPath;
-        _environmentVariables = environmentVariables ?? new Dictionary<string, string>();
+        _environmentVariables = environmentVariables ?? [];
 
-        var allArgs = new List<string>();
-        allArgs.Add("exec");
+        List<string> allArgs = ["exec"];
 
         if (_depsFile != null)
         {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
@@ -87,8 +87,7 @@ internal class FrameworkDependencyFile
 
         RuntimeFallbacks runtimeFallbacks = runtimeFallbacksCandidates[0];
 
-        var runtimeFallbacksIncludesRuntime = new List<string?>();
-        runtimeFallbacksIncludesRuntime.Add(runtimeFallbacks.Runtime);
+        List<string?> runtimeFallbacksIncludesRuntime = [runtimeFallbacks.Runtime];
         runtimeFallbacksIncludesRuntime.AddRange(runtimeFallbacks.Fallbacks);
 
         var candidateMap = candidateRuntimeIdentifiers

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -38,8 +38,7 @@ internal class MSBuildForwardingAppWithoutLogging
 
     private readonly Dictionary<string, string> _msbuildRequiredEnvironmentVariables = GetMSBuildRequiredEnvironmentVariables();
 
-    private readonly List<string> _msbuildRequiredParameters =
-        [ "-maxcpucount", "-verbosity:m" ];
+    private readonly List<string> _msbuildRequiredParameters = [ "-maxcpucount", "-verbosity:m" ];
 
     public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string? msbuildPath = null, bool includeLogo = false)
     {
@@ -126,7 +125,7 @@ internal class MSBuildForwardingAppWithoutLogging
     public int ExecuteInProc(string[] arguments)
     {
         // Save current environment variables before overwriting them.
-        Dictionary<string, string?> savedEnvironmentVariables = new();
+        Dictionary<string, string?> savedEnvironmentVariables = [];
         try
         {
             foreach (KeyValuePair<string, string> kvp in _msbuildRequiredEnvironmentVariables)
@@ -162,11 +161,8 @@ internal class MSBuildForwardingAppWithoutLogging
     }
 
     private static string Escape(string arg) =>
-            // this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
-            IsRestoreSources(arg) ?
-            arg.Replace(";", "%3B")
-                .Replace("://", ":%2F%2F") :
-            arg;
+        // this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
+        IsRestoreSources(arg) ? arg.Replace(";", "%3B").Replace("://", ":%2F%2F") : arg;
 
     private static string GetMSBuildExePath()
     {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Cli.Utils;
 
 public sealed class StreamForwarder
 {
-    private static readonly char[] s_ignoreCharacters = new char[] { '\r' };
+    private static readonly char[] s_ignoreCharacters = ['\r'];
     private static readonly char s_flushBuilderCharacter = '\n';
 
     private StringBuilder? _builder;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
@@ -75,7 +75,7 @@ public class BlockFilter : ITelemetryFilter
 {
     public IEnumerable<ApplicationInsightsEntryFormat> Filter(object o)
     {
-        return new List<ApplicationInsightsEntryFormat>();
+        return [];
     }
 }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TypoCorrection.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TypoCorrection.cs
@@ -127,7 +127,7 @@ public static class TypoCorrection
         // so just O(m) space. Initialize the current row.
 
         int curRow = 0, nextRow = 1;
-        int[][] rows = { new int[m + 1], new int[m + 1] };
+        int[][] rows = [new int[m + 1], new int[m + 1]];
 
         for (int j = 0; j <= m; ++j)
         {

--- a/src/Cli/dotnet/BuildServer/RazorServer.cs
+++ b/src/Cli/dotnet/BuildServer/RazorServer.cs
@@ -33,13 +33,13 @@ internal class RazorServer(
         var command = _commandFactory
             .Create(
                 "exec",
-                new string[] {
+                [
                     PidFile.ServerPath.Value,
                     "shutdown",
                     "-w",   // Wait for exit
                     "-p",   // Pipe name
                     PidFile.PipeName
-                })
+                ])
             .CaptureStdOut()
             .CaptureStdErr();
 

--- a/src/Cli/dotnet/CliTransaction.cs
+++ b/src/Cli/dotnet/CliTransaction.cs
@@ -79,10 +79,10 @@ internal class CliTransaction
 
     class TransactionContext : ITransactionContext
     {
-        public List<Action> RollbackActions { get; set; } = new List<Action>();
+        public List<Action> RollbackActions { get; set; } = [];
 
         //  Actions which will be run either when the transaction completes successfully, or after rollback actions have been run
-        public List<Action> CleanupActions { get; set; } = new List<Action>();
+        public List<Action> CleanupActions { get; set; } = [];
 
         public void AddRollbackAction(Action action)
         {

--- a/src/Cli/dotnet/CommandFactory/CommandFactoryUsingResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandFactoryUsingResolver.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Cli.CommandFactory;
 
 public static class CommandFactoryUsingResolver
 {
-    private static string[] _knownCommandsAvailableAsDotNetTool = new[] { "dotnet-dev-certs", "dotnet-sql-cache", "dotnet-user-secrets", "dotnet-watch", "dotnet-user-jwts" };
+    private static string[] _knownCommandsAvailableAsDotNetTool = ["dotnet-dev-certs", "dotnet-sql-cache", "dotnet-user-secrets", "dotnet-watch", "dotnet-user-jwts"];
 
     public static Command CreateDotNet(
         string commandName,

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/CompositeCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/CompositeCommandResolver.cs
@@ -20,7 +20,7 @@ public class CompositeCommandResolver : ICommandResolver
 
     public CompositeCommandResolver()
     {
-        _orderedCommandResolvers = new List<ICommandResolver>();
+        _orderedCommandResolvers = [];
     }
 
     public void AddCommandResolver(ICommandResolver commandResolver)

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
@@ -187,10 +187,7 @@ public class DepsJsonCommandResolver : ICommandResolver
         var depsFileArguments = GetDepsFileArguments(depsJsonFile);
         var additionalProbingPathArguments = GetAdditionalProbingPathArguments();
 
-        var muxerArgs = new List<string>
-        {
-            "exec"
-        };
+        List<string> muxerArgs = ["exec"];
         muxerArgs.AddRange(depsFileArguments);
         muxerArgs.AddRange(additionalProbingPathArguments);
         muxerArgs.Add(commandPath);
@@ -220,12 +217,12 @@ public class DepsJsonCommandResolver : ICommandResolver
 
     private IEnumerable<string> GetDepsFileArguments(string depsJsonFile)
     {
-        return new[] { "--depsfile", depsJsonFile };
+        return ["--depsfile", depsJsonFile];
     }
 
     private IEnumerable<string> GetAdditionalProbingPathArguments()
     {
-        return new[] { "--additionalProbingPath", _nugetPackageRoot };
+        return ["--additionalProbingPath", _nugetPackageRoot];
     }
 
     private class CommandCandidate

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
@@ -187,8 +187,10 @@ public class DepsJsonCommandResolver : ICommandResolver
         var depsFileArguments = GetDepsFileArguments(depsJsonFile);
         var additionalProbingPathArguments = GetAdditionalProbingPathArguments();
 
-        var muxerArgs = new List<string>();
-        muxerArgs.Add("exec");
+        var muxerArgs = new List<string>
+        {
+            "exec"
+        };
         muxerArgs.AddRange(depsFileArguments);
         muxerArgs.AddRange(additionalProbingPathArguments);
         muxerArgs.Add(commandPath);

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/LockFileTargetExtensions.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/LockFileTargetExtensions.cs
@@ -45,7 +45,7 @@ internal static class LockFileTargetExtensions
         Dictionary<string, LockFileTargetLibrary> libraryLookup =
             runtimeLibraries.ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
 
-        HashSet<string> allExclusionList = new();
+        HashSet<string> allExclusionList = [];
 
         if (lockFileTarget.IsPortable())
         {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/PackagedCommandSpecFactoryWithCliRuntime.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/PackagedCommandSpecFactoryWithCliRuntime.cs
@@ -50,7 +50,7 @@ public class PackagedCommandSpecFactoryWithCliRuntime : PackagedCommandSpecFacto
 
     private static Version GetVersionWithoutPrerelease(string version)
     {
-        int dashOrPlusIndex = version.IndexOfAny(new char[] { '-', '+' });
+        int dashOrPlusIndex = version.IndexOfAny(['-', '+']);
 
         if (dashOrPlusIndex >= 0)
         {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -26,10 +26,10 @@ public class ProjectToolsCommandResolver : ICommandResolver
         _packagedCommandSpecFactory = packagedCommandSpecFactory;
         _environment = environment;
 
-        _allowedCommandExtensions = new List<string>()
-        {
+        _allowedCommandExtensions =
+        [
             FileNameSuffixes.DotNet.DynamicLib
-        };
+        ];
     }
 
     public CommandSpec Resolve(CommandResolverArguments commandResolverArguments)
@@ -124,8 +124,7 @@ public class ProjectToolsCommandResolver : ICommandResolver
             ProjectToolsCommandResolverName,
             string.Join(Environment.NewLine, possiblePackageRoots.Select((p) => $"- {p}"))));
 
-        List<NuGetFramework> toolFrameworksToCheck = new();
-        toolFrameworksToCheck.Add(project.DotnetCliToolTargetFramework);
+        List<NuGetFramework> toolFrameworksToCheck = [project.DotnetCliToolTargetFramework];
 
         //  NuGet restore in Visual Studio may restore for netcoreapp1.0.  So if that happens, fall back to
         //  looking for a netcoreapp1.0 or netcoreapp1.1 tool restore.
@@ -340,12 +339,13 @@ public class ProjectToolsCommandResolver : ICommandResolver
 
         var tempDepsFile = Path.Combine(PathUtilities.CreateTempSubdirectory(), Path.GetRandomFileName());
 
-        var args = new List<string>();
-
-        args.Add(toolDepsJsonGeneratorProject);
-        args.Add($"-property:ProjectAssetsFile=\"{toolLockFile.Path}\"");
-        args.Add($"-property:ToolName={toolLibrary.Name}");
-        args.Add($"-property:ProjectDepsFilePath={tempDepsFile}");
+        var args = new List<string>
+        {
+            toolDepsJsonGeneratorProject,
+            $"-property:ProjectAssetsFile=\"{toolLockFile.Path}\"",
+            $"-property:ToolName={toolLibrary.Name}",
+            $"-property:ProjectDepsFilePath={tempDepsFile}"
+        };
 
         var toolTargetFramework = toolLockFile.Targets.First().TargetFramework.GetShortFolderName();
         args.Add($"-property:TargetFramework={toolTargetFramework}");

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -26,10 +26,7 @@ public class ProjectToolsCommandResolver : ICommandResolver
         _packagedCommandSpecFactory = packagedCommandSpecFactory;
         _environment = environment;
 
-        _allowedCommandExtensions =
-        [
-            FileNameSuffixes.DotNet.DynamicLib
-        ];
+        _allowedCommandExtensions = [FileNameSuffixes.DotNet.DynamicLib];
     }
 
     public CommandSpec Resolve(CommandResolverArguments commandResolverArguments)
@@ -339,13 +336,13 @@ public class ProjectToolsCommandResolver : ICommandResolver
 
         var tempDepsFile = Path.Combine(PathUtilities.CreateTempSubdirectory(), Path.GetRandomFileName());
 
-        var args = new List<string>
-        {
+        List<string> args =
+        [
             toolDepsJsonGeneratorProject,
             $"-property:ProjectAssetsFile=\"{toolLockFile.Path}\"",
             $"-property:ToolName={toolLibrary.Name}",
             $"-property:ProjectDepsFilePath={tempDepsFile}"
-        };
+        ];
 
         var toolTargetFramework = toolLockFile.Targets.First().TargetFramework.GetShortFolderName();
         args.Add($"-property:TargetFramework={toolTargetFramework}");

--- a/src/Cli/dotnet/CommandFactory/CommandSpec.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandSpec.cs
@@ -14,7 +14,7 @@ public class CommandSpec
     {
         Path = path;
         Args = args;
-        EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>();
+        EnvironmentVariables = environmentVariables ?? [];
     }
 
     public string Path { get; }

--- a/src/Cli/dotnet/Commands/Complete/Complete.cs
+++ b/src/Cli/dotnet/Commands/Complete/Complete.cs
@@ -55,7 +55,7 @@ internal static class Complete
     {
         try
         {
-            return (GetMSBuildProject()?.GetConfigurations() ?? new[] { "Debug", "Release" }).Select(ToCompletionItem);
+            return (GetMSBuildProject()?.GetConfigurations() ?? ["Debug", "Release"]).Select(ToCompletionItem);
         }
         catch (Exception)
         {

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -25,11 +25,9 @@ public class MSBuildForwardingApp
                 Type loggerType = typeof(MSBuildLogger);
                 Type forwardingLoggerType = typeof(MSBuildForwardingLogger);
 
-                return argsToForward
-                    .Concat(new[]
-                    {
-                        $"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"
-                    });
+                return argsToForward.Concat(
+                    [$"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"]
+                );
             }
             catch (Exception)
             {

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -25,9 +25,8 @@ public class MSBuildForwardingApp
                 Type loggerType = typeof(MSBuildLogger);
                 Type forwardingLoggerType = typeof(MSBuildForwardingLogger);
 
-                return argsToForward.Concat(
-                    [$"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"]
-                );
+                return argsToForward
+                    .Concat([$"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"]);
             }
             catch (Exception)
             {

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -133,28 +133,28 @@ public sealed class MSBuildLogger : INodeLogger
                 }
             case BuildTelemetryEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildTelemetryEventName}", args.Properties,
-                    toBeHashed: new[] { "ProjectPath", "BuildTarget" },
-                    toBeMeasured: new[] { "BuildDurationInMilliseconds", "InnerBuildDurationInMilliseconds" });
+                    toBeHashed: ["ProjectPath", "BuildTarget"],
+                    toBeMeasured: ["BuildDurationInMilliseconds", "InnerBuildDurationInMilliseconds"]);
                 break;
             case LoggingConfigurationTelemetryEventName:
                 TrackEvent(telemetry, $"msbuild/{LoggingConfigurationTelemetryEventName}", args.Properties,
                     toBeHashed: Array.Empty<string>(),
-                    toBeMeasured: new[] { "FileLoggersCount" });
+                    toBeMeasured: ["FileLoggersCount"]);
                 break;
             case BuildcheckAcquisitionFailureEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildcheckAcquisitionFailureEventName}", args.Properties,
-                    toBeHashed: new[] { "AssemblyName", "ExceptionType", "ExceptionMessage" },
+                    toBeHashed: ["AssemblyName", "ExceptionType", "ExceptionMessage"],
                     toBeMeasured: Array.Empty<string>());
                 break;
             case BuildcheckRunEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildcheckRunEventName}", args.Properties,
                     toBeHashed: Array.Empty<string>(),
-                    toBeMeasured: new[] { "TotalRuntimeInMilliseconds" });
+                    toBeMeasured: ["TotalRuntimeInMilliseconds"]);
                 break;
             case BuildcheckRuleStatsEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildcheckRuleStatsEventName}", args.Properties,
-                    toBeHashed: new[] { "RuleId", "CheckFriendlyName" },
-                    toBeMeasured: new[] { "TotalRuntimeInMilliseconds" });
+                    toBeHashed: ["RuleId", "CheckFriendlyName"],
+                    toBeMeasured: ["TotalRuntimeInMilliseconds"]);
                 break;
             // Pass through events that don't need special handling
             case SdkTaskBaseCatchExceptionTelemetryEventName:

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -110,7 +110,7 @@ public sealed class MSBuildLogger : INodeLogger
             case TargetFrameworkTelemetryEventName:
                 {
                     var newEventName = $"msbuild/{TargetFrameworkTelemetryEventName}";
-                    Dictionary<string, string> maskedProperties = new();
+                    Dictionary<string, string> maskedProperties = [];
 
                     foreach (var key in new[] {
                         TargetFrameworkVersionTelemetryPropertyKey,
@@ -197,7 +197,7 @@ public sealed class MSBuildLogger : INodeLogger
                 if (double.TryParse(value, CultureInfo.InvariantCulture, out double realValue))
                 {
                     // Lets lazy allocate in case there is tons of telemetry
-                    measurements ??= new Dictionary<string, double>();
+                    measurements ??= [];
                     measurements[propertyToBeMeasured] = realValue;
                 }
             }

--- a/src/Cli/dotnet/Commands/New/DotnetCommandCallbacks.cs
+++ b/src/Cli/dotnet/Commands/New/DotnetCommandCallbacks.cs
@@ -14,8 +14,8 @@ internal static class DotnetCommandCallbacks
 {
     internal static bool AddPackageReference(string projectPath, string packageName, string? version)
     {
-        PathUtility.EnsureAllPathsExist(new[] { projectPath }, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
-        IEnumerable<string> commandArgs = new[] { "add", projectPath, "package", packageName };
+        PathUtility.EnsureAllPathsExist([projectPath], CommonLocalizableStrings.FileNotFound, allowDirectories: false);
+        IEnumerable<string> commandArgs = ["add", projectPath, "package", packageName];
         if (!string.IsNullOrWhiteSpace(version))
         {
             commandArgs = commandArgs.Append(PackageAddCommandParser.VersionOption.Name).Append(version);
@@ -26,23 +26,23 @@ internal static class DotnetCommandCallbacks
 
     internal static bool AddProjectReference(string projectPath, string projectToAdd)
     {
-        PathUtility.EnsureAllPathsExist(new[] { projectPath }, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
-        PathUtility.EnsureAllPathsExist(new[] { projectToAdd }, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
-        IEnumerable<string> commandArgs = new[] { "add", projectPath, "reference", projectToAdd };
+        PathUtility.EnsureAllPathsExist([projectPath], CommonLocalizableStrings.FileNotFound, allowDirectories: false);
+        PathUtility.EnsureAllPathsExist([projectToAdd], CommonLocalizableStrings.FileNotFound, allowDirectories: false);
+        IEnumerable<string> commandArgs = ["add", projectPath, "reference", projectToAdd];
         var addProjectReferenceCommand = new AddProjectToProjectReferenceCommand(AddCommandParser.GetCommand().Parse(commandArgs.ToArray()));
         return addProjectReferenceCommand.Execute() == 0;
     }
 
     internal static bool RestoreProject(string pathToRestore)
     {
-        PathUtility.EnsureAllPathsExist(new[] { pathToRestore }, CommonLocalizableStrings.FileNotFound, allowDirectories: true);
+        PathUtility.EnsureAllPathsExist([pathToRestore], CommonLocalizableStrings.FileNotFound, allowDirectories: true);
         // for the implicit restore we do not want the terminal logger to emit any output unless there are errors
         return RestoreCommand.Run([pathToRestore, "-tlp:verbosity=quiet"]) == 0;
     }
 
     internal static bool AddProjectsToSolution(string solutionPath, IReadOnlyList<string> projectsToAdd, string? solutionFolder, bool? inRoot)
     {
-        PathUtility.EnsureAllPathsExist(new[] { solutionPath }, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
+        PathUtility.EnsureAllPathsExist([solutionPath], CommonLocalizableStrings.FileNotFound, allowDirectories: false);
         PathUtility.EnsureAllPathsExist(projectsToAdd, CommonLocalizableStrings.FileNotFound, allowDirectories: false);
         IEnumerable<string> commandArgs = new[] { "solution", solutionPath, "add" }.Concat(projectsToAdd);
         if (!string.IsNullOrWhiteSpace(solutionFolder))

--- a/src/Cli/dotnet/Commands/New/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/Commands/New/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -162,7 +162,7 @@ internal class MSBuildEvaluator : IIdentifiedComponent
             }
 
             //For multi-target project, we need to do additional evaluation for each target framework.
-            Dictionary<string, Project?> evaluatedTfmBasedProjects = new();
+            Dictionary<string, Project?> evaluatedTfmBasedProjects = [];
             innerBuildWatch.Start();
             foreach (string tfm in targetFrameworks)
             {

--- a/src/Cli/dotnet/Commands/New/MSBuildEvaluation/ProjectCapabilityConstraint.cs
+++ b/src/Cli/dotnet/Commands/New/MSBuildEvaluation/ProjectCapabilityConstraint.cs
@@ -108,7 +108,7 @@ internal class ProjectCapabilityConstraintFactory : ITemplateConstraintFactory
             }
             if (_evaluationResult.Status == MSBuildEvaluationResult.EvalStatus.MultipleProjectFound)
             {
-                string foundProjects = string.Join("; ", (_evaluationResult as MultipleProjectsEvaluationResult)?.ProjectPaths ?? (IReadOnlyList<string?>)new[] { _evaluationResult.ProjectPath });
+                string foundProjects = string.Join("; ", (_evaluationResult as MultipleProjectsEvaluationResult)?.ProjectPaths ?? (IReadOnlyList<string?>)[_evaluationResult.ProjectPath]);
                 _logger.LogDebug("Multiple projects found: {0}, specify the project to use.", foundProjects);
                 return TemplateConstraintResult.CreateRestricted(
                     this,

--- a/src/Cli/dotnet/Commands/New/NewCommandParser.cs
+++ b/src/Cli/dotnet/Commands/New/NewCommandParser.cs
@@ -137,12 +137,12 @@ internal static class NewCommandParser
         builtIns.AddRange(TemplateSearch.Common.Components.AllComponents);
 
         //post actions
-        builtIns.AddRange(new (Type, IIdentifiedComponent)[]
-        {
+        builtIns.AddRange(
+        [
             (typeof(IPostActionProcessor), new DotnetAddPostActionProcessor()),
             (typeof(IPostActionProcessor), new DotnetSlnPostActionProcessor()),
             (typeof(IPostActionProcessor), new DotnetRestorePostActionProcessor())
-        });
+        ]);
         if (!disableSdkTemplates)
         {
             builtIns.Add((typeof(ITemplatePackageProviderFactory), new BuiltInTemplatePackageProviderFactory()));

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetAddPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetAddPostActionProcessor.cs
@@ -55,7 +55,7 @@ internal class DotnetAddPostActionProcessor : PostActionProcessorBase
                     return false;
                 }
 
-                extensionLimiters.UnionWith(projectFileExtensions.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+                extensionLimiters.UnionWith(projectFileExtensions.Split([';'], StringSplitOptions.RemoveEmptyEntries));
             }
             projectsToProcess = TryFindProjects(environment, outputBasePath, extensionLimiters);
             if (projectsToProcess.Count > 1)

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -33,7 +33,7 @@ internal class DotnetSlnPostActionProcessor : PostActionProcessorBase
     // If any indexes are out of range or non-numeric, this method returns false and projectFiles is set to null.
     internal static bool TryGetProjectFilesToAdd(IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath, [NotNullWhen(true)] out IReadOnlyList<string> projectFiles)
     {
-        List<string> filesToAdd = new();
+        List<string> filesToAdd = [];
         projectFiles = new List<string>();
 
         if ((actionConfig.Args != null) && actionConfig.Args.TryGetValue("primaryOutputIndexes", out string? projectIndexes))

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -34,11 +34,11 @@ internal class DotnetSlnPostActionProcessor : PostActionProcessorBase
     internal static bool TryGetProjectFilesToAdd(IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath, [NotNullWhen(true)] out IReadOnlyList<string> projectFiles)
     {
         List<string> filesToAdd = [];
-        projectFiles = new List<string>();
+        projectFiles = [];
 
         if ((actionConfig.Args != null) && actionConfig.Args.TryGetValue("primaryOutputIndexes", out string? projectIndexes))
         {
-            foreach (string indexString in projectIndexes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string indexString in projectIndexes.Split([';'], StringSplitOptions.RemoveEmptyEntries))
             {
                 if (int.TryParse(indexString.Trim(), out int index))
                 {

--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
@@ -77,7 +77,7 @@ internal static class NuGetCommandParser
         CliCommand localsCommand = new("locals");
 
         CliArgument<string> foldersArgument = new("folders");
-        foldersArgument.AcceptOnlyFromAmong(new string[] { "all", "http-cache", "global-packages", "plugins-cache", "temp" });
+        foldersArgument.AcceptOnlyFromAmong(["all", "http-cache", "global-packages", "plugins-cache", "temp"]);
 
         localsCommand.Arguments.Add(foldersArgument);
 

--- a/src/Cli/dotnet/Commands/Package/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/Program.cs
@@ -67,25 +67,26 @@ internal class AddPackageReferenceCommand : CommandBase
 
     private void GetProjectDependencyGraph(string projectFilePath, string dgFilePath)
     {
-        var args = new List<string>();
+        var args = new List<string>
+        {
+            // Pass the project file path
+            projectFilePath,
 
-        // Pass the project file path
-        args.Add(projectFilePath);
+            // Pass the task as generate restore Dependency Graph file
+            "-target:GenerateRestoreGraphFile",
 
-        // Pass the task as generate restore Dependency Graph file
-        args.Add("-target:GenerateRestoreGraphFile");
+            // Pass Dependency Graph file output path
+            $"-property:RestoreGraphOutputPath=\"{dgFilePath}\"",
 
-        // Pass Dependency Graph file output path
-        args.Add($"-property:RestoreGraphOutputPath=\"{dgFilePath}\"");
+            // Turn off recursive restore
+            $"-property:RestoreRecursive=false",
 
-        // Turn off recursive restore
-        args.Add($"-property:RestoreRecursive=false");
+            // Turn off restore for Dotnet cli tool references so that we do not generate extra dg specs
+            $"-property:RestoreDotnetCliToolReferences=false",
 
-        // Turn off restore for Dotnet cli tool references so that we do not generate extra dg specs
-        args.Add($"-property:RestoreDotnetCliToolReferences=false");
-
-        // Output should not include MSBuild version header
-        args.Add("-nologo");
+            // Output should not include MSBuild version header
+            "-nologo"
+        };
 
         var result = new MSBuildForwardingApp(args).Execute();
 

--- a/src/Cli/dotnet/Commands/Package/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/Program.cs
@@ -67,8 +67,8 @@ internal class AddPackageReferenceCommand : CommandBase
 
     private void GetProjectDependencyGraph(string projectFilePath, string dgFilePath)
     {
-        var args = new List<string>
-        {
+        List<string> args =
+        [
             // Pass the project file path
             projectFilePath,
 
@@ -86,7 +86,7 @@ internal class AddPackageReferenceCommand : CommandBase
 
             // Output should not include MSBuild version header
             "-nologo"
-        };
+        ];
 
         var result = new MSBuildForwardingApp(args).Execute();
 

--- a/src/Cli/dotnet/Commands/Package/List/ListPackageReferencesCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/List/ListPackageReferencesCommand.cs
@@ -51,9 +51,8 @@ internal class ListPackageReferencesCommand : CommandBase
         {
             "package",
             "list",
+            GetProjectOrSolution()
         };
-
-        args.Add(GetProjectOrSolution());
 
         args.AddRange(_parseResult.OptionValuesToBeForwarded(PackageListCommandParser.GetCommand()));
 

--- a/src/Cli/dotnet/Commands/Package/List/PackageListCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/List/PackageListCommandParser.cs
@@ -63,7 +63,7 @@ internal static class PackageListCommandParser
     {
         Description = LocalizableStrings.CmdConfigDescription,
         HelpName = LocalizableStrings.CmdConfig
-    }.ForwardAsMany(o => new[] { "--config", o });
+    }.ForwardAsMany(o => ["--config", o]);
 
     public static readonly CliOption SourceOption = new ForwardedOption<IEnumerable<string>>("--source", "-s")
     {

--- a/src/Cli/dotnet/Commands/Reference/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Reference/Add/Program.cs
@@ -72,9 +72,7 @@ internal class AddProjectToProjectReferenceCommand : CommandBase
             {
                 if (!@ref.CanWorkOnFramework(framework))
                 {
-                    Reporter.Error.Write(GetProjectNotCompatibleWithFrameworksDisplayString(
-                                             @ref,
-                                             new string[] { frameworkString }));
+                    Reporter.Error.Write(GetProjectNotCompatibleWithFrameworksDisplayString(@ref, [frameworkString]));
                     return 1;
                 }
             }

--- a/src/Cli/dotnet/Commands/Restore/RestoreCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoreCommandParser.cs
@@ -89,7 +89,7 @@ internal static class RestoreCommandParser
     private static string GetArchFromRid(string rid) => rid.Substring(rid.LastIndexOf("-", StringComparison.InvariantCulture) + 1, rid.Length - rid.LastIndexOf("-", StringComparison.InvariantCulture) - 1);
     public static string RestoreRuntimeArgFunc(IEnumerable<string> rids)
     {
-        List<string> convertedRids = new();
+        List<string> convertedRids = [];
         foreach (string rid in rids)
         {
             if (GetArchFromRid(rid.ToString()) == "amd64")

--- a/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
@@ -115,8 +115,8 @@ public class RestoringCommand : MSBuildForwardingApp
     private static (string[] newArgumentsToAdd, string[] existingArgumentsToForward) ProcessForwardedArgumentsForSeparateRestore(IEnumerable<string> forwardedArguments)
     {
         // Separate restore should be silent in terminal logger - regardless of actual scenario
-        HashSet<string> newArgumentsToAdd = new() { "-tlp:verbosity=quiet" };
-        List<string> existingArgumentsToForward = new();
+        HashSet<string> newArgumentsToAdd = ["-tlp:verbosity=quiet"];
+        List<string> existingArgumentsToForward = [];
 
         foreach (var argument in forwardedArguments ?? Enumerable.Empty<string>())
         {

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -276,10 +276,7 @@ public partial class RunCommand
 
     private string[] GetRestoreArguments(IEnumerable<string> cliRestoreArgs)
     {
-        List<string> args =
-        [
-            "-nologo"
-        ];
+        List<string> args = ["-nologo"];
 
         if (Verbosity is null)
         {

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -276,10 +276,10 @@ public partial class RunCommand
 
     private string[] GetRestoreArguments(IEnumerable<string> cliRestoreArgs)
     {
-        List<string> args = new()
-        {
+        List<string> args =
+        [
             "-nologo"
-        };
+        ];
 
         if (Verbosity is null)
         {

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -26,7 +26,7 @@ internal sealed class VirtualProjectBuildingCommand
     public int Execute(string[] binaryLoggerArgs, ILogger consoleLogger)
     {
         var binaryLogger = GetBinaryLogger(binaryLoggerArgs);
-        Dictionary<string, string?> savedEnvironmentVariables = new();
+        Dictionary<string, string?> savedEnvironmentVariables = [];
         try
         {
             // Set environment variables.

--- a/src/Cli/dotnet/Commands/Sdk/Check/Program.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Check/Program.cs
@@ -65,10 +65,10 @@ public class SdkCheckCommand : CommandBase
                 switch (hostfxrResolutionException)
                 {
                     case HostFxrRuntimePropertyNotSetException:
-                        throw new GracefulException(new[] { LocalizableStrings.RuntimePropertyNotFound }, new string[] { }, isUserError: false);
+                        throw new GracefulException([LocalizableStrings.RuntimePropertyNotFound], [], isUserError: false);
 
                     case HostFxrNotFoundException hostFxrNotFoundException:
-                        throw new GracefulException(new[] { LocalizableStrings.HostFxrCouldNotBeLoaded }, new string[] { hostFxrNotFoundException.Message }, isUserError: false);
+                        throw new GracefulException([LocalizableStrings.HostFxrCouldNotBeLoaded], [hostFxrNotFoundException.Message], isUserError: false);
                 }
             }
         }

--- a/src/Cli/dotnet/Commands/Solution/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Solution/Add/Program.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.Tools.Sln.Add;
 
 internal class AddProjectToSolutionCommand : CommandBase
 {
-    private static string[] _defaultPlatforms = new[] { "Any CPU", "x64", "x86" };
-    private static string[] _defaultBuildTypes = new[] { "Debug", "Release" };
+    private static string[] _defaultPlatforms = ["Any CPU", "x64", "x86"];
+    private static string[] _defaultBuildTypes = ["Debug", "Release"];
     private readonly string _fileOrDirectory;
     private readonly bool _inRoot;
     private readonly IReadOnlyCollection<string> _projects;

--- a/src/Cli/dotnet/Commands/Solution/SlnArgumentValidator.cs
+++ b/src/Cli/dotnet/Commands/Solution/SlnArgumentValidator.cs
@@ -48,12 +48,12 @@ internal static class SlnArgumentValidator
 
             var projectArgs = string.Join(" ", _arguments.Where(path => !path.HasExtension(".sln") && !path.HasExtension(".slnx")));
             string command = commandType == CommandType.Add ? "add" : "remove";
-            throw new GracefulException(new string[]
-            {
+            throw new GracefulException(
+            [
                 string.Format(CommonLocalizableStrings.SolutionArgumentMisplaced, slnFile),
                 CommonLocalizableStrings.DidYouMean,
                 $"  dotnet solution {slnFile} {command} {args}{projectArgs}"
-            });
+            ]);
         }
     }
 }

--- a/src/Cli/dotnet/Commands/Store/StoreCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Store/StoreCommandParser.cs
@@ -29,18 +29,11 @@ internal static class StoreCommandParser
 
         if (o.Count() == 1)
         {
-            return new[]
-            {
-                materializedString
-            };
+            return [materializedString];
         }
         else
         {
-            return new[]
-            {
-                materializedString,
-                $"-property:AdditionalProjects={string.Join("%3B", o.Skip(1).Select(CommandDirectoryContext.GetFullPath))}"
-            };
+            return [materializedString, $"-property:AdditionalProjects={string.Join("%3B", o.Skip(1).Select(CommandDirectoryContext.GetFullPath))}"];
         }
     }).AllowSingleArgPerToken();
 

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -31,8 +31,8 @@ internal static class CliConstants
     public const string RuntimeIdentifier = "RuntimeIdentifier";
     public const string TargetFramework = "TargetFramework";
 
-    public static readonly string[] ProjectExtensions = { ".proj", ".csproj", ".vbproj", ".fsproj" };
-    public static readonly string[] SolutionExtensions = { ".sln", ".slnx", ".slnf" };
+    public static readonly string[] ProjectExtensions = [".proj", ".csproj", ".vbproj", ".fsproj"];
+    public static readonly string[] SolutionExtensions = [".sln", ".slnx", ".slnf"];
 
     public const string ProjectExtensionPattern = "*.*proj";
     public const string SolutionExtensionPattern = "*.sln";

--- a/src/Cli/dotnet/Commands/Test/IPC/Serializers/HandshakeMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/IPC/Serializers/HandshakeMessageSerializer.cs
@@ -11,7 +11,7 @@ internal sealed class HandshakeMessageSerializer : BaseSerializer, INamedPipeSer
 
     public object Deserialize(Stream stream)
     {
-        Dictionary<byte, string> properties = new();
+        Dictionary<byte, string> properties = [];
 
         ushort fieldCount = ReadShort(stream);
 

--- a/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
@@ -16,7 +16,7 @@ internal sealed class MSBuildHandler : IDisposable
     private readonly TestApplicationActionQueue _actionQueue;
     private readonly TerminalTestReporter _output;
 
-    private readonly ConcurrentBag<TestApplication> _testApplications = new();
+    private readonly ConcurrentBag<TestApplication> _testApplications = [];
     private bool _areTestingPlatformApplications = true;
 
     public MSBuildHandler(BuildOptions buildOptions, TestApplicationActionQueue actionQueue, TerminalTestReporter output)

--- a/src/Cli/dotnet/Commands/Test/Program.cs
+++ b/src/Cli/dotnet/Commands/Test/Program.cs
@@ -641,25 +641,25 @@ public class TerminalLoggerDetector
     internal static class AnsiDetector
     {
         private static readonly Regex[] TerminalsRegexes =
-        {
-    new("^xterm"), // xterm, PuTTY, Mintty
-    new("^rxvt"), // RXVT
-    new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
-    new("^screen"), // GNU screen, tmux
-    new("tmux"), // tmux
-    new("^vt100"), // DEC VT series
-    new("^vt102"), // DEC VT series
-    new("^vt220"), // DEC VT series
-    new("^vt320"), // DEC VT series
-    new("ansi"), // ANSI
-    new("scoansi"), // SCO ANSI
-    new("cygwin"), // Cygwin, MinGW
-    new("linux"), // Linux console
-    new("konsole"), // Konsole
-    new("bvterm"), // Bitvise SSH Client
-    new("^st-256color"), // Suckless Simple Terminal, st
-    new("alacritty"), // Alacritty
-};
+        [
+            new("^xterm"), // xterm, PuTTY, Mintty
+            new("^rxvt"), // RXVT
+            new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
+            new("^screen"), // GNU screen, tmux
+            new("tmux"), // tmux
+            new("^vt100"), // DEC VT series
+            new("^vt102"), // DEC VT series
+            new("^vt220"), // DEC VT series
+            new("^vt320"), // DEC VT series
+            new("ansi"), // ANSI
+            new("scoansi"), // SCO ANSI
+            new("cygwin"), // Cygwin, MinGW
+            new("linux"), // Linux console
+            new("konsole"), // Konsole
+            new("bvterm"), // Bitvise SSH Client
+            new("^st-256color"), // Suckless Simple Terminal, st
+            new("alacritty"), // Alacritty
+        ];
 
         public static bool IsAnsiSupported(string termType)
             => !String.IsNullOrEmpty(termType) && TerminalsRegexes.Any(regex => regex.IsMatch(termType));

--- a/src/Cli/dotnet/Commands/Test/Terminal/AnsiDetector.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/AnsiDetector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 internal static class AnsiDetector
 {
     private static readonly Regex[] TerminalsRegexes =
-    {
+    [
         new("^xterm"), // xterm, PuTTY, Mintty
         new("^rxvt"), // RXVT
         new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
@@ -34,7 +34,7 @@ internal static class AnsiDetector
         new("bvterm"), // Bitvise SSH Client
         new("^st-256color"), // Suckless Simple Terminal, st
         new("alacritty"), // Alacritty
-    };
+    ];
 
     public static bool IsAnsiSupported(string? termType)
         => !String.IsNullOrEmpty(termType) && TerminalsRegexes.Any(regex => regex.IsMatch(termType));

--- a/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
@@ -17,8 +17,8 @@ internal sealed class AnsiTerminal : ITerminal
     /// File extensions that we will link to directly, all other files
     /// are linked to their directory, to avoid opening dlls, or executables.
     /// </summary>
-    private static readonly string[] KnownFileExtensions = new string[]
-    {
+    private static readonly string[] KnownFileExtensions =
+    [
         // code files
         ".cs",
         ".vb",
@@ -35,7 +35,7 @@ internal sealed class AnsiTerminal : ITerminal
         ".trx",
         ".xml",
         ".xunit",
-    };
+    ];
 
     private readonly IConsole _console;
     private readonly string? _baseDirectory;

--- a/src/Cli/dotnet/Commands/Test/Terminal/ExceptionFlattener.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/ExceptionFlattener.cs
@@ -17,10 +17,10 @@ internal sealed class ExceptionFlattener
         string? stackTrace = exception?.StackTrace;
         var flatException = new FlatException(message, type, stackTrace);
 
-        List<FlatException> flatExceptions = new()
-        {
+        List<FlatException> flatExceptions =
+        [
            flatException,
-        };
+        ];
 
         // Add all inner exceptions. This will flatten top level AggregateExceptions,
         // and all AggregateExceptions that are directly in AggregateExceptions, but won't expand

--- a/src/Cli/dotnet/Commands/Test/Terminal/ExceptionFlattener.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/ExceptionFlattener.cs
@@ -17,10 +17,7 @@ internal sealed class ExceptionFlattener
         string? stackTrace = exception?.StackTrace;
         var flatException = new FlatException(message, type, stackTrace);
 
-        List<FlatException> flatExceptions =
-        [
-           flatException,
-        ];
+        List<FlatException> flatExceptions = [flatException];
 
         // Add all inner exceptions. This will flatten top level AggregateExceptions,
         // and all AggregateExceptions that are directly in AggregateExceptions, but won't expand

--- a/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
@@ -19,7 +19,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     /// <summary>
     /// The two directory separator characters to be passed to methods like <see cref="string.IndexOfAny(char[])"/>.
     /// </summary>
-    private static readonly string[] NewLineStrings = { "\r\n", "\n" };
+    private static readonly string[] NewLineStrings = ["\r\n", "\n"];
 
     internal const string SingleIndentation = "  ";
 

--- a/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
@@ -41,7 +41,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private readonly ConcurrentDictionary<string, TestProgressState> _assemblies = new();
 
-    private readonly List<TestRunArtifact> _artifacts = new();
+    private readonly List<TestRunArtifact> _artifacts = [];
 
     private readonly TerminalTestReporterOptions _options;
 

--- a/src/Cli/dotnet/Commands/Test/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TestProgressState.cs
@@ -27,9 +27,9 @@ internal sealed class TestProgressState
 
     public IStopwatch Stopwatch { get; }
 
-    public List<string> Attachments { get; } = new();
+    public List<string> Attachments { get; } = [];
 
-    public List<IProgressMessage> Messages { get; } = new();
+    public List<IProgressMessage> Messages { get; } = [];
 
     public int FailedTests { get; internal set; }
 
@@ -47,7 +47,7 @@ internal sealed class TestProgressState
 
     public long Version { get; internal set; }
 
-    public List<(string? DisplayName, string? UID)> DiscoveredTests { get; internal set; } = new();
+    public List<(string? DisplayName, string? UID)> DiscoveredTests { get; internal set; } = [];
     public int? ExitCode { get; internal set; }
     public bool Success { get; internal set; }
 

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -19,7 +19,7 @@ internal sealed class TestApplication : IDisposable
     private readonly CancellationTokenSource _cancellationToken = new();
 
     private Task _testAppPipeConnectionLoop;
-    private readonly List<NamedPipeServer> _testAppPipeConnections = new();
+    private readonly List<NamedPipeServer> _testAppPipeConnections = [];
 
     public event EventHandler<HandshakeArgs> HandshakeReceived;
     public event EventHandler<HelpEventArgs> HelpRequested;

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -104,8 +104,8 @@ internal static class TestCommandParser
             Description = LocalizableStrings.CmdBlameCrashDumpTypeDescription,
             HelpName = LocalizableStrings.CrashDumpTypeArgumentName,
         }
-        .ForwardAsMany(o => new[] { "-property:VSTestBlameCrash=true", $"-property:VSTestBlameCrashDumpType={o}" });
-        result.AcceptOnlyFromAmong(new string[] { "full", "mini" });
+        .ForwardAsMany(o => ["-property:VSTestBlameCrash=true", $"-property:VSTestBlameCrashDumpType={o}"]);
+        result.AcceptOnlyFromAmong(["full", "mini"]);
         return result;
     }
 
@@ -113,7 +113,7 @@ internal static class TestCommandParser
     {
         Description = LocalizableStrings.CmdBlameCrashCollectAlwaysDescription,
         Arity = ArgumentArity.Zero
-    }.ForwardAsMany(o => new[] { "-property:VSTestBlameCrash=true", "-property:VSTestBlameCrashCollectAlways=true" });
+    }.ForwardAsMany(o => ["-property:VSTestBlameCrash=true", "-property:VSTestBlameCrashCollectAlways=true"]);
 
     public static readonly CliOption<bool> BlameHangOption = new ForwardedOption<bool>("--blame-hang")
     {
@@ -130,8 +130,8 @@ internal static class TestCommandParser
             Description = LocalizableStrings.CmdBlameHangDumpTypeDescription,
             HelpName = LocalizableStrings.HangDumpTypeArgumentName
         }
-        .ForwardAsMany(o => new[] { "-property:VSTestBlameHang=true", $"-property:VSTestBlameHangDumpType={o}" });
-        result.AcceptOnlyFromAmong(new string[] { "full", "mini", "none" });
+        .ForwardAsMany(o => ["-property:VSTestBlameHang=true", $"-property:VSTestBlameHangDumpType={o}"]);
+        result.AcceptOnlyFromAmong(["full", "mini", "none"]);
         return result;
     }
 
@@ -139,7 +139,7 @@ internal static class TestCommandParser
     {
         Description = LocalizableStrings.CmdBlameHangTimeoutDescription,
         HelpName = LocalizableStrings.HangTimeoutArgumentName
-    }.ForwardAsMany(o => new[] { "-property:VSTestBlameHang=true", $"-property:VSTestBlameHangTimeout={o}" });
+    }.ForwardAsMany(o => ["-property:VSTestBlameHang=true", $"-property:VSTestBlameHangTimeout={o}"]);
 
     public static readonly CliOption<bool> NoLogoOption = new ForwardedOption<bool>("--nologo")
     {

--- a/src/Cli/dotnet/Commands/Test/VSTestArgumentConverter.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTestArgumentConverter.cs
@@ -89,7 +89,7 @@ public class VSTestArgumentConverter
     public List<string> Convert(string[] args, out List<string> ignoredArgs)
     {
         var newArgList = new List<string>();
-        ignoredArgs = new List<string>();
+        ignoredArgs = [];
 
         string activeArgument = null;
         BlameArgs blame = new();

--- a/src/Cli/dotnet/Commands/Tool/Common/ToolAppliedOption.cs
+++ b/src/Cli/dotnet/Commands/Tool/Common/ToolAppliedOption.cs
@@ -45,7 +45,7 @@ internal class ToolAppliedOption
         ParseResult parseResult,
         string message)
     {
-        List<string> options = new();
+        List<string> options = [];
         if (parseResult.GetResult(GlobalOption) is not null)
         {
             options.Add(GlobalOption.Name);
@@ -74,7 +74,7 @@ internal class ToolAppliedOption
         ParseResult parseResult,
         string message)
     {
-        List<string> options = new List<string>();
+        List<string> options = [];
         if (parseResult.GetResult(UpdateAllOption) is not null)
         {
             options.Add(UpdateAllOption.Name);

--- a/src/Cli/dotnet/Commands/Tool/Common/ToolManifestFinderExtensions.cs
+++ b/src/Cli/dotnet/Commands/Tool/Common/ToolManifestFinderExtensions.cs
@@ -23,18 +23,11 @@ internal static class ToolManifestFinderExtensions
         IReadOnlyList<FilePath> manifestFilesContainPackageId;
         try
         {
-            manifestFilesContainPackageId
-             = toolManifestFinder.FindByPackageId(packageId);
+            manifestFilesContainPackageId = toolManifestFinder.FindByPackageId(packageId);
         }
         catch (ToolManifestCannotBeFoundException e)
         {
-            throw new GracefulException(new[]
-                {
-                    e.Message,
-                    LocalizableStrings.NoManifestGuide
-                },
-                verboseMessages: new[] { e.VerboseMessage },
-                isUserError: false);
+            throw new GracefulException([e.Message, LocalizableStrings.NoManifestGuide], verboseMessages: [e.VerboseMessage], isUserError: false);
         }
 
         if (manifestFilesContainPackageId.Any())

--- a/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
@@ -29,21 +29,14 @@ internal class ProjectRestorer : IProjectRestorer
         PackageLocation packageLocation,
         string verbosity = null)
     {
-        var argsToPassToRestore = new List<string>
-        {
-            project.Value
-        };
+        List<string> argsToPassToRestore = [project.Value];
         if (packageLocation.NugetConfig != null)
         {
             argsToPassToRestore.Add("--configfile");
             argsToPassToRestore.Add(packageLocation.NugetConfig.Value.Value);
         }
 
-        argsToPassToRestore.AddRange(new List<string>
-        {
-            "--runtime",
-            Constants.AnyRid
-        });
+        argsToPassToRestore.AddRange(["--runtime", Constants.AnyRid]);
 
         argsToPassToRestore.Add($"--verbosity:{verbosity ?? GetDefaultVerbosity()}");
 

--- a/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
@@ -29,9 +29,10 @@ internal class ProjectRestorer : IProjectRestorer
         PackageLocation packageLocation,
         string verbosity = null)
     {
-        var argsToPassToRestore = new List<string>();
-
-        argsToPassToRestore.Add(project.Value);
+        var argsToPassToRestore = new List<string>
+        {
+            project.Value
+        };
         if (packageLocation.NugetConfig != null)
         {
             argsToPassToRestore.Add("--configfile");

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
@@ -258,12 +258,11 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         if (oldPackageNullable != null && (newInstalledPackage.Version < oldPackageNullable.Version && !allowDowngrade))
         {
             throw new GracefulException(
-                new[]
-                {
+                [
                     string.Format(Update.LocalizableStrings.UpdateToLowerVersion,
                         newInstalledPackage.Version.ToNormalizedString(),
                         oldPackageNullable.Version.ToNormalizedString())
-                },
+                ],
                 isUserError: false);
         }
     }
@@ -298,7 +297,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 
             throw new GracefulException(
                 messages: message,
-                verboseMessages: new[] { ex.ToString() },
+                verboseMessages: [ex.ToString()],
                 isUserError: false);
         }
     }
@@ -321,7 +320,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 
             throw new GracefulException(
                 messages: message,
-                verboseMessages: new[] { ex.ToString() },
+                verboseMessages: [ex.ToString()],
                 isUserError: false);
         }
     }
@@ -347,12 +346,12 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         catch (InvalidOperationException)
         {
             throw new GracefulException(
-                messages: new[]
-                {
+                messages:
+                [
                     string.Format(
                         Update.LocalizableStrings.ToolHasMultipleVersionsInstalled,
                         packageId),
-                },
+                ],
                 isUserError: false);
         }
 

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalCommand.cs
@@ -121,14 +121,14 @@ internal class ToolInstallLocalCommand : CommandBase
     {
         if (existingPackage.Version > toolDownloadedPackage.Version && !_allowPackageDowngrade)
         {
-            throw new GracefulException(new[]
-                {
+            throw new GracefulException(
+                [
                     string.Format(
                         Update.LocalizableStrings.UpdateLocalToolToLowerVersion,
                         toolDownloadedPackage.Version.ToNormalizedString(),
                         existingPackage.Version.ToNormalizedString(),
                         manifestFile.Value)
-                },
+                ],
                 isUserError: false);
         }
         else if (existingPackage.Version == toolDownloadedPackage.Version)
@@ -200,12 +200,9 @@ internal class ToolInstallLocalCommand : CommandBase
         }
         catch (ToolManifestCannotBeFoundException e)
         {
-            throw new GracefulException(new[]
-                {
-                    e.Message,
-                    LocalizableStrings.NoManifestGuide
-                },
-                verboseMessages: new[] { e.VerboseMessage },
+            throw new GracefulException(
+                [e.Message, LocalizableStrings.NoManifestGuide],
+                verboseMessages: [e.VerboseMessage],
                 isUserError: false);
         }
     }

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalInstaller.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalInstaller.cs
@@ -83,7 +83,7 @@ internal class ToolInstallLocalInstaller
         {
             throw new GracefulException(
                 messages: InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId),
-                verboseMessages: new[] { ex.ToString() },
+                verboseMessages: [ex.ToString()],
                 isUserError: false);
         }
     }

--- a/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
@@ -44,9 +44,7 @@ internal class ToolRunCommand : CommandBase
 
         if (commandspec == null)
         {
-            throw new GracefulException(
-                new string[] { string.Format(LocalizableStrings.CannotFindCommandName, _toolCommandName) },
-                isUserError: false);
+            throw new GracefulException([string.Format(LocalizableStrings.CannotFindCommandName, _toolCommandName)], isUserError: false);
         }
 
         var result = CommandFactoryUsingResolver.Create(commandspec).Execute();

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
@@ -14,23 +14,11 @@ internal static class ToolUninstallCommandLowLevelErrorConverter
         string[] userFacingMessages = null;
         if (ex is ToolPackageException)
         {
-            userFacingMessages = new[]
-            {
-                string.Format(
-                    CommonLocalizableStrings.FailedToUninstallToolPackage,
-                    packageId,
-                    ex.Message),
-            };
+            userFacingMessages = [string.Format(CommonLocalizableStrings.FailedToUninstallToolPackage, packageId, ex.Message)];
         }
         else if (ex is ToolConfigurationException || ex is ShellShimException)
         {
-            userFacingMessages = new[]
-            {
-                string.Format(
-                    LocalizableStrings.FailedToUninstallTool,
-                    packageId,
-                    ex.Message)
-            };
+            userFacingMessages = [string.Format(LocalizableStrings.FailedToUninstallTool, packageId, ex.Message)];
         }
 
         return userFacingMessages;

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommand.cs
@@ -68,26 +68,12 @@ internal class ToolUninstallGlobalOrToolPathCommand : CommandBase
             package = toolPackageStoreQuery.EnumeratePackageVersions(packageId).SingleOrDefault();
             if (package == null)
             {
-                throw new GracefulException(
-                    messages: new[]
-                    {
-                        string.Format(
-                            LocalizableStrings.ToolNotInstalled,
-                            packageId),
-                    },
-                isUserError: false);
+                throw new GracefulException(messages: [string.Format(LocalizableStrings.ToolNotInstalled, packageId)], isUserError: false);
             }
         }
         catch (InvalidOperationException)
         {
-            throw new GracefulException(
-                    messages: new[]
-                    {
-                        string.Format(
-                    LocalizableStrings.ToolHasMultipleVersionsInstalled,
-                    packageId),
-                    },
-                isUserError: false);
+            throw new GracefulException(messages: [string.Format(LocalizableStrings.ToolHasMultipleVersionsInstalled, packageId)], isUserError: false);
         }
 
         try
@@ -114,7 +100,7 @@ internal class ToolUninstallGlobalOrToolPathCommand : CommandBase
         {
             throw new GracefulException(
                 messages: ToolUninstallCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId),
-                verboseMessages: new[] { ex.ToString() },
+                verboseMessages: [ex.ToString()],
                 isUserError: false);
         }
     }

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallLocalCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallLocalCommand.cs
@@ -45,9 +45,7 @@ internal class ToolUninstallLocalCommand : CommandBase
 
         if (!manifestFileOptional.HasValue)
         {
-            throw new GracefulException(
-                new[] { string.Format(LocalizableStrings.NoManifestFileContainPackageId, _packageId) },
-                isUserError: false);
+            throw new GracefulException([string.Format(LocalizableStrings.NoManifestFileContainPackageId, _packageId)], isUserError: false);
         }
 
         var manifestFile = manifestFileOptional.Value;

--- a/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommand.cs
@@ -61,7 +61,7 @@ internal class ToolUpdateCommand : CommandBase
         ParseResult parseResult,
         string message)
     {
-        List<string> options = new List<string>();
+        List<string> options = [];
         if (parseResult.GetResult(ToolAppliedOption.UpdateAllOption) is not null)
         {
             options.Add(ToolAppliedOption.UpdateAllOption.Name);

--- a/src/Cli/dotnet/Commands/Workload/Clean/WorkloadCleanCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Clean/WorkloadCleanCommand.cs
@@ -80,7 +80,7 @@ internal class WorkloadCleanCommand : WorkloadCommandBase
         {
             // All VS Workloads should have a corresponding MSI based SDK. This means we can pull all of the VS SDK feature bands using MSI/VS related registry keys.
             var installedSDKVersionsWithPotentialVSRecords = MsiInstallerBase.GetInstalledSdkVersions();
-            HashSet<string> vsWorkloadUninstallWarnings = new();
+            HashSet<string> vsWorkloadUninstallWarnings = [];
 
             string defaultDotnetWinPath = MsiInstallerBase.GetDotNetHome();
             foreach (string sdkVersion in installedSDKVersionsWithPotentialVSRecords)

--- a/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
+++ b/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
@@ -37,7 +37,7 @@ internal class GlobalJsonWorkloadSetsFile
             }
             else
             {
-                globalJsonWorkloadSetVersions = new();
+                globalJsonWorkloadSetVersions = [];
             }
             globalJsonWorkloadSetVersions[globalJsonPath] = workloadSetVersion;
             fileStream.Seek(0, SeekOrigin.Begin);
@@ -68,7 +68,7 @@ internal class GlobalJsonWorkloadSetsFile
         {
             if (fileStream == null)
             {
-                return new Dictionary<string, string>();
+                return [];
             }
 
             var globalJsonWorkloadSetVersions = JsonSerializer.Deserialize<Dictionary<string, string>>(fileStream, _jsonSerializerOptions);

--- a/src/Cli/dotnet/Commands/Workload/History/WorkloadHistoryCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/History/WorkloadHistoryCommand.cs
@@ -53,7 +53,7 @@ internal class WorkloadHistoryCommand : WorkloadCommandBase
             table.AddColumn(LocalizableStrings.Id, r => r.ID?.ToString() ?? "");
             table.AddColumn(LocalizableStrings.Date, r => r.TimeStarted?.ToString() ?? "");
             table.AddColumn(LocalizableStrings.Command, r => r.Command);
-            table.AddColumn(LocalizableStrings.Workloads, r => string.Join(", ", r.HistoryState.InstalledWorkloads ?? new List<string>(0)));
+            table.AddColumn(LocalizableStrings.Workloads, r => string.Join(", ", r.HistoryState.InstalledWorkloads ?? []));
             table.AddColumn(LocalizableStrings.GlobalJsonVersion, r => r.GlobalJsonVersion ?? string.Empty);
             table.AddColumn(LocalizableStrings.WorkloadSetVersion, r => r.HistoryState.WorkloadSetVersion ?? string.Empty);
 

--- a/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
@@ -423,7 +423,7 @@ internal class FileBasedInstaller : IInstaller
                 //  If there are no install records for a workload set that is on disk, then ignore it.  It is probably a baseline workload set.
                 continue;
             }
-            List<SdkFeatureBand> featureBandsToRemove = new();
+            List<SdkFeatureBand> featureBandsToRemove = [];
             foreach (var referencingFeatureBand in referencingFeatureBands)
             {
                 if (!installedSdkFeatureBands.Contains(referencingFeatureBand))
@@ -463,7 +463,7 @@ internal class FileBasedInstaller : IInstaller
         foreach (var (manifestId, manifestVersion, manifestFeatureBand) in manifestInstallRecords.Keys)
         {
             var referencingFeatureBands = manifestInstallRecords[(manifestId, manifestVersion, manifestFeatureBand)];
-            List<SdkFeatureBand> featureBandsToRemove = new();
+            List<SdkFeatureBand> featureBandsToRemove = [];
             foreach (var referencingFeatureBand in referencingFeatureBands)
             {
                 if (!installedSdkFeatureBands.Contains(referencingFeatureBand))
@@ -500,7 +500,7 @@ internal class FileBasedInstaller : IInstaller
         foreach (var (packId, packVersion) in packInstallRecords.Keys)
         {
             var referencingFeatureBands = packInstallRecords[(packId, packVersion)];
-            List<SdkFeatureBand> featureBandsToRemove = new();
+            List<SdkFeatureBand> featureBandsToRemove = [];
             foreach (var referencingFeatureBand in referencingFeatureBands)
             {
                 if (cleanAllPacks)
@@ -740,7 +740,7 @@ internal class FileBasedInstaller : IInstaller
 
     private Dictionary<(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand), List<SdkFeatureBand>> GetAllWorkloadSetInstallRecords()
     {
-        Dictionary<(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand), List<SdkFeatureBand>> records = new();
+        Dictionary<(string workloadSetVersion, SdkFeatureBand workloadSetFeatureBand), List<SdkFeatureBand>> records = [];
 
         var installedWorkloadSetsDir = Path.Combine(_workloadMetadataDir, InstalledWorkloadSetsDir, "v1");
 
@@ -760,7 +760,7 @@ internal class FileBasedInstaller : IInstaller
                     var referencingFeatureBand = new SdkFeatureBand(Path.GetFileName(featureBandInstallationRecord));
                     if (!records.TryGetValue((workloadSetVersion, workloadSetFeatureBand), out var referencingFeatureBands))
                     {
-                        referencingFeatureBands = new List<SdkFeatureBand>();
+                        referencingFeatureBands = [];
                         records[(workloadSetVersion, workloadSetFeatureBand)] = referencingFeatureBands;
                     }
 
@@ -791,7 +791,7 @@ internal class FileBasedInstaller : IInstaller
 
     private Dictionary<(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand manifestFeatureBand), List<SdkFeatureBand>> GetAllManifestInstallRecords()
     {
-        Dictionary<(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand manifestFeatureBand), List<SdkFeatureBand>> records = new();
+        Dictionary<(ManifestId manifestId, ManifestVersion manifestVersion, SdkFeatureBand manifestFeatureBand), List<SdkFeatureBand>> records = [];
 
         var installedManifestsDir = Path.Combine(_workloadMetadataDir, InstalledManifestsDir, "v1");
 
@@ -815,7 +815,7 @@ internal class FileBasedInstaller : IInstaller
 
                         if (!records.TryGetValue((manifestId, manifestVersion, manifestFeatureBand), out var referencingFeatureBands))
                         {
-                            referencingFeatureBands = new List<SdkFeatureBand>();
+                            referencingFeatureBands = [];
                             records[(manifestId, manifestVersion, manifestFeatureBand)] = referencingFeatureBands;
                         }
 
@@ -833,7 +833,7 @@ internal class FileBasedInstaller : IInstaller
 
     private Dictionary<(WorkloadPackId packId, string packVersion), List<SdkFeatureBand>> GetAllPackInstallRecords()
     {
-        Dictionary<(WorkloadPackId packId, string packVersion), List<SdkFeatureBand>> records = new();
+        Dictionary<(WorkloadPackId packId, string packVersion), List<SdkFeatureBand>> records = [];
 
         var installedPacksDir = Path.Combine(_workloadMetadataDir, InstalledPacksDir, "v1");
 
@@ -854,7 +854,7 @@ internal class FileBasedInstaller : IInstaller
 
                     if (!records.TryGetValue((packId, packVersion), out var referencingFeatureBands))
                     {
-                        referencingFeatureBands = new List<SdkFeatureBand>();
+                        referencingFeatureBands = [];
                         records[(packId, packVersion)] = referencingFeatureBands;
                     }
                     referencingFeatureBands.Add(referencingFeatureBand);

--- a/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
@@ -22,7 +22,7 @@ internal abstract class MsiInstallerBase : InstallerBase
     /// <summary>
     /// Track messages that should never be reported more than once.
     /// </summary>
-    private HashSet<string> _reportedMessages = new();
+    private HashSet<string> _reportedMessages = [];
 
     /// <summary>
     /// Backing field for the install location of .NET

--- a/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
@@ -55,7 +55,7 @@ internal abstract class MsiInstallerBase : InstallerBase
     /// Supported installer architectures used to map workload packs to architecture
     /// specific payload packs to acquire MSIs.
     /// </summary>
-    protected static readonly string[] SupportedArchitectures = { "x86", "amd64", "arm64" };
+    protected static readonly string[] SupportedArchitectures = ["x86", "amd64", "arm64"];
 
     /// <summary>
     /// Determines whether the parent process is still active.

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.InstallRecords.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.InstallRecords.cs
@@ -82,7 +82,7 @@ internal partial class NetSdkMsiInstallerClient
         Log?.LogMessage($"Detecting installed workload manifests for {HostArchitecture}.");
 
         var manifestRecords = new List<WorkloadManifestRecord>();
-        HashSet<(string id, string version)> discoveredManifests = new();
+        HashSet<(string id, string version)> discoveredManifests = [];
 
         using RegistryKey installedManifestsKey = Registry.LocalMachine.OpenSubKey(@$"SOFTWARE\Microsoft\dotnet\InstalledManifests\{HostArchitecture}");
         if (installedManifestsKey != null)
@@ -300,7 +300,7 @@ internal partial class NetSdkMsiInstallerClient
     protected List<WorkloadPackRecord> GetWorkloadPackRecords()
     {
         Log?.LogMessage($"Detecting installed workload packs for {HostArchitecture}.");
-        List<WorkloadPackRecord> workloadPackRecords = new();
+        List<WorkloadPackRecord> workloadPackRecords = [];
         using RegistryKey installedPacksKey = Registry.LocalMachine.OpenSubKey(@$"SOFTWARE\Microsoft\dotnet\InstalledPacks\{HostArchitecture}");
 
         static void SetRecordMsiProperties(WorkloadPackRecord record, RegistryKey key)

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.PackGroup.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.PackGroup.cs
@@ -15,7 +15,7 @@ internal partial class NetSdkMsiInstallerClient
         public string GroupPackageId { get; set; }
         public string GroupPackageVersion { get; set; }
 
-        public List<WorkloadPackJson> Packs { get; set; } = new List<WorkloadPackJson>();
+        public List<WorkloadPackJson> Packs { get; set; } = [];
     }
 
     class WorkloadPackJson
@@ -27,7 +27,7 @@ internal partial class NetSdkMsiInstallerClient
 
     Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> GetWorkloadPackGroups()
     {
-        Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> ret = new();
+        Dictionary<(string packId, string packVersion), List<WorkloadPackGroupJson>> ret = [];
 
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_DISABLE_PACK_GROUPS)))
         {
@@ -49,7 +49,7 @@ internal partial class NetSdkMsiInstallerClient
                         var pack = (packId: packJson.PackId, packVersion: packJson.PackVersion);
                         if (!ret.TryGetValue(pack, out var groupsWithPack))
                         {
-                            groupsWithPack = new();
+                            groupsWithPack = [];
                             ret[pack] = groupsWithPack;
                         }
                         groupsWithPack.Add(packGroup);
@@ -74,8 +74,8 @@ internal partial class NetSdkMsiInstallerClient
 
     List<WorkloadDownload> GetMsisForPacks(IEnumerable<PackInfo> packInfos)
     {
-        List<WorkloadDownload> msisToInstall = new();
-        HashSet<(string packId, string packVersion)> packsProcessed = new();
+        List<WorkloadDownload> msisToInstall = [];
+        HashSet<(string packId, string packVersion)> packsProcessed = [];
 
         var groupsForPacks = GetWorkloadPackGroups();
 

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
@@ -94,7 +94,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
         IEnumerable<WorkloadDownload> msis = GetMsisForWorkloads(workloadIds);
         if (!includeInstalledItems)
         {
-            HashSet<(string id, string version)> installedItems = new(GetInstalledPacks(sdkFeatureBand).Select(t => (t.Id.ToString(), t.Version)));
+            HashSet<(string id, string version)> installedItems = [.. GetInstalledPacks(sdkFeatureBand).Select(t => (t.Id.ToString(), t.Version))];
             msis = msis.Where(m => !installedItems.Contains((m.Id, m.NuGetPackageVersion)));
         }
 
@@ -138,7 +138,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
 
             IEnumerable<SdkFeatureBand> installedFeatureBands = GetInstalledFeatureBands(Log);
 
-            List<WorkloadSetRecord> workloadSetsToRemove = new();
+            List<WorkloadSetRecord> workloadSetsToRemove = [];
             var installedWorkloadSets = GetWorkloadSetRecords();
             foreach (var workloadSetRecord in installedWorkloadSets)
             {
@@ -187,7 +187,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
 
             RemoveWorkloadSets(workloadSetsToRemove, offlineCache);
 
-            List<WorkloadManifestRecord> manifestsToRemove = new();
+            List<WorkloadManifestRecord> manifestsToRemove = [];
             var installedWorkloadManifests = GetWorkloadManifestRecords();
             foreach (var manifestRecord in installedWorkloadManifests)
             {
@@ -240,7 +240,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
             //  If aliased, the pack records here are the resolved pack from the alias
             IEnumerable<WorkloadPackRecord> installedWorkloadPacks = GetWorkloadPackRecords();
 
-            List<WorkloadPackRecord> packsToRemove = new();
+            List<WorkloadPackRecord> packsToRemove = [];
 
             // We first need to clean up the dependents and then do a pass at removing them. Querying the installed packs
             // is effectively a table scan of the registry to make sure we have accurate information and there's a
@@ -971,7 +971,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
     /// <returns>A List of all the installed SDK feature bands.</returns>
     private static IEnumerable<SdkFeatureBand> GetInstalledFeatureBands(ISetupLogger log = null)
     {
-        HashSet<SdkFeatureBand> installedFeatureBands = new();
+        HashSet<SdkFeatureBand> installedFeatureBands = [];
         foreach (string sdkVersion in GetInstalledSdkVersions())
         {
             try

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
@@ -26,9 +26,9 @@ internal class WorkloadGarbageCollector
     Dictionary<string, string> _globalJsonWorkloadSetVersions;
     IReporter _verboseReporter;
 
-    public HashSet<string> WorkloadSetsToKeep = new();
-    public HashSet<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand)> ManifestsToKeep = new();
-    public HashSet<(WorkloadPackId id, string version)> PacksToKeep = new();
+    public HashSet<string> WorkloadSetsToKeep = [];
+    public HashSet<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand)> ManifestsToKeep = [];
+    public HashSet<(WorkloadPackId id, string version)> PacksToKeep = [];
 
     enum GCAction
     {
@@ -37,8 +37,8 @@ internal class WorkloadGarbageCollector
         Keep = 2,
     }
 
-    Dictionary<string, GCAction> _workloadSets = new();
-    Dictionary<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand), GCAction> _manifests = new();
+    Dictionary<string, GCAction> _workloadSets = [];
+    Dictionary<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand), GCAction> _manifests = [];
 
     //  globalJsonWorkloadSetVersions should be the contents of the GC Roots file.  The keys should be paths to global.json files, and the values
     //  should be the workload set version referred to by that file.  Before calling this method, the installer implementation should update the
@@ -135,8 +135,7 @@ internal class WorkloadGarbageCollector
         //  - Any manifests listed in the rollback state file (default.json)
         //  - The latest version of each manifest, if a workload set is not installed and there is no rollback state file
 
-        List<(IWorkloadResolver, string workloadSet, GCAction gcAction)> resolvers = new();
-        resolvers.Add((GetResolver(), "<none>", GCAction.Keep));
+        List<(IWorkloadResolver, string workloadSet, GCAction gcAction)> resolvers = [(GetResolver(), "<none>", GCAction.Keep)];
 
 
         //  Iterate through all installed workload sets for this SDK feature band that have not been marked for garbage collection

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/FileBasedInstallationRecordInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/FileBasedInstallationRecordInstaller.cs
@@ -26,7 +26,7 @@ internal class FileBasedInstallationRecordRepository : IWorkloadInstallationReco
         }
         else
         {
-            return new List<SdkFeatureBand>();
+            return [];
         }
     }
 
@@ -40,7 +40,7 @@ internal class FileBasedInstallationRecordRepository : IWorkloadInstallationReco
         }
         else
         {
-            return new List<WorkloadId>();
+            return [];
         }
     }
 

--- a/src/Cli/dotnet/Commands/Workload/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/InstallingWorkloadCommand.cs
@@ -361,7 +361,7 @@ internal abstract class InstallingWorkloadCommand : WorkloadCommandBase
         reporter ??= Reporter;
         packageDownloader ??= PackageDownloader;
 
-        List<WorkloadDownload> ret = new();
+        List<WorkloadDownload> ret = [];
         DirectoryPath? tempPath = null;
         try
         {

--- a/src/Cli/dotnet/Commands/Workload/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/InstallingWorkloadCommand.cs
@@ -444,7 +444,7 @@ internal abstract class InstallingWorkloadCommand : WorkloadCommandBase
                 var maxPriorFeatureBand = priorFeatureBands.Max();
                 return _workloadInstaller.GetWorkloadInstallationRecordRepository().GetInstalledWorkloads(maxPriorFeatureBand);
             }
-            return new List<WorkloadId>();
+            return [];
         }
         else
         {

--- a/src/Cli/dotnet/Commands/Workload/List/InstalledWorkloadsCollection.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/InstalledWorkloadsCollection.cs
@@ -27,7 +27,7 @@ internal class InstalledWorkloadsCollection
 
     public InstalledWorkloadsCollection()
     {
-        _workloads = new();
+        _workloads = [];
     }
 
     public IEnumerable<KeyValuePair<string, string>> AsEnumerable() =>

--- a/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
@@ -103,7 +103,7 @@ internal static class VisualStudioWorkloads
         InstalledWorkloadsCollection installedWorkloads, SdkFeatureBand? sdkFeatureBand = null)
     {
         Dictionary<string, string> visualStudioWorkloadIds = GetAvailableVisualStudioWorkloads(workloadResolver);
-        HashSet<string> installedWorkloadComponents = new();
+        HashSet<string> installedWorkloadComponents = [];
 
         // Visual Studio instances contain a large set of packages and we have to perform a linear
         // search to determine whether a matching SDK was installed and look for each installable
@@ -211,7 +211,7 @@ internal static class VisualStudioWorkloads
         // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2241752/
         lock (s_guard)
         {
-            List<ISetupInstance> vsInstances = new();
+            List<ISetupInstance> vsInstances = [];
 
             try
             {

--- a/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
@@ -27,12 +27,12 @@ internal static class VisualStudioWorkloads
     /// Visual Studio product ID filters. We dont' want to query SKUs such as Server, TeamExplorer, TestAgent
     /// TestController and BuildTools.
     /// </summary>
-    private static readonly string[] s_visualStudioProducts = new string[]
-    {
+    private static readonly string[] s_visualStudioProducts =
+    [
         "Microsoft.VisualStudio.Product.Community",
         "Microsoft.VisualStudio.Product.Professional",
         "Microsoft.VisualStudio.Product.Enterprise",
-    };
+    ];
 
     /// <summary>
     /// Default prefix to use for Visual Studio component and component group IDs.
@@ -42,7 +42,7 @@ internal static class VisualStudioWorkloads
     /// <summary>
     /// Well-known prefixes used by some workloads that can be replaced when generating component IDs.
     /// </summary>
-    private static readonly string[] s_wellKnownWorkloadPrefixes = { "Microsoft.NET.", "Microsoft." };
+    private static readonly string[] s_wellKnownWorkloadPrefixes = ["Microsoft.NET.", "Microsoft."];
 
     /// <summary>
     /// The SWIX package ID wrapping the SDK installer in Visual Studio. The ID should contain

--- a/src/Cli/dotnet/Commands/Workload/WorkloadHistoryDisplay.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadHistoryDisplay.cs
@@ -20,7 +20,7 @@ internal static class WorkloadHistoryDisplay
 
     public static List<DisplayRecord> ProcessWorkloadHistoryRecords(IEnumerable<WorkloadHistoryRecord> historyRecords, out bool unknownRecordsPresent)
     {
-        List<DisplayRecord> displayRecords = new();
+        List<DisplayRecord> displayRecords = [];
         unknownRecordsPresent = false;
 
         int currentId = 2;

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -60,7 +60,7 @@ internal static class CommonOptions
         {
             rid = GetOsFromRid(rid) + "-x64";
         }
-        return new string[] { $"-property:RuntimeIdentifier={rid}", "-property:_CommandLineDefinedRuntimeIdentifier=true" };
+        return [$"-property:RuntimeIdentifier={rid}", "-property:_CommandLineDefinedRuntimeIdentifier=true"];
     }
 
     public static CliOption<string> RuntimeOption =
@@ -280,7 +280,7 @@ internal static class CommonOptions
     }
 
     private static IEnumerable<string> ResolveRidShorthandOptions(string os, string arch) =>
-        new string[] { $"-property:RuntimeIdentifier={ResolveRidShorthandOptionsToRuntimeIdentifier(os, arch)}" };
+        [$"-property:RuntimeIdentifier={ResolveRidShorthandOptionsToRuntimeIdentifier(os, arch)}"];
 
     internal static string ResolveRidShorthandOptionsToRuntimeIdentifier(string os, string arch)
     {
@@ -303,9 +303,7 @@ internal static class CommonOptions
         string runtimeIdentifierChainPath = string.IsNullOrEmpty(Product.Version) || !Directory.Exists(Path.Combine(dotnetRootPath, "sdk", Product.Version)) ?
             Path.Combine(Directory.GetDirectories(Path.Combine(dotnetRootPath, "sdk"))[0], ridFileName) :
             Path.Combine(dotnetRootPath, "sdk", Product.Version, ridFileName);
-        string[] currentRuntimeIdentifiers = File.Exists(runtimeIdentifierChainPath) ?
-            File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray() :
-            new string[] { };
+        string[] currentRuntimeIdentifiers = File.Exists(runtimeIdentifierChainPath) ? File.ReadAllLines(runtimeIdentifierChainPath).Where(l => !string.IsNullOrEmpty(l)).ToArray() : [];
         if (currentRuntimeIdentifiers == null || !currentRuntimeIdentifiers.Any() || !currentRuntimeIdentifiers[0].Contains("-"))
         {
             throw new GracefulException(CommonLocalizableStrings.CannotResolveRuntimeIdentifier);
@@ -319,7 +317,7 @@ internal static class CommonOptions
 
     private static IEnumerable<string> ForwardSelfContainedOptions(bool isSelfContained, ParseResult parseResult)
     {
-        IEnumerable<string> selfContainedProperties = new string[] { $"-property:SelfContained={isSelfContained}", "-property:_CommandLineDefinedSelfContained=true" };
+        IEnumerable<string> selfContainedProperties = [$"-property:SelfContained={isSelfContained}", "-property:_CommandLineDefinedSelfContained=true"];
         return selfContainedProperties;
     }
 

--- a/src/Cli/dotnet/Extensions/OptionForwardingExtensions.cs
+++ b/src/Cli/dotnet/Extensions/OptionForwardingExtensions.cs
@@ -88,7 +88,7 @@ public static class OptionForwardingExtensions
         return option;
     }
 
-    internal static Dictionary<CliOption, Dictionary<CliCommand, string>> HelpDescriptionCustomizations = new();
+    internal static Dictionary<CliOption, Dictionary<CliCommand, string>> HelpDescriptionCustomizations = [];
 
     public static CliOption<T> WithHelpDescription<T>(this CliOption<T> option, CliCommand command, string helpText)
     {

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -127,7 +127,7 @@ public static class ParseResultExtensions
         // Don't remove any arguments that are being passed to the app in dotnet run
         var dashDashIndex = subargs.IndexOf("--");
 
-        var runArgs = dashDashIndex > -1 ? subargs.GetRange(dashDashIndex, subargs.Count() - dashDashIndex) : new List<string>(0);
+        var runArgs = dashDashIndex > -1 ? subargs.GetRange(dashDashIndex, subargs.Count() - dashDashIndex) : [];
         subargs = dashDashIndex > -1 ? subargs.GetRange(0, dashDashIndex) : subargs;
 
         return subargs

--- a/src/Cli/dotnet/Extensions/ProjectInstanceExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ProjectInstanceExtensions.cs
@@ -29,9 +29,7 @@ public static class ProjectInstanceExtensions
     public static IEnumerable<string> GetPlatforms(this ProjectInstance projectInstance)
     {
         return (projectInstance.GetPropertyValue("Platforms") ?? "")
-            .Split(
-                [';'],
-                StringSplitOptions.RemoveEmptyEntries)
+            .Split([';'], StringSplitOptions.RemoveEmptyEntries)
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .DefaultIfEmpty("AnyCPU");
     }
@@ -45,9 +43,7 @@ public static class ProjectInstanceExtensions
         }
 
         return foundConfig
-            .Split(
-                [';'],
-                StringSplitOptions.RemoveEmptyEntries)
+            .Split([';'], StringSplitOptions.RemoveEmptyEntries)
             .Where(c => !string.IsNullOrWhiteSpace(c))
             .DefaultIfEmpty("Debug");
     }

--- a/src/Cli/dotnet/Extensions/ProjectInstanceExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ProjectInstanceExtensions.cs
@@ -30,7 +30,7 @@ public static class ProjectInstanceExtensions
     {
         return (projectInstance.GetPropertyValue("Platforms") ?? "")
             .Split(
-                new char[] { ';' },
+                [';'],
                 StringSplitOptions.RemoveEmptyEntries)
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .DefaultIfEmpty("AnyCPU");
@@ -46,7 +46,7 @@ public static class ProjectInstanceExtensions
 
         return foundConfig
             .Split(
-                new char[] { ';' },
+                [';'],
                 StringSplitOptions.RemoveEmptyEntries)
             .Where(c => !string.IsNullOrWhiteSpace(c))
             .DefaultIfEmpty("Debug");

--- a/src/Cli/dotnet/Extensions/ProjectRootElementExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ProjectRootElementExtensions.cs
@@ -13,7 +13,7 @@ public static class ProjectRootElementExtensions
             .Properties
             .FirstOrDefault(p => string.Equals(p.Name, "ProjectTypeGuids", StringComparison.OrdinalIgnoreCase))
             ?.Value
-            .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            .Split([';'], StringSplitOptions.RemoveEmptyEntries)
             .LastOrDefault(g => !string.IsNullOrWhiteSpace(g));
     }
 }

--- a/src/Cli/dotnet/FilePermissionSetter.cs
+++ b/src/Cli/dotnet/FilePermissionSetter.cs
@@ -30,7 +30,7 @@ internal class FilePermissionSetter : IFilePermissionSetter
         }
 
         CommandResult result = new CommandFactory.CommandFactory()
-            .Create("chmod", new[] { chmodArgument, path })
+            .Create("chmod", [chmodArgument, path])
             .CaptureStdOut()
             .CaptureStdErr()
             .Execute();

--- a/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/TimestampedFileLogger.cs
@@ -19,7 +19,7 @@ internal class TimestampedFileLogger : SetupLoggerBase, IDisposable, ISynchroniz
     /// <summary>
     /// Thread safe queue use to store incoming log request messages.
     /// </summary>
-    private readonly BlockingCollection<string> _messageQueue = new();
+    private readonly BlockingCollection<string> _messageQueue = [];
 
     private bool _disposed;
     private readonly StreamWriter _stream;

--- a/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
+++ b/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
@@ -63,7 +63,7 @@ public static class WindowsUtils
         using RegistryKey cbsKey = localMachineKey?.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending");
         using RegistryKey sessionKey = localMachineKey?.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Session Manager");
 
-        string[] pendingFileRenameOperations = (string[])sessionKey?.GetValue("PendingFileRenameOperations") ?? new string[0];
+        string[] pendingFileRenameOperations = (string[])sessionKey?.GetValue("PendingFileRenameOperations") ?? [];
         // Destination files for pending renames start with !\??\, whereas the source does not have the leading "!".
         bool hasPendingFileRenames = pendingFileRenameOperations.Any(s => !string.IsNullOrWhiteSpace(s) && s.StartsWith(@"!\??\"));
 

--- a/src/Cli/dotnet/Installer/Windows/WorkloadPackRecord.cs
+++ b/src/Cli/dotnet/Installer/Windows/WorkloadPackRecord.cs
@@ -46,7 +46,7 @@ internal class WorkloadPackRecord
     /// <summary>
     /// The workload pack IDs and versions that are installed by this MSI
     /// </summary>
-    public List<(WorkloadPackId id, NuGetVersion version)> InstalledPacks { get; set; } = new();
+    public List<(WorkloadPackId id, NuGetVersion version)> InstalledPacks { get; set; } = [];
 
     /// <summary>
     /// The product code (GUID) of the workload pack MSI.

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -10,7 +10,7 @@ internal static class LoggerUtility
 {
     public static FacadeLogger? DetermineBinlogger(string[] restoreArgs, string verb)
     {
-        List<BinaryLogger> binaryLoggers = new();
+        List<BinaryLogger> binaryLoggers = [];
 
         for (int i = restoreArgs.Length - 1; i >= 0; i--)
         {

--- a/src/Cli/dotnet/MsbuildProject.cs
+++ b/src/Cli/dotnet/MsbuildProject.cs
@@ -280,10 +280,7 @@ internal class MsbuildProject
     private IEnumerable<string> GetIncludeAlternativesForRemoval(string reference)
     {
         // We do not care about duplicates in case when i.e. reference is already full path
-        var ret = new List<string>
-        {
-            reference
-        };
+        List<string> ret = [reference];
 
         string fullPath = Path.GetFullPath(reference);
         ret.Add(fullPath);

--- a/src/Cli/dotnet/MsbuildProject.cs
+++ b/src/Cli/dotnet/MsbuildProject.cs
@@ -280,8 +280,10 @@ internal class MsbuildProject
     private IEnumerable<string> GetIncludeAlternativesForRemoval(string reference)
     {
         // We do not care about duplicates in case when i.e. reference is already full path
-        var ret = new List<string>();
-        ret.Add(reference);
+        var ret = new List<string>
+        {
+            reference
+        };
 
         string fullPath = Path.GetFullPath(reference);
         ret.Add(fullPath);

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -363,7 +363,7 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
 
     private List<PackageSource> LoadDefaultSources(PackageId packageId, PackageSourceLocation packageSourceLocation = null, PackageSourceMapping packageSourceMapping = null)
     {
-        List<PackageSource> defaultSources = new();
+        List<PackageSource> defaultSources = [];
         string currentDirectory = _currentWorkingDirectory ?? Directory.GetCurrentDirectory();
         ISettings settings;
         if (packageSourceLocation?.NugetConfig != null)

--- a/src/Cli/dotnet/NugetSearch/AuthorsConverter.cs
+++ b/src/Cli/dotnet/NugetSearch/AuthorsConverter.cs
@@ -24,7 +24,7 @@ internal class AuthorsConverter : JsonConverter<NugetSearchApiAuthorsSerializabl
         else
         {
             var s = reader.GetString();
-            return new NugetSearchApiAuthorsSerializable() { Authors = new string[] { s } };
+            return new NugetSearchApiAuthorsSerializable() { Authors = [s] };
         }
     }
 

--- a/src/Cli/dotnet/NugetSearch/NugetSearchApiRequestException.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetSearchApiRequestException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.NugetSearch;
 internal class NugetSearchApiRequestException : GracefulException
 {
     public NugetSearchApiRequestException(string message)
-        : base(new[] { message }, null, false)
+        : base([message], null, false)
     {
     }
 }

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -259,8 +259,8 @@ public static class Parser
 
         public void additionalOption(HelpContext context)
         {
-            List<TwoColumnHelpRow> options = new();
-            HashSet<CliOption> uniqueOptions = new();
+            List<TwoColumnHelpRow> options = [];
+            HashSet<CliOption> uniqueOptions = [];
             foreach (CliOption option in context.Command.Options)
             {
                 if (!option.Hidden && uniqueOptions.Add(option))

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -26,8 +26,8 @@ public static class Parser
     public static readonly CliCommand InstallSuccessCommand = InternalReportinstallsuccessCommandParser.GetCommand();
 
     // Subcommands
-    public static readonly CliCommand[] Subcommands = new CliCommand[]
-    {
+    public static readonly CliCommand[] Subcommands =
+    [
         AddCommandParser.GetCommand(),
         BuildCommandParser.GetCommand(),
         BuildServerCommandParser.GetCommand(),
@@ -58,7 +58,7 @@ public static class Parser
         InstallSuccessCommand,
         WorkloadCommandParser.GetCommand(),
         new System.CommandLine.StaticCompletions.CompletionsCommand()
-    };
+    ];
 
     public static readonly CliOption<bool> DiagOption = CommonOptionsFactory.CreateDiagnosticsOption(recursive: false);
 

--- a/src/Cli/dotnet/PerformanceLogEventListener.cs
+++ b/src/Cli/dotnet/PerformanceLogEventListener.cs
@@ -15,15 +15,15 @@ internal sealed class PerformanceLogEventListener : EventListener
         internal EventLevel Level { get; set; }
     }
 
-    private static ProviderConfiguration[] s_config = new ProviderConfiguration[]
-    {
+    private static ProviderConfiguration[] s_config =
+    [
         new ProviderConfiguration()
         {
             Name = "Microsoft-Dotnet-CLI-Performance",
             Keywords = EventKeywords.All,
             Level = EventLevel.Verbose
         }
-    };
+    ];
 
     private const char EventDelimiter = '\n';
     private StreamWriter _writer;

--- a/src/Cli/dotnet/PerformanceLogManager.cs
+++ b/src/Cli/dotnet/PerformanceLogManager.cs
@@ -82,7 +82,7 @@ internal sealed class PerformanceLogManager
     {
         if (_fileSystem.Directory.Exists(_perfLogRoot))
         {
-            List<DirectoryInfo> logDirectories = new();
+            List<DirectoryInfo> logDirectories = [];
             foreach (string directoryPath in _fileSystem.Directory.EnumerateDirectories(_perfLogRoot))
             {
                 logDirectories.Add(new DirectoryInfo(directoryPath));

--- a/src/Cli/dotnet/PrintableTable.cs
+++ b/src/Cli/dotnet/PrintableTable.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli;
 internal class PrintableTable<T>
 {
     public const string ColumnDelimiter = "      ";
-    private List<Column> _columns = new();
+    private List<Column> _columns = [];
 
     private class Column
     {

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -118,7 +118,7 @@ public class Program
 
     internal static int ProcessArgs(string[] args, TimeSpan startupTime, ITelemetry telemetryClient = null)
     {
-        Dictionary<string, double> performanceData = new();
+        Dictionary<string, double> performanceData = [];
 
         PerformanceLogEventSource.Log.BuiltInCommandParserStart();
         ParseResult parseResult;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -156,8 +156,8 @@ internal class ReleasePropertyProjectLocator
         }
 
         _isHandlingSolution = true;
-        List<ProjectInstance> configuredProjects = new();
-        HashSet<string> configValues = new();
+        List<ProjectInstance> configuredProjects = [];
+        HashSet<string> configValues = [];
         object projectDataLock = new();
 
         if (string.Equals(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_LAZY_PUBLISH_AND_PACK_RELEASE_FOR_SOLUTIONS), "true", StringComparison.OrdinalIgnoreCase))

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -70,7 +70,7 @@ internal class ReleasePropertyProjectLocator
         // Configuration doesn't work in a .proj file, but it does as a global property.
         // Detect either A) --configuration option usage OR /p:Configuration=Foo, if so, don't use these properties.
         if (_options.ConfigurationOption != null || globalProperties.ContainsKey(MSBuildPropertyNames.CONFIGURATION))
-            return new List<string> { $"-property:{EnvironmentVariableNames.DISABLE_PUBLISH_AND_PACK_RELEASE}=true" }; // Don't throw error if publish* conflicts but global config specified.
+            return [$"-property:{EnvironmentVariableNames.DISABLE_PUBLISH_AND_PACK_RELEASE}=true"]; // Don't throw error if publish* conflicts but global config specified.
 
         // Determine the project being acted upon
         ProjectInstance? project = GetTargetedProject(globalProperties);

--- a/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DotNet.Cli.Telemetry;
 internal class CIEnvironmentDetectorForTelemetry : ICIEnvironmentDetector
 {
     // Systems that provide boolean values only, so we can simply parse and check for true
-    private static readonly string[] _booleanVariables = new string[] {
+    private static readonly string[] _booleanVariables = [
         // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
         "TF_BUILD",
         // GitHub Actions - https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
@@ -20,25 +20,25 @@ internal class CIEnvironmentDetectorForTelemetry : ICIEnvironmentDetector
         "TRAVIS",
         // CircleCI - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
         "CIRCLECI",
-    };
+    ];
 
     // Systems where every variable must be present and not-null before returning true
-    private static readonly string[][] _allNotNullVariables = new string[][] {
+    private static readonly string[][] _allNotNullVariables = [
         // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
-        new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" },
+        ["CODEBUILD_BUILD_ID", "AWS_REGION"],
         // Jenkins - https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
-        new string[]{ "BUILD_ID", "BUILD_URL" },
+        ["BUILD_ID", "BUILD_URL"],
         // Google Cloud Build - https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
-        new string[]{ "BUILD_ID", "PROJECT_ID" }
-    };
+        ["BUILD_ID", "PROJECT_ID"]
+    ];
 
     // Systems where the variable must be present and not-null
-    private static readonly string[] _ifNonNullVariables = new string[] {
+    private static readonly string[] _ifNonNullVariables = [
         // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
         "TEAMCITY_VERSION",
         // JetBrains Space - https://www.jetbrains.com/help/space/automation-environment-variables.html#general
         "JB_SPACE_API_URL"
-    };
+    ];
 
     public bool IsCIEnvironment()
     {

--- a/src/Cli/dotnet/Telemetry/PersistenceChannel/FlushManager.cs
+++ b/src/Cli/dotnet/Telemetry/PersistenceChannel/FlushManager.cs
@@ -42,7 +42,7 @@ internal class FlushManager
     {
         if (telemetryItem != null)
         {
-            byte[] data = JsonSerializer.Serialize(new[] { telemetryItem });
+            byte[] data = JsonSerializer.Serialize([telemetryItem]);
             Transmission transmission = new(
                 EndpointAddress,
                 data,

--- a/src/Cli/dotnet/Telemetry/PersistenceChannel/PersistenceTransmitter.cs
+++ b/src/Cli/dotnet/Telemetry/PersistenceChannel/PersistenceTransmitter.cs
@@ -16,7 +16,7 @@ internal class PersistenceTransmitter : IDisposable
     /// <summary>
     ///     A list of senders that sends transmissions.
     /// </summary>
-    private readonly List<Sender> _senders = new();
+    private readonly List<Sender> _senders = [];
 
     /// <summary>
     ///     The storage that is used to persist all the transmissions.
@@ -71,7 +71,7 @@ internal class PersistenceTransmitter : IDisposable
             return;
         }
 
-        List<Task> stoppedTasks = new();
+        List<Task> stoppedTasks = [];
         foreach (Sender sender in _senders)
         {
             stoppedTasks.Add(sender.StopAsync());

--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -149,7 +149,7 @@ public class Telemetry : ITelemetry
             _client.Context.Device.OperatingSystem = CLIRuntimeEnvironment.OperatingSystem;
 
             _commonProperties = new TelemetryCommonProperties().GetTelemetryCommonProperties();
-            _commonMeasurements = new Dictionary<string, double>();
+            _commonMeasurements = [];
         }
         catch (Exception e)
         {

--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -82,42 +82,42 @@ internal class TelemetryFilter : ITelemetryFilter
             }).ToList();
     }
 
-    private static List<IParseResultLogRule> ParseResultLogRules => new()
-    {
-        new AllowListToSendFirstArgument(new HashSet<string> {"new", "help"}),
-        new AllowListToSendFirstAppliedOptions(new HashSet<string> {"add", "remove", "list", "solution", "nuget"}),
+    private static List<IParseResultLogRule> ParseResultLogRules =>
+    [
+        new AllowListToSendFirstArgument(["new", "help"]),
+        new AllowListToSendFirstAppliedOptions(["add", "remove", "list", "solution", "nuget"]),
         new TopLevelCommandNameAndOptionToLog
         (
-            topLevelCommandName: new HashSet<string> {"build", "publish"},
-            optionsToLog: new HashSet<CliOption> { BuildCommandParser.FrameworkOption, PublishCommandParser.FrameworkOption,
+            topLevelCommandName: ["build", "publish"],
+            optionsToLog: [ BuildCommandParser.FrameworkOption, PublishCommandParser.FrameworkOption,
                 BuildCommandParser.RuntimeOption, PublishCommandParser.RuntimeOption, BuildCommandParser.ConfigurationOption,
-                PublishCommandParser.ConfigurationOption }
+                PublishCommandParser.ConfigurationOption ]
         ),
         new TopLevelCommandNameAndOptionToLog
         (
-            topLevelCommandName: new HashSet<string> {"run", "clean", "test"},
-            optionsToLog: new HashSet<CliOption> { RunCommandParser.FrameworkOption, CleanCommandParser.FrameworkOption,
+            topLevelCommandName: ["run", "clean", "test"],
+            optionsToLog: [ RunCommandParser.FrameworkOption, CleanCommandParser.FrameworkOption,
                 TestCommandParser.FrameworkOption, RunCommandParser.ConfigurationOption, CleanCommandParser.ConfigurationOption,
-                TestCommandParser.ConfigurationOption }
+                TestCommandParser.ConfigurationOption ]
         ),
         new TopLevelCommandNameAndOptionToLog
         (
-            topLevelCommandName: new HashSet<string> {"pack"},
-            optionsToLog: new HashSet<CliOption> { PackCommandParser.ConfigurationOption }
+            topLevelCommandName: ["pack"],
+            optionsToLog: [PackCommandParser.ConfigurationOption]
         ),
         new TopLevelCommandNameAndOptionToLog
         (
-            topLevelCommandName: new HashSet<string> {"vstest"},
-            optionsToLog: new HashSet<CliOption> { CommonOptions.TestPlatformOption,
-                CommonOptions.TestFrameworkOption, CommonOptions.TestLoggerOption }
+            topLevelCommandName: ["vstest"],
+            optionsToLog: [ CommonOptions.TestPlatformOption,
+                CommonOptions.TestFrameworkOption, CommonOptions.TestLoggerOption ]
         ),
         new TopLevelCommandNameAndOptionToLog
         (
-            topLevelCommandName: new HashSet<string> {"publish"},
-            optionsToLog: new HashSet<CliOption> { PublishCommandParser.RuntimeOption }
+            topLevelCommandName: ["publish"],
+            optionsToLog: [PublishCommandParser.RuntimeOption]
         ),
-        new AllowListToSendVerbSecondVerbFirstArgument(new HashSet<string> {"workload", "tool", "new"}),
-    };
+        new AllowListToSendVerbSecondVerbFirstArgument(["workload", "tool", "new"]),
+    ];
 
     private static void LogVerbosityForAllTopLevelCommand(
         ICollection<ApplicationInsightsEntryFormat> result,

--- a/src/Cli/dotnet/ToolManifest/ToolManifestCannotBeFoundException.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestCannotBeFoundException.cs
@@ -7,12 +7,12 @@ namespace Microsoft.DotNet.Cli.ToolManifest;
 
 internal class ToolManifestCannotBeFoundException : GracefulException
 {
-    public ToolManifestCannotBeFoundException(string message) : base(new[] { message }, null, false)
+    public ToolManifestCannotBeFoundException(string message) : base([message], null, false)
     {
     }
 
     public ToolManifestCannotBeFoundException(string message, string optionalMessage)
-        : base(new[] { message }, new[] { optionalMessage }, false)
+        : base([message], [optionalMessage], false)
     {
     }
 }

--- a/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
@@ -68,7 +68,7 @@ internal class ToolManifestEditor : IToolManifestEditor
 
         if (deserializedManifest.Tools == null)
         {
-            deserializedManifest.Tools = new List<SerializableLocalToolSinglePackage>();
+            deserializedManifest.Tools = [];
         }
 
         deserializedManifest.Tools.Add(
@@ -160,7 +160,7 @@ internal class ToolManifestEditor : IToolManifestEditor
                 if (root.TryGetProperty(JsonPropertyTools, out var tools))
                 {
                     serializableLocalToolsManifest.Tools =
-                        new List<SerializableLocalToolSinglePackage>();
+                        [];
 
                     if (tools.ValueKind != JsonValueKind.Object)
                     {
@@ -233,7 +233,7 @@ internal class ToolManifestEditor : IToolManifestEditor
         FilePath path,
         DirectoryPath correspondingDirectory)
     {
-        List<ToolManifestPackage> result = new();
+        List<ToolManifestPackage> result = [];
         var errors = new List<string>();
 
         ValidateVersion(deserializedManifest, errors);
@@ -257,7 +257,7 @@ internal class ToolManifestEditor : IToolManifestEditor
         }
 
         foreach (var tools
-            in deserializedManifest.Tools ?? new List<SerializableLocalToolSinglePackage>())
+            in deserializedManifest.Tools ?? [])
         {
             var packageLevelErrors = new List<string>();
             var packageIdString = tools.PackageId;

--- a/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
@@ -159,8 +159,7 @@ internal class ToolManifestEditor : IToolManifestEditor
 
                 if (root.TryGetProperty(JsonPropertyTools, out var tools))
                 {
-                    serializableLocalToolsManifest.Tools =
-                        [];
+                    serializableLocalToolsManifest.Tools = [];
 
                     if (tools.ValueKind != JsonValueKind.Object)
                     {

--- a/src/Cli/dotnet/ToolManifest/ToolManifestException.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestException.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.ToolManifest;
 
 internal class ToolManifestException : GracefulException
 {
-    public ToolManifestException(string message) : base(new[] { message }, null, false)
+    public ToolManifestException(string message) : base([message], null, false)
     {
 
     }

--- a/src/Cli/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -62,7 +62,7 @@ internal class ToolManifestFinder : IToolManifestFinder, IToolManifestInspector
         if (!TryFindToolManifestPackages(allPossibleManifests, out var toolManifestPackageAndSource))
         {
             toolManifestPackageAndSource =
-                new List<(ToolManifestPackage toolManifestPackage, FilePath SourceManifest)>();
+                [];
         }
 
         return toolManifestPackageAndSource.ToArray();
@@ -74,7 +74,7 @@ internal class ToolManifestFinder : IToolManifestFinder, IToolManifestInspector
     {
         bool findAnyManifest = false;
         toolManifestPackageAndSource
-            = new List<(ToolManifestPackage toolManifestPackage, FilePath SourceManifest)>();
+            = [];
         foreach ((FilePath possibleManifest, DirectoryPath correspondingDirectory) in allPossibleManifests)
         {
             if (!_fileSystem.File.Exists(possibleManifest.Value))

--- a/src/Cli/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -32,9 +32,7 @@ internal class ToolManifestFinder : IToolManifestFinder, IToolManifestInspector
     public IReadOnlyCollection<ToolManifestPackage> Find(FilePath? filePath = null)
     {
         IEnumerable<(FilePath manifestfile, DirectoryPath _)> allPossibleManifests =
-            filePath != null
-                ? new[] { (filePath.Value, filePath.Value.GetDirectoryPath()) }
-                : EnumerateDefaultAllPossibleManifests();
+            filePath != null ? [(filePath.Value, filePath.Value.GetDirectoryPath())] : EnumerateDefaultAllPossibleManifests();
 
         var findAnyManifest =
             TryFindToolManifestPackages(allPossibleManifests, out var toolManifestPackageAndSource);
@@ -54,15 +52,11 @@ internal class ToolManifestFinder : IToolManifestFinder, IToolManifestInspector
         FilePath? filePath = null)
     {
         IEnumerable<(FilePath manifestfile, DirectoryPath _)> allPossibleManifests =
-            filePath != null
-                ? new[] { (filePath.Value, filePath.Value.GetDirectoryPath()) }
-                : EnumerateDefaultAllPossibleManifests();
-
+            filePath != null ? [(filePath.Value, filePath.Value.GetDirectoryPath())] : EnumerateDefaultAllPossibleManifests();
 
         if (!TryFindToolManifestPackages(allPossibleManifests, out var toolManifestPackageAndSource))
         {
-            toolManifestPackageAndSource =
-                [];
+            toolManifestPackageAndSource = [];
         }
 
         return toolManifestPackageAndSource.ToArray();
@@ -73,8 +67,7 @@ internal class ToolManifestFinder : IToolManifestFinder, IToolManifestInspector
         out List<(ToolManifestPackage toolManifestPackage, FilePath SourceManifest)> toolManifestPackageAndSource)
     {
         bool findAnyManifest = false;
-        toolManifestPackageAndSource
-            = [];
+        toolManifestPackageAndSource = [];
         foreach ((FilePath possibleManifest, DirectoryPath correspondingDirectory) in allPossibleManifests)
         {
             if (!_fileSystem.File.Exists(possibleManifest.Value))

--- a/src/Cli/dotnet/ToolPackage/LockFileMatchChecker.cs
+++ b/src/Cli/dotnet/ToolPackage/LockFileMatchChecker.cs
@@ -71,7 +71,7 @@ internal class LockFileMatcher
     {
         if (string.IsNullOrEmpty(path))
         {
-            return new string[0];
+            return [];
         }
 
         return path.Split('\\', '/');

--- a/src/Cli/dotnet/ToolPackage/ToolConfiguration.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfiguration.cs
@@ -28,7 +28,7 @@ internal class ToolConfiguration
 
         CommandName = commandName;
         ToolAssemblyEntryPoint = toolAssemblyEntryPoint;
-        Warnings = warnings ?? new List<string>();
+        Warnings = warnings ?? [];
     }
 
     private void EnsureNoInvalidFilenameCharacters(string commandName)

--- a/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
@@ -68,7 +68,7 @@ internal static class ToolConfigurationDeserializer
 
     private static List<string> GenerateWarningAccordingToVersionAttribute(DotNetCliTool dotNetCliTool)
     {
-        List<string> warnings = new();
+        List<string> warnings = [];
         if (string.IsNullOrWhiteSpace(dotNetCliTool.Version))
         {
             warnings.Add(CommonLocalizableStrings.FormatVersionIsMissing);

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -329,7 +329,7 @@ internal class ToolPackageDownloader : IToolPackageDownloader
             Name = packageId.ToString(),
             Version = version,
             Type = LibraryType.Package,
-            PackageType = new List<PackageType>() { PackageType.DotnetTool }
+            PackageType = [PackageType.DotnetTool]
         };
 
         //  Create NuGetv3LocalRepository

--- a/src/Common/WorkloadFileBasedInstall.cs
+++ b/src/Common/WorkloadFileBasedInstall.cs
@@ -53,7 +53,7 @@ static class WorkloadFileBasedInstall
             return Enumerable.Empty<WorkloadHistoryRecord>();
         }
 
-        List<WorkloadHistoryRecord> historyRecords = new();
+        List<WorkloadHistoryRecord> historyRecords = [];
 
         foreach (var file in Directory.GetFiles(workloadHistoryDirectory, "*.json"))
         {


### PR DESCRIPTION
## Summary

This is running the automatic cleanup for IDE0028 and IDE0300, "Collection initialization can be simplified", in the `dotnet` and `Cli.Utils` projects. Any other formatting changes are a result of that analyzer. ~~No manual code changes were made.~~ Manual adjustments to style were made after PR feedback.

> [!NOTE]  
> The tool crashes the first time trying to run it on the `dotnet` project. To get the tool to run properly, run it once, let it crash, hit the `Enable` button on the gold banner that appears, and run it again.

## Tool in VS

### IDE0028
![image](https://github.com/user-attachments/assets/ccc562a7-09f5-456e-9e1e-d5fd60638ebf)

### IDE0300
![image](https://github.com/user-attachments/assets/2fbe3483-9b64-46a7-a649-e17473975c3f)

