### PR TITLE
skip making archives for inner loop

### DIFF
--- a/src/Layout/redist/targets/Directory.Build.targets
+++ b/src/Layout/redist/targets/Directory.Build.targets
@@ -18,7 +18,7 @@
     <Import Project="BundledTemplates.targets" />
     <Import Project="Crossgen.targets" />
     <Import Project="GenerateInstallerLayout.targets" />
-    <Import Project="GenerateArchives.targets" />
+    <Import Project="GenerateArchives.targets" Condition="'$(SkipBuildingInstallers)' != 'true'" />
 
     <Import Project="OverlaySdkOnLKG.targets" />
   </ImportGroup>


### PR DESCRIPTION
cc @joeloff 

Before:

```
>./build.cmd
...
  redist succeeded (130.0s) → artifacts\bin\redist\Debug\net10.0\redist.dll

Build succeeded in 205.3s
```

After:

```
>./build.cmd
...
  redist succeeded (10.9s) → artifacts\bin\redist\Debug\net10.0\redist.dll

Build succeeded in 52.1s
```