### PR TITLE
dotnet CLI: "Use primary constructor"

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -7,9 +7,9 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
-public class Command : ICommand
+public class Command(Process? process, bool trimTrailingNewlines = false) : ICommand
 {
-    private readonly Process _process;
+    private readonly Process _process = process ?? throw new ArgumentNullException(nameof(process));
 
     private StreamForwarder? _stdOut;
 
@@ -17,13 +17,7 @@ public class Command : ICommand
 
     private bool _running = false;
 
-    private bool _trimTrailingNewlines = false;
-
-    public Command(Process? process, bool trimTrailingNewlines = false)
-    {
-        _trimTrailingNewlines = trimTrailingNewlines;
-        _process = process ?? throw new ArgumentNullException(nameof(process));
-    }
+    private bool _trimTrailingNewlines = trimTrailingNewlines;
 
     public CommandResult Execute()
     {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -5,13 +5,15 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.Utils;
 
-public class EnvironmentProvider : IEnvironmentProvider
+public class EnvironmentProvider(
+    IEnumerable<string>? extensionsOverride = null,
+    IEnumerable<string>? searchPathsOverride = null) : IEnvironmentProvider
 {
     private static char[] s_pathSeparator = [Path.PathSeparator];
     private static char[] s_quote = ['"'];
-    private IEnumerable<string>? _searchPaths;
+    private IEnumerable<string>? _searchPaths = searchPathsOverride;
     private readonly Lazy<string> _userHomeDirectory = new(() => Environment.GetEnvironmentVariable("HOME") ?? string.Empty);
-    private IEnumerable<string>? _executableExtensions;
+    private IEnumerable<string>? _executableExtensions = extensionsOverride;
 
     public IEnumerable<string> ExecutableExtensions
     {
@@ -63,14 +65,6 @@ public class EnvironmentProvider : IEnvironmentProvider
         {
             return path;
         }
-    }
-
-    public EnvironmentProvider(
-        IEnumerable<string>? extensionsOverride = null,
-        IEnumerable<string>? searchPathsOverride = null)
-    {
-        _executableExtensions = extensionsOverride;
-        _searchPaths = searchPathsOverride;
     }
 
     public string? GetCommandPath(string commandName, params string[] extensions)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/TelemetryEventEntry.cs
@@ -96,21 +96,14 @@ public class InstrumentationEventArgs : EventArgs
     public IDictionary<string, double>? Measurements { get; }
 }
 
-public class ApplicationInsightsEntryFormat
+public class ApplicationInsightsEntryFormat(
+    string? eventName = null,
+    IDictionary<string, string?>? properties = null,
+    IDictionary<string, double>? measurements = null)
 {
-    public ApplicationInsightsEntryFormat(
-        string? eventName = null,
-        IDictionary<string, string?>? properties = null,
-        IDictionary<string, double>? measurements = null)
-    {
-        EventName = eventName;
-        Properties = properties;
-        Measurements = measurements;
-    }
-
-    public string? EventName { get; }
-    public IDictionary<string, string?>? Properties { get; }
-    public IDictionary<string, double>? Measurements { get; }
+    public string? EventName { get; } = eventName;
+    public IDictionary<string, string?>? Properties { get; } = properties;
+    public IDictionary<string, double>? Measurements { get; } = measurements;
 
     public ApplicationInsightsEntryFormat WithAppliedToPropertiesValue(Func<string?, string> func)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/AppBaseCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/AppBaseCommandResolver.cs
@@ -5,11 +5,9 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class AppBaseCommandResolver : AbstractPathBasedCommandResolver
+public class AppBaseCommandResolver(IEnvironmentProvider environment,
+    IPlatformCommandSpecFactory commandSpecFactory) : AbstractPathBasedCommandResolver(environment, commandSpecFactory)
 {
-    public AppBaseCommandResolver(IEnvironmentProvider environment,
-        IPlatformCommandSpecFactory commandSpecFactory) : base(environment, commandSpecFactory) { }
-
     internal override string ResolveCommandPath(CommandResolverArguments commandResolverArguments)
     {
         return _environment.GetCommandPathFromRootPath(

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/DepsJsonCommandResolver.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class DepsJsonCommandResolver : ICommandResolver
+public class DepsJsonCommandResolver(Muxer muxer, string nugetPackageRoot) : ICommandResolver
 {
     private static readonly string[] s_extensionPreferenceOrder =
     [
@@ -16,17 +16,11 @@ public class DepsJsonCommandResolver : ICommandResolver
         ".dll"
     ];
 
-    private string _nugetPackageRoot;
-    private Muxer _muxer;
+    private string _nugetPackageRoot = nugetPackageRoot;
+    private Muxer _muxer = muxer;
 
     public DepsJsonCommandResolver(string nugetPackageRoot)
         : this(new Muxer(), nugetPackageRoot) { }
-
-    public DepsJsonCommandResolver(Muxer muxer, string nugetPackageRoot)
-    {
-        _muxer = muxer;
-        _nugetPackageRoot = nugetPackageRoot;
-    }
 
     public CommandSpec Resolve(CommandResolverArguments commandResolverArguments)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
@@ -9,23 +9,16 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-internal class LocalToolsCommandResolver : ICommandResolver
+internal class LocalToolsCommandResolver(
+    ToolManifestFinder toolManifest = null,
+    ILocalToolsResolverCache localToolsResolverCache = null,
+    IFileSystem fileSystem = null,
+    string currentWorkingDirectory = null) : ICommandResolver
 {
-    private readonly ToolManifestFinder _toolManifest;
-    private readonly ILocalToolsResolverCache _localToolsResolverCache;
-    private readonly IFileSystem _fileSystem;
+    private readonly ToolManifestFinder _toolManifest = toolManifest ?? new ToolManifestFinder(new DirectoryPath(currentWorkingDirectory ?? Directory.GetCurrentDirectory()));
+    private readonly ILocalToolsResolverCache _localToolsResolverCache = localToolsResolverCache ?? new LocalToolsResolverCache();
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystemWrapper();
     private const string LeadingDotnetPrefix = "dotnet-";
-
-    public LocalToolsCommandResolver(
-        ToolManifestFinder toolManifest = null,
-        ILocalToolsResolverCache localToolsResolverCache = null,
-        IFileSystem fileSystem = null,
-        string currentWorkingDirectory = null)
-    {
-        _toolManifest = toolManifest ?? new ToolManifestFinder(new DirectoryPath(currentWorkingDirectory ?? Directory.GetCurrentDirectory()));
-        _localToolsResolverCache = localToolsResolverCache ?? new LocalToolsResolverCache();
-        _fileSystem = fileSystem ?? new FileSystemWrapper();
-    }
 
     public CommandSpec ResolveStrict(CommandResolverArguments arguments, bool allowRollForward = false)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/PathCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/PathCommandResolver.cs
@@ -5,11 +5,9 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class PathCommandResolver : AbstractPathBasedCommandResolver
+public class PathCommandResolver(IEnvironmentProvider environment,
+    IPlatformCommandSpecFactory commandSpecFactory) : AbstractPathBasedCommandResolver(environment, commandSpecFactory)
 {
-    public PathCommandResolver(IEnvironmentProvider environment,
-        IPlatformCommandSpecFactory commandSpecFactory) : base(environment, commandSpecFactory) { }
-
     internal override string ResolveCommandPath(CommandResolverArguments commandResolverArguments)
     {
         return _environment.GetCommandPath(commandResolverArguments.CommandName);

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectFactory.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectFactory.cs
@@ -8,16 +8,11 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-internal class ProjectFactory
+internal class ProjectFactory(IEnvironmentProvider environment)
 {
     private const string ProjectFactoryName = "projectfactory";
 
-    private IEnvironmentProvider _environment;
-
-    public ProjectFactory(IEnvironmentProvider environment)
-    {
-        _environment = environment;
-    }
+    private IEnvironmentProvider _environment = environment;
 
     public IProject GetProject(
         string projectDirectory,

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectPathCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectPathCommandResolver.cs
@@ -6,11 +6,9 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class ProjectPathCommandResolver : AbstractPathBasedCommandResolver
+public class ProjectPathCommandResolver(IEnvironmentProvider environment,
+    IPlatformCommandSpecFactory commandSpecFactory) : AbstractPathBasedCommandResolver(environment, commandSpecFactory)
 {
-    public ProjectPathCommandResolver(IEnvironmentProvider environment,
-        IPlatformCommandSpecFactory commandSpecFactory) : base(environment, commandSpecFactory) { }
-
     internal override string ResolveCommandPath(CommandResolverArguments commandResolverArguments)
     {
         if (commandResolverArguments.ProjectDirectory == null)

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ProjectToolsCommandResolver.cs
@@ -10,24 +10,16 @@ using ConcurrencyUtilities = NuGet.Common.ConcurrencyUtilities;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class ProjectToolsCommandResolver : ICommandResolver
+public class ProjectToolsCommandResolver(
+    IPackagedCommandSpecFactory packagedCommandSpecFactory,
+    IEnvironmentProvider environment) : ICommandResolver
 {
     private const string ProjectToolsCommandResolverName = "projecttoolscommandresolver";
 
-    private List<string> _allowedCommandExtensions;
-    private IPackagedCommandSpecFactory _packagedCommandSpecFactory;
+    private List<string> _allowedCommandExtensions = [FileNameSuffixes.DotNet.DynamicLib];
+    private IPackagedCommandSpecFactory _packagedCommandSpecFactory = packagedCommandSpecFactory;
 
-    private IEnvironmentProvider _environment;
-
-    public ProjectToolsCommandResolver(
-        IPackagedCommandSpecFactory packagedCommandSpecFactory,
-        IEnvironmentProvider environment)
-    {
-        _packagedCommandSpecFactory = packagedCommandSpecFactory;
-        _environment = environment;
-
-        _allowedCommandExtensions = [FileNameSuffixes.DotNet.DynamicLib];
-    }
+    private IEnvironmentProvider _environment = environment;
 
     public CommandSpec Resolve(CommandResolverArguments commandResolverArguments)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/PublishedPathCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/PublishedPathCommandResolver.cs
@@ -6,20 +6,14 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class PublishedPathCommandResolver : ICommandResolver
+public class PublishedPathCommandResolver(
+    IEnvironmentProvider environment,
+    IPublishedPathCommandSpecFactory commandSpecFactory) : ICommandResolver
 {
     private const string PublishedPathCommandResolverName = "PublishedPathCommandResolver";
 
-    private readonly IEnvironmentProvider _environment;
-    private readonly IPublishedPathCommandSpecFactory _commandSpecFactory;
-
-    public PublishedPathCommandResolver(
-        IEnvironmentProvider environment,
-        IPublishedPathCommandSpecFactory commandSpecFactory)
-    {
-        _environment = environment;
-        _commandSpecFactory = commandSpecFactory;
-    }
+    private readonly IEnvironmentProvider _environment = environment;
+    private readonly IPublishedPathCommandSpecFactory _commandSpecFactory = commandSpecFactory;
 
     public CommandSpec Resolve(CommandResolverArguments commandResolverArguments)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ResourceAssemblyInfo.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ResourceAssemblyInfo.cs
@@ -3,14 +3,8 @@
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-internal class ResourceAssemblyInfo
+internal class ResourceAssemblyInfo(string culture, string relativePath)
 {
-    public string Culture { get; }
-    public string RelativePath { get; }
-
-    public ResourceAssemblyInfo(string culture, string relativePath)
-    {
-        Culture = culture;
-        RelativePath = relativePath;
-    }
+    public string Culture { get; } = culture;
+    public string RelativePath { get; } = relativePath;
 }

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/SingleProjectInfo.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/SingleProjectInfo.cs
@@ -3,19 +3,12 @@
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-internal class SingleProjectInfo
+internal class SingleProjectInfo(string name, string version, IEnumerable<ResourceAssemblyInfo> resourceAssemblies)
 {
-    public string Name { get; }
-    public string Version { get; }
+    public string Name { get; } = name;
+    public string Version { get; } = version;
 
-    public IEnumerable<ResourceAssemblyInfo> ResourceAssemblies { get; }
-
-    public SingleProjectInfo(string name, string version, IEnumerable<ResourceAssemblyInfo> resourceAssemblies)
-    {
-        Name = name;
-        Version = version;
-        ResourceAssemblies = resourceAssemblies;
-    }
+    public IEnumerable<ResourceAssemblyInfo> ResourceAssemblies { get; } = resourceAssemblies;
 
     public string GetOutputName()
     {

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ToolPathCalculator.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ToolPathCalculator.cs
@@ -7,14 +7,9 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
-public class ToolPathCalculator
+public class ToolPathCalculator(string packagesDirectory)
 {
-    private readonly string _packagesDirectory;
-
-    public ToolPathCalculator(string packagesDirectory)
-    {
-        _packagesDirectory = packagesDirectory;
-    }
+    private readonly string _packagesDirectory = packagesDirectory;
 
     public string GetBestLockFilePath(string packageId, VersionRange versionRange, NuGetFramework framework)
     {

--- a/src/Cli/dotnet/CommandFactory/CommandSpec.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandSpec.cs
@@ -5,23 +5,16 @@ using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
 namespace Microsoft.DotNet.Cli.CommandFactory;
 
-public class CommandSpec
+public class CommandSpec(
+    string? path,
+    string? args,
+    Dictionary<string, string> environmentVariables = null)
 {
-    public CommandSpec(
-        string? path,
-        string? args,
-        Dictionary<string, string> environmentVariables = null)
-    {
-        Path = path;
-        Args = args;
-        EnvironmentVariables = environmentVariables ?? [];
-    }
+    public string Path { get; } = path;
 
-    public string Path { get; }
+    public string Args { get; } = args;
 
-    public string Args { get; }
-
-    public Dictionary<string, string> EnvironmentVariables { get; }
+    public Dictionary<string, string> EnvironmentVariables { get; } = environmentVariables ?? [];
 
     internal void AddEnvironmentVariablesFromProject(IProject project)
     {

--- a/src/Cli/dotnet/Commands/Build/BuildCommand.cs
+++ b/src/Cli/dotnet/Commands/Build/BuildCommand.cs
@@ -7,16 +7,11 @@ using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Tools.Build;
 
-public class BuildCommand : RestoringCommand
+public class BuildCommand(
+    IEnumerable<string> msbuildArgs,
+    bool noRestore,
+    string msbuildPath = null) : RestoringCommand(msbuildArgs, noRestore, msbuildPath)
 {
-    public BuildCommand(
-        IEnumerable<string> msbuildArgs,
-        bool noRestore,
-        string msbuildPath = null)
-        : base(msbuildArgs, noRestore, msbuildPath)
-    {
-    }
-
     public static BuildCommand FromArgs(string[] args, string msbuildPath = null)
     {
         var parser = Parser.Instance;

--- a/src/Cli/dotnet/Commands/Clean/Program.cs
+++ b/src/Cli/dotnet/Commands/Clean/Program.cs
@@ -8,13 +8,8 @@ using Microsoft.DotNet.Tools.MSBuild;
 
 namespace Microsoft.DotNet.Tools.Clean;
 
-public class CleanCommand : MSBuildForwardingApp
+public class CleanCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null) : MSBuildForwardingApp(msbuildArgs, msbuildPath)
 {
-    public CleanCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
-        : base(msbuildArgs, msbuildPath)
-    {
-    }
-
     public static CleanCommand FromArgs(string[] args, string msbuildPath = null)
     {
 

--- a/src/Cli/dotnet/Commands/Format/DotnetFormatForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/Format/DotnetFormatForwardingApp.cs
@@ -5,7 +5,10 @@ using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Tools.Format;
 
-public class DotnetFormatForwardingApp : ForwardingApp
+public class DotnetFormatForwardingApp(IEnumerable<string> argsToForward) : ForwardingApp(forwardApplicationPath: GetForwardApplicationPath(),
+        argsToForward: argsToForward,
+        depsFile: GetDepsFilePath(),
+        runtimeConfig: GetRuntimeConfigPath())
 {
     private static string GetForwardApplicationPath()
         => Path.Combine(AppContext.BaseDirectory, "DotnetTools/dotnet-format/dotnet-format.dll");
@@ -15,12 +18,4 @@ public class DotnetFormatForwardingApp : ForwardingApp
 
     private static string GetRuntimeConfigPath()
         => Path.Combine(AppContext.BaseDirectory, "DotnetTools/dotnet-format/dotnet-format.runtimeconfig.json");
-
-    public DotnetFormatForwardingApp(IEnumerable<string> argsToForward)
-        : base(forwardApplicationPath: GetForwardApplicationPath(),
-            argsToForward: argsToForward,
-            depsFile: GetDepsFilePath(),
-            runtimeConfig: GetRuntimeConfigPath())
-    {
-    }
 }

--- a/src/Cli/dotnet/Commands/Format/FormatCommand.cs
+++ b/src/Cli/dotnet/Commands/Format/FormatCommand.cs
@@ -8,12 +8,8 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Format;
 
-public class FormatCommand : DotnetFormatForwardingApp
+public class FormatCommand(IEnumerable<string> argsToForward) : DotnetFormatForwardingApp(argsToForward)
 {
-    public FormatCommand(IEnumerable<string> argsToForward) : base(argsToForward)
-    {
-    }
-
     public static FormatCommand FromArgs(string[] args)
     {
         var parser = Parser.Instance;

--- a/src/Cli/dotnet/Commands/Fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/Fsi/FsiForwardingApp.cs
@@ -5,7 +5,7 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli;
 
-public class FsiForwardingApp : ForwardingApp
+public class FsiForwardingApp(string[] arguments) : ForwardingApp(GetFsiAppPath(), processArguments(arguments))
 {
     private const string FsiDllName = @"FSharp/fsi.dll";
     private const string FsiExeName = @"FSharp/fsi.exe";
@@ -21,9 +21,6 @@ public class FsiForwardingApp : ForwardingApp
         {
             return args.Append($"--preferreduilang:{lang.Name}").ToArray();
         }
-    }
-    public FsiForwardingApp(string[] arguments) : base(GetFsiAppPath(), processArguments(arguments))
-    {
     }
 
     private static bool exists(string path)

--- a/src/Cli/dotnet/Commands/InternalReportInstallSuccess/InternalReportinstallsuccessCommand.cs
+++ b/src/Cli/dotnet/Commands/InternalReportInstallSuccess/InternalReportinstallsuccessCommand.cs
@@ -67,12 +67,7 @@ public class InternalReportinstallsuccess
     }
 }
 
-internal class InstallerSuccessReport
+internal class InstallerSuccessReport(string exeName)
 {
-    public string ExeName { get; }
-
-    public InstallerSuccessReport(string exeName)
-    {
-        ExeName = exeName ?? throw new ArgumentNullException(nameof(exeName));
-    }
+    public string ExeName { get; } = exeName ?? throw new ArgumentNullException(nameof(exeName));
 }

--- a/src/Cli/dotnet/Commands/MSBuild/Program.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/Program.cs
@@ -7,16 +7,10 @@ using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Tools.MSBuild;
 
-public class MSBuildCommand : MSBuildForwardingApp
+public class MSBuildCommand(IEnumerable<string> msbuildArgs,
+    string msbuildPath = null
+        ) : MSBuildForwardingApp(msbuildArgs, msbuildPath, includeLogo: true)
 {
-    public MSBuildCommand
-        (IEnumerable<string> msbuildArgs,
-        string msbuildPath = null
-        )
-         : base(msbuildArgs, msbuildPath, includeLogo: true)
-    {
-    }
-
     public static MSBuildCommand FromArgs(string[] args, string msbuildPath = null)
     {
         var parser = Parser.Instance;

--- a/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
+++ b/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
@@ -10,17 +10,11 @@ namespace Microsoft.DotNet.Tools.New;
 /// <summary>
 /// Returns list of *.nupkg files from C:\Program Files\dotnet\templates\x.x.x.x\ (on Windows) to be installed.
 /// </summary>
-internal sealed class BuiltInTemplatePackageProvider : ITemplatePackageProvider
+internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings) : ITemplatePackageProvider
 {
-    private readonly IEngineEnvironmentSettings _environmentSettings;
+    private readonly IEngineEnvironmentSettings _environmentSettings = settings;
 
-    public BuiltInTemplatePackageProvider(BuiltInTemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings)
-    {
-        Factory = factory;
-        _environmentSettings = settings;
-    }
-
-    public ITemplatePackageProviderFactory Factory { get; }
+    public ITemplatePackageProviderFactory Factory { get; } = factory;
 
 #pragma warning disable CS0067
     /// <summary>

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetAddPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetAddPostActionProcessor.cs
@@ -9,18 +9,12 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.DotNet.Tools.New.PostActionProcessors;
 
-internal class DotnetAddPostActionProcessor : PostActionProcessorBase
+internal class DotnetAddPostActionProcessor(
+    Func<string, string, string?, bool>? addPackageReferenceCallback = null,
+    Func<string, string, bool>? addProjectReferenceCallback = null) : PostActionProcessorBase
 {
-    private readonly Func<string, string, string?, bool> _addPackageReferenceCallback;
-    private readonly Func<string, string, bool> _addProjectReferenceCallback;
-
-    public DotnetAddPostActionProcessor(
-        Func<string, string, string?, bool>? addPackageReferenceCallback = null,
-        Func<string, string, bool>? addProjectReferenceCallback = null)
-    {
-        _addPackageReferenceCallback = addPackageReferenceCallback ?? DotnetCommandCallbacks.AddPackageReference;
-        _addProjectReferenceCallback = addProjectReferenceCallback ?? DotnetCommandCallbacks.AddProjectReference;
-    }
+    private readonly Func<string, string, string?, bool> _addPackageReferenceCallback = addPackageReferenceCallback ?? DotnetCommandCallbacks.AddPackageReference;
+    private readonly Func<string, string, bool> _addProjectReferenceCallback = addProjectReferenceCallback ?? DotnetCommandCallbacks.AddProjectReference;
 
     public override Guid Id => ActionProcessorId;
 

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetRestorePostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetRestorePostActionProcessor.cs
@@ -7,14 +7,9 @@ using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 
 namespace Microsoft.DotNet.Tools.New.PostActionProcessors;
 
-internal class DotnetRestorePostActionProcessor : PostActionProcessorBase
+internal class DotnetRestorePostActionProcessor(Func<string, bool>? restoreCallback = null) : PostActionProcessorBase
 {
-    private readonly Func<string, bool> _restoreCallback;
-
-    public DotnetRestorePostActionProcessor(Func<string, bool>? restoreCallback = null)
-    {
-        _restoreCallback = restoreCallback ?? DotnetCommandCallbacks.RestoreProject;
-    }
+    private readonly Func<string, bool> _restoreCallback = restoreCallback ?? DotnetCommandCallbacks.RestoreProject;
 
     public override Guid Id => ActionProcessorId;
 

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -10,14 +10,9 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.DotNet.Tools.New.PostActionProcessors;
 
-internal class DotnetSlnPostActionProcessor : PostActionProcessorBase
+internal class DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, string?, bool?, bool>? addProjToSolutionCallback = null) : PostActionProcessorBase
 {
-    private readonly Func<string, IReadOnlyList<string>, string?, bool?, bool> _addProjToSolutionCallback;
-
-    public DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, string?, bool?, bool>? addProjToSolutionCallback = null)
-    {
-        _addProjToSolutionCallback = addProjToSolutionCallback ?? DotnetCommandCallbacks.AddProjectsToSolution;
-    }
+    private readonly Func<string, IReadOnlyList<string>, string?, bool?, bool> _addProjToSolutionCallback = addProjToSolutionCallback ?? DotnetCommandCallbacks.AddProjectsToSolution;
 
     public override Guid Id => ActionProcessorId;
 

--- a/src/Cli/dotnet/Commands/New/WorkloadsInfoProvider.cs
+++ b/src/Cli/dotnet/Commands/New/WorkloadsInfoProvider.cs
@@ -6,15 +6,10 @@ using Microsoft.TemplateEngine.Abstractions.Components;
 
 namespace Microsoft.DotNet.Tools.New;
 
-internal class WorkloadsInfoProvider : IWorkloadsInfoProvider
+internal class WorkloadsInfoProvider(Lazy<IWorkloadsRepositoryEnumerator> workloadsRepositoryEnumerator) : IWorkloadsInfoProvider
 {
-    private readonly Lazy<IWorkloadsRepositoryEnumerator> _workloadsRepositoryEnumerator;
+    private readonly Lazy<IWorkloadsRepositoryEnumerator> _workloadsRepositoryEnumerator = workloadsRepositoryEnumerator;
     public Guid Id { get; } = Guid.Parse("{F8BA5B13-7BD6-47C8-838C-66626526817B}");
-
-    public WorkloadsInfoProvider(Lazy<IWorkloadsRepositoryEnumerator> workloadsRepositoryEnumerator)
-    {
-        _workloadsRepositoryEnumerator = workloadsRepositoryEnumerator;
-    }
 
     public Task<IEnumerable<WorkloadInfo>> GetInstalledWorkloadsAsync(CancellationToken cancellationToken)
     {

--- a/src/Cli/dotnet/Commands/Pack/PackCommand.cs
+++ b/src/Cli/dotnet/Commands/Pack/PackCommand.cs
@@ -8,16 +8,11 @@ using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Pack;
 
-public class PackCommand : RestoringCommand
+public class PackCommand(
+    IEnumerable<string> msbuildArgs,
+    bool noRestore,
+    string msbuildPath = null) : RestoringCommand(msbuildArgs, noRestore, msbuildPath)
 {
-    public PackCommand(
-        IEnumerable<string> msbuildArgs,
-        bool noRestore,
-        string msbuildPath = null)
-        : base(msbuildArgs, noRestore, msbuildPath)
-    {
-    }
-
     public static PackCommand FromArgs(string[] args, string msbuildPath = null)
     {
         var parser = Parser.Instance;

--- a/src/Cli/dotnet/Commands/Package/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/Program.cs
@@ -10,18 +10,12 @@ using Microsoft.DotNet.Tools.NuGet;
 
 namespace Microsoft.DotNet.Tools.Package.Add;
 
-internal class AddPackageReferenceCommand : CommandBase
+internal class AddPackageReferenceCommand(ParseResult parseResult) : CommandBase(parseResult)
 {
-    private readonly string _packageId;
-    private readonly string _fileOrDirectory;
-
-    public AddPackageReferenceCommand(ParseResult parseResult) : base(parseResult)
-    {
-        _fileOrDirectory = parseResult.HasOption(PackageCommandParser.ProjectOption) ?
+    private readonly string _packageId = parseResult.GetValue(PackageAddCommandParser.CmdPackageArgument);
+    private readonly string _fileOrDirectory = parseResult.HasOption(PackageCommandParser.ProjectOption) ?
             parseResult.GetValue(PackageCommandParser.ProjectOption) :
             parseResult.GetValue(AddCommandParser.ProjectArgument);
-        _packageId = parseResult.GetValue(PackageAddCommandParser.CmdPackageArgument);
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Package/List/ListPackageReferencesCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/List/ListPackageReferencesCommand.cs
@@ -9,19 +9,14 @@ using Microsoft.DotNet.Tools.NuGet;
 
 namespace Microsoft.DotNet.Tools.Package.List;
 
-internal class ListPackageReferencesCommand : CommandBase
+internal class ListPackageReferencesCommand(
+    ParseResult parseResult) : CommandBase(parseResult)
 {
     //The file or directory passed down by the command
-    private readonly string _fileOrDirectory;
-
-    public ListPackageReferencesCommand(
-        ParseResult parseResult) : base(parseResult)
-    {
-        _fileOrDirectory = GetAbsolutePath(Directory.GetCurrentDirectory(),
+    private readonly string _fileOrDirectory = GetAbsolutePath(Directory.GetCurrentDirectory(),
             parseResult.HasOption(PackageCommandParser.ProjectOption) ?
             parseResult.GetValue(PackageCommandParser.ProjectOption) :
             parseResult.GetValue(ListCommandParser.SlnOrProjectArgument) ?? "");
-    }
 
     private static string GetAbsolutePath(string currentDirectory, string relativePath)
     {

--- a/src/Cli/dotnet/Commands/Package/Search/PackageSearchCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Search/PackageSearchCommand.cs
@@ -7,10 +7,8 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.Cli;
 
-internal class PackageSearchCommand : CommandBase
+internal class PackageSearchCommand(ParseResult parseResult) : CommandBase(parseResult)
 {
-    public PackageSearchCommand(ParseResult parseResult) : base(parseResult) { }
-
     public override int Execute()
     {
         var args = new List<string>

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -12,16 +12,10 @@ using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Tools.Project.Convert;
 
-internal sealed class ProjectConvertCommand : CommandBase
+internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBase(parseResult)
 {
-    private readonly string _file;
-    private readonly string? _outputDirectory;
-
-    public ProjectConvertCommand(ParseResult parseResult) : base(parseResult)
-    {
-        _file = parseResult.GetValue(ProjectConvertCommandParser.FileArgument) ?? string.Empty;
-        _outputDirectory = parseResult.GetValue(SharedOptions.OutputOption)?.FullName;
-    }
+    private readonly string _file = parseResult.GetValue(ProjectConvertCommandParser.FileArgument) ?? string.Empty;
+    private readonly string? _outputDirectory = parseResult.GetValue(SharedOptions.OutputOption)?.FullName;
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Reference/Add/Program.cs
+++ b/src/Cli/dotnet/Commands/Reference/Add/Program.cs
@@ -10,16 +10,11 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Reference.Add;
 
-internal class AddProjectToProjectReferenceCommand : CommandBase
+internal class AddProjectToProjectReferenceCommand(ParseResult parseResult) : CommandBase(parseResult)
 {
-    private readonly string _fileOrDirectory;
-
-    public AddProjectToProjectReferenceCommand(ParseResult parseResult) : base(parseResult)
-    {
-        _fileOrDirectory = parseResult.HasOption(ReferenceCommandParser.ProjectOption) ?
+    private readonly string _fileOrDirectory = parseResult.HasOption(ReferenceCommandParser.ProjectOption) ?
             parseResult.GetValue(ReferenceCommandParser.ProjectOption) :
             parseResult.GetValue(AddCommandParser.ProjectArgument);
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Run/LaunchSettings/LaunchSettingsApplyResult.cs
+++ b/src/Cli/dotnet/Commands/Run/LaunchSettings/LaunchSettingsApplyResult.cs
@@ -3,18 +3,11 @@
 
 namespace Microsoft.DotNet.Tools.Run.LaunchSettings;
 
-public class LaunchSettingsApplyResult
+public class LaunchSettingsApplyResult(bool success, string? failureReason, ProjectLaunchSettingsModel launchSettings = null)
 {
-    public LaunchSettingsApplyResult(bool success, string? failureReason, ProjectLaunchSettingsModel launchSettings = null)
-    {
-        Success = success;
-        FailureReason = failureReason;
-        LaunchSettings = launchSettings;
-    }
+    public bool Success { get; } = success;
 
-    public bool Success { get; }
+    public string FailureReason { get; } = failureReason;
 
-    public string FailureReason { get; }
-
-    public ProjectLaunchSettingsModel LaunchSettings { get; }
+    public ProjectLaunchSettingsModel LaunchSettings { get; } = launchSettings;
 }

--- a/src/Cli/dotnet/Commands/Sdk/Check/BundleOutputWriter.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Check/BundleOutputWriter.cs
@@ -7,23 +7,16 @@ using Microsoft.DotNet.NativeWrapper;
 
 namespace Microsoft.DotNet.Tools.Sdk.Check;
 
-internal class BundleOutputWriter
+internal class BundleOutputWriter(
+    ProductCollection productCollection,
+    IProductCollectionProvider productCollectionProvider,
+    IReporter reporter)
 {
-    protected ProductCollection _productCollection;
+    protected ProductCollection _productCollection = productCollection;
 
-    protected readonly IProductCollectionProvider _productCollectionProvider;
+    protected readonly IProductCollectionProvider _productCollectionProvider = productCollectionProvider;
 
-    protected readonly IReporter _reporter;
-
-    public BundleOutputWriter(
-        ProductCollection productCollection,
-        IProductCollectionProvider productCollectionProvider,
-        IReporter reporter)
-    {
-        _productCollection = productCollection;
-        _productCollectionProvider = productCollectionProvider;
-        _reporter = reporter;
-    }
+    protected readonly IReporter _reporter = reporter;
 
     protected bool? BundleIsMaintenance(INetBundleInfo bundle)
     {

--- a/src/Cli/dotnet/Commands/Sdk/Check/RuntimeOutputWriter.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Check/RuntimeOutputWriter.cs
@@ -8,18 +8,13 @@ using Microsoft.DotNet.NativeWrapper;
 
 namespace Microsoft.DotNet.Tools.Sdk.Check;
 
-internal class RuntimeOutputWriter : BundleOutputWriter
+internal class RuntimeOutputWriter(
+    IEnumerable<NetRuntimeInfo> runtimeInfo,
+    ProductCollection productCollection,
+    IProductCollectionProvider productCollectionProvider,
+    IReporter reporter) : BundleOutputWriter(productCollection, productCollectionProvider, reporter)
 {
-    private IEnumerable<NetRuntimeInfo> _runtimeInfo;
-
-    public RuntimeOutputWriter(
-        IEnumerable<NetRuntimeInfo> runtimeInfo,
-        ProductCollection productCollection,
-        IProductCollectionProvider productCollectionProvider,
-        IReporter reporter) : base(productCollection, productCollectionProvider, reporter)
-    {
-        _runtimeInfo = runtimeInfo;
-    }
+    private IEnumerable<NetRuntimeInfo> _runtimeInfo = runtimeInfo;
 
     public void PrintRuntimeInfo()
     {

--- a/src/Cli/dotnet/Commands/Sdk/Check/SdkOutputWriter.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Check/SdkOutputWriter.cs
@@ -8,18 +8,13 @@ using Microsoft.DotNet.NativeWrapper;
 
 namespace Microsoft.DotNet.Tools.Sdk.Check;
 
-internal class SdkOutputWriter : BundleOutputWriter
+internal class SdkOutputWriter(
+    IEnumerable<NetSdkInfo> sdkInfo,
+    ProductCollection productCollection,
+    IProductCollectionProvider productCollectionProvider,
+    IReporter reporter) : BundleOutputWriter(productCollection, productCollectionProvider, reporter)
 {
-    private IEnumerable<NetSdkInfo> _sdkInfo;
-
-    public SdkOutputWriter(
-        IEnumerable<NetSdkInfo> sdkInfo,
-        ProductCollection productCollection,
-        IProductCollectionProvider productCollectionProvider,
-        IReporter reporter) : base(productCollection, productCollectionProvider, reporter)
-    {
-        _sdkInfo = sdkInfo;
-    }
+    private IEnumerable<NetSdkInfo> _sdkInfo = sdkInfo;
 
     public void PrintSdkInfo()
     {

--- a/src/Cli/dotnet/Commands/Solution/List/Program.cs
+++ b/src/Cli/dotnet/Commands/Solution/List/Program.cs
@@ -9,17 +9,11 @@ using CommandLocalizableStrings = Microsoft.DotNet.Cli.CommonLocalizableStrings;
 
 namespace Microsoft.DotNet.Tools.Sln.List;
 
-internal class ListProjectsInSolutionCommand : CommandBase
+internal class ListProjectsInSolutionCommand(
+    ParseResult parseResult) : CommandBase(parseResult)
 {
-    private readonly string _fileOrDirectory;
-    private readonly bool _displaySolutionFolders;
-
-    public ListProjectsInSolutionCommand(
-        ParseResult parseResult) : base(parseResult)
-    {
-        _fileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
-        _displaySolutionFolders = parseResult.GetValue(SlnListParser.SolutionFolderOption);
-    }
+    private readonly string _fileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
+    private readonly bool _displaySolutionFolders = parseResult.GetValue(SlnListParser.SolutionFolderOption);
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Solution/Migrate/SlnMigrateCommand.cs
+++ b/src/Cli/dotnet/Commands/Solution/Migrate/SlnMigrateCommand.cs
@@ -9,18 +9,12 @@ using LocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli;
 
-internal class SlnMigrateCommand : CommandBase
+internal class SlnMigrateCommand(
+    ParseResult parseResult,
+    IReporter reporter = null) : CommandBase(parseResult)
 {
-    private readonly string _slnFileOrDirectory;
-    private readonly IReporter _reporter;
-    public SlnMigrateCommand(
-        ParseResult parseResult,
-        IReporter reporter = null)
-        : base(parseResult)
-    {
-        _slnFileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
-        _reporter = reporter ?? Reporter.Output;
-    }
+    private readonly string _slnFileOrDirectory = parseResult.GetValue(SlnCommandParser.SlnArgument);
+    private readonly IReporter _reporter = reporter ?? Reporter.Output;
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Test/IPC/NamedPipeClient.cs
+++ b/src/Cli/dotnet/Commands/Test/IPC/NamedPipeClient.cs
@@ -6,23 +6,17 @@ using System.IO.Pipes;
 
 namespace Microsoft.DotNet.Tools.Test;
 
-internal sealed class NamedPipeClient : NamedPipeBase, IClient
+internal sealed class NamedPipeClient(string name) : NamedPipeBase, IClient
 {
-    private readonly NamedPipeClientStream _namedPipeClientStream;
+    private readonly NamedPipeClientStream _namedPipeClientStream = new(".", name, PipeDirection.InOut);
     private readonly SemaphoreSlim _lock = new(1, 1);
 
     private readonly MemoryStream _serializationBuffer = new();
     private readonly MemoryStream _messageBuffer = new();
     private readonly byte[] _readBuffer = new byte[250000];
-    private readonly string _pipeName;
+    private readonly string _pipeName = name;
 
     private bool _disposed;
-
-    public NamedPipeClient(string name)
-    {
-        _namedPipeClientStream = new(".", name, PipeDirection.InOut);
-        _pipeName = name;
-    }
 
     public string PipeName => _pipeName;
 

--- a/src/Cli/dotnet/Commands/Test/IPC/Serializers/UnknownMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/IPC/Serializers/UnknownMessageSerializer.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.DotNet.Tools.Test;
 
-internal sealed class UnknownMessageSerializer : BaseSerializer, INamedPipeSerializer
+internal sealed class UnknownMessageSerializer(int SerializerId) : BaseSerializer, INamedPipeSerializer
 {
-    public int Id { get; }
-
-    public UnknownMessageSerializer(int SerializerId) => Id = SerializerId;
+    public int Id { get; } = SerializerId;
 
     public object Deserialize(Stream _)
     {

--- a/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
@@ -10,21 +10,14 @@ using Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 namespace Microsoft.DotNet.Cli;
 
-internal sealed class MSBuildHandler : IDisposable
+internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationActionQueue actionQueue, TerminalTestReporter output) : IDisposable
 {
-    private readonly BuildOptions _buildOptions;
-    private readonly TestApplicationActionQueue _actionQueue;
-    private readonly TerminalTestReporter _output;
+    private readonly BuildOptions _buildOptions = buildOptions;
+    private readonly TestApplicationActionQueue _actionQueue = actionQueue;
+    private readonly TerminalTestReporter _output = output;
 
     private readonly ConcurrentBag<TestApplication> _testApplications = [];
     private bool _areTestingPlatformApplications = true;
-
-    public MSBuildHandler(BuildOptions buildOptions, TestApplicationActionQueue actionQueue, TerminalTestReporter output)
-    {
-        _buildOptions = buildOptions;
-        _actionQueue = actionQueue;
-        _output = output;
-    }
 
     public bool RunMSBuild()
     {

--- a/src/Cli/dotnet/Commands/Test/Program.cs
+++ b/src/Cli/dotnet/Commands/Test/Program.cs
@@ -11,16 +11,11 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Tools.Test;
 
-public class TestCommand : RestoringCommand
+public class TestCommand(
+    IEnumerable<string> msbuildArgs,
+    bool noRestore,
+    string msbuildPath = null) : RestoringCommand(msbuildArgs, noRestore, msbuildPath)
 {
-    public TestCommand(
-        IEnumerable<string> msbuildArgs,
-        bool noRestore,
-        string msbuildPath = null)
-        : base(msbuildArgs, noRestore, msbuildPath)
-    {
-    }
-
     public static int Run(ParseResult parseResult)
     {
         parseResult.HandleDebugSwitch();

--- a/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
@@ -39,6 +39,8 @@ internal sealed class AnsiTerminal(IConsole console, string? baseDirectory) : IT
 
     private readonly IConsole _console = console;
     private readonly string? _baseDirectory = baseDirectory ?? Directory.GetCurrentDirectory();
+    // Output ansi code to get spinner on top of a terminal, to indicate in-progress task.
+    // https://github.com/dotnet/msbuild/issues/8958: iTerm2 treats ;9 code to post a notification instead, so disable progress reporting on Mac.
     private readonly bool _useBusyIndicator = !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
     private readonly StringBuilder _stringBuilder = new();
     private bool _isBatching;

--- a/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminal.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// Terminal writer that is used when writing ANSI is allowed. It is capable of batching as many updates as possible and writing them at the end,
 /// because the terminal is responsible for rendering the colors and control codes.
 /// </summary>
-internal sealed class AnsiTerminal : ITerminal
+internal sealed class AnsiTerminal(IConsole console, string? baseDirectory) : ITerminal
 {
     /// <summary>
     /// File extensions that we will link to directly, all other files
@@ -37,22 +37,12 @@ internal sealed class AnsiTerminal : ITerminal
         ".xunit",
     ];
 
-    private readonly IConsole _console;
-    private readonly string? _baseDirectory;
-    private readonly bool _useBusyIndicator;
+    private readonly IConsole _console = console;
+    private readonly string? _baseDirectory = baseDirectory ?? Directory.GetCurrentDirectory();
+    private readonly bool _useBusyIndicator = !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
     private readonly StringBuilder _stringBuilder = new();
     private bool _isBatching;
     private AnsiTerminalTestProgressFrame _currentFrame = new(0, 0);
-
-    public AnsiTerminal(IConsole console, string? baseDirectory)
-    {
-        _console = console;
-        _baseDirectory = baseDirectory ?? Directory.GetCurrentDirectory();
-
-        // Output ansi code to get spinner on top of a terminal, to indicate in-progress task.
-        // https://github.com/dotnet/msbuild/issues/8958: iTerm2 treats ;9 code to post a notification instead, so disable progress reporting on Mac.
-        _useBusyIndicator = !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-    }
 
     public int Width
         => _console.IsOutputRedirected ? int.MaxValue : _console.BufferWidth;

--- a/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -8,21 +8,15 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// <summary>
 /// Captures <see cref="TestProgressState"/> that was rendered to screen, so we can only partially update the screen on next update.
 /// </summary>
-internal sealed class AnsiTerminalTestProgressFrame
+internal sealed class AnsiTerminalTestProgressFrame(int width, int height)
 {
     private const int MaxColumn = 250;
 
-    public int Width { get; }
+    public int Width { get; } = Math.Min(width, MaxColumn);
 
-    public int Height { get; }
+    public int Height { get; } = height;
 
     public List<RenderedProgressItem>? RenderedLines { get; set; }
-
-    public AnsiTerminalTestProgressFrame(int width, int height)
-    {
-        Width = Math.Min(width, MaxColumn);
-        Height = height;
-    }
 
     public void AppendTestWorkerProgress(TestProgressState progress, RenderedProgressItem currentLine, AnsiTerminal terminal)
     {
@@ -335,17 +329,11 @@ internal sealed class AnsiTerminalTestProgressFrame
 
     public void Clear() => RenderedLines?.Clear();
 
-    internal sealed class RenderedProgressItem
+    internal sealed class RenderedProgressItem(long id, long version)
     {
-        public RenderedProgressItem(long id, long version)
-        {
-            ProgressId = id;
-            ProgressVersion = version;
-        }
+        public long ProgressId { get; } = id;
 
-        public long ProgressId { get; }
-
-        public long ProgressVersion { get; }
+        public long ProgressVersion { get; } = version;
 
         public int RenderedHeight { get; set; }
 

--- a/src/Cli/dotnet/Commands/Test/Terminal/TestDetailState.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TestDetailState.cs
@@ -5,22 +5,15 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
-internal sealed class TestDetailState
+internal sealed class TestDetailState(long id, IStopwatch? stopwatch, string text)
 {
-    private string _text;
+    private string _text = text;
 
-    public TestDetailState(long id, IStopwatch? stopwatch, string text)
-    {
-        Id = id;
-        Stopwatch = stopwatch;
-        _text = text;
-    }
-
-    public long Id { get; }
+    public long Id { get; } = id;
 
     public long Version { get; set; }
 
-    public IStopwatch? Stopwatch { get; }
+    public IStopwatch? Stopwatch { get; } = stopwatch;
 
     public string Text
     {

--- a/src/Cli/dotnet/Commands/Test/Terminal/TestNodeResultsState.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TestNodeResultsState.cs
@@ -8,17 +8,11 @@ using LocalizableStrings = Microsoft.DotNet.Tools.Test.LocalizableStrings;
 
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
-internal sealed class TestNodeResultsState
+internal sealed class TestNodeResultsState(long id)
 {
-    public TestNodeResultsState(long id)
-    {
-        Id = id;
-        _summaryDetail = new(id, stopwatch: null, text: string.Empty);
-    }
+    public long Id { get; } = id;
 
-    public long Id { get; }
-
-    private readonly TestDetailState _summaryDetail;
+    private readonly TestDetailState _summaryDetail = new(id, stopwatch: null, text: string.Empty);
     private readonly ConcurrentDictionary<string, TestDetailState> _testNodeProgressStates = new();
 
     public int Count => _testNodeProgressStates.Count;

--- a/src/Cli/dotnet/Commands/Test/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TestProgressState.cs
@@ -5,27 +5,17 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
-internal sealed class TestProgressState
+internal sealed class TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch)
 {
-    public TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch)
-    {
-        Id = id;
-        Assembly = assembly;
-        TargetFramework = targetFramework;
-        Architecture = architecture;
-        Stopwatch = stopwatch;
-        AssemblyName = Path.GetFileName(assembly)!;
-    }
+    public string Assembly { get; } = assembly;
 
-    public string Assembly { get; }
+    public string AssemblyName { get; } = Path.GetFileName(assembly)!;
 
-    public string AssemblyName { get; }
+    public string? TargetFramework { get; } = targetFramework;
 
-    public string? TargetFramework { get; }
+    public string? Architecture { get; } = architecture;
 
-    public string? Architecture { get; }
-
-    public IStopwatch Stopwatch { get; }
+    public IStopwatch Stopwatch { get; } = stopwatch;
 
     public List<string> Attachments { get; } = [];
 
@@ -43,7 +33,7 @@ internal sealed class TestProgressState
 
     public int SlotIndex { get; internal set; }
 
-    public long Id { get; internal set; }
+    public long Id { get; internal set; } = id;
 
     public long Version { get; internal set; }
 

--- a/src/Cli/dotnet/Commands/Test/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TestProgressStateAwareTerminal.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// <summary>
 /// Terminal that updates the progress in place when progress reporting is enabled.
 /// </summary>
-internal sealed partial class TestProgressStateAwareTerminal : IDisposable
+internal sealed partial class TestProgressStateAwareTerminal(ITerminal terminal, Func<bool?> showProgress, bool writeProgressImmediatelyAfterOutput, int updateEvery) : IDisposable
 {
     /// <summary>
     /// A cancellation token to signal the rendering thread that it should exit.
@@ -18,10 +18,10 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
     /// </summary>
     private readonly object _lock = Console.Out;
 
-    private readonly ITerminal _terminal;
-    private readonly Func<bool?> _showProgress;
-    private readonly bool _writeProgressImmediatelyAfterOutput;
-    private readonly int _updateEvery;
+    private readonly ITerminal _terminal = terminal;
+    private readonly Func<bool?> _showProgress = showProgress;
+    private readonly bool _writeProgressImmediatelyAfterOutput = writeProgressImmediatelyAfterOutput;
+    private readonly int _updateEvery = updateEvery;
     private TestProgressState?[] _progressItems = [];
     private bool? _showProgressCached;
 
@@ -66,14 +66,6 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         }
 
         _terminal.EraseProgress();
-    }
-
-    public TestProgressStateAwareTerminal(ITerminal terminal, Func<bool?> showProgress, bool writeProgressImmediatelyAfterOutput, int updateEvery)
-    {
-        _terminal = terminal;
-        _showProgress = showProgress;
-        _writeProgressImmediatelyAfterOutput = writeProgressImmediatelyAfterOutput;
-        _updateEvery = updateEvery;
     }
 
     public int AddWorker(TestProgressState testWorker)

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -8,10 +8,10 @@ using Microsoft.DotNet.Tools.Test;
 
 namespace Microsoft.DotNet.Cli;
 
-internal sealed class TestApplication : IDisposable
+internal sealed class TestApplication(TestModule module, BuildOptions buildOptions) : IDisposable
 {
-    private readonly TestModule _module;
-    private readonly BuildOptions _buildOptions;
+    private readonly TestModule _module = module;
+    private readonly BuildOptions _buildOptions = buildOptions;
 
     private readonly List<string> _outputData = [];
     private readonly List<string> _errorData = [];
@@ -31,12 +31,6 @@ internal sealed class TestApplication : IDisposable
     public event EventHandler<TestProcessExitEventArgs> TestProcessExited;
 
     public TestModule Module => _module;
-
-    public TestApplication(TestModule module, BuildOptions buildOptions)
-    {
-        _module = module;
-        _buildOptions = buildOptions;
-    }
 
     public async Task<int> RunAsync(TestOptions testOptions)
     {

--- a/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
@@ -8,15 +8,10 @@ using Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 namespace Microsoft.DotNet.Cli;
 
-internal sealed class TestApplicationsEventHandlers : IDisposable
+internal sealed class TestApplicationsEventHandlers(TerminalTestReporter output) : IDisposable
 {
     private readonly ConcurrentDictionary<TestApplication, (string ModulePath, string TargetFramework, string Architecture, string ExecutionId)> _executions = new();
-    private readonly TerminalTestReporter _output;
-
-    public TestApplicationsEventHandlers(TerminalTestReporter output)
-    {
-        _output = output;
-    }
+    private readonly TerminalTestReporter _output = output;
 
     public void OnHandshakeReceived(object sender, HandshakeArgs args)
     {

--- a/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
@@ -9,16 +9,10 @@ using Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 namespace Microsoft.DotNet.Cli;
 
-internal sealed class TestModulesFilterHandler
+internal sealed class TestModulesFilterHandler(TestApplicationActionQueue actionQueue, TerminalTestReporter output)
 {
-    private readonly TestApplicationActionQueue _actionQueue;
-    private readonly TerminalTestReporter _output;
-
-    public TestModulesFilterHandler(TestApplicationActionQueue actionQueue, TerminalTestReporter output)
-    {
-        _actionQueue = actionQueue;
-        _output = output;
-    }
+    private readonly TestApplicationActionQueue _actionQueue = actionQueue;
+    private readonly TerminalTestReporter _output = output;
 
     public bool RunWithTestModulesFilter(ParseResult parseResult, BuildOptions buildOptions)
     {

--- a/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ProjectRestorer.cs
@@ -9,21 +9,13 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Tools.Tool.Install;
 
-internal class ProjectRestorer : IProjectRestorer
+internal class ProjectRestorer(IReporter reporter = null,
+    IEnumerable<string> additionalRestoreArguments = null) : IProjectRestorer
 {
-    private readonly IReporter _reporter;
-    private readonly IReporter _errorReporter;
-    private readonly bool _forceOutputRedirection;
-    private readonly IEnumerable<string> _additionalRestoreArguments;
-
-    public ProjectRestorer(IReporter reporter = null,
-        IEnumerable<string> additionalRestoreArguments = null)
-    {
-        _additionalRestoreArguments = additionalRestoreArguments;
-        _reporter = reporter ?? Reporter.Output;
-        _errorReporter = reporter ?? Reporter.Error;
-        _forceOutputRedirection = reporter != null;
-    }
+    private readonly IReporter _reporter = reporter ?? Reporter.Output;
+    private readonly IReporter _errorReporter = reporter ?? Reporter.Error;
+    private readonly bool _forceOutputRedirection = reporter != null;
+    private readonly IEnumerable<string> _additionalRestoreArguments = additionalRestoreArguments;
 
     public void Restore(FilePath project,
         PackageLocation packageLocation,

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallCommand.cs
@@ -8,28 +8,16 @@ using Microsoft.DotNet.Tools.Tool.Common;
 
 namespace Microsoft.DotNet.Tools.Tool.Install;
 
-internal class ToolInstallCommand : CommandBase
+internal class ToolInstallCommand(
+    ParseResult parseResult,
+    ToolInstallGlobalOrToolPathCommand toolInstallGlobalOrToolPathCommand = null,
+    ToolInstallLocalCommand toolInstallLocalCommand = null) : CommandBase(parseResult)
 {
-    private readonly ToolInstallLocalCommand _toolInstallLocalCommand;
-    private readonly ToolInstallGlobalOrToolPathCommand _toolInstallGlobalOrToolPathCommand;
-    private readonly bool _global;
-    private readonly string _toolPath;
-    private readonly string _framework;
-
-    public ToolInstallCommand(
-        ParseResult parseResult,
-        ToolInstallGlobalOrToolPathCommand toolInstallGlobalOrToolPathCommand = null,
-        ToolInstallLocalCommand toolInstallLocalCommand = null)
-        : base(parseResult)
-    {
-        _toolInstallLocalCommand = toolInstallLocalCommand;
-
-        _toolInstallGlobalOrToolPathCommand = toolInstallGlobalOrToolPathCommand;
-
-        _global = parseResult.GetValue(ToolAppliedOption.GlobalOption);
-        _toolPath = parseResult.GetValue(ToolAppliedOption.ToolPathOption);
-        _framework = parseResult.GetValue(ToolInstallCommandParser.FrameworkOption);
-    }
+    private readonly ToolInstallLocalCommand _toolInstallLocalCommand = toolInstallLocalCommand;
+    private readonly ToolInstallGlobalOrToolPathCommand _toolInstallGlobalOrToolPathCommand = toolInstallGlobalOrToolPathCommand;
+    private readonly bool _global = parseResult.GetValue(ToolAppliedOption.GlobalOption);
+    private readonly string _toolPath = parseResult.GetValue(ToolAppliedOption.ToolPathOption);
+    private readonly string _framework = parseResult.GetValue(ToolInstallCommandParser.FrameworkOption);
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/List/ToolListCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/List/ToolListCommand.cs
@@ -7,23 +7,16 @@ using Microsoft.DotNet.Tools.Tool.Common;
 
 namespace Microsoft.DotNet.Tools.Tool.List;
 
-internal class ToolListCommand : CommandBase
+internal class ToolListCommand(
+    ParseResult result,
+    ToolListGlobalOrToolPathCommand toolListGlobalOrToolPathCommand = null,
+    ToolListLocalCommand toolListLocalCommand = null
+    ) : CommandBase(result)
 {
-    private readonly ToolListGlobalOrToolPathCommand _toolListGlobalOrToolPathCommand;
-    private readonly ToolListLocalCommand _toolListLocalCommand;
-
-    public ToolListCommand(
-        ParseResult result,
-        ToolListGlobalOrToolPathCommand toolListGlobalOrToolPathCommand = null,
-        ToolListLocalCommand toolListLocalCommand = null
-    )
-        : base(result)
-    {
-        _toolListGlobalOrToolPathCommand
+    private readonly ToolListGlobalOrToolPathCommand _toolListGlobalOrToolPathCommand
             = toolListGlobalOrToolPathCommand ?? new ToolListGlobalOrToolPathCommand(result);
-        _toolListLocalCommand
+    private readonly ToolListLocalCommand _toolListLocalCommand
             = toolListLocalCommand ?? new ToolListLocalCommand(result);
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/List/ToolListGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/List/ToolListGlobalOrToolPathCommand.cs
@@ -12,23 +12,15 @@ namespace Microsoft.DotNet.Tools.Tool.List;
 
 internal delegate IToolPackageStoreQuery CreateToolPackageStore(DirectoryPath? nonGlobalLocation = null);
 
-internal class ToolListGlobalOrToolPathCommand : CommandBase
+internal class ToolListGlobalOrToolPathCommand(
+    ParseResult result,
+    CreateToolPackageStore createToolPackageStore = null,
+    IReporter reporter = null) : CommandBase(result)
 {
     public const string CommandDelimiter = ", ";
-    private readonly IReporter _reporter;
-    private readonly IReporter _errorReporter;
-    private CreateToolPackageStore _createToolPackageStore;
-
-    public ToolListGlobalOrToolPathCommand(
-        ParseResult result,
-        CreateToolPackageStore createToolPackageStore = null,
-        IReporter reporter = null)
-        : base(result)
-    {
-        _reporter = reporter ?? Reporter.Output;
-        _errorReporter = reporter ?? Reporter.Error;
-        _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStoreQuery;
-    }
+    private readonly IReporter _reporter = reporter ?? Reporter.Output;
+    private readonly IReporter _errorReporter = reporter ?? Reporter.Error;
+    private CreateToolPackageStore _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStoreQuery;
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
@@ -11,26 +11,16 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Tools.Tool.Run;
 
-internal class ToolRunCommand : CommandBase
+internal class ToolRunCommand(
+    ParseResult result,
+    LocalToolsCommandResolver localToolsCommandResolver = null,
+    ToolManifestFinder toolManifest = null) : CommandBase(result)
 {
-    private readonly string _toolCommandName;
-    private readonly LocalToolsCommandResolver _localToolsCommandResolver;
-    private readonly IEnumerable<string> _forwardArgument;
-    public bool _allowRollForward;
-    private readonly ToolManifestFinder _toolManifest;
-
-    public ToolRunCommand(
-        ParseResult result,
-        LocalToolsCommandResolver localToolsCommandResolver = null,
-        ToolManifestFinder toolManifest = null)
-        : base(result)
-    {
-        _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
-        _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
-        _localToolsCommandResolver = localToolsCommandResolver ?? new LocalToolsCommandResolver();
-        _allowRollForward = result.GetValue(ToolRunCommandParser.RollForwardOption);
-        _toolManifest = toolManifest ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
-    }
+    private readonly string _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
+    private readonly LocalToolsCommandResolver _localToolsCommandResolver = localToolsCommandResolver ?? new LocalToolsCommandResolver();
+    private readonly IEnumerable<string> _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
+    public bool _allowRollForward = result.GetValue(ToolRunCommandParser.RollForwardOption);
+    private readonly ToolManifestFinder _toolManifest = toolManifest ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/Search/NugetSearchSerializables.cs
+++ b/src/Cli/dotnet/Commands/Tool/Search/NugetSearchSerializables.cs
@@ -8,49 +8,30 @@ namespace Microsoft.DotNet.Tools.Tool.Search;
 /// <summary>
 /// All fields are possibly null other than Id, Version, Tags, Authors, Versions
 /// </summary>
-internal class SearchResultPackage
+internal class SearchResultPackage(
+    PackageId id,
+    string latestVersion,
+    string description,
+    string summary,
+    IReadOnlyCollection<string> tags,
+    IReadOnlyCollection<string> authors,
+    int totalDownloads,
+    bool verified,
+    IReadOnlyCollection<SearchResultPackageVersion> versions)
 {
-    public SearchResultPackage(
-        PackageId id,
-        string latestVersion,
-        string description,
-        string summary,
-        IReadOnlyCollection<string> tags,
-        IReadOnlyCollection<string> authors,
-        int totalDownloads,
-        bool verified,
-        IReadOnlyCollection<SearchResultPackageVersion> versions)
-    {
-        Id = id;
-        LatestVersion = latestVersion ?? throw new ArgumentNullException(nameof(latestVersion));
-        Description = description;
-        Summary = summary;
-        Tags = tags ?? throw new ArgumentNullException(nameof(tags));
-        Authors = authors ?? throw new ArgumentNullException(nameof(authors));
-        TotalDownloads = totalDownloads;
-        Verified = verified;
-        Versions = versions ?? throw new ArgumentNullException(nameof(versions));
-    }
-
-    public PackageId Id { get; }
-    public string LatestVersion { get; }
-    public string Description { get; }
-    public string Summary { get; }
-    public IReadOnlyCollection<string> Tags { get; }
-    public IReadOnlyCollection<string> Authors { get; }
-    public int TotalDownloads { get; }
-    public bool Verified { get; }
-    public IReadOnlyCollection<SearchResultPackageVersion> Versions { get; }
+    public PackageId Id { get; } = id;
+    public string LatestVersion { get; } = latestVersion ?? throw new ArgumentNullException(nameof(latestVersion));
+    public string Description { get; } = description;
+    public string Summary { get; } = summary;
+    public IReadOnlyCollection<string> Tags { get; } = tags ?? throw new ArgumentNullException(nameof(tags));
+    public IReadOnlyCollection<string> Authors { get; } = authors ?? throw new ArgumentNullException(nameof(authors));
+    public int TotalDownloads { get; } = totalDownloads;
+    public bool Verified { get; } = verified;
+    public IReadOnlyCollection<SearchResultPackageVersion> Versions { get; } = versions ?? throw new ArgumentNullException(nameof(versions));
 }
 
-internal class SearchResultPackageVersion
+internal class SearchResultPackageVersion(string version, int downloads)
 {
-    public SearchResultPackageVersion(string version, int downloads)
-    {
-        Version = version ?? throw new ArgumentNullException(nameof(version));
-        Downloads = downloads;
-    }
-
-    public string Version { get; }
-    public int Downloads { get; }
+    public string Version { get; } = version ?? throw new ArgumentNullException(nameof(version));
+    public int Downloads { get; } = downloads;
 }

--- a/src/Cli/dotnet/Commands/Tool/Search/SearchResultPrinter.cs
+++ b/src/Cli/dotnet/Commands/Tool/Search/SearchResultPrinter.cs
@@ -7,14 +7,9 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Tools.Tool.Search;
 
-internal class SearchResultPrinter
+internal class SearchResultPrinter(IReporter reporter)
 {
-    private readonly IReporter _reporter;
-
-    public SearchResultPrinter(IReporter reporter)
-    {
-        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
-    }
+    private readonly IReporter _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
 
     public void Print(bool isDetailed, IReadOnlyCollection<SearchResultPackage> searchResultPackages)
     {

--- a/src/Cli/dotnet/Commands/Tool/Search/ToolSearchCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Search/ToolSearchCommand.cs
@@ -8,20 +8,13 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Tool.Search;
 
-internal class ToolSearchCommand : CommandBase
+internal class ToolSearchCommand(
+    ParseResult result,
+    INugetToolSearchApiRequest nugetToolSearchApiRequest = null
+    ) : CommandBase(result)
 {
-    private readonly INugetToolSearchApiRequest _nugetToolSearchApiRequest;
-    private readonly SearchResultPrinter _searchResultPrinter;
-
-    public ToolSearchCommand(
-        ParseResult result,
-        INugetToolSearchApiRequest nugetToolSearchApiRequest = null
-    )
-        : base(result)
-    {
-        _nugetToolSearchApiRequest = nugetToolSearchApiRequest ?? new NugetToolSearchApiRequest();
-        _searchResultPrinter = new SearchResultPrinter(Reporter.Output);
-    }
+    private readonly INugetToolSearchApiRequest _nugetToolSearchApiRequest = nugetToolSearchApiRequest ?? new NugetToolSearchApiRequest();
+    private readonly SearchResultPrinter _searchResultPrinter = new SearchResultPrinter(Reporter.Output);
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommand.cs
@@ -8,31 +8,20 @@ using Microsoft.DotNet.Tools.Tool.Common;
 
 namespace Microsoft.DotNet.Tools.Tool.Uninstall;
 
-internal class ToolUninstallCommand : CommandBase
+internal class ToolUninstallCommand(
+    ParseResult result,
+    IReporter reporter = null,
+    ToolUninstallGlobalOrToolPathCommand toolUninstallGlobalOrToolPathCommand = null,
+    ToolUninstallLocalCommand toolUninstallLocalCommand = null) : CommandBase(result)
 {
-    private readonly ToolUninstallLocalCommand _toolUninstallLocalCommand;
-    private readonly ToolUninstallGlobalOrToolPathCommand _toolUninstallGlobalOrToolPathCommand;
-    private readonly bool _global;
-    private readonly string _toolPath;
-
-    public ToolUninstallCommand(
-        ParseResult result,
-        IReporter reporter = null,
-        ToolUninstallGlobalOrToolPathCommand toolUninstallGlobalOrToolPathCommand = null,
-        ToolUninstallLocalCommand toolUninstallLocalCommand = null)
-        : base(result)
-    {
-        _toolUninstallLocalCommand
+    private readonly ToolUninstallLocalCommand _toolUninstallLocalCommand
             = toolUninstallLocalCommand ??
               new ToolUninstallLocalCommand(result);
-
-        _toolUninstallGlobalOrToolPathCommand =
+    private readonly ToolUninstallGlobalOrToolPathCommand _toolUninstallGlobalOrToolPathCommand =
             toolUninstallGlobalOrToolPathCommand
             ?? new ToolUninstallGlobalOrToolPathCommand(result);
-
-        _global = result.GetValue(ToolUninstallCommandParser.GlobalOption);
-        _toolPath = result.GetValue(ToolUninstallCommandParser.ToolPathOption);
-    }
+    private readonly bool _global = result.GetValue(ToolUninstallCommandParser.GlobalOption);
+    private readonly string _toolPath = result.GetValue(ToolUninstallCommandParser.ToolPathOption);
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallCommand.cs
@@ -3,14 +3,12 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Tool.Common;
 
 namespace Microsoft.DotNet.Tools.Tool.Uninstall;
 
 internal class ToolUninstallCommand(
     ParseResult result,
-    IReporter reporter = null,
     ToolUninstallGlobalOrToolPathCommand toolUninstallGlobalOrToolPathCommand = null,
     ToolUninstallLocalCommand toolUninstallLocalCommand = null) : CommandBase(result)
 {

--- a/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommand.cs
@@ -15,27 +15,17 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall;
 
 internal delegate IShellShimRepository CreateShellShimRepository(string appHostSourceDirectory, DirectoryPath? nonGlobalLocation = null);
 internal delegate (IToolPackageStore, IToolPackageStoreQuery, IToolPackageUninstaller) CreateToolPackageStoresAndUninstaller(DirectoryPath? nonGlobalLocation = null);
-internal class ToolUninstallGlobalOrToolPathCommand : CommandBase
+internal class ToolUninstallGlobalOrToolPathCommand(
+    ParseResult result,
+    CreateToolPackageStoresAndUninstaller createToolPackageStoreAndUninstaller = null,
+    CreateShellShimRepository createShellShimRepository = null,
+    IReporter reporter = null) : CommandBase(result)
 {
-    private readonly IReporter _reporter;
-    private readonly IReporter _errorReporter;
-    private CreateShellShimRepository _createShellShimRepository;
-    private CreateToolPackageStoresAndUninstaller _createToolPackageStoresAndUninstaller;
-
-    public ToolUninstallGlobalOrToolPathCommand(
-        ParseResult result,
-        CreateToolPackageStoresAndUninstaller createToolPackageStoreAndUninstaller = null,
-        CreateShellShimRepository createShellShimRepository = null,
-        IReporter reporter = null)
-        : base(result)
-    {
-        _reporter = reporter ?? Reporter.Output;
-        _errorReporter = reporter ?? Reporter.Error;
-
-        _createShellShimRepository = createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
-        _createToolPackageStoresAndUninstaller = createToolPackageStoreAndUninstaller ??
+    private readonly IReporter _reporter = reporter ?? Reporter.Output;
+    private readonly IReporter _errorReporter = reporter ?? Reporter.Error;
+    private CreateShellShimRepository _createShellShimRepository = createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
+    private CreateToolPackageStoresAndUninstaller _createToolPackageStoresAndUninstaller = createToolPackageStoreAndUninstaller ??
                                                 ToolPackageFactory.CreateToolPackageStoresAndUninstaller;
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Workload/Elevate/WorkloadElevateCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Elevate/WorkloadElevateCommand.cs
@@ -7,13 +7,9 @@ using Microsoft.DotNet.Workloads.Workload.Install;
 
 namespace Microsoft.DotNet.Workloads.Workload.Elevate;
 
-internal class WorkloadElevateCommand : WorkloadCommandBase
+internal class WorkloadElevateCommand(ParseResult parseResult) : WorkloadCommandBase(parseResult)
 {
     private NetSdkMsiInstallerServer _server;
-
-    public WorkloadElevateCommand(ParseResult parseResult) : base(parseResult)
-    {
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
+++ b/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
@@ -6,9 +6,9 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload;
 
-internal class GlobalJsonWorkloadSetsFile
+internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string dotnetDir)
 {
-    string _path;
+    string _path = System.IO.Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, dotnetDir), "globaljsonworkloadsets.json");
 
     public string Path { get { return _path; } }
 
@@ -17,11 +17,6 @@ internal class GlobalJsonWorkloadSetsFile
         WriteIndented = true,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
-
-    public GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string dotnetDir)
-    {
-        _path = System.IO.Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, dotnetDir), "globaljsonworkloadsets.json");
-    }
 
     public void RecordWorkloadSetInGlobalJson(string globalJsonPath, string workloadSetVersion)
     {

--- a/src/Cli/dotnet/Commands/Workload/Install/IInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/IInstaller.cs
@@ -72,21 +72,14 @@ internal interface IWorkloadManifestInstaller
     Task ExtractManifestAsync(string nupkgPath, string targetPath);
 }
 
-public class WorkloadDownload
+public class WorkloadDownload(string id, string nuGetPackageId, string nuGetPackageVersion)
 {
     /// <summary>
     /// The ID of the workload pack or manifest to be downloaded (not necessarily the same as the <see cref="NuGetPackageId"/>)
     /// </summary>
-    public string Id { get; }
+    public string Id { get; } = id;
 
-    public string NuGetPackageId { get; }
+    public string NuGetPackageId { get; } = nuGetPackageId;
 
-    public string NuGetPackageVersion { get; }
-
-    public WorkloadDownload(string id, string nuGetPackageId, string nuGetPackageVersion)
-    {
-        Id = id;
-        NuGetPackageId = nuGetPackageId;
-        NuGetPackageVersion = nuGetPackageVersion;
-    }
+    public string NuGetPackageVersion { get; } = nuGetPackageVersion;
 }

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
@@ -102,14 +102,9 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
     }
 
     //  Wrap the setup logger in an IReporter so it can be passed to the garbage collector
-    private class SetupLogReporter : IReporter
+    private class SetupLogReporter(ISetupLogger setupLogger) : IReporter
     {
-        private ISetupLogger _setupLogger;
-
-        public SetupLogReporter(ISetupLogger setupLogger)
-        {
-            _setupLogger = setupLogger;
-        }
+        private ISetupLogger _setupLogger = setupLogger;
 
         //  SetupLogger doesn't have a way of writing a message that shouldn't include a newline.  So if this method is used a message may be split across multiple lines,
         //  but that's probably better than not writing a message at all or throwing an exception

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
@@ -17,14 +17,15 @@ namespace Microsoft.DotNet.Workloads.Workload.Install;
 /// for the current feature band for items not specified in ManifestsToKeep and PacksToKeep.  Then, if an item
 /// has no reference counts left, it can actually be deleted / uninstalled.
 /// </summary>
-internal class WorkloadGarbageCollector
+internal class WorkloadGarbageCollector(string dotnetDir, SdkFeatureBand sdkFeatureBand, IEnumerable<WorkloadId> installedWorkloads, Func<string, IWorkloadResolver> getResolverForWorkloadSet,
+    Dictionary<string, string> globalJsonWorkloadSetVersions, IReporter verboseReporter)
 {
-    SdkFeatureBand _sdkFeatureBand;
-    string _dotnetDir;
-    IEnumerable<WorkloadId> _installedWorkloads;
-    Func<string, IWorkloadResolver> _getResolverForWorkloadSet;
-    Dictionary<string, string> _globalJsonWorkloadSetVersions;
-    IReporter _verboseReporter;
+    SdkFeatureBand _sdkFeatureBand = sdkFeatureBand;
+    string _dotnetDir = dotnetDir;
+    IEnumerable<WorkloadId> _installedWorkloads = installedWorkloads;
+    Func<string, IWorkloadResolver> _getResolverForWorkloadSet = getResolverForWorkloadSet;
+    Dictionary<string, string> _globalJsonWorkloadSetVersions = globalJsonWorkloadSetVersions;
+    IReporter _verboseReporter = verboseReporter ?? Reporter.NullReporter;
 
     public HashSet<string> WorkloadSetsToKeep = [];
     public HashSet<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand)> ManifestsToKeep = [];
@@ -39,21 +40,6 @@ internal class WorkloadGarbageCollector
 
     Dictionary<string, GCAction> _workloadSets = [];
     Dictionary<(ManifestId id, ManifestVersion version, SdkFeatureBand featureBand), GCAction> _manifests = [];
-
-    //  globalJsonWorkloadSetVersions should be the contents of the GC Roots file.  The keys should be paths to global.json files, and the values
-    //  should be the workload set version referred to by that file.  Before calling this method, the installer implementation should update the
-    //  file by removing any outdated entries in it (where for example the global.json file doesn't exist or no longer specifies the same workload
-    //  set version).
-    public WorkloadGarbageCollector(string dotnetDir, SdkFeatureBand sdkFeatureBand, IEnumerable<WorkloadId> installedWorkloads, Func<string, IWorkloadResolver> getResolverForWorkloadSet,
-        Dictionary<string, string> globalJsonWorkloadSetVersions, IReporter verboseReporter)
-    {
-        _dotnetDir = dotnetDir;
-        _sdkFeatureBand = sdkFeatureBand;
-        _installedWorkloads = installedWorkloads;
-        _getResolverForWorkloadSet = getResolverForWorkloadSet;
-        _globalJsonWorkloadSetVersions = globalJsonWorkloadSetVersions;
-        _verboseReporter = verboseReporter ?? Reporter.NullReporter;
-    }
 
     public void Collect()
     {

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadGarbageCollector.cs
@@ -16,6 +16,11 @@ namespace Microsoft.DotNet.Workloads.Workload.Install;
 /// and manifests for each feature band.  When it runs garbage collection, it should remove those reference counts
 /// for the current feature band for items not specified in ManifestsToKeep and PacksToKeep.  Then, if an item
 /// has no reference counts left, it can actually be deleted / uninstalled.
+///
+/// globalJsonWorkloadSetVersions should be the contents of the GC Roots file.  The keys should be paths to global.json files, and the values
+/// should be the workload set version referred to by that file.  Before calling this method, the installer implementation should update the
+/// file by removing any outdated entries in it (where for example the global.json file doesn't exist or no longer specifies the same workload
+/// set version).
 /// </summary>
 internal class WorkloadGarbageCollector(string dotnetDir, SdkFeatureBand sdkFeatureBand, IEnumerable<WorkloadId> installedWorkloads, Func<string, IWorkloadResolver> getResolverForWorkloadSet,
     Dictionary<string, string> globalJsonWorkloadSetVersions, IReporter verboseReporter)

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/FileBasedInstallationRecordInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/FileBasedInstallationRecordInstaller.cs
@@ -5,15 +5,10 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload.Install.InstallRecord;
 
-internal class FileBasedInstallationRecordRepository : IWorkloadInstallationRecordRepository
+internal class FileBasedInstallationRecordRepository(string workloadMetadataDir) : IWorkloadInstallationRecordRepository
 {
-    private readonly string _workloadMetadataDir;
+    private readonly string _workloadMetadataDir = workloadMetadataDir;
     private const string InstalledWorkloadDir = "InstalledWorkloads";
-
-    public FileBasedInstallationRecordRepository(string workloadMetadataDir)
-    {
-        _workloadMetadataDir = workloadMetadataDir;
-    }
 
     public IEnumerable<SdkFeatureBand> GetFeatureBandsWithInstallationRecords()
     {

--- a/src/Cli/dotnet/Commands/Workload/Restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Restore/WorkloadRestoreCommand.cs
@@ -14,21 +14,14 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload.Restore;
 
-internal class WorkloadRestoreCommand : WorkloadCommandBase
+internal class WorkloadRestoreCommand(
+    ParseResult result,
+    IFileSystem fileSystem = null,
+    IReporter reporter = null) : WorkloadCommandBase(result, reporter: reporter)
 {
-    private readonly ParseResult _result;
-    private readonly IEnumerable<string> _slnOrProjectArgument;
-
-    public WorkloadRestoreCommand(
-        ParseResult result,
-        IFileSystem fileSystem = null,
-        IReporter reporter = null)
-        : base(result, reporter: reporter)
-    {
-        _result = result;
-        _slnOrProjectArgument =
+    private readonly ParseResult _result = result;
+    private readonly IEnumerable<string> _slnOrProjectArgument =
             result.GetValue(RestoreCommandParser.SlnOrProjectArgument);
-    }
 
     public override int Execute()
     {

--- a/src/Cli/dotnet/Commands/Workload/Restore/WorkloadRestoreCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Restore/WorkloadRestoreCommand.cs
@@ -9,14 +9,12 @@ using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.DotNet.Workloads.Workload.Update;
-using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Workloads.Workload.Restore;
 
 internal class WorkloadRestoreCommand(
     ParseResult result,
-    IFileSystem fileSystem = null,
     IReporter reporter = null) : WorkloadCommandBase(result, reporter: reporter)
 {
     private readonly ParseResult _result = result;

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -360,12 +360,10 @@ public enum VerbosityOptions
     diag
 }
 
-public class DynamicOption<T> : CliOption<T>, IDynamicOption
+public class DynamicOption<T>(string name, params string[] aliases) : CliOption<T>(name, aliases), IDynamicOption
 {
-    public DynamicOption(string name, params string[] aliases) : base(name, aliases) { }
 }
 
-public class DynamicArgument<T> : CliArgument<T>, IDynamicArgument
+public class DynamicArgument<T>(string name) : CliArgument<T>(name), IDynamicArgument
 {
-    public DynamicArgument(string name) : base(name) { }
 }

--- a/src/Cli/dotnet/DocumentedCommand.cs
+++ b/src/Cli/dotnet/DocumentedCommand.cs
@@ -6,12 +6,7 @@ using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Cli;
 
-public class DocumentedCommand : CliCommand, ICommandDocument
+public class DocumentedCommand(string name, string docsLink, string description = null) : CliCommand(name, description), ICommandDocument
 {
-    public string DocsLink { get; }
-
-    public DocumentedCommand(string name, string docsLink, string description = null) : base(name, description)
-    {
-        DocsLink = docsLink;
-    }
+    public string DocsLink { get; } = docsLink;
 }

--- a/src/Cli/dotnet/DotNetCommandFactory.cs
+++ b/src/Cli/dotnet/DotNetCommandFactory.cs
@@ -9,16 +9,10 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli;
 
-public class DotNetCommandFactory : ICommandFactory
+public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string currentWorkingDirectory = null) : ICommandFactory
 {
-    private bool _alwaysRunOutOfProc;
-    private readonly string _currentWorkingDirectory;
-
-    public DotNetCommandFactory(bool alwaysRunOutOfProc = false, string currentWorkingDirectory = null)
-    {
-        _alwaysRunOutOfProc = alwaysRunOutOfProc;
-        _currentWorkingDirectory = currentWorkingDirectory;
-    }
+    private bool _alwaysRunOutOfProc = alwaysRunOutOfProc;
+    private readonly string _currentWorkingDirectory = currentWorkingDirectory;
 
     public ICommand Create(
         string commandName,

--- a/src/Cli/dotnet/ForwardingApp.cs
+++ b/src/Cli/dotnet/ForwardingApp.cs
@@ -6,26 +6,21 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli;
 
-public class ForwardingApp
+public class ForwardingApp(
+    string forwardApplicationPath,
+    IEnumerable<string> argsToForward,
+    string depsFile = null,
+    string runtimeConfig = null,
+    string additionalProbingPath = null,
+    Dictionary<string, string> environmentVariables = null)
 {
-    private ForwardingAppImplementation _implementation;
-
-    public ForwardingApp(
-        string forwardApplicationPath,
-        IEnumerable<string> argsToForward,
-        string depsFile = null,
-        string runtimeConfig = null,
-        string additionalProbingPath = null,
-        Dictionary<string, string> environmentVariables = null)
-    {
-        _implementation = new ForwardingAppImplementation(
+    private ForwardingAppImplementation _implementation = new ForwardingAppImplementation(
             forwardApplicationPath,
             argsToForward,
             depsFile,
             runtimeConfig,
             additionalProbingPath,
             environmentVariables);
-    }
 
     public ProcessStartInfo GetProcessStartInfo()
     {

--- a/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
@@ -12,18 +12,13 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// Encapsulates information about elevation to support workload installations.
 /// </summary>
 [SupportedOSPlatform("windows")]
-internal sealed class InstallClientElevationContext : InstallElevationContextBase
+internal sealed class InstallClientElevationContext(ISynchronizingLogger logger) : InstallElevationContextBase
 {
-    private ISynchronizingLogger _log;
+    private ISynchronizingLogger _log = logger;
 
     private Process _serverProcess;
 
     public override bool IsClient => true;
-
-    public InstallClientElevationContext(ISynchronizingLogger logger)
-    {
-        _log = logger;
-    }
 
     /// <summary>
     /// Starts the elevated install server.

--- a/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallMessageDispatcher.cs
@@ -15,11 +15,8 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 #if NETCOREAPP
 [SupportedOSPlatform("windows")]
 #endif
-internal class InstallMessageDispatcher : PipeStreamMessageDispatcherBase, IInstallMessageDispatcher
+internal class InstallMessageDispatcher(PipeStream pipeStream) : PipeStreamMessageDispatcherBase(pipeStream), IInstallMessageDispatcher
 {
-    public InstallMessageDispatcher(PipeStream pipeStream) : base(pipeStream)
-    {
-    }
 
     /// <summary>
     /// Sends a message and blocks until a reply is received.

--- a/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
@@ -13,8 +13,14 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// <summary>
 /// Base class for Windows installer components.
 /// </summary>
+/// <remarks>
+/// Creates a new <see cref="InstallerBase"/> instance using the specified elevation context and logger.
+/// </remarks>
+/// <param name="elevationContext"></param>
+/// <param name="logger"></param>
+/// <param name="verifySignatures">Determines whether MSI signatures should be verified</param>
 [SupportedOSPlatform("windows")]
-internal abstract class InstallerBase
+internal abstract class InstallerBase(InstallElevationContextBase elevationContext, ISetupLogger logger, bool verifySignatures)
 {
     /// <summary>
     /// The current process.
@@ -38,7 +44,7 @@ internal abstract class InstallerBase
     protected InstallElevationContextBase ElevationContext
     {
         get;
-    }
+    } = elevationContext;
 
     /// <summary>
     /// Returns true if the current process is 64-bit.
@@ -59,7 +65,7 @@ internal abstract class InstallerBase
     /// <summary>
     /// Provides access to the underlying setup log.
     /// </summary>
-    protected readonly ISetupLogger Log;
+    protected readonly ISetupLogger Log = logger;
 
     /// <summary>
     /// The parent process of this process.
@@ -96,20 +102,7 @@ internal abstract class InstallerBase
     protected bool VerifySignatures
     {
         get;
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="InstallerBase"/> instance using the specified elevation context and logger.
-    /// </summary>
-    /// <param name="elevationContext"></param>
-    /// <param name="logger"></param>
-    /// <param name="verifySignatures">Determines whether MSI signatures should be verified</param>
-    protected InstallerBase(InstallElevationContextBase elevationContext, ISetupLogger logger, bool verifySignatures)
-    {
-        ElevationContext = elevationContext;
-        Log = logger;
-        VerifySignatures = verifySignatures;
-    }
+    } = verifySignatures;
 
     /// <summary>
     /// Starts an elevated process to perform privileged operations.

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -16,26 +16,20 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// Manages caching workload pack MSI packages.
 /// </summary>
 [SupportedOSPlatform("windows")]
-internal class MsiPackageCache : InstallerBase
+internal class MsiPackageCache(InstallElevationContextBase elevationContext, ISetupLogger logger,
+    bool verifySignatures, string packageCacheRoot = null) : InstallerBase(elevationContext, logger, verifySignatures)
 {
     /// <summary>
     /// Determines whether revocation checks can go online.
     /// </summary>
-    private bool _allowOnlineRevocationChecks;
+    private bool _allowOnlineRevocationChecks = SignCheck.AllowOnlineRevocationChecks();
 
     /// <summary>
     /// The root directory of the package cache where MSI workload packs are stored.
     /// </summary>
-    public readonly string PackageCacheRoot;
-
-    public MsiPackageCache(InstallElevationContextBase elevationContext, ISetupLogger logger,
-        bool verifySignatures, string packageCacheRoot = null) : base(elevationContext, logger, verifySignatures)
-    {
-        PackageCacheRoot = string.IsNullOrWhiteSpace(packageCacheRoot)
+    public readonly string PackageCacheRoot = string.IsNullOrWhiteSpace(packageCacheRoot)
             ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "dotnet", "workloads")
             : packageCacheRoot;
-        _allowOnlineRevocationChecks = SignCheck.AllowOnlineRevocationChecks();
-    }
 
     /// <summary>
     /// Moves the MSI payload described by the manifest file to the cache.

--- a/src/Cli/dotnet/Installer/Windows/MsiPayload.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPayload.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// Represents the payload associated with a single workload pack installer. The payload
 /// consists of the installer (MSI) and its JSON manifest.
 /// </summary>
-internal class MsiPayload
+internal class MsiPayload(string manifestPath, string msiPath)
 {
     private MsiManifest _manifest;
 
@@ -18,12 +18,12 @@ internal class MsiPayload
     /// <summary>
     /// The full path of the JSON manifest associated with this payload.
     /// </summary>
-    public readonly string ManifestPath;
+    public readonly string ManifestPath = manifestPath;
 
     /// <summary>
     /// The full path of the MSI associated with this payload.
     /// </summary>
-    public readonly string MsiPath;
+    public readonly string MsiPath = msiPath;
 
     /// <summary>
     /// The name of the MSI package.
@@ -82,10 +82,4 @@ internal class MsiPayload
     /// The upgrade code of the MSI.
     /// </summary>
     public string UpgradeCode => Manifest.UpgradeCode;
-
-    public MsiPayload(string manifestPath, string msiPath)
-    {
-        ManifestPath = manifestPath;
-        MsiPath = msiPath;
-    }
 }

--- a/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/PipeStreamMessageDispatcherBase.cs
@@ -9,8 +9,14 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// <summary>
 /// Base class used for dispatching messages (<see cref="PipeTransmissionMode.Message"/>) over a named pipe.
 /// </summary>
+/// <remarks>
+/// Creates a new <see cref="PipeStreamMessageDispatcherBase"/> instance.
+/// </remarks>
+/// <param name="pipeStream">The pipe stream to use for reading and writing messages. The pipe must be configured
+/// to use <see cref="PipeTransmissionMode.Message"/>.</param>
+/// <exception cref="ArgumentNullException" />
 [SupportedOSPlatform("windows")]
-internal class PipeStreamMessageDispatcherBase
+internal class PipeStreamMessageDispatcherBase(PipeStream pipeStream)
 {
     /// <summary>
     /// The maxmimum length of a message.
@@ -20,7 +26,7 @@ internal class PipeStreamMessageDispatcherBase
     /// <summary>
     /// The backing stream used for reading & writing messages.
     /// </summary>
-    private PipeStream _pipeStream;
+    private PipeStream _pipeStream = pipeStream ?? throw new ArgumentNullException(nameof(pipeStream));
 
     /// <summary>
     /// The number of milliseconds to wait for a pipe connection to be established. See <see cref="Connect"/>.
@@ -36,17 +42,6 @@ internal class PipeStreamMessageDispatcherBase
     /// Gets whether the underlying stream is connected.
     /// </summary>
     public bool IsConnected => _pipeStream.IsConnected;
-
-    /// <summary>
-    /// Creates a new <see cref="PipeStreamMessageDispatcherBase"/> instance.
-    /// </summary>
-    /// <param name="pipeStream">The pipe stream to use for reading and writing messages. The pipe must be configured
-    /// to use <see cref="PipeTransmissionMode.Message"/>.</param>
-    /// <exception cref="ArgumentNullException" />
-    public PipeStreamMessageDispatcherBase(PipeStream pipeStream)
-    {
-        _pipeStream = pipeStream ?? throw new ArgumentNullException(nameof(pipeStream));
-    }
 
     /// <summary>
     /// Waits for the underlying <see cref="PipeStream"/> to establish a connection. If the stream is a 

--- a/src/Cli/dotnet/Installer/Windows/PipeStreamSetupLogger.cs
+++ b/src/Cli/dotnet/Installer/Windows/PipeStreamSetupLogger.cs
@@ -9,10 +9,15 @@ namespace Microsoft.DotNet.Cli.Installer.Windows;
 /// <summary>
 /// Provides logging support for external processes, allowing them to send log requests through a named pipe.
 /// </summary>
+/// <remarks>
+/// Creates a new <see cref="PipeStreamSetupLogger"/> instance.
+/// </remarks>
+/// <param name="pipeStream">The <see cref="PipeStream"/> to use for sending log requests.</param>
+/// <param name="pipeName"></param>
 [SupportedOSPlatform("windows")]
-internal class PipeStreamSetupLogger : SetupLoggerBase, ISetupLogger
+internal class PipeStreamSetupLogger(PipeStream pipeStream, string pipeName) : SetupLoggerBase, ISetupLogger
 {
-    private PipeStreamMessageDispatcherBase _dispatcher;
+    private PipeStreamMessageDispatcherBase _dispatcher = new PipeStreamMessageDispatcherBase(pipeStream);
 
     /// <summary>
     /// Queue to track log requests issued before the pipestream is connected.
@@ -23,18 +28,7 @@ internal class PipeStreamSetupLogger : SetupLoggerBase, ISetupLogger
     {
         get;
         private set;
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="PipeStreamSetupLogger"/> instance.
-    /// </summary>
-    /// <param name="pipeStream">The <see cref="PipeStream"/> to use for sending log requests.</param>
-    /// <param name="pipeName"></param>
-    public PipeStreamSetupLogger(PipeStream pipeStream, string pipeName)
-    {
-        _dispatcher = new PipeStreamMessageDispatcherBase(pipeStream);
-        LogPath = pipeName;
-    }
+    } = pipeName;
 
     /// <summary>
     /// Waits for the underlying pipe stream to become connected.

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackagePathResolver.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackagePathResolver.cs
@@ -7,12 +7,8 @@ using NuGet.Packaging.Core;
 namespace Microsoft.DotNet.Cli.NuGetPackageDownloader;
 
 // Extract NuGet package content directly to the specified target directory (instead of creating subdirs)
-internal class NuGetPackagePathResolver : PackagePathResolver
+internal class NuGetPackagePathResolver(string rootDirectory) : PackagePathResolver(rootDirectory, false)
 {
-    public NuGetPackagePathResolver(string rootDirectory) : base(rootDirectory, false)
-    {
-    }
-
     public override string GetPackageDirectoryName(PackageIdentity packageIdentity)
     {
         return string.Empty;

--- a/src/Cli/dotnet/NugetSearch/NugetSearchApiRequestException.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetSearchApiRequestException.cs
@@ -5,10 +5,6 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.NugetSearch;
 
-internal class NugetSearchApiRequestException : GracefulException
+internal class NugetSearchApiRequestException(string message) : GracefulException([message], null, false)
 {
-    public NugetSearchApiRequestException(string message)
-        : base([message], null, false)
-    {
-    }
 }

--- a/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/Cli/dotnet/ShellShim/AppHostShimMaker.cs
@@ -6,21 +6,14 @@ using Microsoft.NET.HostModel.AppHost;
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class AppHostShellShimMaker : IAppHostShellShimMaker
+internal class AppHostShellShimMaker(string appHostSourceDirectory, IFilePermissionSetter filePermissionSetter = null) : IAppHostShellShimMaker
 {
     private const string ApphostNameWithoutExtension = "apphost";
-    private readonly string _appHostSourceDirectory;
-    private readonly IFilePermissionSetter _filePermissionSetter;
-    private const ushort WindowsGUISubsystem = 0x2;
-
-    public AppHostShellShimMaker(string appHostSourceDirectory, IFilePermissionSetter filePermissionSetter = null)
-    {
-        _appHostSourceDirectory = appHostSourceDirectory;
-
-        _filePermissionSetter =
+    private readonly string _appHostSourceDirectory = appHostSourceDirectory;
+    private readonly IFilePermissionSetter _filePermissionSetter =
             filePermissionSetter
             ?? new FilePermissionSetter();
-    }
+    private const ushort WindowsGUISubsystem = 0x2;
 
     public void CreateApphostShellShim(FilePath entryPoint, FilePath shimPath)
     {

--- a/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
@@ -17,14 +17,10 @@ internal class OsxBashEnvironmentPath(
     private const string PathName = "PATH";
     private readonly BashPathUnderHomeDirectory _packageExecutablePath = executablePath;
     private readonly IFile _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-    private readonly IEnvironmentProvider _environmentProvider
-            = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
-    private readonly IReporter _reporter
-            = reporter ?? throw new ArgumentNullException(nameof(reporter));
+    private readonly IEnvironmentProvider _environmentProvider = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
+    private readonly IReporter _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
 
-    internal static readonly string DotnetCliToolsPathsDPath
-        = Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_OSX_PATHSD_PATH")
-          ?? @"/etc/paths.d/dotnet-cli-tools";
+    internal static readonly string DotnetCliToolsPathsDPath = Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_OSX_PATHSD_PATH") ?? @"/etc/paths.d/dotnet-cli-tools";
 
     public void AddPackageExecutablePathToUserPath()
     {

--- a/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/OsxBashEnvironmentPath.cs
@@ -7,32 +7,24 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class OsxBashEnvironmentPath : IEnvironmentPath
+internal class OsxBashEnvironmentPath(
+    BashPathUnderHomeDirectory executablePath,
+    IReporter reporter,
+    IEnvironmentProvider environmentProvider,
+    IFile fileSystem
+    ) : IEnvironmentPath
 {
     private const string PathName = "PATH";
-    private readonly BashPathUnderHomeDirectory _packageExecutablePath;
-    private readonly IFile _fileSystem;
-    private readonly IEnvironmentProvider _environmentProvider;
-    private readonly IReporter _reporter;
+    private readonly BashPathUnderHomeDirectory _packageExecutablePath = executablePath;
+    private readonly IFile _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    private readonly IEnvironmentProvider _environmentProvider
+            = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
+    private readonly IReporter _reporter
+            = reporter ?? throw new ArgumentNullException(nameof(reporter));
 
     internal static readonly string DotnetCliToolsPathsDPath
         = Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_OSX_PATHSD_PATH")
           ?? @"/etc/paths.d/dotnet-cli-tools";
-
-    public OsxBashEnvironmentPath(
-        BashPathUnderHomeDirectory executablePath,
-        IReporter reporter,
-        IEnvironmentProvider environmentProvider,
-        IFile fileSystem
-    )
-    {
-        _packageExecutablePath = executablePath;
-        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        _environmentProvider
-            = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
-        _reporter
-            = reporter ?? throw new ArgumentNullException(nameof(reporter));
-    }
 
     public void AddPackageExecutablePathToUserPath()
     {

--- a/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
+++ b/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
@@ -6,26 +6,18 @@ using Microsoft.DotNet.Configurer;
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class OsxZshEnvironmentPathInstruction : IEnvironmentPathInstruction
+internal class OsxZshEnvironmentPathInstruction(
+    BashPathUnderHomeDirectory executablePath,
+    IReporter reporter,
+    IEnvironmentProvider environmentProvider
+    ) : IEnvironmentPathInstruction
 {
     private const string PathName = "PATH";
-    private readonly BashPathUnderHomeDirectory _packageExecutablePath;
-    private readonly IEnvironmentProvider _environmentProvider;
-    private readonly IReporter _reporter;
-
-
-    public OsxZshEnvironmentPathInstruction(
-        BashPathUnderHomeDirectory executablePath,
-        IReporter reporter,
-        IEnvironmentProvider environmentProvider
-    )
-    {
-        _packageExecutablePath = executablePath;
-        _environmentProvider
+    private readonly BashPathUnderHomeDirectory _packageExecutablePath = executablePath;
+    private readonly IEnvironmentProvider _environmentProvider
             = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
-        _reporter
+    private readonly IReporter _reporter
             = reporter ?? throw new ArgumentNullException(nameof(reporter));
-    }
 
     private bool PackageExecutablePathExists()
     {

--- a/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
+++ b/src/Cli/dotnet/ShellShim/OsxZshEnvironmentPathInstruction.cs
@@ -14,10 +14,8 @@ internal class OsxZshEnvironmentPathInstruction(
 {
     private const string PathName = "PATH";
     private readonly BashPathUnderHomeDirectory _packageExecutablePath = executablePath;
-    private readonly IEnvironmentProvider _environmentProvider
-            = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
-    private readonly IReporter _reporter
-            = reporter ?? throw new ArgumentNullException(nameof(reporter));
+    private readonly IEnvironmentProvider _environmentProvider = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
+    private readonly IReporter _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
 
     private bool PackageExecutablePathExists()
     {
@@ -27,9 +25,7 @@ internal class OsxZshEnvironmentPathInstruction(
             return false;
         }
 
-        return value
-            .Split(':')
-            .Any(p => p == _packageExecutablePath.Path);
+        return value.Split(':').Any(p => p == _packageExecutablePath.Path);
     }
 
     public void PrintAddPathInstructionIfPathDoesNotExist()

--- a/src/Cli/dotnet/ShellShim/ShellShimRepository.cs
+++ b/src/Cli/dotnet/ShellShim/ShellShimRepository.cs
@@ -6,25 +6,17 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class ShellShimRepository : IShellShimRepository
+internal class ShellShimRepository(
+    DirectoryPath shimsDirectory,
+    string appHostSourceDirectory,
+    IFileSystem fileSystem = null,
+    IAppHostShellShimMaker appHostShellShimMaker = null,
+    IFilePermissionSetter filePermissionSetter = null) : IShellShimRepository
 {
-    private readonly DirectoryPath _shimsDirectory;
-    private readonly IFileSystem _fileSystem;
-    private readonly IAppHostShellShimMaker _appHostShellShimMaker;
-    private readonly IFilePermissionSetter _filePermissionSetter;
-
-    public ShellShimRepository(
-        DirectoryPath shimsDirectory,
-        string appHostSourceDirectory,
-        IFileSystem fileSystem = null,
-        IAppHostShellShimMaker appHostShellShimMaker = null,
-        IFilePermissionSetter filePermissionSetter = null)
-    {
-        _shimsDirectory = shimsDirectory;
-        _fileSystem = fileSystem ?? new FileSystemWrapper();
-        _appHostShellShimMaker = appHostShellShimMaker ?? new AppHostShellShimMaker(appHostSourceDirectory: appHostSourceDirectory);
-        _filePermissionSetter = filePermissionSetter ?? new FilePermissionSetter();
-    }
+    private readonly DirectoryPath _shimsDirectory = shimsDirectory;
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystemWrapper();
+    private readonly IAppHostShellShimMaker _appHostShellShimMaker = appHostShellShimMaker ?? new AppHostShellShimMaker(appHostSourceDirectory: appHostSourceDirectory);
+    private readonly IFilePermissionSetter _filePermissionSetter = filePermissionSetter ?? new FilePermissionSetter();
 
     public void CreateShim(FilePath targetExecutablePath, ToolCommandName commandName, IReadOnlyList<FilePath> packagedShims = null)
     {

--- a/src/Cli/dotnet/ShellShim/ShellShimTemplateFinder.cs
+++ b/src/Cli/dotnet/ShellShim/ShellShimTemplateFinder.cs
@@ -11,21 +11,14 @@ using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Install.LocalizableString
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class ShellShimTemplateFinder
+internal class ShellShimTemplateFinder(
+    INuGetPackageDownloader nugetPackageDownloader,
+    DirectoryPath tempDir,
+    PackageSourceLocation packageSourceLocation)
 {
-    private readonly DirectoryPath _tempDir;
-    private readonly INuGetPackageDownloader _nugetPackageDownloader;
-    private readonly PackageSourceLocation _packageSourceLocation;
-
-    public ShellShimTemplateFinder(
-        INuGetPackageDownloader nugetPackageDownloader,
-        DirectoryPath tempDir,
-        PackageSourceLocation packageSourceLocation)
-    {
-        _tempDir = tempDir;
-        _nugetPackageDownloader = nugetPackageDownloader;
-        _packageSourceLocation = packageSourceLocation;
-    }
+    private readonly DirectoryPath _tempDir = tempDir;
+    private readonly INuGetPackageDownloader _nugetPackageDownloader = nugetPackageDownloader;
+    private readonly PackageSourceLocation _packageSourceLocation = packageSourceLocation;
 
     public async Task<string> ResolveAppHostSourceDirectoryAsync(string archOption, NuGetFramework targetFramework, Architecture arch)
     {

--- a/src/Cli/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -14,24 +14,20 @@ internal class WindowsEnvironmentPath(string packageExecutablePath,
 {
     private readonly IReporter _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
     private const string PathName = "PATH";
-    private readonly string _expandedPackageExecutablePath =
-            packageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
-    private readonly string _nonExpandedPackageExecutablePath = nonExpandedPackageExecutablePath ??
-                                            throw new ArgumentNullException(nameof(packageExecutablePath));
+    private readonly string _expandedPackageExecutablePath = packageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
+    private readonly string _nonExpandedPackageExecutablePath = nonExpandedPackageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
 
     /// <summary>
     /// This will read cached and expanded environment variable. We use this
     /// to check if the expanded tool shim path exists. Since this is ultimately how shell will invoke command
     /// </summary>
-    private readonly IEnvironmentProvider _expandedEnvironmentReader =
-            expandedEnvironmentReader ?? throw new ArgumentNullException(nameof(expandedEnvironmentReader));
+    private readonly IEnvironmentProvider _expandedEnvironmentReader = expandedEnvironmentReader ?? throw new ArgumentNullException(nameof(expandedEnvironmentReader));
 
     /// <summary>
     /// This will read from registry with non expanded environment like %USERPROFILE%\AppData\Local\Microsoft\WindowsApps
     /// when append tool shim PATH. Use to read and write to avoid edit existing PATH.
     /// </summary>
-    private readonly IWindowsRegistryEnvironmentPathEditor _environmentPathEditor =
-            environmentPathEditor ?? throw new ArgumentNullException(nameof(environmentPathEditor));
+    private readonly IWindowsRegistryEnvironmentPathEditor _environmentPathEditor = environmentPathEditor ?? throw new ArgumentNullException(nameof(environmentPathEditor));
 
     public void AddPackageExecutablePathToUserPath()
     {

--- a/src/Cli/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/Cli/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -6,43 +6,32 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.ShellShim;
 
-internal class WindowsEnvironmentPath : IEnvironmentPath
+internal class WindowsEnvironmentPath(string packageExecutablePath,
+    string nonExpandedPackageExecutablePath,
+    IEnvironmentProvider expandedEnvironmentReader,
+    IWindowsRegistryEnvironmentPathEditor environmentPathEditor,
+    IReporter reporter) : IEnvironmentPath
 {
-    private readonly IReporter _reporter;
+    private readonly IReporter _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
     private const string PathName = "PATH";
-    private readonly string _expandedPackageExecutablePath;
-    private readonly string _nonExpandedPackageExecutablePath;
+    private readonly string _expandedPackageExecutablePath =
+            packageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
+    private readonly string _nonExpandedPackageExecutablePath = nonExpandedPackageExecutablePath ??
+                                            throw new ArgumentNullException(nameof(packageExecutablePath));
 
     /// <summary>
     /// This will read cached and expanded environment variable. We use this
     /// to check if the expanded tool shim path exists. Since this is ultimately how shell will invoke command
     /// </summary>
-    private readonly IEnvironmentProvider _expandedEnvironmentReader;
+    private readonly IEnvironmentProvider _expandedEnvironmentReader =
+            expandedEnvironmentReader ?? throw new ArgumentNullException(nameof(expandedEnvironmentReader));
 
     /// <summary>
     /// This will read from registry with non expanded environment like %USERPROFILE%\AppData\Local\Microsoft\WindowsApps
     /// when append tool shim PATH. Use to read and write to avoid edit existing PATH.
     /// </summary>
-    private readonly IWindowsRegistryEnvironmentPathEditor _environmentPathEditor;
-
-    public WindowsEnvironmentPath(string packageExecutablePath,
-        string nonExpandedPackageExecutablePath,
-        IEnvironmentProvider expandedEnvironmentReader,
-        IWindowsRegistryEnvironmentPathEditor environmentPathEditor,
-        IReporter reporter)
-    {
-        _nonExpandedPackageExecutablePath = nonExpandedPackageExecutablePath ??
-                                            throw new ArgumentNullException(nameof(packageExecutablePath));
-        _expandedPackageExecutablePath =
-            packageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
-        _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
-
-        _expandedEnvironmentReader =
-            expandedEnvironmentReader ?? throw new ArgumentNullException(nameof(expandedEnvironmentReader));
-
-        _environmentPathEditor =
+    private readonly IWindowsRegistryEnvironmentPathEditor _environmentPathEditor =
             environmentPathEditor ?? throw new ArgumentNullException(nameof(environmentPathEditor));
-    }
 
     public void AddPackageExecutablePathToUserPath()
     {

--- a/src/Cli/dotnet/Telemetry/AllowListToSendFirstAppliedOptions.cs
+++ b/src/Cli/dotnet/Telemetry/AllowListToSendFirstAppliedOptions.cs
@@ -7,15 +7,10 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class AllowListToSendFirstAppliedOptions : IParseResultLogRule
+internal class AllowListToSendFirstAppliedOptions(
+    HashSet<string> topLevelCommandNameAllowList) : IParseResultLogRule
 {
-    public AllowListToSendFirstAppliedOptions(
-        HashSet<string> topLevelCommandNameAllowList)
-    {
-        _topLevelCommandNameAllowList = topLevelCommandNameAllowList;
-    }
-
-    private HashSet<string> _topLevelCommandNameAllowList { get; }
+    private HashSet<string> _topLevelCommandNameAllowList { get; } = topLevelCommandNameAllowList;
 
     public List<ApplicationInsightsEntryFormat> AllowList(ParseResult parseResult, Dictionary<string, double> measurements = null)
     {

--- a/src/Cli/dotnet/Telemetry/AllowListToSendFirstArgument.cs
+++ b/src/Cli/dotnet/Telemetry/AllowListToSendFirstArgument.cs
@@ -7,15 +7,10 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class AllowListToSendFirstArgument : IParseResultLogRule
+internal class AllowListToSendFirstArgument(
+    HashSet<string> topLevelCommandNameAllowList) : IParseResultLogRule
 {
-    public AllowListToSendFirstArgument(
-        HashSet<string> topLevelCommandNameAllowList)
-    {
-        _topLevelCommandNameAllowList = topLevelCommandNameAllowList;
-    }
-
-    private HashSet<string> _topLevelCommandNameAllowList { get; }
+    private HashSet<string> _topLevelCommandNameAllowList { get; } = topLevelCommandNameAllowList;
 
     public List<ApplicationInsightsEntryFormat> AllowList(ParseResult parseResult, Dictionary<string, double> measurements = null)
     {

--- a/src/Cli/dotnet/Telemetry/AllowListToSendVerbSecondVerbFirstArgument.cs
+++ b/src/Cli/dotnet/Telemetry/AllowListToSendVerbSecondVerbFirstArgument.cs
@@ -8,15 +8,10 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class AllowListToSendVerbSecondVerbFirstArgument : IParseResultLogRule
+internal class AllowListToSendVerbSecondVerbFirstArgument(
+    HashSet<string> topLevelCommandNameAllowList) : IParseResultLogRule
 {
-    public AllowListToSendVerbSecondVerbFirstArgument(
-        HashSet<string> topLevelCommandNameAllowList)
-    {
-        TopLevelCommandNameAllowList = topLevelCommandNameAllowList;
-    }
-
-    private HashSet<string> TopLevelCommandNameAllowList { get; }
+    private HashSet<string> TopLevelCommandNameAllowList { get; } = topLevelCommandNameAllowList;
 
     public List<ApplicationInsightsEntryFormat> AllowList(ParseResult parseResult, Dictionary<string, double> measurements = null)
     {

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -8,33 +8,22 @@ using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class TelemetryCommonProperties
+internal class TelemetryCommonProperties(
+    Func<string> getCurrentDirectory = null,
+    Func<string, string> hasher = null,
+    Func<string> getMACAddress = null,
+    Func<string> getDeviceId = null,
+    IDockerContainerDetector dockerContainerDetector = null,
+    IUserLevelCacheWriter userLevelCacheWriter = null,
+    ICIEnvironmentDetector ciEnvironmentDetector = null)
 {
-    public TelemetryCommonProperties(
-        Func<string> getCurrentDirectory = null,
-        Func<string, string> hasher = null,
-        Func<string> getMACAddress = null,
-        Func<string> getDeviceId = null,
-        IDockerContainerDetector dockerContainerDetector = null,
-        IUserLevelCacheWriter userLevelCacheWriter = null,
-        ICIEnvironmentDetector ciEnvironmentDetector = null)
-    {
-        _getCurrentDirectory = getCurrentDirectory ?? Directory.GetCurrentDirectory;
-        _hasher = hasher ?? Sha256Hasher.Hash;
-        _getMACAddress = getMACAddress ?? MacAddressGetter.GetMacAddress;
-        _getDeviceId = getDeviceId ?? DeviceIdGetter.GetDeviceId;
-        _dockerContainerDetector = dockerContainerDetector ?? new DockerContainerDetectorForTelemetry();
-        _userLevelCacheWriter = userLevelCacheWriter ?? new UserLevelCacheWriter();
-        _ciEnvironmentDetector = ciEnvironmentDetector ?? new CIEnvironmentDetectorForTelemetry();
-    }
-
-    private readonly IDockerContainerDetector _dockerContainerDetector;
-    private readonly ICIEnvironmentDetector _ciEnvironmentDetector;
-    private Func<string> _getCurrentDirectory;
-    private Func<string, string> _hasher;
-    private Func<string> _getMACAddress;
-    private Func<string> _getDeviceId;
-    private IUserLevelCacheWriter _userLevelCacheWriter;
+    private readonly IDockerContainerDetector _dockerContainerDetector = dockerContainerDetector ?? new DockerContainerDetectorForTelemetry();
+    private readonly ICIEnvironmentDetector _ciEnvironmentDetector = ciEnvironmentDetector ?? new CIEnvironmentDetectorForTelemetry();
+    private Func<string> _getCurrentDirectory = getCurrentDirectory ?? Directory.GetCurrentDirectory;
+    private Func<string, string> _hasher = hasher ?? Sha256Hasher.Hash;
+    private Func<string> _getMACAddress = getMACAddress ?? MacAddressGetter.GetMacAddress;
+    private Func<string> _getDeviceId = getDeviceId ?? DeviceIdGetter.GetDeviceId;
+    private IUserLevelCacheWriter _userLevelCacheWriter = userLevelCacheWriter ?? new UserLevelCacheWriter();
     private const string OSVersion = "OS Version";
     private const string OSPlatform = "OS Platform";
     private const string OSArchitecture = "OS Architecture";

--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -8,15 +8,10 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class TelemetryFilter : ITelemetryFilter
+internal class TelemetryFilter(Func<string, string> hash) : ITelemetryFilter
 {
     private const string ExceptionEventName = "mainCatchException/exception";
-    private readonly Func<string, string> _hash;
-
-    public TelemetryFilter(Func<string, string> hash)
-    {
-        _hash = hash ?? throw new ArgumentNullException(nameof(hash));
-    }
+    private readonly Func<string, string> _hash = hash ?? throw new ArgumentNullException(nameof(hash));
 
     public IEnumerable<ApplicationInsightsEntryFormat> Filter(object objectToFilter)
     {

--- a/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
+++ b/src/Cli/dotnet/Telemetry/TopLevelCommandNameAndOptionToLog.cs
@@ -9,18 +9,12 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
-internal class TopLevelCommandNameAndOptionToLog : IParseResultLogRule
+internal class TopLevelCommandNameAndOptionToLog(
+    HashSet<string> topLevelCommandName,
+    HashSet<CliOption> optionsToLog) : IParseResultLogRule
 {
-    public TopLevelCommandNameAndOptionToLog(
-        HashSet<string> topLevelCommandName,
-        HashSet<CliOption> optionsToLog)
-    {
-        _topLevelCommandName = topLevelCommandName;
-        _optionsToLog = optionsToLog;
-    }
-
-    private HashSet<string> _topLevelCommandName { get; }
-    private HashSet<CliOption> _optionsToLog { get; }
+    private HashSet<string> _topLevelCommandName { get; } = topLevelCommandName;
+    private HashSet<CliOption> _optionsToLog { get; } = optionsToLog;
 
     public List<ApplicationInsightsEntryFormat> AllowList(ParseResult parseResult, Dictionary<string, double> measurements = null)
     {

--- a/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestEditor.cs
@@ -10,10 +10,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.ToolManifest;
 
-internal class ToolManifestEditor : IToolManifestEditor
+internal class ToolManifestEditor(IFileSystem fileSystem = null, IDangerousFileDetector dangerousFileDetector = null) : IToolManifestEditor
 {
-    private readonly IDangerousFileDetector _dangerousFileDetector;
-    private readonly IFileSystem _fileSystem;
+    private readonly IDangerousFileDetector _dangerousFileDetector = dangerousFileDetector ?? new DangerousFileDetector();
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystemWrapper();
 
     private const int SupportedToolManifestFileVersion = 1;
     private const int DefaultToolManifestFileVersion = 1;
@@ -22,12 +22,6 @@ internal class ToolManifestEditor : IToolManifestEditor
     private const string JsonPropertyCommands = "commands";
     private const string JsonPropertyTools = "tools";
     private const string JsonPropertyRollForward = "rollForward";
-
-    public ToolManifestEditor(IFileSystem fileSystem = null, IDangerousFileDetector dangerousFileDetector = null)
-    {
-        _dangerousFileDetector = dangerousFileDetector ?? new DangerousFileDetector();
-        _fileSystem = fileSystem ?? new FileSystemWrapper();
-    }
 
     public void Add(
         FilePath manifest,

--- a/src/Cli/dotnet/ToolManifest/ToolManifestException.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestException.cs
@@ -5,10 +5,6 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.ToolManifest;
 
-internal class ToolManifestException : GracefulException
+internal class ToolManifestException(string message) : GracefulException([message], null, false)
 {
-    public ToolManifestException(string message) : base([message], null, false)
-    {
-
-    }
 }

--- a/src/Cli/dotnet/ToolManifest/ToolManifestPackage.cs
+++ b/src/Cli/dotnet/ToolManifest/ToolManifestPackage.cs
@@ -8,31 +8,22 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.ToolManifest;
 
-internal struct ToolManifestPackage : IEquatable<ToolManifestPackage>
+internal struct ToolManifestPackage(PackageId packagePackageId,
+    NuGetVersion version,
+    ToolCommandName[] toolCommandNames,
+    DirectoryPath firstEffectDirectory,
+    bool rollForward) : IEquatable<ToolManifestPackage>
 {
-    public PackageId PackageId { get; }
-    public NuGetVersion Version { get; }
-    public ToolCommandName[] CommandNames { get; }
-    public bool RollForward { get; }
+    public PackageId PackageId { get; } = packagePackageId;
+    public NuGetVersion Version { get; } = version ?? throw new ArgumentNullException(nameof(version));
+    public ToolCommandName[] CommandNames { get; } = toolCommandNames ?? throw new ArgumentNullException(nameof(toolCommandNames));
+    public bool RollForward { get; } = rollForward;
     /// <summary>
     /// The directory that will take effect first.
     /// When it is under .config directory, it is not .config directory
     /// it is .config's parent directory
     /// </summary>
-    public DirectoryPath FirstEffectDirectory { get; }
-
-    public ToolManifestPackage(PackageId packagePackageId,
-        NuGetVersion version,
-        ToolCommandName[] toolCommandNames,
-        DirectoryPath firstEffectDirectory,
-        bool rollForward)
-    {
-        FirstEffectDirectory = firstEffectDirectory;
-        PackageId = packagePackageId;
-        Version = version ?? throw new ArgumentNullException(nameof(version));
-        CommandNames = toolCommandNames ?? throw new ArgumentNullException(nameof(toolCommandNames));
-        RollForward = rollForward;
-    }
+    public DirectoryPath FirstEffectDirectory { get; } = firstEffectDirectory;
 
     public override bool Equals(object obj)
     {

--- a/src/Cli/dotnet/ToolPackage/PackageId.cs
+++ b/src/Cli/dotnet/ToolPackage/PackageId.cs
@@ -3,14 +3,9 @@
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal struct PackageId : IEquatable<PackageId>, IComparable<PackageId>
+internal struct PackageId(string id) : IEquatable<PackageId>, IComparable<PackageId>
 {
-    private string _id;
-
-    public PackageId(string id)
-    {
-        _id = id?.ToLowerInvariant() ?? throw new ArgumentNullException(nameof(id));
-    }
+    private string _id = id?.ToLowerInvariant() ?? throw new ArgumentNullException(nameof(id));
 
     public bool Equals(PackageId other)
     {

--- a/src/Cli/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/Cli/dotnet/ToolPackage/PackageLocation.cs
@@ -5,22 +5,14 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal class PackageLocation
+internal class PackageLocation(
+    FilePath? nugetConfig = null,
+    DirectoryPath? rootConfigDirectory = null,
+    string[] additionalFeeds = null,
+    string[] sourceFeedOverrides = null)
 {
-    public PackageLocation(
-        FilePath? nugetConfig = null,
-        DirectoryPath? rootConfigDirectory = null,
-        string[] additionalFeeds = null,
-        string[] sourceFeedOverrides = null)
-    {
-        NugetConfig = nugetConfig;
-        RootConfigDirectory = rootConfigDirectory;
-        AdditionalFeeds = additionalFeeds ?? Array.Empty<string>();
-        SourceFeedOverrides = sourceFeedOverrides ?? Array.Empty<string>();
-    }
-
-    public FilePath? NugetConfig { get; }
-    public DirectoryPath? RootConfigDirectory { get; }
-    public string[] AdditionalFeeds { get; }
-    public string[] SourceFeedOverrides { get; }
+    public FilePath? NugetConfig { get; } = nugetConfig;
+    public DirectoryPath? RootConfigDirectory { get; } = rootConfigDirectory;
+    public string[] AdditionalFeeds { get; } = additionalFeeds ?? Array.Empty<string>();
+    public string[] SourceFeedOverrides { get; } = sourceFeedOverrides ?? Array.Empty<string>();
 }

--- a/src/Cli/dotnet/ToolPackage/ResolverCacheInconsistentException.cs
+++ b/src/Cli/dotnet/ToolPackage/ResolverCacheInconsistentException.cs
@@ -3,9 +3,6 @@
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal class ResolverCacheInconsistentException : Exception
+internal class ResolverCacheInconsistentException(string message) : Exception(message)
 {
-    public ResolverCacheInconsistentException(string message) : base(message)
-    {
-    }
 }

--- a/src/Cli/dotnet/ToolPackage/RestoredCommand.cs
+++ b/src/Cli/dotnet/ToolPackage/RestoredCommand.cs
@@ -6,23 +6,16 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal class RestoredCommand
+internal class RestoredCommand(
+    ToolCommandName name,
+    string runner,
+    FilePath executable)
 {
-    public RestoredCommand(
-        ToolCommandName name,
-        string runner,
-        FilePath executable)
-    {
-        Name = name;
-        Runner = runner ?? throw new ArgumentNullException(nameof(runner));
-        Executable = executable;
-    }
+    public ToolCommandName Name { get; private set; } = name;
 
-    public ToolCommandName Name { get; private set; }
+    public string Runner { get; private set; } = runner ?? throw new ArgumentNullException(nameof(runner));
 
-    public string Runner { get; private set; }
-
-    public FilePath Executable { get; private set; }
+    public FilePath Executable { get; private set; } = executable;
 
     public string DebugToString()
     {

--- a/src/Cli/dotnet/ToolPackage/RestoredCommandIdentifier.cs
+++ b/src/Cli/dotnet/ToolPackage/RestoredCommandIdentifier.cs
@@ -10,27 +10,18 @@ namespace Microsoft.DotNet.Cli.ToolPackage;
 /// <summary>
 ///     Given the following parameter, a list of RestoredCommand of a NuGet package can be uniquely identified
 /// </summary>
-internal class RestoredCommandIdentifier : IEquatable<RestoredCommandIdentifier>
+internal class RestoredCommandIdentifier(
+    PackageId packageId,
+    NuGetVersion version,
+    NuGetFramework targetFramework,
+    string runtimeIdentifier,
+    ToolCommandName commandName) : IEquatable<RestoredCommandIdentifier>
 {
-    public RestoredCommandIdentifier(
-        PackageId packageId,
-        NuGetVersion version,
-        NuGetFramework targetFramework,
-        string runtimeIdentifier,
-        ToolCommandName commandName)
-    {
-        PackageId = packageId;
-        Version = version ?? throw new ArgumentException(nameof(version));
-        TargetFramework = targetFramework ?? throw new ArgumentException(nameof(targetFramework));
-        RuntimeIdentifier = runtimeIdentifier ?? throw new ArgumentException(nameof(runtimeIdentifier));
-        CommandName = commandName;
-    }
-
-    public PackageId PackageId { get; }
-    public NuGetVersion Version { get; }
-    public NuGetFramework TargetFramework { get; }
-    public string RuntimeIdentifier { get; }
-    public ToolCommandName CommandName { get; }
+    public PackageId PackageId { get; } = packageId;
+    public NuGetVersion Version { get; } = version ?? throw new ArgumentException(nameof(version));
+    public NuGetFramework TargetFramework { get; } = targetFramework ?? throw new ArgumentException(nameof(targetFramework));
+    public string RuntimeIdentifier { get; } = runtimeIdentifier ?? throw new ArgumentException(nameof(runtimeIdentifier));
+    public ToolCommandName CommandName { get; } = commandName;
 
     public bool Equals(RestoredCommandIdentifier other)
     {

--- a/src/Cli/dotnet/ToolPackage/RestoredCommandIdentifierVersionRange.cs
+++ b/src/Cli/dotnet/ToolPackage/RestoredCommandIdentifierVersionRange.cs
@@ -10,27 +10,18 @@ namespace Microsoft.DotNet.Cli.ToolPackage;
 /// <summary>
 ///     A range of RestoredCommandIdentifier that is only different in the Version field.
 /// </summary>
-internal class RestoredCommandIdentifierVersionRange
+internal class RestoredCommandIdentifierVersionRange(
+    PackageId packageId,
+    VersionRange versionRange,
+    NuGetFramework targetFramework,
+    string runtimeIdentifier,
+    ToolCommandName commandName)
 {
-    public RestoredCommandIdentifierVersionRange(
-        PackageId packageId,
-        VersionRange versionRange,
-        NuGetFramework targetFramework,
-        string runtimeIdentifier,
-        ToolCommandName commandName)
-    {
-        PackageId = packageId;
-        VersionRange = versionRange ?? throw new ArgumentException(nameof(versionRange));
-        TargetFramework = targetFramework ?? throw new ArgumentException(nameof(targetFramework));
-        RuntimeIdentifier = runtimeIdentifier ?? throw new ArgumentException(nameof(runtimeIdentifier));
-        CommandName = commandName;
-    }
-
-    public PackageId PackageId { get; }
-    public VersionRange VersionRange { get; }
-    public NuGetFramework TargetFramework { get; }
-    public string RuntimeIdentifier { get; }
-    public ToolCommandName CommandName { get; }
+    public PackageId PackageId { get; } = packageId;
+    public VersionRange VersionRange { get; } = versionRange ?? throw new ArgumentException(nameof(versionRange));
+    public NuGetFramework TargetFramework { get; } = targetFramework ?? throw new ArgumentException(nameof(targetFramework));
+    public string RuntimeIdentifier { get; } = runtimeIdentifier ?? throw new ArgumentException(nameof(runtimeIdentifier));
+    public ToolCommandName CommandName { get; } = commandName;
 
     public RestoredCommandIdentifier WithVersion(NuGetVersion version)
     {

--- a/src/Cli/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
@@ -6,16 +6,11 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal class ToolPackageStoreAndQuery : IToolPackageStoreQuery, IToolPackageStore
+internal class ToolPackageStoreAndQuery(DirectoryPath root) : IToolPackageStoreQuery, IToolPackageStore
 {
     public const string StagingDirectory = ".stage";
 
-    public ToolPackageStoreAndQuery(DirectoryPath root)
-    {
-        Root = new DirectoryPath(Path.GetFullPath(root.Value));
-    }
-
-    public DirectoryPath Root { get; private set; }
+    public DirectoryPath Root { get; private set; } = new DirectoryPath(Path.GetFullPath(root.Value));
 
     public DirectoryPath GetRandomStagingDirectory()
     {

--- a/src/Cli/dotnet/ToolPackage/ToolPackageUninstaller.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageUninstaller.cs
@@ -6,14 +6,9 @@ using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.EnvironmentAbstractions;
 
-internal class ToolPackageUninstaller : IToolPackageUninstaller
+internal class ToolPackageUninstaller(IToolPackageStore toolPackageStoreQuery) : IToolPackageUninstaller
 {
-    private readonly IToolPackageStore _toolPackageStoreQuery;
-
-    public ToolPackageUninstaller(IToolPackageStore toolPackageStoreQuery)
-    {
-        _toolPackageStoreQuery = toolPackageStoreQuery ?? throw new ArgumentException(nameof(toolPackageStoreQuery));
-    }
+    private readonly IToolPackageStore _toolPackageStoreQuery = toolPackageStoreQuery ?? throw new ArgumentException(nameof(toolPackageStoreQuery));
 
     public void Uninstall(DirectoryPath packageDirectory)
     {

--- a/src/Cli/dotnet/TopLevelCommandParserResult.cs
+++ b/src/Cli/dotnet/TopLevelCommandParserResult.cs
@@ -3,17 +3,12 @@
 
 namespace Microsoft.DotNet.Cli;
 
-internal class TopLevelCommandParserResult
+internal class TopLevelCommandParserResult(string command)
 {
     public static TopLevelCommandParserResult Empty
     {
         get { return new TopLevelCommandParserResult(string.Empty); }
     }
 
-    public string Command { get; }
-
-    public TopLevelCommandParserResult(string command)
-    {
-        Command = command;
-    }
+    public string Command { get; } = command;
 }

--- a/src/Cli/dotnet/TransactionalAction.cs
+++ b/src/Cli/dotnet/TransactionalAction.cs
@@ -14,16 +14,10 @@ public sealed class TransactionalAction
         DisableTransactionTimeoutUpperLimit();
     }
 
-    private class EnlistmentNotification : IEnlistmentNotification
+    private class EnlistmentNotification(Action commit, Action rollback) : IEnlistmentNotification
     {
-        private Action _commit;
-        private Action _rollback;
-
-        public EnlistmentNotification(Action commit, Action rollback)
-        {
-            _commit = commit;
-            _rollback = rollback;
-        }
+        private Action _commit = commit;
+        private Action _rollback = rollback;
 
         public void Commit(Enlistment enlistment)
         {

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/FXVersion.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/FXVersion.cs
@@ -5,22 +5,13 @@ namespace Microsoft.DotNet.MSBuildSdkResolver;
 
 // Note: This is SemVer 2.0.0 https://semver.org/spec/v2.0.0.html
 // See the original version of this code here: https://github.com/dotnet/core-setup/blob/master/src/corehost/cli/fxr/fx_ver.cpp
-internal sealed class FXVersion
+internal sealed class FXVersion(int major, int minor, int patch, string pre = "", string build = "")
 {
-    public int Major { get; }
-    public int Minor { get; }
-    public int Patch { get; }
-    public string Pre { get; }
-    public string Build { get; }
-
-    public FXVersion(int major, int minor, int patch, string pre = "", string build = "")
-    {
-        Major = major;
-        Minor = minor;
-        Patch = patch;
-        Pre = pre;
-        Build = build;
-    }
+    public int Major { get; } = major;
+    public int Minor { get; } = minor;
+    public int Patch { get; } = patch;
+    public string Pre { get; } = pre;
+    public string Build { get; } = build;
 
     private static string GetId(string ids, int idStart)
     {


### PR DESCRIPTION
## Summary

Another cleanup PR that ran the VS tool against IDE0290, "Use primary constructor", for the `dotnet` and `Cli.Utils` projects.

![image](https://github.com/user-attachments/assets/0b1d6e0b-a630-4c7d-9bea-fd03e12e93c5)