### PR TITLE
Do not include symbols nupkgs in PSB archive

### DIFF
--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -227,10 +227,12 @@
     <!-- Inputs: Packages to include in the tarball -->
     <ItemGroup>
       <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
-                                          $(ArtifactsNonShippingPackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
-      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+                                          $(ArtifactsNonShippingPackagesDir)**" />
+      <ArtifactsPackageToBundle Remove="@(ArtifactsPackageToBundle)"
+                                Condition="$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**" />
+      <ReferencePackageToBundle Remove="@(ReferencePackageToBundle)"
+                                Condition="$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
       <MergedAssetManifest Include="$(MergedAssetManifestOutputPath)" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4973

This PR fixes the issue with conditioning out of symbols nupkgs when creating the PSB archive. It appears that current code never worked. This has suddenly become apparent as repo publishing process is now publishing these symbols nupkgs, even in source-build, which was not the case before. To ensure that we don't get regressed by any future publishing changes, the fix is being implemented in source-build's post-build target, and fixes the previously broken code.

This issue is unrelated to packaging of symbols in a separate archive. Symbols (PDBs) are collected using a completely different method, and not from symbols nupkgs.