### PR TITLE
Use TargetArchitecture and TargetRid properties

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -216,7 +216,7 @@ extends:
               buildArchitecture: arm64
               runtimeIdentifier: linux-arm64
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true
+              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties) /p:BuildSdkDeb=true
               runTests: false
@@ -232,7 +232,7 @@ extends:
               buildArchitecture: arm64
               runtimeIdentifier: linux-arm64
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true
+              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
               runTests: false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</TargetArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</TargetArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</Architecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,11 +4,11 @@
 
   <PropertyGroup>
     <BuildArchitecture Condition="'$(BuildArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
-    <Architecture Condition="'$(Architecture)' == '' AND ('$(BuildArchitecture)' == 'arm64')">$(BuildArchitecture)</Architecture>
-    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Architecture>
-    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Architecture>
-    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</Architecture>
-    <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND ('$(BuildArchitecture)' == 'arm64')">$(BuildArchitecture)</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</Architecture>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
     <HostOSName Condition="'$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('ILLUMOS'))">illumos</HostOSName>
     <HostOSName Condition="'$(HostOSName)' == '' AND '$(IsLinux)' == 'true'">linux</HostOSName>
 
-    <OSName Condition="'$(OSName)' == '' AND $(Rid) != ''">$(Rid.Substring(0, $(Rid.LastIndexOf('-'))))</OSName>
+    <OSName Condition="'$(OSName)' == '' AND $(TargetRid) != ''">$(TargetRid.Substring(0, $(TargetRid.LastIndexOf('-'))))</OSName>
     <OSName Condition="'$(OSName)' == ''">$(HostOSName)</OSName>
   </PropertyGroup>
 

--- a/eng/Badge.proj
+++ b/eng/Badge.proj
@@ -8,8 +8,8 @@
   <Target Name="GenerateVersionBadge" AfterTargets="Build" Returns="$(VersionBadge)">
     <PropertyGroup>
       <!-- Replace '-' with '_' for os names like 'linux-musl' -->
-      <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(Architecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(IsLinuxPortable)' == 'true'">linux_$(Architecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(TargetArchitecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(IsLinuxPortable)' == 'true'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
 
       <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <VersionSvgTemplate>$(MSBuildThisFileDirectory)version_badge.svg</VersionSvgTemplate>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -4,7 +4,7 @@
        they depend on assets from other verticals that are built in the first build pass. -->
   <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and
                         '$(OS)' == 'Windows_NT' and
-                        '$(Architecture)' == 'x64'">
+                        '$(TargetArchitecture)' == 'x64'">
     <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj" DotNetBuildPass="2" />
     <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj" DotNetBuildPass="2" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -83,7 +83,7 @@
   </ItemGroup>
 
   <!-- Only publish this file from win-x64 so that we don't end up with duplicates. -->
-  <ItemGroup Condition="'$(PublishBinariesAndBadge)' == 'true' and '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x64' and '$(PgoInstrument)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">
+  <ItemGroup Condition="'$(PublishBinariesAndBadge)' == 'true' and '$(OS)' == 'Windows_NT' and '$(TargetArchitecture)' == 'x64' and '$(PgoInstrument)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">
     <SdkArtifact Include="$(ArtifactsShippingPackagesDir)productVersion.txt" />
     <SdkArtifact Include="$(ArtifactsShippingPackagesDir)sdk-productVersion.txt" />
   </ItemGroup>

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -17,7 +17,7 @@ parameters:
   testFullMSBuild: false
   runAoTTests: false
   ### MSBUILD ###
-  buildArchitecture: x64
+  targetArchitecture: x64
   publishArgument: ''
   signArgument: ''
   runTestsAsTool: false
@@ -34,11 +34,11 @@ jobs:
 - template: /eng/common/${{ parameters.oneESCompat.templateFolderName }}/job/job.yml
   parameters:
     ${{ if eq(parameters.container, '') }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.buildArchitecture }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.buildArchitecture }})'
+      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.targetArchitecture }}
+      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.targetArchitecture }})'
     ${{ else }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.buildArchitecture }}_${{ parameters.container }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.buildArchitecture }}) [${{ parameters.container }}]'
+      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.targetArchitecture }}_${{ parameters.container }}
+      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.targetArchitecture }}) [${{ parameters.container }}]'
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
     strategy: ${{ parameters.strategy }}
@@ -82,7 +82,7 @@ jobs:
           ${{ parameters.publishArgument }}
           ${{ parameters.signArgument }}
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }}
-          /p:Architecture=${{ parameters.buildArchitecture }}
+          /p:TargetArchitecture=${{ parameters.targetArchitecture }}
           /p:RunTestsAsTool=${{ parameters.runTestsAsTool }}
           /p:PgoInstrument=${{ parameters.pgoInstrument }}
           ${{ parameters.runtimeSourceProperties }}
@@ -104,10 +104,10 @@ jobs:
           ${{ parameters.publishArgument }} \
           ${{ parameters.signArgument }} \
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }} \
-          /p:Architecture=${{ parameters.buildArchitecture }} \
+          /p:TargetArchitecture=${{ parameters.targetArchitecture }} \
           /p:RunTestsAsTool=${{ parameters.runTestsAsTool }} \
           /p:PgoInstrument=${{ parameters.pgoInstrument }} \
-          /p:Rid=${{ parameters.runtimeIdentifier }} \
+          /p:TargetRid=${{ parameters.runtimeIdentifier }} \
           ${{ parameters.osProperties }} \
           ${{ parameters.runtimeSourceProperties }} \
           ${{ parameters.officialBuildProperties }} \
@@ -128,7 +128,7 @@ jobs:
             -restore -test -ci -prepareMachine -nativeToolsOnMachine
             -configuration $(buildConfiguration)
             /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
-            /p:Architecture=${{ parameters.buildArchitecture }}
+            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
@@ -148,8 +148,8 @@ jobs:
             -restore -test -ci -prepareMachine
             -configuration $(buildConfiguration)
             '/p:Projects="${{ parameters.testProjects }}"'
-            /p:Architecture=${{ parameters.buildArchitecture }}
-            /p:Rid=${{ parameters.runtimeIdentifier }}
+            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+            /p:TargetRid=${{ parameters.runtimeIdentifier }}
             ${{ parameters.osProperties }}
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
@@ -171,7 +171,7 @@ jobs:
           testResultsFormat: xUnit
           testResultsFiles: artifacts/TestResults/$(buildConfiguration)/*.xml
           testRunTitle: $(System.PhaseName)
-          buildPlatform: ${{ parameters.buildArchitecture }}
+          buildPlatform: ${{ parameters.targetArchitecture }}
           buildConfiguration: $(buildConfiguration)
         continueOnError: true
         condition: always()

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -23,7 +23,7 @@ parameters:
   - categoryName: TestBuild
     osProperties: $(linuxOsPortableProperties)
   - categoryName: TestBuild
-    buildArchitecture: arm64
+    targetArchitecture: arm64
     runtimeIdentifier: linux-arm64
     osProperties: $(linuxOsPortableProperties)
     # Don't run the tests on arm64. Only perform the build itself.

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -30,11 +30,11 @@
     <ExeExtension>.exe</ExeExtension>
     <ExeExtension Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))"></ExeExtension>
 
-    <Rid>$(OSName)-$(Architecture)</Rid>
-    <ProductMonikerRid>$(Rid)</ProductMonikerRid>
+    <TargetRid Condition="'$(TargetRid)' == ''">$(OSName)-$(TargetArchitecture)</TargetRid>
+    <ProductMonikerRid>$(TargetRid)</ProductMonikerRid>
 
     <PortableOSName Condition="'$(PortableOSName)' == ''">$(OSName)</PortableOSName>
-    <PortableRid>$(PortableOSName)-$(Architecture)</PortableRid>
+    <PortableRid>$(PortableOSName)-$(TargetArchitecture)</PortableRid>
     <PortableProductMonikerRid>$(PortableRid)</PortableProductMonikerRid>
   </PropertyGroup>
 
@@ -43,9 +43,9 @@
     <SkipBuildingInstallers Condition="'$(PgoInstrument)' == 'true'">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition="
       (
-       $(Rid.StartsWith('freebsd')) or
-       $(Rid.StartsWith('illumos')) or
-       $(Rid.StartsWith('linux-musl'))
+       $(TargetRid.StartsWith('freebsd')) or
+       $(TargetRid.StartsWith('illumos')) or
+       $(TargetRid.StartsWith('linux-musl'))
       )">true</SkipBuildingInstallers>
   </PropertyGroup>
 
@@ -55,18 +55,18 @@
     <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
 
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
-    <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' and '$(IsLinux)' == 'true' and !$(Rid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>
+    <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' and '$(IsLinux)' == 'true' and !$(TargetRid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>
     <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <PropertyGroup>
     <NetRuntimeRid Condition="'$(NetRuntimeRid)' == ''">$(HostRid)</NetRuntimeRid>
-    <NetRuntimeRid Condition="('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd' or '$(OSName)' == 'illumos' or '$(OSName)' == 'solaris') and '$(DotNetBuildSourceOnly)' != 'true'">$(OSName)-$(Architecture)</NetRuntimeRid>
+    <NetRuntimeRid Condition="('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd' or '$(OSName)' == 'illumos' or '$(OSName)' == 'solaris') and '$(DotNetBuildSourceOnly)' != 'true'">$(OSName)-$(TargetArchitecture)</NetRuntimeRid>
     <NetRuntimeRid Condition="'$(DotNetBuild)' != 'true' and $(NetRuntimeRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</NetRuntimeRid>
 
     <SharedFrameworkRid>$(NetRuntimeRid)</SharedFrameworkRid>
     <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
-    <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
+    <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(TargetArchitecture)</SharedFrameworkRid>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj
@@ -7,7 +7,7 @@
          verticals that are built in the first build pass. -->
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuildPass)' != '2'">true</ExcludeFromDotNetBuild>
     <IsPackable Condition="'$(OS)' == 'Windows_NT' and
-                           '$(Architecture)' == 'x64' and
+                           '$(TargetArchitecture)' == 'x64' and
                            '$(PgoInstrument)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
     <PackageDescription>MSBuild extensions bundled with .NET Core SDK for internal Visual Studio build consumption</PackageDescription>

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <IsPackable Condition="'$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x64' and '$(PgoInstrument)' != 'true'">true</IsPackable>
+    <IsPackable Condition="'$(OS)' == 'Windows_NT' and '$(TargetArchitecture)' == 'x64' and '$(PgoInstrument)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
     <PackageDescription>Analyzers and generators from the runtime and SDK for VS insertion</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator/VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj
@@ -7,7 +7,7 @@
          verticals that are built in the first build pass. -->
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuildPass)' != '2'">true</ExcludeFromDotNetBuild>
     <IsPackable Condition="'$(OS)' == 'Windows_NT' and
-                           '$(Architecture)' == 'x64' and
+                           '$(TargetArchitecture)' == 'x64' and
                            '$(PgoInstrument)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
     <PackageDescription>MSBuild extensions bundled with .NET Core SDK for internal Visual Studio build consumption</PackageDescription>

--- a/src/Layout/VS.Redist.Common.NetCore.SdkPlaceholder/VS.Redist.Common.NetCore.SdkPlaceholder.proj
+++ b/src/Layout/VS.Redist.Common.NetCore.SdkPlaceholder/VS.Redist.Common.NetCore.SdkPlaceholder.proj
@@ -4,8 +4,8 @@
     <TargetFramework>net472</TargetFramework>
     <IsPackable Condition="'$(OS)' == 'Windows_NT' and '$(SkipBuildingInstallers)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
-    <PackageId>VS.Redist.Common.NetCore.SdkPlaceholder.$(Architecture).$(MajorMinorVersion)</PackageId>
-    <PackageDescription>.NET $(MajorMinorVersion) SDK ARP Placeholder ($(Architecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
+    <PackageId>VS.Redist.Common.NetCore.SdkPlaceholder.$(TargetArchitecture).$(MajorMinorVersion)</PackageId>
+    <PackageDescription>.NET $(MajorMinorVersion) SDK ARP Placeholder ($(TargetArchitecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsShippingPackage>false</IsShippingPackage>

--- a/src/Layout/VS.Redist.Common.NetCore.Templates/VS.Redist.Common.NetCore.Templates.proj
+++ b/src/Layout/VS.Redist.Common.NetCore.Templates/VS.Redist.Common.NetCore.Templates.proj
@@ -4,8 +4,8 @@
     <TargetFramework>net472</TargetFramework>
     <IsPackable Condition="'$(OS)' == 'Windows_NT' and '$(SkipBuildingInstallers)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
-    <PackageId>VS.Redist.Common.NetCore.Templates.$(Architecture).$(MajorMinorVersion)</PackageId>
-    <PackageDescription>.NET $(MajorMinorVersion) Templates ($(Architecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
+    <PackageId>VS.Redist.Common.NetCore.Templates.$(TargetArchitecture).$(MajorMinorVersion)</PackageId>
+    <PackageDescription>.NET $(MajorMinorVersion) Templates ($(TargetArchitecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsShippingPackage>false</IsShippingPackage>

--- a/src/Layout/VS.Redist.Common.NetCore.Toolset/VS.Redist.Common.NetCore.Toolset.proj
+++ b/src/Layout/VS.Redist.Common.NetCore.Toolset/VS.Redist.Common.NetCore.Toolset.proj
@@ -4,8 +4,8 @@
     <TargetFramework>net472</TargetFramework>
     <IsPackable Condition="'$(OS)' == 'Windows_NT' and '$(SkipBuildingInstallers)' != 'true'">true</IsPackable>
     <BeforePack>$(BeforePack);GenerateLayout</BeforePack>
-    <PackageId>VS.Redist.Common.NetCore.Toolset.$(Architecture).$(MajorMinorVersion)</PackageId>
-    <PackageDescription>.NET $(MajorMinorVersion) SDK Toolset ($(Architecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
+    <PackageId>VS.Redist.Common.NetCore.Toolset.$(TargetArchitecture).$(MajorMinorVersion)</PackageId>
+    <PackageDescription>.NET $(MajorMinorVersion) SDK Toolset ($(TargetArchitecture)) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</PackageDescription>
     <NoWarn>$(NoWarn);NU5100;NU5109;NU5123</NoWarn>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsShippingPackage>false</IsShippingPackage>

--- a/src/Layout/finalizer/finalizer.csproj
+++ b/src/Layout/finalizer/finalizer.csproj
@@ -11,7 +11,7 @@
     <OptimizationPreference>Size</OptimizationPreference>
     <StackTraceSupport>false</StackTraceSupport>
     <_IsPublishing>true</_IsPublishing>
-    <PublishDir>$(ArtifactsBinDir)finalizer\win-$(Architecture)\$(Configuration)\bin</PublishDir>
+    <PublishDir>$(ArtifactsBinDir)finalizer\win-$(TargetArchitecture)\$(Configuration)\bin</PublishDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -4,7 +4,7 @@
     <BuildSdkRpm Condition="'$(BuildSdkRpm)' == '' and '$(IsRPMBasedDistro)' == 'true'">true</BuildSdkRpm>
     <SkipBuild Condition="'$(BuildSdkDeb)' != 'true' and '$(BuildSdkRpm)' != 'true'">true</SkipBuild>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <RuntimeIdentifier>$(Rid)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
     <GenerateInstallers>true</GenerateInstallers>
     <BuildDebPackage Condition="'$(BuildSdkDeb)' == 'true'">true</BuildDebPackage>
     <BuildRpmPackage Condition="'$(BuildSdkRpm)' == 'true'">true</BuildRpmPackage>

--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -24,7 +24,7 @@
       All supported installer runtime identifiers should be specified here.
       New arcade infra is only used for Linux installers, at the moment.
     -->
-    <InstallerRuntimeIdentifiers>linux-$(Architecture)</InstallerRuntimeIdentifiers>
+    <InstallerRuntimeIdentifiers>linux-$(TargetArchitecture)</InstallerRuntimeIdentifiers>
     <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
@@ -116,7 +116,7 @@
       <LinuxPackageDependency Include="dotnet-runtime-$(MicrosoftNETCoreAppMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimePackageVersionWithTilde)" />
       <LinuxPackageDependency Include="dotnet-targeting-pack-$(MicrosoftNETCoreAppMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRefPackageVersionWithTilde)" />
       <LinuxPackageDependency Include="dotnet-apphost-pack-$(MicrosoftNETCoreAppMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimePackageVersionWithTilde)" />
-      <LinuxPackageDependency Condition="'$(Architecture)' == 'x64'" Include="netstandard-targeting-pack-$(NetStandardTargetingPackMajorMinorVersion)" Version="$(NetStandardTargetingPackPackageVersionWithTilde)" />
+      <LinuxPackageDependency Condition="'$(TargetArchitecture)' == 'x64'" Include="netstandard-targeting-pack-$(NetStandardTargetingPackMajorMinorVersion)" Version="$(NetStandardTargetingPackPackageVersionWithTilde)" />
       <LinuxPackageDependency Include="aspnetcore-runtime-$(AspNetCoreMajorMinorVersion)" Version="$(AspNetCoreRuntimeVersionWithTilde)" />
       <LinuxPackageDependency Include="aspnetcore-targeting-pack-$(AspNetCoreMajorMinorVersion)" Version="$(AspNetCoreRefVersionWithTilde)" />
       <LinuxPostInstallScript Include="$(DebianPostinstFile)" Condition="'$(BuildDebPackage)' == 'true'" />

--- a/src/Layout/redist/targets/BundledManifests.targets
+++ b/src/Layout/redist/targets/BundledManifests.targets
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <!-- TODO: Not exactly sure how this value should be calculated -->
     <!--<MsiArchitectureForWorkloadManifests>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</MsiArchitectureForWorkloadManifests>-->
-    <MsiArchitectureForWorkloadManifests>$(Architecture)</MsiArchitectureForWorkloadManifests>
+    <MsiArchitectureForWorkloadManifests>$(TargetArchitecture)</MsiArchitectureForWorkloadManifests>
   </PropertyGroup>
   <ItemGroup>
     <BundledManifests Update="@(BundledManifests)">

--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
-    <IsCrossgenSupported Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'">true</IsCrossgenSupported>
+    <IsCrossgenSupported Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(TargetArchitecture)' != 's390x' AND '$(TargetArchitecture)' != 'ppc64le'">true</IsCrossgenSupported>
 
     <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
     <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
@@ -150,7 +150,7 @@
     <Crossgen
         SourceAssembly="%(RoslynTargets.FullPath)"
         DestinationPath="%(RoslynTargets.FullPath)"
-        Architecture="$(Architecture)"
+        Architecture="$(TargetArchitecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -159,7 +159,7 @@
     <Crossgen
         SourceAssembly="%(FSharpTargets.FullPath)"
         DestinationPath="%(FSharpTargets.FullPath)"
-        Architecture="$(Architecture)"
+        Architecture="$(TargetArchitecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -168,7 +168,7 @@
     <Crossgen
         SourceAssembly="%(RemainingTargets.FullPath)"
         DestinationPath="%(RemainingTargets.FullPath)"
-        Architecture="$(Architecture)"
+        Architecture="$(TargetArchitecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -177,7 +177,7 @@
     <Crossgen
         SourceAssembly="%(RazorToolTargets.FullPath)"
         DestinationPath="%(RazorToolTargets.FullPath)"
-        Architecture="$(Architecture)"
+        Architecture="$(TargetArchitecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"

--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -49,7 +49,7 @@
        sdk_commit="%commit%" sdk_version="%version%"
     -->
     <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"
+      File="$(ArtifactsShippingPackagesDir)productCommit-$(TargetRid).txt"
       Lines="@(Line->'%(Identity)_commit=&quot;%(Commit)&quot; %(Identity)_version=&quot;%(Version)&quot;', '%0A')"
       Overwrite="true"
       Encoding="ASCII" />
@@ -67,7 +67,7 @@
     </PropertyGroup>
 
     <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).json"
+      File="$(ArtifactsShippingPackagesDir)productCommit-$(TargetRid).json"
       Lines="$(JsonContents)"
       Overwrite="true"
       Encoding="ASCII" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -20,21 +20,20 @@
   </Target>
 
   <Target Name="PublishVersionFile">
-    <WriteLinesToFile File="$(OutputPath)/.toolsetversion"
-                      Lines="$(SourceRevisionId);$(Version);$(Rid)"
+    <WriteLinesToFile File="$(OutputPath).toolsetversion"
+                      Lines="$(SourceRevisionId);$(Version);$(TargetRid)"
                       Overwrite="true" />
 
-    <!-- The .version file in the final product will be the .NET Core SDK version.  But
-         for the layout we produce here, use the toolset information, so that we don't
-         just always use the stage 0 version. -->
-    <WriteLinesToFile File="$(OutputPath)/.version"
-                      Lines="$(SourceRevisionId);$(Version);$(Rid)"
+    <WriteLinesToFile File="$(OutputPath).version"
+                      Lines="$(SourceRevisionId);$(Version);$(TargetRid);$(FullNugetVersion);$(SdkFeatureBand)"
                       Overwrite="true" />
 
-	<!-- Development env and CI loads DotnetFiles type from the following location
-	      The resolution of the product version (https://github.com/dotnet/sdk/blob/main/src/Cli/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs#L21)
-		  then need the version file there as well. -->
-    <Copy SourceFiles="$(OutputPath)/.version" DestinationFiles="$(BaseOutputPath)$(Configuration)/.version" SkipUnchangedFiles="true" />
+    <!-- Development env and CI loads DotnetFiles type from the following location
+         The resolution of the product version (https://github.com/dotnet/sdk/blob/main/src/Cli/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs#L21)
+         then need the version file there as well. -->
+    <Copy SourceFiles="$(OutputPath).version"
+          DestinationFiles="$(BaseOutputPath)$(Configuration)/.version"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="PublishRoslyn">
@@ -472,12 +471,6 @@
     <Message Text="Copy from @(NativeRestoredAppHostNETCore) to $(AppHostTemplatePath)." Importance="High" />
   </Target>
 
-  <Target Name="GenerateVersionFile">
-    <WriteLinesToFile File="$(OutputPath).version"
-                      Lines="$(SourceRevisionId);$(Version);$(Rid);$(FullNugetVersion);$(SdkFeatureBand)"
-                      Overwrite="true" />
-  </Target>
-
   <Target Name="ChmodPublishDir"
           DependsOnTargets="GenerateCliRuntimeConfigurationFiles"
           Condition="'$(OSName)' != 'win'">
@@ -536,7 +529,6 @@
                             PublishSdks;
                             PublishDotnetWatchToRedist;
                             GenerateBundledVersions;
-                            GenerateVersionFile;
                             CopyKnownWorkloadManifestFile;
                             LayoutAppHostTemplate;
                             LayoutBundledTools;

--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -34,7 +34,7 @@
     <SdkStableFileIdForApphostTransform>$(SdkPkgSourcesWindowsDirectory)\stablefileidforapphosttransform.xslt</SdkStableFileIdForApphostTransform>
     <SdkGenerateBundlePowershellScript>$(SdkPkgSourcesWindowsDirectory)\generatebundle.ps1</SdkGenerateBundlePowershellScript>
 
-    <FinalizerExe>$(ArtifactsBinDir)finalizer\win-$(Architecture)\$(Configuration)\bin\finalizer.exe</FinalizerExe>
+    <FinalizerExe>$(ArtifactsBinDir)finalizer\win-$(TargetArchitecture)\$(Configuration)\bin\finalizer.exe</FinalizerExe>
 
     <!-- Temp directory for light command layouts -->
     <LightCommandObjDir>$(ArtifactsObjDir)LightCommandPackages</LightCommandObjDir>
@@ -114,7 +114,7 @@
                       '$(VersionMinor)' ^
                       '$(SdkInstallerUpgradeCode)' ^
                       '$(SdkDependencyKeyName)' ^
-                      '$(Architecture)' ^
+                      '$(TargetArchitecture)' ^
                       '$(SdkStableFileIdForApphostTransform)' ^
                       -InformationAction Continue" />
 
@@ -158,7 +158,7 @@
                       '$(VersionMinor)' ^
                       '$(SdkPlaceholderInstallerUpgradeCode)' ^
                       '$(SdkPlaceholderDependencyKeyName)' ^
-                      '$(Architecture)' ^
+                      '$(TargetArchitecture)' ^
                       -InformationAction Continue" />
 
     <ItemGroup>
@@ -195,7 +195,7 @@
                       '$(VersionMinor)' ^
                       '%(TemplatesMsiComponent.UpgradeCode)' ^
                       '%(TemplatesMsiComponent.DependencyKeyName)' ^
-                      '$(Architecture)' ^
+                      '$(TargetArchitecture)' ^
                       -InformationAction Continue" />
 
     <ItemGroup>
@@ -321,7 +321,7 @@
                       -WindowsDesktopVersion '$(MicrosoftWindowsDesktopAppRuntimePackageVersion)' ^
                       -UpgradeCode '$(CombinedFrameworkSDKHostInstallerUpgradeCode)' ^
                       -DependencyKeyName '$(SdkDependencyKeyName)' ^
-                      -Architecture '$(Architecture)' ^
+                      -Architecture '$(TargetArchitecture)' ^
                       -DotNetRuntimeVersion '$(MicrosoftNETCoreAppRuntimePackageVersion)' ^
                       -AspNetCoreVersion '$(MicrosoftAspNetCoreAppRuntimePackageVersion)' ^
                       -SDKProductBandVersion '$(CliProductBandVersion)' ^

--- a/src/Layout/redist/targets/GeneratePKG.targets
+++ b/src/Layout/redist/targets/GeneratePKG.targets
@@ -5,14 +5,14 @@
       <PkgIntermediateDirectory>$(IntermediateOutputPath)pkgs/$(Version)</PkgIntermediateDirectory>
 
       <!-- Properties for pkg build -->
-      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.$(SharedHostVersion).component.osx.$(Architecture)</SharedHostComponentId>
-      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostFxrVersion).component.osx.$(Architecture)</HostFxrComponentId>
-      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppPackageVersion).component.osx.$(Architecture)</SharedFrameworkComponentId>
-      <NetCoreAppTargetingPackComponentId>com.microsoft.dotnet.pack.targeting.$(MicrosoftNETCoreAppRefPackageVersion).component.osx.$(Architecture)</NetCoreAppTargetingPackComponentId>
-      <NetCoreAppHostPackComponentId>com.microsoft.dotnet.pack.apphost.$(MicrosoftNETCoreAppHostPackageVersion).component.osx.$(Architecture)</NetCoreAppHostPackComponentId>
-      <NetStandardTargetingPackComponentId>com.microsoft.standard.pack.targeting.$(NETStandardLibraryRefPackageVersion).component.osx.$(Architecture)</NetStandardTargetingPackComponentId>
-      <SdkComponentId>com.microsoft.dotnet.dev.$(Version).component.osx.$(Architecture)</SdkComponentId>
-      <SdkProductArchiveId>com.microsoft.dotnet.dev.$(Version).osx.$(Architecture)</SdkProductArchiveId>
+      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.$(SharedHostVersion).component.osx.$(TargetArchitecture)</SharedHostComponentId>
+      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostFxrVersion).component.osx.$(TargetArchitecture)</HostFxrComponentId>
+      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppPackageVersion).component.osx.$(TargetArchitecture)</SharedFrameworkComponentId>
+      <NetCoreAppTargetingPackComponentId>com.microsoft.dotnet.pack.targeting.$(MicrosoftNETCoreAppRefPackageVersion).component.osx.$(TargetArchitecture)</NetCoreAppTargetingPackComponentId>
+      <NetCoreAppHostPackComponentId>com.microsoft.dotnet.pack.apphost.$(MicrosoftNETCoreAppHostPackageVersion).component.osx.$(TargetArchitecture)</NetCoreAppHostPackComponentId>
+      <NetStandardTargetingPackComponentId>com.microsoft.standard.pack.targeting.$(NETStandardLibraryRefPackageVersion).component.osx.$(TargetArchitecture)</NetStandardTargetingPackComponentId>
+      <SdkComponentId>com.microsoft.dotnet.dev.$(Version).component.osx.$(TargetArchitecture)</SdkComponentId>
+      <SdkProductArchiveId>com.microsoft.dotnet.dev.$(Version).osx.$(TargetArchitecture)</SdkProductArchiveId>
 
       <PkgInstallDirectory>/usr/local/share/dotnet</PkgInstallDirectory>
       <x64EmulationPkgInstallDirectory>/usr/local/share/dotnet/x64</x64EmulationPkgInstallDirectory>
@@ -24,8 +24,8 @@
       <SdkPkgScriptFile>$(SdkPkgDestinationScriptsDirectory)/postinstall</SdkPkgScriptFile>
       <SdkProductArchiveResourcesDirectory>$(PkgIntermediateDirectory)/resources</SdkProductArchiveResourcesDirectory>
 
-      <SdkProductArchiveDistributionTemplateFile Condition="'$(Architecture)' != 'x64'">$(SdkPkgSourcesOSXDirectory)/Distribution-Template</SdkProductArchiveDistributionTemplateFile>
-      <SdkProductArchiveDistributionTemplateFile Condition="'$(Architecture)' == 'x64'">$(SdkPkgSourcesOSXDirectory)/Distribution-Template-x64</SdkProductArchiveDistributionTemplateFile>
+      <SdkProductArchiveDistributionTemplateFile Condition="'$(TargetArchitecture)' != 'x64'">$(SdkPkgSourcesOSXDirectory)/Distribution-Template</SdkProductArchiveDistributionTemplateFile>
+      <SdkProductArchiveDistributionTemplateFile Condition="'$(TargetArchitecture)' == 'x64'">$(SdkPkgSourcesOSXDirectory)/Distribution-Template-x64</SdkProductArchiveDistributionTemplateFile>
       <SdkProductArchiveDistributionFile>$(PkgIntermediateDirectory)/CLI-SDK-Formatted-Distribution-Template.xml</SdkProductArchiveDistributionFile>
 
       <SdkPkgIntermediatePath>$(PkgIntermediateDirectory)/$(SdkComponentId).pkg</SdkPkgIntermediatePath>
@@ -89,11 +89,11 @@
         <ReplacementString>$(HostFxrBrandName)</ReplacementString>
       </DistributionTemplateReplacement>
       <DistributionTemplateReplacement Include="{arch}">
-        <ReplacementString>$(Architecture)</ReplacementString>
+        <ReplacementString>$(TargetArchitecture)</ReplacementString>
       </DistributionTemplateReplacement>
       <DistributionTemplateReplacement Include="{hostArchitectures}">
-        <ReplacementString>$(Architecture)</ReplacementString>
-        <ReplacementString Condition="'$(Architecture)' == 'x64'" >x86_64</ReplacementString>
+        <ReplacementString>$(TargetArchitecture)</ReplacementString>
+        <ReplacementString Condition="'$(TargetArchitecture)' == 'x64'">x86_64</ReplacementString>
       </DistributionTemplateReplacement>
       <DistributionTemplateReplacement Include="{minOsVersion}">
         <!-- keep in sync with SetOSTargetMinVersions in the root Directory.Build.props in dotnet/runtime -->

--- a/src/Layout/redist/targets/RestoreLayout.targets
+++ b/src/Layout/redist/targets/RestoreLayout.targets
@@ -4,8 +4,8 @@
     <!-- Only the runtime OSX .pkgs have a `-internal` suffix -->
     <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>
     <!-- Use the "x64" Rid when downloading Linux shared framework 'DEB' installer files. -->
-    <InstallerTargetArchitecture>$(Architecture)</InstallerTargetArchitecture>
-    <InstallerTargetArchitecture Condition="'$(IsRPMBasedDistro)' == 'true' and '$(Architecture)' == 'Arm64'">aarch64</InstallerTargetArchitecture>
+    <InstallerTargetArchitecture>$(TargetArchitecture)</InstallerTargetArchitecture>
+    <InstallerTargetArchitecture Condition="'$(IsRPMBasedDistro)' == 'true' and '$(TargetArchitecture)' == 'Arm64'">aarch64</InstallerTargetArchitecture>
 
     <SharedFrameworkInstallerFileRid>$(NetRuntimeRid)</SharedFrameworkInstallerFileRid>
     <SharedFrameworkInstallerFileRid Condition="'$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true'">$(InstallerTargetArchitecture)</SharedFrameworkInstallerFileRid>
@@ -18,8 +18,8 @@
     <WindowsDesktopBlobVersion Condition="'$(DotNetBuildOrchestrator)' == 'true'">$(MicrosoftWindowsDesktopAppRuntimePackageVersion)</WindowsDesktopBlobVersion>
     <NETStandardTargetingPackBlobVersion>3.0.0</NETStandardTargetingPackBlobVersion>
 
-    <AlternateArchitecture Condition="'$(Architecture)' == 'x86'">x64</AlternateArchitecture>
-    <AlternateArchitecture Condition="'$(Architecture)' == 'x64'">x86</AlternateArchitecture>
+    <AlternateArchitecture Condition="'$(TargetArchitecture)' == 'x86'">x64</AlternateArchitecture>
+    <AlternateArchitecture Condition="'$(TargetArchitecture)' == 'x64'">x86</AlternateArchitecture>
     <DownloadedSharedHostInstallerFileName Condition="'$(InstallerExtension)' != ''">dotnet-host$(InstallerStartSuffix)-$(SharedHostVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedHostInstallerFileName>
     <DownloadedHostFxrInstallerFileName Condition="'$(InstallerExtension)' != ''">dotnet-hostfxr$(InstallerStartSuffix)-$(HostFxrVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedHostFxrInstallerFileName>
     <DownloadedSharedFrameworkInstallerFileName Condition="'$(InstallerExtension)' != '' and '$(PgoInstrument)' != 'true'">dotnet-runtime$(InstallerStartSuffix)-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
@@ -45,8 +45,8 @@
 
     <AspNetCoreInstallerRid Condition="'$(AspNetCoreInstallerRid)' == ''">$(SharedFrameworkRid)</AspNetCoreInstallerRid>
     <AspNetCoreArchiveRid>$(AspNetCoreInstallerRid)</AspNetCoreArchiveRid>
-    <AspNetCoreInstallerRid Condition="('$(InstallerExtension)' == '.deb' OR '$(InstallerExtension)' == '.rpm') AND '$(Architecture)' != 'arm64'">x64</AspNetCoreInstallerRid>
-    <AspNetCoreInstallerRid Condition="'$(InstallerExtension)' == '.rpm' AND '$(Architecture)' == 'arm64'">aarch64</AspNetCoreInstallerRid>
+    <AspNetCoreInstallerRid Condition="('$(InstallerExtension)' == '.deb' OR '$(InstallerExtension)' == '.rpm') AND '$(TargetArchitecture)' != 'arm64'">x64</AspNetCoreInstallerRid>
+    <AspNetCoreInstallerRid Condition="'$(InstallerExtension)' == '.rpm' AND '$(TargetArchitecture)' == 'arm64'">aarch64</AspNetCoreInstallerRid>
 
     <DownloadedAspNetCoreSharedFxInstallerFileName Condition="'$(InstallerExtension)' != '' AND !$([MSBuild]::IsOSPlatform('OSX'))">aspnetcore-runtime-$(MicrosoftAspNetCoreAppRuntimePackageVersion)-$(AspNetCoreInstallerRid)$(InstallerExtension)</DownloadedAspNetCoreSharedFxInstallerFileName>
     <DownloadedAspNetCoreSharedFxInstallerFileName Condition="'$(InstallerExtension)' == '.msi'">aspnetcore-runtime-$(VSRedistCommonAspNetCoreSharedFrameworkx64100PackageVersion)-$(AspNetCoreInstallerRid)$(InstallerExtension)</DownloadedAspNetCoreSharedFxInstallerFileName>
@@ -160,7 +160,7 @@
     <!-- The AspNet does not provide native MacOS PKG installers at this time; we use AspNet archives.
           https://github.com/aspnet/AspNetCore/issues/8806 -->
     <BundledLayoutComponent Include="DownloadedAspNetTargetingPackArchiveFile"
-                            Condition="'$(IncludeAspNetCoreRuntime)' != 'false' and '$(InstallerExtension)' == '.pkg' And '$(SkipBuildingInstallers)' != 'true' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'osx-arm64')">
+                            Condition="'$(IncludeAspNetCoreRuntime)' != 'false' and '$(InstallerExtension)' == '.pkg' And '$(SkipBuildingInstallers)' != 'true' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(AspNetCoreSharedFxRootUrl)</BaseUrl>
       <DownloadFileName>$(AspNetTargetingPackArchiveFileName)</DownloadFileName>
       <RelativeLayoutPath></RelativeLayoutPath>
@@ -178,52 +178,52 @@
   <!-- BEGIN: Bundled installer components -->
   <ItemGroup Condition="'$(SkipBuildingInstallers)' != 'true'">
     <BundledInstallerComponent Include="DownloadedSharedFrameworkInstallerFile"
-                                Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                                Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedSharedFrameworkInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <BundledInstallerComponent Include="DownloadedSharedHostInstallerFile"
-                                Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                                Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedSharedHostInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <BundledInstallerComponent Include="DownloadedHostFxrInstallerFile"
-                                Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                                Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedHostFxrInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <BundledInstallerComponent Include="DownloadedNetCoreAppTargetingPackInstallerFile"
-                                Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                                Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedNetCoreAppTargetingPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <!-- TODO: Should we somehow obtain a .NET Standard ARM64 package? -->
     <BundledInstallerComponent Include="DownloadedNetStandardTargetingPackInstallerFile"
-                          Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'osx-arm64')">
+                          Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetStandardTargetingPackRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedNetStandardTargetingPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <BundledInstallerComponent Include="DownloadedNetCoreAppHostPackInstallerFile"
-                    Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                    Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedNetCoreAppHostPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <!-- These are apphosts from a different vertical which require a join in the VMR. -->
     <BundledInstallerComponent Include="DownloadedAlternateNetCoreAppHostPackInstallerFile"
-                                Condition="'$(InstallerExtension)' == '.msi' and !$(Architecture.StartsWith('arm')) and ('$(DotNetBuild)' != 'true' or '$(GenerateSdkBundleOnly)' == 'true')">
+                                Condition="'$(InstallerExtension)' == '.msi' and !$(TargetArchitecture.StartsWith('arm')) and ('$(DotNetBuild)' != 'true' or '$(GenerateSdkBundleOnly)' == 'true')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedAlternateNetCoreAppHostPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <!-- These are apphosts from a different vertical which require a join in the VMR. -->
     <BundledInstallerComponent Include="DownloadedArm64NetCoreAppHostPackInstallerFile"
-                                Condition="'$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))  and ('$(DotNetBuild)' != 'true' or '$(GenerateSdkBundleOnly)' == 'true')">
+                                Condition="'$(InstallerExtension)' == '.msi' And !$(TargetArchitecture.StartsWith('arm'))  and ('$(DotNetBuild)' != 'true' or '$(GenerateSdkBundleOnly)' == 'true')">
       <BaseUrl>$(NetRuntimeRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedArm64NetCoreAppHostPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
@@ -237,13 +237,13 @@
 
   <ItemGroup Condition="'$(SkipBuildingInstallers)' != 'true' and '$(IncludeAspNetCoreRuntime)' != 'false'">
     <BundledInstallerComponent Include="DownloadedAspNetTargetingPackInstallerFile"
-                                Condition="'$(InstallerExtension)' != '.pkg' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                Condition="'$(InstallerExtension)' != '.pkg' And '$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64')">
       <BaseUrl>$(AspNetCoreSharedFxRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedAspNetTargetingPackInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
 
     <BundledInstallerComponent Include="DownloadedAspNetCoreSharedFxInstallerFile"
-                                Condition="'$(InstallerExtension)' != '.pkg' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                Condition="'$(InstallerExtension)' != '.pkg' And '$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64')">
       <BaseUrl>$(AspNetCoreSharedFxRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedAspNetCoreSharedFxInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>
@@ -251,7 +251,7 @@
 
   <ItemGroup Condition="'$(SkipBuildingInstallers)' != 'true' and '$(IncludeWpfAndWinForms)' != 'false'">
     <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
-                                Condition="'$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
+                                Condition="'$(InstallerExtension)' != '' And (!$(TargetArchitecture.StartsWith('arm')) or '$(TargetRid)' == 'win-arm64' or '$(TargetRid)' == 'osx-arm64')">
       <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)</BaseUrl>
       <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
     </BundledInstallerComponent>

--- a/src/Layout/redist/tools/tool_fsc.csproj
+++ b/src/Layout/redist/tools/tool_fsc.csproj
@@ -9,7 +9,7 @@
   <!-- MIBC, PGO -->
   <PropertyGroup>
     <MibcPath>$(PkgMicrosoft_FSharp_Compiler)/contentFiles/mibc</MibcPath>
-    <MibcRid>$(Rid)</MibcRid>
+    <MibcRid>$(TargetRid)</MibcRid>
     <MibcRid Condition="$(MibcRid.Contains('musl-'))">$(MibcRid.Replace('musl-', ''))</MibcRid>
     <MibcFile>$(MibcPath)/optimization.$(MibcRid).mibc.runtime/DotNet_FSharp.mibc</MibcFile>
     <ReadyToRunOptimizationData>$(MibcFile)</ReadyToRunOptimizationData>

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/Microsoft.Net.Sdk.AnalyzerRedirecting.csproj
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/Microsoft.Net.Sdk.AnalyzerRedirecting.csproj
@@ -40,6 +40,6 @@
 
   <!-- Order matters here. VSSDK appends to PrepareForRunDependsOn but Microsoft.NET.Sdk overwrites it. See https://github.com/dotnet/msbuild/issues/2393. -->
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets') and '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64'" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets') and '$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' == 'x64'" />
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -20,8 +20,8 @@
          or from the Rid if supplied. -->
     <BuildArgs Condition="$(PortableBuild) != 'true'">$(BuildArgs) /p:OSName=$(TargetRid.Substring(0, $(TargetRid.IndexOf("-"))))</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:PortableOSName=$(__PortableTargetOS)</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:Rid=$(TargetRid)</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:Architecture=$(TargetArchitecture)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:TargetRid=$(TargetRid)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:TargetArchitecture=$(TargetArchitecture)</BuildArgs>
 
     <!-- sdk always wants to build portable on FreeBSD etc. -->
     <BuildArgs Condition="('$(TargetOS)' == 'freebsd' or '$(TargetOS)' == 'solaris') and '$(DotNetBuildSourceOnly)' == 'true'">$(BuildArgs) /p:PortableBuild=true</BuildArgs>
@@ -74,7 +74,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="CLIBUILD_SKIP_TESTS=true" />
     <!-- https://github.com/dotnet/source-build/issues/4115. -->
     <EnvironmentVariables Include="PublishWindowsPdb=false" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47950

By renaming `Architecture` to `TargetArchitecture`, the RID specific publishing logic works correctly.

Architecture -> TargetArchitecture
Rid -> TargetRid

Unrelated changes:
- Remove unused CLIBUILD_SKIP_TESTS property / env var
- Consolidate PublishVersionFile and GenerateVersionFile targets