### PR TITLE
Nonfunctional code

### DIFF
--- a/src/Cli/dotnet/IDeprecated.cs
+++ b/src/Cli/dotnet/IDeprecated.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+namespace Microsoft.DotNet.Cli;
+
+public interface IDeprecated
+{
+    public static Dictionary<CliOption, (string messageToShow, Version errorLevel)> DeprecatedOptions { get; } = new()
+    {
+        { PackageListCommandParser.DeprecatedOption, ("old versions are old", new Version(10, 0, 100)) }
+    };
+
+    public static Dictionary<CliArgument, (string messageToShow, Version errorLevel)> DeprecatedArguments { get; } = new()
+    {
+        { PackageAddCommandParser.CmdPackageArgument, ("argument bad; use option", new Version(10, 0, 100)) }
+    };
+
+    public bool IsDeprecated { get; set; }
+
+    public static void WarnIfNecessary(IReporter reporter, string messageToShow, Version errorLevel)
+    {
+        reporter.WriteLine(messageToShow);
+    }
+}

--- a/src/Cli/dotnet/IDeprecated.cs
+++ b/src/Cli/dotnet/IDeprecated.cs
@@ -2,25 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli.Utils.Extensions;
 namespace Microsoft.DotNet.Cli;
 
 public interface IDeprecated
 {
-    public static Dictionary<CliOption, (string messageToShow, Version errorLevel)> DeprecatedOptions { get; } = new()
+    public static Dictionary<CliOption, (string messageToShow, ReleaseVersion errorLevel)> DeprecatedOptions { get; } = new()
     {
-        { PackageListCommandParser.DeprecatedOption, ("old versions are old", new Version(10, 0, 100)) }
+        { PackageListCommandParser.DeprecatedOption, ("old versions are old", new ReleaseVersion(10, 0, 100)) }
     };
 
-    public static Dictionary<CliArgument, (string messageToShow, Version errorLevel)> DeprecatedArguments { get; } = new()
+    public static Dictionary<CliArgument, (string messageToShow, ReleaseVersion errorLevel)> DeprecatedArguments { get; } = new()
     {
-        { PackageAddCommandParser.CmdPackageArgument, ("argument bad; use option", new Version(10, 0, 100)) }
+        { PackageAddCommandParser.CmdPackageArgument, ("argument bad; use option", new ReleaseVersion(10, 0, 100)) }
     };
 
     public bool IsDeprecated { get; set; }
 
-    public static void WarnIfNecessary(IReporter reporter, string messageToShow, Version errorLevel)
+    public static void WarnIfNecessary(IReporter reporter, string messageToShow, ReleaseVersion errorLevel)
     {
-        reporter.WriteLine(messageToShow);
+        if (new ReleaseVersion(Utils.Product.Version) < errorLevel)
+        {
+            reporter.WriteLine(messageToShow);
+        }
+        else
+        {
+            reporter.WriteLine(messageToShow.Yellow());
+        }
     }
 }

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -134,6 +134,8 @@ public class Program
         }
         PerformanceLogEventSource.Log.BuiltInCommandParserStop();
 
+        DeprecatedCheck(parseResult);
+
         using (IFirstTimeUseNoticeSentinel disposableFirstTimeUseNoticeSentinel =
             new FirstTimeUseNoticeSentinel())
         {
@@ -304,6 +306,39 @@ public class Program
         }
 
         return exitCode;
+    }
+
+    private static void DeprecatedCheck(ParseResult parseResult)
+    {
+        if (parseResult.Errors.Any())
+        {
+            // There are errors anyway; don't worry about deprecation
+            return;
+        }
+
+        var command = parseResult.CommandResult;
+        if (command.Command is IDeprecated)
+        {
+            // Doesn't work because what we want is for the Command's Action's output to be deprecated (or not)
+            // And what about parents?
+        }
+
+        foreach (var entry in IDeprecated.DeprecatedArguments)
+        {
+            if (parseResult.GetArguments().Any(a => entry.Key.Name.Equals(a)))
+            {
+                // Doesn't work because this is the value, not the key, of the argument
+            }
+        }
+
+        foreach (var entry in IDeprecated.DeprecatedOptions)
+        {
+            if (parseResult.HasOption(entry.Key))
+            {
+                // Finally works!
+                IDeprecated.WarnIfNecessary(Reporter.ConsoleOutReporter, entry.Value.messageToShow, entry.Value.errorLevel);
+            }
+        }
     }
 
     private static void ReportDotnetHomeUsage(IEnvironmentProvider provider)

--- a/src/Cli/dotnet/commands/dotnet-package/remove/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/remove/Program.cs
@@ -9,10 +9,11 @@ using Microsoft.DotNet.Tools.NuGet;
 
 namespace Microsoft.DotNet.Tools.Package.Remove;
 
-internal class RemovePackageReferenceCommand : CommandBase
+internal class RemovePackageReferenceCommand : CommandBase, IDeprecated
 {
     private readonly string _fileOrDirectory;
     private readonly IReadOnlyCollection<string> _arguments;
+    public bool IsDeprecated { get; set; } = false;
 
     public RemovePackageReferenceCommand(
         ParseResult parseResult) : base(parseResult)

--- a/src/Cli/dotnet/commands/dotnet-package/remove/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-package/remove/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
@@ -34,6 +35,11 @@ internal class RemovePackageReferenceCommand : CommandBase, IDeprecated
 
     public override int Execute()
     {
+        if (IsDeprecated)
+        {
+            IDeprecated.WarnIfNecessary(Reporter.ConsoleOutReporter, "wrong verb order", new ReleaseVersion(10, 0, 100));
+        }
+
         var projectFilePath = string.Empty;
 
         if (!File.Exists(_fileOrDirectory))

--- a/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
@@ -23,7 +23,7 @@ internal static class RemovePackageParser
         command.Arguments.Add(PackageRemoveCommandParser.CmdPackageArgument);
         command.Options.Add(PackageRemoveCommandParser.InteractiveOption);
 
-        command.SetAction((parseResult) => new RemovePackageReferenceCommand(parseResult).Execute());
+        command.SetAction((parseResult) => new RemovePackageReferenceCommand(parseResult) { IsDeprecated = true }.Execute());
 
         return command;
     }


### PR DESCRIPTION
This doesn't work as intended (explained in comments).

It's intended to provide a fairly easy mechanism for making various commands, arguments, and options deprecated, with an example of each.

The first commit contains the original version, and only Option works at all. The second version additionally has Command sorta working, but it's not my favorite solution.

@MiYanni, @baronfel,

This is as far as I've gotten with this at this point. Any thoughts on how best to proceed?