### PR TITLE
Only publish FSharp packages when needed

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -16,14 +16,18 @@
     <FSharpCorePath Condition="'$(DotNetFinalVersionKind)' != 'release'">Shipping</FSharpCorePath>
     <FSharpCorePath Condition="'$(DotNetFinalVersionKind)' == 'release'">Release</FSharpCorePath>
 
-    <!-- We only want to publish the FSharp assets externally when we're publishing all artifacts, not only RID-specific ones. -->
-    <ShouldPublishFSharpPackages Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldPublishFSharpPackages>
+    <!--
+      We only want to publish the FSharp assets externally when we're publishing all artifacts, not only RID-specific ones.
+      Add these packages as "Vertical" visibility when we're only publishing RID-specific packages so we don't publish this one.
+    -->
+    <FSharpArtifactVisibility Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">Vertical</FSharpArtifactVisibility>
+    <FSharpArtifactVisibility Condition="'$(FSharpArtifactVisibility)' == ''">External</FSharpArtifactVisibility>
   </PropertyGroup>
-  <ItemGroup Condition="'$(ShouldPublishFSharpPackages)' == 'true'">
-    <Artifact Include="$(NuGetPackageRoot)microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg;
-                       $(NuGetPackageRoot)microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg"
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">
+    <Artifact Include="$(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg;
+                       $(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg"
               Kind="Package"
-              Visibility="External" />
+              Visibility="$(FSharpArtifactVisibility)" />
   </ItemGroup>
 
   <!-- The PGO sdk should always have External visibility, even if someone changes the default artifact visibility -->

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,26 +7,23 @@
   </PropertyGroup>
 
   <!-- FSharp needs to push different packages to nuget.org depending on whether the SDK is preview or not,
-      To achieve this, we find the FSharp compiler package, then the stable or non-stable FSharp.Core and Compiler service
-      package contained within, depending on the stability switch of the SDK. The SDK then treats these packages as its own outputs,
-      which means they get automatically pushed on release day.
+       To achieve this, we find the FSharp compiler package, then the stable or non-stable FSharp.Core and Compiler service
+       package contained within, depending on the stability switch of the SDK. The SDK then treats these packages as its own outputs,
+       which means they get automatically pushed on release day.
 
-      These packages have already been signed by the FSharp build so we don't need to re-include them for signing. -->
+       These packages have already been signed by the FSharp build so we don't need to re-include them for signing. -->
   <PropertyGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
     <FSharpCorePath Condition="'$(DotNetFinalVersionKind)' != 'release'">Shipping</FSharpCorePath>
     <FSharpCorePath Condition="'$(DotNetFinalVersionKind)' == 'release'">Release</FSharpCorePath>
-    <!--
-      We only want to publish the FSharp assets externally when we're publishing all artifacts, not only RID-specific ones.
-      Add these packages as "Vertical" visibility when we're only publishing RID-specific packages so we don't publish this one.
-    -->
-    <FSharpArtifactVisibility Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true' or ('$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1')">Vertical</FSharpArtifactVisibility>
-    <FSharpArtifactVisibility Condition="'$(FSharpArtifactVisibility)' == ''">External</FSharpArtifactVisibility>
+
+    <!-- We only want to publish the FSharp assets externally when we're publishing all artifacts, not only RID-specific ones. -->
+    <ShouldPublishFSharpPackages Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldPublishFSharpPackages>
   </PropertyGroup>
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <Artifact Include="$(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg;
-                       $(NuGetPackageRoot)\microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg"
+  <ItemGroup Condition="'$(ShouldPublishFSharpPackages)' == 'true'">
+    <Artifact Include="$(NuGetPackageRoot)microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Core.*.nupkg;
+                       $(NuGetPackageRoot)microsoft.fsharp.compiler\$(MicrosoftFSharpCompilerPackageVersion)\contentFiles\$(FSharpCorePath)\FSharp.Compiler.Service.*.nupkg"
               Kind="Package"
-              Visibility="$(FSharpArtifactVisibility)" />
+              Visibility="External" />
   </ItemGroup>
 
   <!-- The PGO sdk should always have External visibility, even if someone changes the default artifact visibility -->


### PR DESCRIPTION
The fsharp packages don't need to get published in a BP>1 build with Vertical visibility. They really only need to get published (with External visibility) when all artifacts get published (not just the RID specific ones).

They current are getting published in BP2 jobs:

![image](https://github.com/user-attachments/assets/90f10e21-2440-471a-a475-0efc246d2755)
