### PR TITLE
Make it possible to prep other RIDs and architectures

### DIFF
--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -13,7 +13,8 @@
 ###   --no-sdk                    Exclude the download of the .NET SDK
 ###   --artifacts-rid             The RID of the previously source-built artifacts archive to download
 ###                               Default is centos.9-x64
-###   --rid, --target-rid <value> Overrides the target rid for the build. e.g. alpine.3.18-arm64, fedora.37-x64, freebsd.13-arm64, ubuntu.19.10-x64
+###   --bootstrap-rid <value>     The (portable) RID for the bootstrap artifacts to restore. For example, linux-arm64, linux-musl-x64
+###                               Default is the current portable RID.
 ###   --runtime-source-feed       URL of a remote server or a local directory, from which SDKs and
 ###                               runtimes can be downloaded
 ###   --runtime-source-feed-key   Key for accessing the above server, if necessary
@@ -49,7 +50,7 @@ downloadPrebuilts=true
 removeBinaries=true
 installDotnet=true
 artifactsRid=$defaultArtifactsRid
-target_rid=''
+bootstrap_rid=''
 runtime_source_feed='' # IBM requested these to support s390x scenarios
 runtime_source_feed_key='' # IBM requested these to support s390x scenarios
 
@@ -83,8 +84,8 @@ while :; do
     --artifacts-rid)
       artifactsRid=$2
       ;;
-    --rid|--target-rid)
-      target_rid=$2
+    --bootstrap-rid)
+      bootstrap_rid=$2
       shift
       ;;
     --runtime-source-feed)
@@ -203,8 +204,8 @@ function BootstrapArtifacts {
   fi
 
   properties=( "/p:ArchiveDir=$packagesArchiveDir" )
-  if [[ -n "$target_rid" ]]; then
-    properties+=( "/p:TargetRid=$target_rid" )
+  if [[ -n "$bootstrap_rid" ]]; then
+    properties+=( "/p:PortableRid=$bootstrap_rid" )
   fi
 
   # Run restore on project to initiate download of bootstrap packages


### PR DESCRIPTION
Before #46575 (commit cfe99e0e4437d147f2c5830cb8ff5d0d8b4fc673), a ./prep-source-build.sh in the VMR would produce a
Private.SourceBuilt.Artifacts.Bootstrap.tar.gz that would contain assets for all architectuers and portable RIDs. However, after that change, it becomes difficult to generate bootstrap artifacts for arm64 on x64. The expected approach doesn't work:

    $ ./prep-source-build.sh --rid linux-arm64

This has no effect, because it only sets TargetRid; the logic that computes what packages to download only uses PortableRid.

After this commit, running the above command produces a bootstrap archive that contains arm64 artifacts too:

        $ tar tf ./prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz | grep linux
        Microsoft.AspNetCore.App.Runtime.linux-arm64.10.0.0-preview.2.25164.1.nupkg
        Microsoft.NETCore.App.Crossgen2.linux-arm64.10.0.0-preview.2.25163.2.nupkg
        Microsoft.NETCore.App.Crossgen2.linux-x64.10.0.0-preview.2.25163.2.nupkg
        Microsoft.NETCore.App.Crossgen2.linux-x64.10.0.0-preview.2.25163.2.symbols.nupkg
        Microsoft.NETCore.App.Host.linux-arm64.10.0.0-preview.2.25163.2.nupkg
        Microsoft.NETCore.App.Runtime.linux-arm64.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.Microsoft.DotNet.ILCompiler.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.Microsoft.NETCore.ILAsm.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.Microsoft.NETCore.ILDAsm.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.Microsoft.NETCore.TestHost.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-arm64.runtime.native.System.IO.Ports.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-x64.Microsoft.DotNet.ILCompiler.10.0.0-preview.2.25163.2.nupkg
        runtime.linux-x64.Microsoft.DotNet.ILCompiler.10.0.0-preview.2.25163.2.symbols.nupkg