### PR TITLE
Remove SB test exception for Microsoft.AspNetCore.App.Internal.Assets package

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.Tests/WebScenarioTests.cs
@@ -54,12 +54,6 @@ public class WebScenarioTests : SdkTests
 
         Assert.True(restoredPackageFiles is not null, "Failed to parse project.nuget.cache");
 
-        string[] allowedPackages = [
-            // Temporarily allowed due to https://github.com/dotnet/sdk/issues/46165
-            // TODO: Remove this once the issue is resolved
-            "Microsoft.AspNetCore.App.Internal.Assets"
-        ];
-
         string packagesDirectory = Path.Combine(Environment.CurrentDirectory, "packages");
 
         IEnumerable<string> packages = restoredPackageFiles.GetValues<string>()
@@ -68,8 +62,7 @@ public class WebScenarioTests : SdkTests
             {
                 string path = file.Substring(packagesDirectory.Length + 1); // trim the leading path up to the package name directory
                 return path.Substring(0, path.IndexOf('/')); // trim the rest of the path
-            })
-            .Except(allowedPackages, StringComparer.OrdinalIgnoreCase);
+            });
 
         if (packages.Any())
         {


### PR DESCRIPTION
This should be no longer needed since https://github.com/dotnet/sdk/issues/46165 is supposed to be fixed.