### PR TITLE
Allow additional package types with PackAsTool

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -44,7 +44,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
-    <PackageType Condition=" '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
+    <PackageType Condition=" '$(PackageType)' == '' and '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
     <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -42,8 +42,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DotnetCliToolTargetFramework>netcoreapp2.2</DotnetCliToolTargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
+  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <!--
     PackageType is semicolon-delimited, case-insensitive, with an optional version.
 
@@ -60,10 +60,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     _PaddedPackageType is used to ensure that the PackageType is semicolon delimited and can be easily checked for an existing DotnetTool package type.
     -->
-    <_PaddedPackageType Condition=" '$(PackAsTool)' == 'true' ">;$(PackageType.Replace(' ', '').Trim().ToLowerInvariant());</_PaddedPackageType>
-    <PackageType Condition=" '$(PackAsTool)' == 'true' and '$(_PaddedPackageType)' != ';;' and !$(_PaddedPackageType.Contains(';dotnettool;')) and !$(_PaddedPackageType.Contains(';dotnettool,')) ">DotnetTool;$(PackageType)</PackageType>
-    <PackageType Condition=" '$(PackAsTool)' == 'true' and '$(_PaddedPackageType)' == ';;' ">DotnetTool</PackageType>
-    <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
+    <_PaddedPackageType>;$(PackageType.Replace(' ', '').Trim().ToLowerInvariant());</_PaddedPackageType>
+    <PackageType Condition=" '$(_PaddedPackageType)' != ';;' and !$(_PaddedPackageType.Contains(';dotnettool;')) and !$(_PaddedPackageType.Contains(';dotnettool,')) ">DotnetTool;$(PackageType)</PackageType>
+    <PackageType Condition=" '$(_PaddedPackageType)' == ';;' ">DotnetTool</PackageType>
+    <RuntimeIdentifiers>$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnablePreviewFeatures)' == 'true' And '$(IsNetCoreAppTargetingLatestTFM)' == 'true'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -44,7 +44,23 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
-    <PackageType Condition=" '$(PackageType)' == '' and '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
+    <!--
+    PackageType is semicolon-delimited, case-insensitive, with an optional version.
+
+    DotnetTool should be added to the set of package types if the PackAsTool property is set to true.
+
+    Examples:
+       PackageType = ''                     -> 'DotnetTool'
+       PackageType = 'MyCustomType'         -> 'DotnetTool;MyCustomType'
+       PackageType = 'dotnettool'           -> 'dotnettool'
+       PackageType = 'DotnetTool, 1.0.0.0'  -> 'DotnetTool, 1.0.0.0'
+       PackageType = 'DotnetTool , 1.0.0.0' -> 'DotnetTool , 1.0.0.0'
+    
+    _PaddedPackageType is used to ensure that the PackageType is semicolon delimited and can be easily checked for an existing DotnetTool package type.
+    -->
+    <_PaddedPackageType Condition=" '$(PackAsTool)' == 'true' ">;$(PackageType.Replace(' ', '').Trim().ToLowerInvariant());</_PaddedPackageType>
+    <PackageType Condition=" '$(PackAsTool)' == 'true' and '$(_PaddedPackageType)' != ';;' and !$(_PaddedPackageType.Contains(';dotnettool;')) and !$(_PaddedPackageType.Contains(';dotnettool,')) ">DotnetTool;$(PackageType)</PackageType>
+    <PackageType Condition=" '$(PackAsTool)' == 'true' and '$(_PaddedPackageType)' == ';;' ">DotnetTool</PackageType>
     <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -52,9 +52,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Examples:
        PackageType = ''                     -> 'DotnetTool'
        PackageType = 'MyCustomType'         -> 'DotnetTool;MyCustomType'
+       PackageType = 'MyCustomType, 1.0'    -> 'DotnetTool;MyCustomType, 1.0'
        PackageType = 'dotnettool'           -> 'dotnettool'
        PackageType = 'DotnetTool, 1.0.0.0'  -> 'DotnetTool, 1.0.0.0'
        PackageType = 'DotnetTool , 1.0.0.0' -> 'DotnetTool , 1.0.0.0'
+       PackageType = 'MyDotnetTool'         -> 'DotnetTool;MyDotnetTool'
     
     _PaddedPackageType is used to ensure that the PackageType is semicolon delimited and can be easily checked for an existing DotnetTool package type.
     -->

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -268,7 +268,7 @@ namespace Microsoft.NET.ToolPack.Tests
         [InlineData("DotnetTool, 1.0.0.0", "DotnetTool, 1.0.0.0")]
         [InlineData("DotnetTool , 1.0.0.0", "DotnetTool , 1.0.0.0")]
         [InlineData("MyDotnetTool", "DotnetTool;MyDotnetTool")]
-        public void It_contains_allows_more_package_types(string input, string expectedString)
+        public void It_allows_more_package_types(string input, string expectedString)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget: false, packageType: input);
             using (var nupkgReader = new PackageArchiveReader(nugetPackage))

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 
 namespace Microsoft.NET.ToolPack.Tests
 {
@@ -17,7 +18,7 @@ namespace Microsoft.NET.ToolPack.Tests
         {
         }
 
-        private string SetupNuGetPackage(bool multiTarget, [CallerMemberName] string callingMethod = "")
+        private string SetupNuGetPackage(bool multiTarget, string packageType = null, [CallerMemberName] string callingMethod = "")
         {
 
             TestAsset helloWorldAsset = _testAssetsManager
@@ -27,6 +28,10 @@ namespace Microsoft.NET.ToolPack.Tests
                 {
                     XNamespace ns = project.Root.Name.Namespace;
                     XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                    if (packageType is not null)
+                    {
+                        propertyGroup.Add(new XElement("packageType", packageType));
+                    }
                 })
                 .WithTargetFrameworkOrFrameworks(_targetFrameworkOrFrameworks, multiTarget);
 
@@ -252,6 +257,35 @@ namespace Microsoft.NET.ToolPack.Tests
             {
                 nupkgReader
                     .GetPackageTypes().Should().ContainSingle(t => t.Name == "DotnetTool");
+            }
+        }
+
+        [Theory]
+        [InlineData("", "DotnetTool")]
+        [InlineData("MyCustomType", "DotnetTool;MyCustomType")]
+        [InlineData("MyCustomType, 1.0", "DotnetTool;MyCustomType, 1.0")]
+        [InlineData("dotnettool", "dotnettool")]
+        [InlineData("DotnetTool, 1.0.0.0", "DotnetTool, 1.0.0.0")]
+        [InlineData("DotnetTool , 1.0.0.0", "DotnetTool , 1.0.0.0")]
+        [InlineData("MyDotnetTool", "DotnetTool;MyDotnetTool")]
+        public void It_contains_allows_more_package_types(string input, string expectedString)
+        {
+            var nugetPackage = SetupNuGetPackage(multiTarget: false, packageType: input);
+            using (var nupkgReader = new PackageArchiveReader(nugetPackage))
+            {
+                var packageTypes = nupkgReader.GetPackageTypes();
+                var expected = expectedString
+                    .Split(';')
+                    .Select(t => t.Split(',').Select(x => x.Trim()).ToArray())
+                    .Select(t => (Name: t[0], Version: t.Length > 1 ? Version.Parse(t[1]) : PackageType.EmptyVersion))
+                    .Select(t => new PackageType(t.Name, t.Version))
+                    .ToList();
+                packageTypes.Count.Should().Be(expected.Count);
+                for (var i = 0; i < packageTypes.Count; i++)
+                {
+                    packageTypes[i].Name.Should().Be(expected[i].Name);
+                    packageTypes[i].Version.Should().Be(expected[i].Version);
+                }
             }
         }
 


### PR DESCRIPTION
This resolves https://github.com/NuGet/Home/issues/14220.

When creating a .NET tool package, it can be helpful to allow a custom package type. I am investigating this because I would like to enable a new package type like `McpServer` to mark a package as an MCP server. The exact package type is TBD but we want to be able to mark a package as an MCP server so it can be properly filtered on NuGet.org.

With https://github.com/dotnet/sdk/issues/47517, a user will be able to set `<PackageType>McpServer</PackageType>` (to append the `McpServer` package type) and then run the MCP server as a .NET tool.

I have built the change locally, ran `.\eng\dogfood.cmd`, packed a package, and verified the output .nuspec.

[edit] custom package types can be searched on NuGet.org via URL manipulation, e.g.
https://www.nuget.org/packages?packagetype=McpServer