### PR TITLE
Fixes #44839 to unblock runtime when changes TFMs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -33,7 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
         <!-- This is for a better error experience when using an older VS (with an older SDK) to target a newer TFM. The value should be the min VS version for N+1 version-->
-        <UnsupportedTargetFrameworkVersion>11.0</UnsupportedTargetFrameworkVersion>
+        <UnsupportedTargetFrameworkVersion>$([MSBuild]::Add($(NETCoreAppMaximumVersion), 1)).0</UnsupportedTargetFrameworkVersion>
         <MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>17.16</MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes #44839 to unblock runtime when changes TFMs
The add method trims off the end. Not sure if there's a different method that doesn't.