### PR TITLE
Basic support for launchSettings in the new dotnet test

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -94,4 +94,5 @@ internal static class ProjectProperties
     internal const string RunCommand = "RunCommand";
     internal const string RunArguments = "RunArguments";
     internal const string RunWorkingDirectory = "RunWorkingDirectory";
+    internal const string AppDesignerFolder = "AppDesignerFolder";
 }

--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -53,7 +53,7 @@ internal static class MSBuildUtility
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
         var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
-        IEnumerable<TestModule> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection);
+        IEnumerable<TestModule> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, buildOptions.NoLaunchProfile);
         logger?.ReallyShutdown();
 
         return (projects, isBuiltOrRestored);
@@ -89,6 +89,7 @@ internal static class MSBuildUtility
             parseResult.GetValue(CommonOptions.NoRestoreOption),
             parseResult.GetValue(TestingPlatformOptions.NoBuildOption),
             parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
+            parseResult.GetValue(TestingPlatformOptions.NoLaunchProfileOption),
             degreeOfParallelism,
             otherArgs,
             msbuildArgs);
@@ -120,7 +121,7 @@ internal static class MSBuildUtility
             new ParallelOptions { MaxDegreeOfParallelism = buildOptions.DegreeOfParallelism },
             (project) =>
             {
-                IEnumerable<TestModule> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project, projectCollection);
+                IEnumerable<TestModule> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project, projectCollection, buildOptions.NoLaunchProfile);
                 foreach (var projectMetadata in projectsMetadata)
                 {
                     allProjects.Add(projectMetadata);

--- a/src/Cli/dotnet/Commands/Test/Models.cs
+++ b/src/Cli/dotnet/Commands/Test/Models.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Tools.Run.LaunchSettings;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, bool IsTestingPlatformApplication, bool IsTestProject);
+internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, bool IsTestingPlatformApplication, bool IsTestProject, ProjectLaunchSettingsModel? LaunchSettings);
 
 internal sealed record Handshake(Dictionary<byte, string>? Properties);
 

--- a/src/Cli/dotnet/Commands/Test/Models.cs
+++ b/src/Cli/dotnet/Commands/Test/Models.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Run;
-using Microsoft.DotNet.Tools.Run.LaunchSettings;
+using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 

--- a/src/Cli/dotnet/Commands/Test/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/Options.cs
@@ -7,4 +7,4 @@ internal record TestOptions(string Architecture, bool HasFilterMode, bool IsHelp
 
 internal record PathOptions(string ProjectPath, string SolutionPath, string DirectoryPath);
 
-internal record BuildOptions(PathOptions PathOptions, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
+internal record BuildOptions(PathOptions PathOptions, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, bool NoLaunchProfile, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
-using Microsoft.DotNet.Tools.Run.LaunchSettings;
+using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 using Microsoft.DotNet.Tools.Test;
 using LocalizableStrings = Microsoft.DotNet.Tools.Test.LocalizableStrings;
 

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -73,6 +73,7 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
                 processStartInfo.EnvironmentVariables[entry.Key] = value;
             }
 
+            // TODO: Support --no-launch-profile-arguments
             if (!string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {
                 processStartInfo.Arguments = $"{processStartInfo.Arguments} {Module.LaunchSettings.CommandLineArgs}";

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -65,17 +65,17 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
             processStartInfo.WorkingDirectory = Module.RunProperties.RunWorkingDirectory;
         }
 
-        if (_module.LaunchSettings is not null)
+        if (Module.LaunchSettings is not null)
         {
-            foreach (var entry in _module.LaunchSettings.EnvironmentVariables)
+            foreach (var entry in Module.LaunchSettings.EnvironmentVariables)
             {
                 string value = Environment.ExpandEnvironmentVariables(entry.Value);
                 processStartInfo.EnvironmentVariables[entry.Key] = value;
             }
 
-            if (!string.IsNullOrEmpty(_module.LaunchSettings.CommandLineArgs))
+            if (!string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {
-                processStartInfo.Arguments = $"{processStartInfo.Arguments} {_module.LaunchSettings.CommandLineArgs}";
+                processStartInfo.Arguments = $"{processStartInfo.Arguments} {Module.LaunchSettings.CommandLineArgs}";
             }
         }
 

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -242,6 +242,7 @@ internal static class TestCommandParser
         command.Options.Add(CommonOptions.NoRestoreOption);
         command.Options.Add(TestingPlatformOptions.NoBuildOption);
         command.Options.Add(TestingPlatformOptions.NoAnsiOption);
+        command.Options.Add(TestingPlatformOptions.NoLaunchProfileOption);
         command.Options.Add(TestingPlatformOptions.NoProgressOption);
         command.Options.Add(TestingPlatformOptions.OutputOption);
 

--- a/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
@@ -48,7 +48,7 @@ internal sealed class TestModulesFilterHandler(TestApplicationActionQueue action
 
         foreach (string testModule in testModulePaths)
         {
-            var testApp = new TestApplication(new TestModule(new RunProperties(testModule, null, null), null, null, true, true), buildOptions);
+            var testApp = new TestApplication(new TestModule(new RunProperties(testModule, null, null), null, null, true, true, null), buildOptions);
             // Write the test application to the channel
             _actionQueue.Enqueue(testApp);
         }

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
@@ -63,6 +63,12 @@ internal static class TestingPlatformOptions
         Arity = ArgumentArity.Zero
     };
 
+    public static readonly CliOption<bool> NoLaunchProfileOption = new("--no-launch-profile")
+    {
+        Description = Tools.Run.LocalizableStrings.CommandOptionNoLaunchProfileDescription,
+        Arity = ArgumentArity.Zero
+    };
+
     public static readonly CliOption<bool> NoProgressOption = new("--no-progress")
     {
         Description = LocalizableStrings.CmdNoProgressDescription,

--- a/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Program.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+if (!args.Contains("--from-launch-settings"))
+{
+	throw new Exception("FAILED to find argument from launchSettings.json");
+}
+
+if (!args.Contains("--from-run-arguments"))
+{
+	throw new Exception("FAILED to find argument from RunArguments");
+}
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test1",
+			DisplayName = "Test1",
+			Properties = new PropertyBag(new SkippedTestNodeStateProperty("OK skipped!")),
+		}));
+		
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Program.cs
@@ -13,6 +13,8 @@ if (!args.Contains("--from-run-arguments"))
 	throw new Exception("FAILED to find argument from RunArguments");
 }
 
+args = args.Where(arg => arg != "--from-launch-settings" && arg != "--from-run-arguments").ToArray();
+
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());

--- a/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Properties/launchSettings.json
+++ b/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "ConsoleApp25": {
+      "commandName": "Project",
+      "commandLineArgs": "--from-launch-settings",
+      "environmentVariables": {
+        "MY_VARIABLE_FROM_LAUNCH_SETTINGS": "true"
+      }
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/TestProjectWithLaunchSettings.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/TestProjectWithLaunchSettings.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+		<RunArguments>--from-run-arguments</RunArguments>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/dotnet.config
+++ b/test/TestAssets/TestProjects/TestProjectWithLaunchSettings/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -119,6 +119,37 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
+        public void RunTestProjectWithTestsAndNoLaunchSettings_ShouldReturnExitCodeSuccess(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithLaunchSettings", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(
+                                        TestingPlatformOptions.ConfigurationOption.Name, configuration,
+                                        TestingPlatformOptions.NoLaunchProfileOption.Name);
+
+            result.StdOut.Should()
+                .Contain("FAILED to find argument from launchSettings.json")
+                .And.Contain("FAILED to find argument from RunArguments");
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("skipped Test1")
+                    .And.Contain("total: 2")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 1");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
         public void RunMultipleTestProjectsWithFailingTests_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -93,6 +93,32 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
+        public void RunTestProjectWithTestsAndLaunchSettings_ShouldReturnExitCodeSuccess(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithLaunchSettings", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
+
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("skipped Test1")
+                    .And.Contain("total: 2")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 1");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
         public void RunMultipleTestProjectsWithFailingTests_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -132,18 +132,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.StdOut.Should()
                 .Contain("FAILED to find argument from launchSettings.json");
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut
-                    .Should().Contain("Test run summary: Passed!")
-                    .And.Contain("skipped Test1")
-                    .And.Contain("total: 2")
-                    .And.Contain("succeeded: 1")
-                    .And.Contain("failed: 0")
-                    .And.Contain("skipped: 1");
-            }
-
-            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -131,8 +131,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         TestingPlatformOptions.NoLaunchProfileOption.Name);
 
             result.StdOut.Should()
-                .Contain("FAILED to find argument from launchSettings.json")
-                .And.Contain("FAILED to find argument from RunArguments");
+                .Contain("FAILED to find argument from launchSettings.json");
             if (!TestContext.IsLocalized())
             {
                 result.StdOut


### PR DESCRIPTION
Part of #47548

To follow-up. Support the following:

- [ ] `--no-launch-profile-arguments`
- [ ] `--launch-profile`