### PR TITLE
Fix using undefined property in GeneratePKG.targets

### DIFF
--- a/src/Layout/redist/targets/GeneratePKG.targets
+++ b/src/Layout/redist/targets/GeneratePKG.targets
@@ -7,7 +7,7 @@
       <!-- Properties for pkg build -->
       <SharedHostComponentId>com.microsoft.dotnet.sharedhost.$(SharedHostVersion).component.osx.$(TargetArchitecture)</SharedHostComponentId>
       <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostFxrVersion).component.osx.$(TargetArchitecture)</HostFxrComponentId>
-      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppPackageVersion).component.osx.$(TargetArchitecture)</SharedFrameworkComponentId>
+      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppRuntimePackageVersion).component.osx.$(TargetArchitecture)</SharedFrameworkComponentId>
       <NetCoreAppTargetingPackComponentId>com.microsoft.dotnet.pack.targeting.$(MicrosoftNETCoreAppRefPackageVersion).component.osx.$(TargetArchitecture)</NetCoreAppTargetingPackComponentId>
       <NetCoreAppHostPackComponentId>com.microsoft.dotnet.pack.apphost.$(MicrosoftNETCoreAppHostPackageVersion).component.osx.$(TargetArchitecture)</NetCoreAppHostPackComponentId>
       <NetStandardTargetingPackComponentId>com.microsoft.standard.pack.targeting.$(NETStandardLibraryRefPackageVersion).component.osx.$(TargetArchitecture)</NetStandardTargetingPackComponentId>


### PR DESCRIPTION
MicrosoftNETCoreAppPackageVersion was removed years ago in https://github.com/dotnet/installer/commit/0f52aed34c765c54fbb7affad075313ae2390e2f

Discovered in https://github.com/dotnet/source-build/issues/4994