### PR TITLE
Use hardlinks for preparing the testhost folder

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -32,7 +32,8 @@
     <!-- Copy artifacts to the testhost folder. -->
     <Copy DestinationFiles="@(InstallerOutputFile)"
           SourceFiles="@(InstallerOutputFile->Metadata('Source'))"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          UseHardLinksIfPossible="true" />
   </Target>
 
   <Target Name="PublishTestWorkloads"


### PR DESCRIPTION
This should save ~5GB of disk space when building the sdk repo.