### PR TITLE
Fix sdk msi's relative layout path

### DIFF
--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -87,7 +87,7 @@
 
   <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is
        necessary for the msi/pkg to install correctly and put the content under that sub path. -->
-  <Target Name="PrepareSdkInstallerLayout" DependsOnTargets="GenerateSdkLayout">
+  <Target Name="PrepareIntermediateSdkInstallerOutput" DependsOnTargets="GenerateSdkLayout">
     <PropertyGroup>
       <IntermediateSdkInstallerOutputPath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'sdk-installer'))</IntermediateSdkInstallerOutputPath>
     </PropertyGroup>

--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -66,7 +66,7 @@
 
   <!-- Replace files from the runtime packs with symbolic links to the corresponding shared framework files (and hostfxr) to reduce the size of the runtime pack directories. -->
   <Target Name="ReplaceBundledRuntimePackFilesWithSymbolicLinks" DependsOnTargets="LayoutBundledComponents"
-                                                                 Condition="'$(BundleRuntimePacks)' == 'true' and  !$([MSBuild]::IsOSPlatform('WINDOWS'))">
+                                                                 Condition="'$(BundleRuntimePacks)' == 'true' and !$([MSBuild]::IsOSPlatform('WINDOWS'))">
     <ReplaceFilesWithSymbolicLinks Directory="$(RedistInstallerLayoutPath)/packs/Microsoft.NETCore.App.Runtime.$(SharedFrameworkRid)/$(MicrosoftNETCoreAppRuntimePackageVersion)" LinkToFilesFrom="$(RedistInstallerLayoutPath)/shared/Microsoft.NETCore.App/$(MicrosoftNETCoreAppRuntimePackageVersion)" />
     <ReplaceFilesWithSymbolicLinks Directory="$(RedistInstallerLayoutPath)/packs/Microsoft.NETCore.App.Runtime.$(SharedFrameworkRid)/$(MicrosoftNETCoreAppRuntimePackageVersion)" LinkToFilesFrom="$(RedistInstallerLayoutPath)/host/fxr/$(MicrosoftNETCoreAppRuntimePackageVersion)" />
     <ReplaceFilesWithSymbolicLinks Directory="$(RedistInstallerLayoutPath)/packs/Microsoft.AspNetCore.App.Runtime.$(SharedFrameworkRid)/$(MicrosoftAspNetCoreAppRuntimePackageVersion)" LinkToFilesFrom="$(RedistInstallerLayoutPath)/shared/Microsoft.AspNetCore.App/$(MicrosoftAspNetCoreAppRuntimePackageVersion)" />
@@ -84,5 +84,23 @@
                             CrossgenLayout;
                             ReplaceBundledRuntimePackFilesWithSymbolicLinks"
           AfterTargets="Build" />
+
+  <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is
+       necessary for the msi/pkg to install correctly and put the content under that sub path. -->
+  <Target Name="PrepareSdkInstallerLayout" DependsOnTargets="GenerateSdkLayout">
+    <PropertyGroup>
+      <IntermediateSdkInstallerOutputPath>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'sdk-installer'))</IntermediateSdkInstallerOutputPath>
+    </PropertyGroup>
+
+    <!-- Create "SDK Internal" layout. -->
+    <ItemGroup>
+      <SdkOutputFile Include="$(OutputPath)**\*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(SdkOutputFile)"
+          DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')"
+          UseHardLinksIfPossible="true"
+          SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -93,8 +93,8 @@
   </Target>
 
   <Target Name="GenerateSdkMsi"
-          DependsOnTargets="GenerateInstallerLayout;AcquireWix;MsiTargetsSetupInputOutputs"
-          Inputs="$(OutputPath)**/*;
+          DependsOnTargets="GenerateInstallerLayout;AcquireWix;MsiTargetsSetupInputOutputs;PrepareSdkInstallerLayout"
+          Inputs="$(IntermediateSdkInstallerOutputPath)**/*;
                   $(SdkGenerateMsiPowershellScript)"
           Outputs="$(SdkMSIInstallerFile)">
     <GenerateGuidFromName Name="$(SdkMSIInstallerFile)">
@@ -102,7 +102,7 @@
     </GenerateGuidFromName>
 
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript) ^
-                      '$(OutputPath.TrimEnd('\'))' ^
+                      '$(IntermediateSdkInstallerOutputPath.TrimEnd('\'))' ^
                       '$(SdkMSIInstallerFile)' ^
                       '$(WixRoot)' ^
                       '$(ToolsetBrandName)' ^

--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -93,7 +93,7 @@
   </Target>
 
   <Target Name="GenerateSdkMsi"
-          DependsOnTargets="GenerateInstallerLayout;AcquireWix;MsiTargetsSetupInputOutputs;PrepareSdkInstallerLayout"
+          DependsOnTargets="GenerateInstallerLayout;AcquireWix;MsiTargetsSetupInputOutputs;PrepareIntermediateSdkInstallerOutput"
           Inputs="$(IntermediateSdkInstallerOutputPath)**/*;
                   $(SdkGenerateMsiPowershellScript)"
           Outputs="$(SdkMSIInstallerFile)">

--- a/src/Layout/redist/targets/GeneratePKG.targets
+++ b/src/Layout/redist/targets/GeneratePKG.targets
@@ -139,28 +139,13 @@
   <Target Name="GenerateSdkPkg"
           Inputs="@(GenerateSdkPkgInputs)"
           Outputs="$(SdkPKGInstallerFile)"
-          DependsOnTargets="GenerateInstallerLayout;SetupPkgInputsOutputs">
-    <!-- Copy the sdk layout into a temporary folder to be able to make changes to it. -->
-    <PropertyGroup>
-      <SdkInternalLayoutPath>$(IntermediateOutputPath)installer/</SdkInternalLayoutPath>
-    </PropertyGroup>
-
-    <!-- Create "SDK Internal" layout. -->
-    <ItemGroup>
-      <SdkOutputFile Include="$(OutputPath)**/*" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(SdkOutputFile)"
-          DestinationFiles="@(SdkOutputFile -> '$(SdkInternalLayoutPath)sdk/$(Version)/%(RecursiveDir)%(Filename)%(Extension)')"
-          UseHardLinksIfPossible="true"
-          SkipUnchangedFiles="true" />
-
+          DependsOnTargets="GenerateInstallerLayout;SetupPkgInputsOutputs;PrepareSdkInstallerLayout">
     <!-- Copy ASP.NET runtime and targeting pack to internal layout, as we don't currently chain that in with a pkg dependency -->
     <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetCoreSharedFxArchiveFileName)"
-                               DestinationDirectory="$(SdkInternalLayoutPath)"
+                               DestinationDirectory="$(IntermediateSdkInstallerOutputPath)"
                                DirectoriesToCopy="shared/Microsoft.AspNetCore.App" />
     <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetTargetingPackArchiveFileName)"
-                               DestinationDirectory="$(SdkInternalLayoutPath)" />
+                               DestinationDirectory="$(IntermediateSdkInstallerOutputPath)" />
 
     <ItemGroup>
       <TemplateFiles Include="$(RedistInstallerLayoutPath)templates/**/*" />
@@ -168,12 +153,12 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(TemplateFiles)"
-          DestinationFiles="@(TemplateFiles->'$(SdkInternalLayoutPath)templates/%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(TemplateFiles->'$(IntermediateSdkInstallerOutputPath)templates/%(RecursiveDir)%(Filename)%(Extension)')"
           UseHardLinksIfPossible="true"
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(ManifestFiles)"
-          DestinationFiles="@(ManifestFiles->'$(SdkInternalLayoutPath)sdk-manifests/%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(ManifestFiles->'$(IntermediateSdkInstallerOutputPath)sdk-manifests/%(RecursiveDir)%(Filename)%(Extension)')"
           UseHardLinksIfPossible="true"
           SkipUnchangedFiles="true" />
 
@@ -192,7 +177,7 @@
     <Exec Command="chmod ugo+x $(SdkPkgScriptFile)" />
 
     <Exec Command="pkgbuild \
-                    --root '$(SdkInternalLayoutPath)' \
+                    --root '$(IntermediateSdkInstallerOutputPath)' \
                     --identifier '$(SdkComponentId)' \
                     --version '$(Version)' \
                     --install-location '$(PkgInstallDirectory)' \

--- a/src/Layout/redist/targets/GeneratePKG.targets
+++ b/src/Layout/redist/targets/GeneratePKG.targets
@@ -139,8 +139,8 @@
   <Target Name="GenerateSdkPkg"
           Inputs="@(GenerateSdkPkgInputs)"
           Outputs="$(SdkPKGInstallerFile)"
-          DependsOnTargets="GenerateInstallerLayout;SetupPkgInputsOutputs;PrepareSdkInstallerLayout">
-    <!-- Copy ASP.NET runtime and targeting pack to internal layout, as we don't currently chain that in with a pkg dependency -->
+          DependsOnTargets="GenerateInstallerLayout;SetupPkgInputsOutputs;PrepareIntermediateSdkInstallerOutput">
+    <!-- Copy ASP.NET runtime and targeting pack to the sdk layout, as we currently don't chain that in with a pkg dependency -->
     <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetCoreSharedFxArchiveFileName)"
                                DestinationDirectory="$(IntermediateSdkInstallerOutputPath)"
                                DirectoriesToCopy="shared/Microsoft.AspNetCore.App" />


### PR DESCRIPTION
... and consolidate with the same pkg infrastructure

---

> the SDK is no longer installing to the correct folder in Windows. It's placing the install under Program Files\dotnet instead of Program Files\dotnet\sdk\10.0.xxxx

The PR fixes that.