### PR TITLE
Added 30 to the width and X location to make sure there is room for the progress label

### DIFF
--- a/src/Layout/pkg/windows/bundle.thm
+++ b/src/Layout/pkg/windows/bundle.thm
@@ -51,8 +51,8 @@
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="ProgressHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
-        <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
-        <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
+        <Text Name="ProgressLabel" X="11" Y="121" Width="100" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
+        <Text Name="OverallProgressPackageText" X="115" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
         <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
         <Button Name="ProgressCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
     </Page>


### PR DESCRIPTION
@joeloff not sure how these numbers were chosen or what I should have done to figure out how to modify this. I picked 30 and per my testing, it works but no idea if the font size affects this.

Also, does wix 5 change this?

![image](https://github.com/user-attachments/assets/1a67ff4b-432b-4419-a27e-ba164ae67f95)
