### PR TITLE
allow @ syntax for package versions in package add

### DIFF
--- a/src/Cli/dotnet/Commands/Add/Package/AddPackageParser.cs
+++ b/src/Cli/dotnet/Commands/Add/Package/AddPackageParser.cs
@@ -31,16 +31,17 @@ internal static class AddPackageParser
         command.Options.Add(PackageAddCommandParser.PrereleaseOption);
         command.Options.Add(PackageCommandParser.ProjectOption);
 
-        command.SetAction((parseResult) => {
+        command.SetAction((parseResult) =>
+        {
             // this command can be called with an argument or an option for the project path - we prefer the option.
             // if the option is not present, we use the argument value instead.
             if (parseResult.HasOption(PackageCommandParser.ProjectOption))
             {
-                new AddPackageReferenceCommand(parseResult, parseResult.GetValue(PackageCommandParser.ProjectOption)).Execute();
+                return new AddPackageReferenceCommand(parseResult, parseResult.GetValue(PackageCommandParser.ProjectOption)).Execute();
             }
             else
             {
-                new AddPackageReferenceCommand(parseResult, parseResult.GetValue(AddCommandParser.ProjectArgument)).Execute();
+                return new AddPackageReferenceCommand(parseResult, parseResult.GetValue(AddCommandParser.ProjectArgument)).Execute();
             }
         });
 

--- a/src/Cli/dotnet/Commands/Add/Package/AddPackageParser.cs
+++ b/src/Cli/dotnet/Commands/Add/Package/AddPackageParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Tools.Package.Add;
 using LocalizableStrings = Microsoft.DotNet.Tools.Package.Add.LocalizableStrings;
 
@@ -30,7 +31,18 @@ internal static class AddPackageParser
         command.Options.Add(PackageAddCommandParser.PrereleaseOption);
         command.Options.Add(PackageCommandParser.ProjectOption);
 
-        command.SetAction((parseResult) => new AddPackageReferenceCommand(parseResult).Execute());
+        command.SetAction((parseResult) => {
+            // this command can be called with an argument or an option for the project path - we prefer the option.
+            // if the option is not present, we use the argument value instead.
+            if (parseResult.HasOption(PackageCommandParser.ProjectOption))
+            {
+                new AddPackageReferenceCommand(parseResult, parseResult.GetValue(PackageCommandParser.ProjectOption)).Execute();
+            }
+            else
+            {
+                new AddPackageReferenceCommand(parseResult, parseResult.GetValue(AddCommandParser.ProjectArgument)).Execute();
+            }
+        });
 
         return command;
     }

--- a/src/Cli/dotnet/Commands/New/DotnetCommandCallbacks.cs
+++ b/src/Cli/dotnet/Commands/New/DotnetCommandCallbacks.cs
@@ -20,7 +20,7 @@ internal static class DotnetCommandCallbacks
         {
             commandArgs = commandArgs.Append(PackageAddCommandParser.VersionOption.Name).Append(version);
         }
-        var addPackageReferenceCommand = new AddPackageReferenceCommand(AddCommandParser.GetCommand().Parse(commandArgs.ToArray()));
+        var addPackageReferenceCommand = new AddPackageReferenceCommand(AddCommandParser.GetCommand().Parse(commandArgs.ToArray()), projectPath);
         return addPackageReferenceCommand.Execute() == 0;
     }
 

--- a/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
+++ b/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
@@ -124,7 +124,7 @@
     <value>Command to add package reference</value>
   </data>
   <data name="CmdPackageDescription" xml:space="preserve">
-    <value>The package reference to add.</value>
+    <value>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</value>
   </data>
   <data name="SpecifyExactlyOnePackageReference" xml:space="preserve">
     <value>Specify one package reference to add.</value>

--- a/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
+++ b/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
@@ -170,7 +170,7 @@
     <comment>{Locked="--version"}</comment>
   </data>
   <data name="InvalidSemVerVersionString" xml:space="preserve">
-    <value>$"Invalid version string: {0}."</value>
+    <value>Failed to parse "{0}" as a semantic version.</value>
     <comment>{0} is a version string that the user entered that was not parsed as a Semantic Version</comment>
   </data>
 </root>

--- a/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
+++ b/src/Cli/dotnet/Commands/Package/Add/LocalizableStrings.resx
@@ -165,4 +165,12 @@
   <data name="CmdDGFileIOException" xml:space="preserve">
     <value>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</value>
   </data>
+  <data name="ValidationFailedDuplicateVersion" xml:space="preserve">
+    <value>Cannot specify --version when the package argument already contains a version.</value>
+    <comment>{Locked="--version"}</comment>
+  </data>
+  <data name="InvalidSemVerVersionString" xml:space="preserve">
+    <value>$"Invalid version string: {0}."</value>
+    <comment>{0} is a version string that the user entered that was not parsed as a Semantic Version</comment>
+  </data>
 </root>

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
@@ -41,7 +41,7 @@ internal static class PackageAddCommandParser
             }
             else
             {
-                throw new ArgumentException($"Invalid version string: {versionString}.");
+                throw new ArgumentException(string.Format(LocalizableStrings.InvalidSemVerVersionString, versionString));
             }
         };
     }
@@ -135,7 +135,7 @@ internal static class PackageAddCommandParser
         command.Options.Add(PrereleaseOption);
         command.Options.Add(PackageCommandParser.ProjectOption);
 
-        command.SetAction((parseResult) => new AddPackageReferenceCommand(parseResult).Execute());
+        command.SetAction((parseResult) => new AddPackageReferenceCommand(parseResult, parseResult.GetValue(PackageCommandParser.ProjectOption)).Execute());
 
         return command;
     }
@@ -144,7 +144,7 @@ internal static class PackageAddCommandParser
     {
         if (result.Parent.GetValue(CmdPackageArgument) is PackageIdentity identity && identity.HasVersion)
         {
-            result.AddError("Cannot specify --version when the package argument already has a version.");
+            result.AddError(LocalizableStrings.ValidationFailedDuplicateVersion);
         }
     }
 

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
@@ -8,15 +8,50 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Versioning;
 using Microsoft.DotNet.Tools.Package.Add;
 using Microsoft.DotNet.Cli.Extensions;
+using System.CommandLine.Parsing;
+using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli;
 
 internal static class PackageAddCommandParser
 {
-    public static readonly CliArgument<string> CmdPackageArgument = new DynamicArgument<string>(LocalizableStrings.CmdPackage)
+    public static NuGet.Packaging.Core.PackageIdentity ParsePackageIdentity(ArgumentResult packageArgResult)
+    {
+        // per the Arity of the CmdPackageArgument's Arity, we should have exactly one token - 
+        // this is a safety net for if we change the Arity in the future and forget to update this parser.
+        if (packageArgResult.Tokens.Count != 1)
+        {
+            throw new ArgumentException($"Expected exactly one token, but got {packageArgResult.Tokens.Count}.");
+        }
+        var token = packageArgResult.Tokens[0].Value;
+        var indexOfAt = token.IndexOf('@');
+        if (indexOfAt == -1)
+        {
+            // no version specified, so we just return the package id
+            return new NuGet.Packaging.Core.PackageIdentity(token, null);
+        }
+        // we have a version specified, so we need to split the token into id and version
+        else
+        {
+            var id = token[0..indexOfAt];
+            var versionString = token[(indexOfAt + 1)..];
+            if (NuGet.Versioning.SemanticVersion.TryParse(versionString, out var version))
+            {
+                return new NuGet.Packaging.Core.PackageIdentity(id, new NuGetVersion(version.Major, version.Minor, version.Patch, version.ReleaseLabels, version.Metadata));
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid version string: {versionString}.");
+            }
+        };
+    }
+
+    public static readonly CliArgument<NuGet.Packaging.Core.PackageIdentity> CmdPackageArgument = new DynamicArgument<NuGet.Packaging.Core.PackageIdentity>(LocalizableStrings.CmdPackage)
     {
         Description = LocalizableStrings.CmdPackageDescription,
-        Arity = ArgumentArity.ExactlyOne
+        Arity = ArgumentArity.ExactlyOne,
+        CustomParser = ParsePackageIdentity,
+
     }.AddCompletions((context) =>
     {
         // we should take --prerelease flags into account for version completion
@@ -32,11 +67,11 @@ internal static class PackageAddCommandParser
         .AddCompletions((context) =>
         {
             // we can only do version completion if we have a package id
-            if (context.ParseResult.GetValue(CmdPackageArgument) is string packageId)
+            if (context.ParseResult.GetValue(CmdPackageArgument) is NuGet.Packaging.Core.PackageIdentity packageId && !packageId.HasVersion)
             {
                 // we should take --prerelease flags into account for version completion
                 var allowPrerelease = context.ParseResult.GetValue(PrereleaseOption);
-                return QueryVersionsForPackage(packageId, context.WordToComplete, allowPrerelease, CancellationToken.None)
+                return QueryVersionsForPackage(packageId.Id, context.WordToComplete, allowPrerelease, CancellationToken.None)
                     .Result
                     .Select(version => new CompletionItem(version.ToNormalizedString()));
             }
@@ -89,6 +124,7 @@ internal static class PackageAddCommandParser
     {
         CliCommand command = new("add", LocalizableStrings.AppFullName);
 
+        VersionOption.Validators.Add(DisallowVersionIfPackageIdentityHasVersionValidator);
         command.Arguments.Add(CmdPackageArgument);
         command.Options.Add(VersionOption);
         command.Options.Add(FrameworkOption);
@@ -102,6 +138,14 @@ internal static class PackageAddCommandParser
         command.SetAction((parseResult) => new AddPackageReferenceCommand(parseResult).Execute());
 
         return command;
+    }
+
+    private static void DisallowVersionIfPackageIdentityHasVersionValidator(OptionResult result)
+    {
+        if (result.Parent.GetValue(CmdPackageArgument) is PackageIdentity identity && identity.HasVersion)
+        {
+            result.AddError("Cannot specify --version when the package argument already has a version.");
+        }
     }
 
     public static async Task<IEnumerable<string>> QueryNuGet(string packageStem, bool allowPrerelease, CancellationToken cancellationToken)

--- a/src/Cli/dotnet/Commands/Package/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/Program.cs
@@ -17,7 +17,7 @@ internal class AddPackageReferenceCommand(ParseResult parseResult) : CommandBase
     private readonly string _fileOrDirectory =
         parseResult.HasOption(PackageCommandParser.ProjectOption) ?
             parseResult.GetValue(PackageCommandParser.ProjectOption) :
-            parseResult.GetValue(AddCommandParser.ProjectArgument);      
+            parseResult.GetValue(AddCommandParser.ProjectArgument);
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Package/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/Program.cs
@@ -11,25 +11,26 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Tools.Package.Add;
 
-internal class AddPackageReferenceCommand(ParseResult parseResult) : CommandBase(parseResult)
+/// <param name="parseResult"></param>
+/// <param name="fileOrDirectory">
+/// Since this command is invoked via both 'package add' and 'add package', different symbols will control what the project path to search is. 
+/// It's cleaner for the separate callsites to know this instead of pushing that logic here.
+/// </param>
+internal class AddPackageReferenceCommand(ParseResult parseResult, string fileOrDirectory) : CommandBase(parseResult)
 {
     private readonly PackageIdentity _packageId = parseResult.GetValue(PackageAddCommandParser.CmdPackageArgument);
-    private readonly string _fileOrDirectory =
-        parseResult.HasOption(PackageCommandParser.ProjectOption) ?
-            parseResult.GetValue(PackageCommandParser.ProjectOption) :
-            parseResult.GetValue(AddCommandParser.ProjectArgument);
 
     public override int Execute()
     {
         var projectFilePath = string.Empty;
 
-        if (!File.Exists(_fileOrDirectory))
+        if (!File.Exists(fileOrDirectory))
         {
-            projectFilePath = MsbuildProject.GetProjectFileFromDirectory(_fileOrDirectory).FullName;
+            projectFilePath = MsbuildProject.GetProjectFileFromDirectory(fileOrDirectory).FullName;
         }
         else
         {
-            projectFilePath = _fileOrDirectory;
+            projectFilePath = fileOrDirectory;
         }
 
         var tempDgFilePath = string.Empty;

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Příkaz pro přidání odkazu na balíček</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Zadejte jeden odkaz na balíček, který chcete přidat.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Nejde generovat dočasný soubor pro projekt {0}. Není možné přidat odkaz na balíček. Vyprázdněte dočasný adresář a zkuste to znovu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Odkaz na balíček, který se má přidat</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Odkaz na balíček, který se má přidat</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Der hinzuzufügende Paketverweis.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Der hinzuzufügende Paketverweis.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Befehl zum Hinzufügen eines Paketverweises</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Geben Sie einen Paketverweis an, der hinzugefügt werden soll.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Für das Projekt "{0}" kann keine temporäre Datei generiert werden. Ein Paketverweis kann nicht hinzugefügt werden. Löschen Sie das temporäre Verzeichnis, und versuchen Sie es noch mal.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">La referencia de paquete para agregar.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">La referencia de paquete para agregar.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando para agregar referencia de paquete</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Especifique una referencia de paquete para agregar.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">No se puede generar un archivo temporal para el proyecto "{0}". No se puede agregar la referencia del paquete. Borre el directorio temporal e inténtelo de nuevo.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Commande permettant d'ajouter une référence de package</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Spécifiez une seule référence de package à ajouter.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Impossible de générer un fichier temporaire pour le projet '{0}'. Impossible d'ajouter une référence de package. Effacez le répertoire temporaire et réessayez.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Référence du package à ajouter.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Référence du package à ajouter.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando per aggiungere il riferimento al pacchetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Specificare almeno un riferimento al pacchetto da aggiungere.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Non è possibile generare un file temporaneo per il progetto '{0}'. Non è possibile aggiungere il riferimento al pacchetto. Cancellare la directory temp e riprovare.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Riferimento al pacchetto da aggiungere.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Riferimento al pacchetto da aggiungere.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">パッケージ参照を追加するコマンド</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">追加するパッケージ参照を 1 つ指定してください。</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">プロジェクト '{0}' の一時ファイルを生成できません。パッケージ参照を追加できません。一時ディレクトリをクリアして、もう一度お試しください。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">追加するパッケージ参照。</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">追加するパッケージ参照。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">패키지 참조를 추가하는 명령</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">추가할 패키지 참조를 하나 지정하세요.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">'{0}' 프로젝트에 대한 임시 파일을 생성할 수 없습니다. 패키지 참조를 추가할 수 없습니다. 임시 디렉터리를 지우고 다시 시도하세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">추가할 패키지 참조입니다.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">추가할 패키지 참조입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Odwołanie do pakietu do dodania.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Odwołanie do pakietu do dodania.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Polecenie umożliwiające dodanie odwołania do pakietu</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Podaj jedno odwołanie do pakietu, które ma zostać dodane.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Nie można wygenerować pliku tymczasowego dla projektu „{0}”. Nie można dodać odwołania do pakietu. Wyczyść katalog tymczasowy i spróbuj ponownie.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando para adicionar a referência do pacote</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Especifique uma referência do pacote a ser adicionada.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Não é possível gerar um arquivo temporário para o projeto '{0}'. Não é possível adicionar a referência do pacote. Limpe o diretório temporário e tente novamente.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">A referência do pacote a adicionar.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">A referência do pacote a adicionar.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Команда добавления ссылки на пакет</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Укажите одну добавляемую ссылку на пакет.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">Не удалось создать временный файл для проекта "{0}". Невозможно добавить ссылку на пакет. Очистите временный каталог и повторите попытку.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Добавляемая ссылка на пакет.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Добавляемая ссылка на пакет.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">Eklenecek paket başvurusu.</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">Eklenecek paket başvurusu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Paket başvurusu ekleme komutu</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">Eklenecek tek bir paket başvurusu belirtin.</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">'{0}' projesi için geçici dosya oluşturulamıyor. Paket başvurusu eklenemiyor. Geçici dizini temizleyin ve yeniden deneyin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">要添加的包引用。</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">要添加的包引用。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">添加包引用的命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">请指定一个要添加的包引用。</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">无法为项目“{0}”生成临时文件。无法添加包引用。请清除临时目录，然后再重试。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidSemVerVersionString">
-        <source>$"Invalid version string: {0}."</source>
-        <target state="new">$"Invalid version string: {0}."</target>
+        <source>Failed to parse "{0}" as a semantic version.</source>
+        <target state="new">Failed to parse "{0}" as a semantic version.</target>
         <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">用以新增套件參考的命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSemVerVersionString">
+        <source>$"Invalid version string: {0}."</source>
+        <target state="new">$"Invalid version string: {0}."</target>
+        <note>{0} is a version string that the user entered that was not parsed as a Semantic Version</note>
+      </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageReference">
         <source>Specify one package reference to add.</source>
         <target state="translated">請指定一個要新增的套件參考。</target>
@@ -81,6 +86,11 @@
         <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Clear the temp directory and try again.</source>
         <target state="translated">無法產生專案 '{0}' 的暫存檔案。無法新增套件參考。請清除該暫存目錄，然後再試一次。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ValidationFailedDuplicateVersion">
+        <source>Cannot specify --version when the package argument already contains a version.</source>
+        <target state="new">Cannot specify --version when the package argument already contains a version.</target>
+        <note>{Locked="--version"}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/Package/Add/xlf/LocalizableStrings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdPackageDescription">
-        <source>The package reference to add.</source>
-        <target state="translated">要新增的套件參考。</target>
+        <source>The package reference to add. This can be in the form of just the package identifier, for example 'Newtonsoft.Json', or a package identifier and version separated by '@', for example 'Newtonsoft.Json@13.0.3'</source>
+        <target state="needs-review-translation">要新增的套件參考。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPackage">

--- a/src/Cli/dotnet/Commands/Package/PackageCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/PackageCommandParser.cs
@@ -10,9 +10,11 @@ internal class PackageCommandParser
 {
     private const string DocsLink = "https://aka.ms/dotnet-package";
 
-    public static readonly CliOption<string> ProjectOption = new("--project")
+    public static readonly CliOption<string> ProjectOption = new CliOption<string>("--project")
     {
-        Recursive = true
+        Recursive = true,
+        DefaultValueFactory = _ => Environment.CurrentDirectory,
+        Description = CommonLocalizableStrings.ProjectArgumentDescription
     };
 
     public static CliCommand GetCommand()

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -261,5 +261,9 @@ public static class ParseResultExtensions
         }
     }
 
-    public static bool HasOption(this ParseResult parseResult, CliOption option) => parseResult.GetResult(option) is not null;
+    /// <summary>
+    /// Checks if the option is present and not implicit (i.e. not set by default).
+    /// This is useful for checking if the user has explicitly set an option, as opposed to it being set by default.
+    /// </summary>
+    public static bool HasOption(this ParseResult parseResult, CliOption option) => parseResult.GetResult(option) is OptionResult or && !or.Implicit;
 }

--- a/src/Layout/redist/targets/Directory.Build.targets
+++ b/src/Layout/redist/targets/Directory.Build.targets
@@ -17,8 +17,8 @@
 
     <Import Project="BundledTemplates.targets" />
     <Import Project="Crossgen.targets" />
-    <Import Project="GenerateInstallerLayout.targets" />
-    <Import Project="GenerateArchives.targets" />
+    <Import Project="GenerateInstallerLayout.targets"  />
+    <Import Project="GenerateArchives.targets" Condition="'$(SkipBuildingInstallers)' != 'true'" />
 
     <Import Project="OverlaySdkOnLKG.targets" />
   </ImportGroup>

--- a/src/Layout/redist/targets/Directory.Build.targets
+++ b/src/Layout/redist/targets/Directory.Build.targets
@@ -17,8 +17,8 @@
 
     <Import Project="BundledTemplates.targets" />
     <Import Project="Crossgen.targets" />
-    <Import Project="GenerateInstallerLayout.targets"  />
-    <Import Project="GenerateArchives.targets" Condition="'$(SkipBuildingInstallers)' != 'true'" />
+    <Import Project="GenerateInstallerLayout.targets" />
+    <Import Project="GenerateArchives.targets" />
 
     <Import Project="OverlaySdkOnLKG.targets" />
   </ImportGroup>

--- a/test/dotnet-completions.Tests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet-completions.Tests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -605,7 +605,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
                 [CompletionResult]::new('--package-directory', '--package-directory', [CompletionResultType]::ParameterName, "The directory to restore packages to.")
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--prerelease', '--prerelease', [CompletionResultType]::ParameterName, "Allows prerelease packages to be installed.")
-                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "--project")
+                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "The project file to operate on. If a file is not specified, the command will search the current directory for one.")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )
@@ -636,7 +636,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--format', '--format', [CompletionResultType]::ParameterName, "Specifies the output format type for the list packages command.")
                 [CompletionResult]::new('--output-version', '--output-version', [CompletionResultType]::ParameterName, "Specifies the version of machine-readable output. Requires the `'--format json`' option.")
-                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "--project")
+                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "The project file to operate on. If a file is not specified, the command will search the current directory for one.")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )
@@ -646,7 +646,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
         'testhost;package;remove' {
             $staticCompletions = @(
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
-                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "--project")
+                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "The project file to operate on. If a file is not specified, the command will search the current directory for one.")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )

--- a/test/dotnet-completions.Tests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet-completions.Tests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -593,10 +593,10 @@ _testhost() {
                                             '--package-directory=[The directory to restore packages to.]:PACKAGE_DIR: ' \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--prerelease[Allows prerelease packages to be installed.]' \
-                                            '--project=[]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
-                                            ':PACKAGE_NAME -- The package reference to add.:->dotnet_dynamic_complete' \
+                                            ':PACKAGE_NAME -- The package reference to add. This can be in the form of just the package identifier, for example '\''Newtonsoft.Json'\'', or a package identifier and version separated by '\''@'\'', for example '\''Newtonsoft.Json@13.0.3'\'':->dotnet_dynamic_complete' \
                                             && ret=0
                                             case $state in
                                                 (dotnet_dynamic_complete)
@@ -629,7 +629,7 @@ _testhost() {
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--format=[Specifies the output format type for the list packages command.]: :((console\:"console" json\:"json" ))' \
                                             '--output-version=[Specifies the version of machine-readable output. Requires the '\''--format json'\'' option.]: : ' \
-                                            '--project=[]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             && ret=0
@@ -637,7 +637,7 @@ _testhost() {
                                     (remove)
                                         _arguments "${_arguments_options[@]}" : \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
-                                            '--project=[]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             '*::PACKAGE_NAME -- The package reference to remove.: ' \


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47981

Adds support for syntax like `newtonsoft.json@13.0.3` in `dotnet package add`. When this syntax is used, we should disallow the `--version` option.

This also pushes up a UX fix to the `--project` option of this command - it no longer requires specifying the project in order to work on the current directory. The previous code was trying to make CWD-based usage work but didn't quite get there.

```
> dotnet package add Newtonsoft.Json@13.0.3

Build succeeded in 1.2s
info : X.509 certificate chain validation will use the default trust store selected by .NET for code signing.
info : X.509 certificate chain validation will use the default trust store selected by .NET for timestamping.
info : Adding PackageReference for package 'Newtonsoft.Json' into project 'E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj'.
info : Restoring packages for E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj...
info :   CACHE https://api.nuget.org/v3/vulnerabilities/index.json
info :   CACHE https://api.nuget.org/v3-vulnerabilities/2025.03.26.23.24.54/vulnerability.base.json
info :   CACHE https://api.nuget.org/v3-vulnerabilities/2025.03.26.23.24.54/2025.03.27.23.24.57/vulnerability.update.json
info : Package 'Newtonsoft.Json' is compatible with all the specified frameworks in project 'E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj'.
info : PackageReference for package 'Newtonsoft.Json' version '13.0.3' added to file 'E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj'.
info : Writing assets file to disk. Path: E:\Code\sdk-container-demo\artifacts\obj\sdk-container-demo\project.assets.json
log  : Restored E:\Code\sdk-container-demo\src\sdk-container-demo\sdk-container-demo.csproj (in 365 ms).
```

```
> dotnet package add Newtonsoft.Json@13.0.3 --project . --version 130.0
Cannot specify --version when the package argument already has a version.

Description:
  Add a NuGet package reference to the project.

Usage:
  dotnet package add <PACKAGE_NAME> [options]

Arguments:
  <PACKAGE_NAME>  The package reference to add.

Options:
  -v, --version <VERSION>            The version of the package to add.
  -f, --framework <FRAMEWORK>        Add the reference only when targeting a specific framework.
  -n, --no-restore                   Add the reference without performing restore preview and compatibility check.
  -s, --source <SOURCE>              The NuGet package source to use during the restore.
  --package-directory <PACKAGE_DIR>  The directory to restore packages to.
  --interactive                      Allows the command to stop and wait for user input or action (for example to complete authentication). [default: False]
  --prerelease                       Allows prerelease packages to be installed.
  --project <project>
  -?, -h, --help                     Show command line help.
```