### PR TITLE
Reuse specific job artifacts in installer test jobs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-validation.yml
@@ -74,6 +74,10 @@ stages:
       parameters:
         targetArchitecture: x64
         OS: Linux
+        reuseBuildArtifactsFrom:
+        # Scenario-tests package is built/published by Windows_x64 job
+        - Windows_x64
+        - AzureLinux_x64_Cross_x64
   - job: ValidateInstallers_Linux_arm64
     displayName: Validate Installers - Linux arm64
     pool: ${{ parameters.pool_LinuxArm64 }}
@@ -83,6 +87,10 @@ stages:
       parameters:
         targetArchitecture: arm64
         OS: Linux
+        reuseBuildArtifactsFrom:
+        # Scenario-tests package is built/published by Windows_x64 job
+        - Windows_x64
+        - AzureLinux_x64_Cross_arm64
   - ${{ if eq(variables.signEnabled, 'true') }}:
     - job: ValidateSigning_Windows
       displayName: Validate Signing - Windows

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -10,20 +10,18 @@ parameters:
     - Linux
     - Darwin
 
-steps:
-- task: DownloadBuildArtifacts@1
-  inputs:
-    artifactName: BlobArtifacts
-    downloadPath: $(Build.ArtifactStagingDirectory)
-    checkDownloadedFiles: true
-  displayName: Download Blob Artifacts
+- name: reuseBuildArtifactsFrom
+  type: object
+  default: ''
 
-- task: DownloadBuildArtifacts@1
-  inputs:
-    artifactName: PackageArtifacts
-    downloadPath: $(Build.ArtifactStagingDirectory)
-    checkDownloadedFiles: true
-  displayName: Download Package Artifacts
+steps:
+- ${{ if ne(parameters.reuseBuildArtifactsFrom,'') }}:
+  - ${{ each reuseBuildArtifacts in parameters.reuseBuildArtifactsFrom }}:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: ${{ reuseBuildArtifacts }}_Artifacts
+        targetPath: $(Build.SourcesDirectory)/artifacts/
+      displayName: Download Previous Build (${{ reuseBuildArtifacts }})
 
 # This is necessary whenever we want to publish/restore to an AzDO private feed
 # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
@@ -43,8 +41,6 @@ steps:
       --ci \
       -t \
       --projects test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
-      /p:BlobArtifactsDir=$(Build.ArtifactStagingDirectory)/BlobArtifacts \
-      /p:PackageArtifactsDir=$(Build.ArtifactStagingDirectory)/PackageArtifacts \
       $extraBuildProperties
     displayName: Validate installer packages
     workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
Installer tests require `Microsoft.DotNet.ScenarioTests.SdkTemplateTests` package to run scenario-tests in addition to simple RPM/DEB installation tests.

Due to some recent publishing changes, this package is only available as a job artifact and not in merged artifacts anymore.

As we only publish unique job artifacts, we also need to restore artifacts from `Windows_x64` job even though we run tests on Linux. In addition this job is the only one that publishes `Microsoft.DotNet.ScenarioTests.SdkTemplateTests` package.

A simple change.

Verification build (all green): https://dev.azure.com/dnceng/internal/_build/results?buildId=2676173&view=results