### PR TITLE
Make version identification slightly better

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -430,5 +430,10 @@
     "issueType": "PackageDependencies",
     "idMatch": "Microsoft.Build.Runtime",
     "justification": "Effect of better package pruning in net10"
+  },
+  {
+    "issueType": "MissingNonShipping",
+    "idMatch": "assets/symbols/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents",
+    "justification": "These are a dependency of roslyn's VS insertion packages and not interesting to the VMR build"
   }
 ]


### PR DESCRIPTION
The version identifier apparently has a bit of a hole in it, where it can't figure out roslyn's version numbers due to them not having a standard prerelease suffix. Instead, for symbol nupkgs, we can open them and look at the version. The tool right now is quite fast, but this slows it down a bit (30s) to a minute or two. Will look into fixing the version identifier.