### PR TITLE
Remove EnableDefenderForLinux 1ES PT feature flag

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -83,7 +83,6 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     featureFlags:
-      EnableDefenderForLinux: true
       incrementalSDLBinaryAnalysis: true
     sdl:
       sourceAnalysisPool:


### PR DESCRIPTION
It is turned on by default in the dnceng org now.