### PR TITLE
[StaticWebAssets] Cleanup ApplyCompressionNegotiation.cs and ResolveCompressedAssets.cs

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -27,66 +27,31 @@ public class ApplyCompressionNegotiation : Task
 
         var updatedEndpoints = new HashSet<StaticWebAssetEndpoint>(CandidateEndpoints.Length, StaticWebAssetEndpoint.RouteAndAssetComparer);
 
-        var preservedEndpoints = new Dictionary<(string, string), StaticWebAssetEndpoint>(CandidateEndpoints.Length);
-
-        var compressionHeadersByContentEncoding = new Dictionary<string, StaticWebAssetEndpointResponseHeader[]>(2);
+        var compressionHeadersByEncoding = new Dictionary<string, StaticWebAssetEndpointResponseHeader[]>(2);
 
         // Add response headers to compressed endpoints
-        foreach (var kvp in assetsById)
+        foreach (var compressedAsset in assetsById.Values)
         {
-            var key = kvp.Key;
-            var compressedAsset = kvp.Value;
-
             if (!string.Equals(compressedAsset.AssetTraitName, "Content-Encoding", StringComparison.Ordinal))
             {
                 continue;
             }
 
-            if (!assetsById.TryGetValue(compressedAsset.RelatedAsset, out var relatedAsset))
-            {
-                Log.LogWarning("Related asset not found for compressed asset: {0}", compressedAsset.Identity);
-                throw new InvalidOperationException($"Related asset not found for compressed asset: {compressedAsset.Identity}");
-            }
-
-            if (!endpointsByAsset.TryGetValue(compressedAsset.Identity, out var compressedEndpoints))
-            {
-                Log.LogWarning("Endpoints not found for compressed asset: {0} {1}", compressedAsset.RelativePath, compressedAsset.Identity);
-                throw new InvalidOperationException($"Endpoints not found for compressed asset: {compressedAsset.Identity}");
-            }
-
-            if (!endpointsByAsset.TryGetValue(relatedAsset.Identity, out var relatedAssetEndpoints))
-            {
-                Log.LogWarning("Endpoints not found for related asset: {0}", relatedAsset.Identity);
-                throw new InvalidOperationException($"Endpoints not found for related asset: {relatedAsset.Identity}");
-            }
+            var (compressedEndpoints, relatedAssetEndpoints) = ResolveEndpoints(assetsById, endpointsByAsset, compressedAsset);
 
             Log.LogMessage("Processing compressed asset: {0}", compressedAsset.Identity);
-            if (compressionHeadersByContentEncoding.TryGetValue(compressedAsset.AssetTraitValue, out var compressionHeaders))
-            {
-                compressionHeaders = [
-                    new()
-                    {
-                        Name = "Content-Encoding",
-                        Value = compressedAsset.AssetTraitValue
-                    },
-                    new()
-                    {
-                        Name = "Vary",
-                        Value = "Content-Encoding"
-                    }
-                ];
-                compressionHeadersByContentEncoding.Add(compressedAsset.AssetTraitValue, compressionHeaders);
-            }
+            var compressionHeaders = GetOrCreateCompressionHeaders(compressionHeadersByEncoding, compressedAsset);
 
             var quality = ResolveQuality(compressedAsset);
             foreach (var compressedEndpoint in compressedEndpoints)
             {
-                if (compressedEndpoint.Selectors.Any(s => string.Equals(s.Name, "Content-Encoding", StringComparison.Ordinal)))
+                if (HasContentEncodingSelector(compressedEndpoint))
                 {
-                    Log.LogMessage(MessageImportance.Low, $"  Skipping endpoint '{compressedEndpoint.Route}' since it already has a Content-Encoding selector");
+                    Log.LogMessage(MessageImportance.Low, "  Skipping endpoint '{0}' since it already has a Content-Encoding selector", compressedEndpoint.Route);
                     continue;
                 }
-                if (!compressedEndpoint.ResponseHeaders.Any(s => string.Equals(s.Name, "Content-Encoding", StringComparison.Ordinal)))
+
+                if (!HasContentEncodingResponseHeader(compressedEndpoint))
                 {
                     // Add the Content-Encoding and Vary headers
                     compressedEndpoint.ResponseHeaders = [
@@ -95,64 +60,27 @@ public class ApplyCompressionNegotiation : Task
                     ];
                 }
 
+                var compressedHeaders = GetCompressedHeaders(compressedEndpoint);
+
                 Log.LogMessage(MessageImportance.Low, "  Updated endpoint '{0}' with Content-Encoding and Vary headers", compressedEndpoint.Route);
                 updatedEndpoints.Add(compressedEndpoint);
 
-                var compressedHeaders = GetCompressedHeaders(compressedEndpoint);
                 foreach (var relatedEndpointCandidate in relatedAssetEndpoints)
                 {
                     if (!IsCompatible(compressedEndpoint, relatedEndpointCandidate))
                     {
                         continue;
                     }
-                    Log.LogMessage(MessageImportance.Low, "Processing related endpoint '{0}'", relatedEndpointCandidate.Route);
-                    var encodingSelector = new StaticWebAssetEndpointSelector
-                    {
-                        Name = "Content-Encoding",
-                        Value = compressedAsset.AssetTraitValue,
-                        Quality = quality
-                    };
-                    Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
-                    var endpointCopy = new StaticWebAssetEndpoint
-                    {
-                        AssetFile = compressedAsset.Identity,
-                        Route = relatedEndpointCandidate.Route,
-                        Selectors = [
-                            ..relatedEndpointCandidate.Selectors,
-                            encodingSelector
-                        ],
-                        // Endpoint properties are never modified as part of this step, so we can just copy them and avoid extra work
-                        EndpointProperties = relatedEndpointCandidate.EndpointProperties
-                    };
 
-                    var headers = new List<StaticWebAssetEndpointResponseHeader>(7);
-
-                    ApplyCompressedEndpointHeaders(headers, compressedEndpoint, relatedEndpointCandidate.Route);
-                    ApplyRelatedEndpointCandidateHeaders(headers, relatedEndpointCandidate, compressedHeaders);
-                    endpointCopy.ResponseHeaders = [.. headers];
-
-                    // Update the endpoint
-                    Log.LogMessage(MessageImportance.Low, "  Updated related endpoint '{0}' with Content-Encoding selector '{1}={2}'", relatedEndpointCandidate.Route, encodingSelector.Value, encodingSelector.Quality);
+                    var endpointCopy = CreateUpdatedEndpoint(compressedAsset, quality, compressedEndpoint, compressedHeaders, relatedEndpointCandidate);
                     updatedEndpoints.Add(endpointCopy);
-
                     // Since we are going to remove the endpoints from the associated item group and the route is
                     // the ItemSpec, we want to add the original as well so that it gets re-added.
                     // The endpoint pointing to the uncompressed asset doesn't have a Content-Encoding selector and
                     // will use the default "identity" encoding during content negotiation.
-                    if (!preservedEndpoints.ContainsKey((relatedEndpointCandidate.Route, relatedEndpointCandidate.AssetFile)))
-                    {
-                        preservedEndpoints.Add(
-                            (relatedEndpointCandidate.Route, relatedEndpointCandidate.AssetFile),
-                            relatedEndpointCandidate);
-                    }
+                    updatedEndpoints.Add(relatedEndpointCandidate);
                 }
             }
-        }
-
-        // Add the preserved endpoints to the list of updated endpoints.
-        foreach (var preservedEndpoint in preservedEndpoints.Values)
-        {
-            updatedEndpoints.Add(preservedEndpoint);
         }
 
         // Before we return the updated endpoints we need to capture any other endpoint whose asset is not associated
@@ -182,11 +110,11 @@ public class ApplyCompressionNegotiation : Task
         // We now have only endpoints that might have the same route but point to different assets
         // and we want to include them in the updated endpoints so that we don't incorrectly remove
         // them from the associated item group when we update the endpoints.
-        var endpointsByRoute = endpointsByAsset.Values.SelectMany(e => e).GroupBy(e => e.Route).ToDictionary(g => g.Key, g => g.ToList());
-
-        var updatedEndpointsByRoute = updatedEndpoints.Select(e => e.Route).ToArray();
-        foreach (var route in updatedEndpointsByRoute)
+        var endpointsByRoute = GetEndpointsByRoute(endpointsByAsset);
+        var additionalUpdatedEndpoints = new HashSet<StaticWebAssetEndpoint>(updatedEndpoints.Count, StaticWebAssetEndpoint.RouteAndAssetComparer);
+        foreach (var updatedEndpoint in updatedEndpoints)
         {
+            var route = updatedEndpoint.Route;
             Log.LogMessage(MessageImportance.Low, "Processing route '{0}'", route);
             if (endpointsByRoute.TryGetValue(route, out var endpoints))
             {
@@ -197,24 +125,163 @@ public class ApplyCompressionNegotiation : Task
                 }
                 foreach (var endpoint in endpoints)
                 {
-                    updatedEndpoints.Add(endpoint);
+                    additionalUpdatedEndpoints.Add(endpoint);
                 }
             }
         }
 
-        UpdatedEndpoints = updatedEndpoints.Distinct().Select(e => e.ToTaskItem()).ToArray();
+        updatedEndpoints.UnionWith(additionalUpdatedEndpoints);
+
+        UpdatedEndpoints = StaticWebAssetEndpoint.ToTaskItems(updatedEndpoints);
 
         return true;
     }
 
     private static HashSet<string> GetCompressedHeaders(StaticWebAssetEndpoint compressedEndpoint)
     {
-        var result = new HashSet<string>(compressedEndpoint.Selectors.Length, StringComparer.Ordinal);
+        var result = new HashSet<string>(compressedEndpoint.ResponseHeaders.Length, StringComparer.Ordinal);
         for (var i = 0; i < compressedEndpoint.ResponseHeaders.Length; i++)
         {
-            result.Add(compressedEndpoint.ResponseHeaders[i].Name);
+            var responseHeader = compressedEndpoint.ResponseHeaders[i];
+            result.Add(responseHeader.Name);
         }
+
         return result;
+    }
+
+    private static Dictionary<string, List<StaticWebAssetEndpoint>> GetEndpointsByRoute(
+        IDictionary<string, List<StaticWebAssetEndpoint>> endpointsByAsset)
+    {
+        var result = new Dictionary<string, List<StaticWebAssetEndpoint>>(endpointsByAsset.Count);
+
+        foreach (var endpointsList in endpointsByAsset.Values)
+        {
+            foreach (var endpoint in endpointsList)
+            {
+                if (!result.TryGetValue(endpoint.Route, out var routeEndpoints))
+                {
+                    routeEndpoints = new List<StaticWebAssetEndpoint>(5);
+                    result[endpoint.Route] = routeEndpoints;
+                }
+                routeEndpoints.Add(endpoint);
+            }
+        }
+
+        return result;
+    }
+
+    private static StaticWebAssetEndpointResponseHeader[] GetOrCreateCompressionHeaders(Dictionary<string, StaticWebAssetEndpointResponseHeader[]> compressionHeadersByEncoding, StaticWebAsset compressedAsset)
+    {
+        if (!compressionHeadersByEncoding.TryGetValue(compressedAsset.AssetTraitValue, out var compressionHeaders))
+        {
+            compressionHeaders = CreateCompressionHeaders(compressedAsset);
+            compressionHeadersByEncoding.Add(compressedAsset.AssetTraitValue, compressionHeaders);
+        }
+
+        return compressionHeaders;
+    }
+
+    private static StaticWebAssetEndpointResponseHeader[] CreateCompressionHeaders(StaticWebAsset compressedAsset) =>
+        [
+            new()
+            {
+                Name = "Content-Encoding",
+                Value = compressedAsset.AssetTraitValue
+            },
+            new()
+            {
+                Name = "Vary",
+                Value = "Content-Encoding"
+            }
+        ];
+
+    private StaticWebAssetEndpoint CreateUpdatedEndpoint(
+        StaticWebAsset compressedAsset,
+        string quality,
+        StaticWebAssetEndpoint compressedEndpoint,
+        HashSet<string> compressedHeaders,
+        StaticWebAssetEndpoint relatedEndpointCandidate)
+    {
+        Log.LogMessage(MessageImportance.Low, "Processing related endpoint '{0}'", relatedEndpointCandidate.Route);
+        var encodingSelector = new StaticWebAssetEndpointSelector
+        {
+            Name = "Content-Encoding",
+            Value = compressedAsset.AssetTraitValue,
+            Quality = quality
+        };
+        Log.LogMessage(MessageImportance.Low, "  Created Content-Encoding selector for compressed asset '{0}' with size '{1}' is '{2}'", encodingSelector.Value, encodingSelector.Quality, relatedEndpointCandidate.Route);
+        var endpointCopy = new StaticWebAssetEndpoint
+        {
+            AssetFile = compressedAsset.Identity,
+            Route = relatedEndpointCandidate.Route,
+            Selectors = [
+                ..relatedEndpointCandidate.Selectors,
+                            encodingSelector
+            ],
+            EndpointProperties = relatedEndpointCandidate.EndpointProperties
+        };
+        var headers = new List<StaticWebAssetEndpointResponseHeader>(7);
+        ApplyCompressedEndpointHeaders(headers, compressedEndpoint, relatedEndpointCandidate.Route);
+        ApplyRelatedEndpointCandidateHeaders(headers, relatedEndpointCandidate, compressedHeaders);
+        endpointCopy.ResponseHeaders = [.. headers];
+
+        // Update the endpoint
+        Log.LogMessage(MessageImportance.Low, "  Updated related endpoint '{0}' with Content-Encoding selector '{1}={2}'", relatedEndpointCandidate.Route, encodingSelector.Value, encodingSelector.Quality);
+        return endpointCopy;
+    }
+
+    private static bool HasContentEncodingResponseHeader(StaticWebAssetEndpoint compressedEndpoint)
+    {
+        for (var i = 0; i < compressedEndpoint.ResponseHeaders.Length; i++)
+        {
+            var responseHeader = compressedEndpoint.ResponseHeaders[i];
+            if (string.Equals(responseHeader.Name, "Content-Encoding", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasContentEncodingSelector(StaticWebAssetEndpoint compressedEndpoint)
+    {
+        for (var i = 0; i < compressedEndpoint.Selectors.Length; i++)
+        {
+            var selector = compressedEndpoint.Selectors[i];
+            if (string.Equals(selector.Name, "Content-Encoding", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private (List<StaticWebAssetEndpoint> compressedEndpoints, List<StaticWebAssetEndpoint> relatedAssetEndpoints) ResolveEndpoints(
+        IDictionary<string, StaticWebAsset> assetsById,
+        IDictionary<string, List<StaticWebAssetEndpoint>> endpointsByAsset,
+        StaticWebAsset compressedAsset)
+    {
+        if (!assetsById.TryGetValue(compressedAsset.RelatedAsset, out var relatedAsset))
+        {
+            Log.LogWarning("Related asset not found for compressed asset: {0}", compressedAsset.Identity);
+            throw new InvalidOperationException($"Related asset not found for compressed asset: {compressedAsset.Identity}");
+        }
+
+        if (!endpointsByAsset.TryGetValue(compressedAsset.Identity, out var compressedEndpoints))
+        {
+            Log.LogWarning("Endpoints not found for compressed asset: {0} {1}", compressedAsset.RelativePath, compressedAsset.Identity);
+            throw new InvalidOperationException($"Endpoints not found for compressed asset: {compressedAsset.Identity}");
+        }
+
+        if (!endpointsByAsset.TryGetValue(relatedAsset.Identity, out var relatedAssetEndpoints))
+        {
+            Log.LogWarning("Endpoints not found for related asset: {0}", relatedAsset.Identity);
+            throw new InvalidOperationException($"Endpoints not found for related asset: {relatedAsset.Identity}");
+        }
+
+        return (compressedEndpoints, relatedAssetEndpoints);
     }
 
     private static string ResolveQuality(StaticWebAsset compressedAsset) =>
@@ -222,9 +289,21 @@ public class ApplyCompressionNegotiation : Task
 
     private static bool IsCompatible(StaticWebAssetEndpoint compressedEndpoint, StaticWebAssetEndpoint relatedEndpointCandidate)
     {
-        var compressedFingerprint = compressedEndpoint.EndpointProperties.FirstOrDefault(ep => ep.Name == "fingerprint");
-        var relatedFingerprint = relatedEndpointCandidate.EndpointProperties.FirstOrDefault(ep => ep.Name == "fingerprint");
+        var compressedFingerprint = ResolveFingerprint(compressedEndpoint);
+        var relatedFingerprint = ResolveFingerprint(relatedEndpointCandidate);
         return string.Equals(compressedFingerprint.Value, relatedFingerprint.Value, StringComparison.Ordinal);
+    }
+
+    private static StaticWebAssetEndpointProperty ResolveFingerprint(StaticWebAssetEndpoint compressedEndpoint)
+    {
+        foreach (var property in compressedEndpoint.EndpointProperties)
+        {
+            if (string.Equals(property.Name, "fingerprint", StringComparison.Ordinal))
+            {
+                return property;
+            }
+        }
+        return default;
     }
 
     private void ApplyCompressedEndpointHeaders(List<StaticWebAssetEndpointResponseHeader> headers, StaticWebAssetEndpoint compressedEndpoint, string relatedEndpointCandidateRoute)

--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -216,7 +216,7 @@ public class ApplyCompressionNegotiation : Task
             Route = relatedEndpointCandidate.Route,
             Selectors = [
                 ..relatedEndpointCandidate.Selectors,
-                            encodingSelector
+                encodingSelector
             ],
             EndpointProperties = relatedEndpointCandidate.EndpointProperties
         };

--- a/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
@@ -66,7 +66,7 @@ public class ResolveCompressedAssets : Task
             .AddExcludePatterns(excludePatterns)
             .Build();
 
-        var matchingCandidateAssets = new List<StaticWebAsset>();
+        var matchingCandidateAssets = new List<StaticWebAsset>(CandidateAssets.Length);
 
         var matchContext = StaticWebAssetGlobMatcher.CreateMatchContext();
 
@@ -115,16 +115,22 @@ public class ResolveCompressedAssets : Task
         // Process the final set of candidate assets, deduplicating assets to be compressed in the same format multiple times and
         // generating new a static web asset definition for each compressed item.
         var formats = SplitPattern(Formats);
-        var assetsToCompress = new List<ITaskItem>();
+        var assetsToCompress = new ITaskItem[matchingCandidateAssets.Count * formats.Length];
         var outputPath = Path.GetFullPath(OutputPath);
-        foreach (var format in formats)
+        var assetCounter = 0;
+        foreach (var asset in matchingCandidateAssets)
         {
-            foreach (var asset in matchingCandidateAssets)
+            // Reset common properties
+            StaticWebAsset previousAsset = null;
+            string pathTemplate = null;
+            string relativePath = null;
+
+            foreach (var format in formats)
             {
                 var itemSpec = asset.Identity;
                 if (!existingCompressionFormatsByAssetItemSpec.TryGetValue(itemSpec, out var existingFormats))
                 {
-                    existingFormats = [];
+                    existingFormats = new HashSet<string>(2);
                     existingCompressionFormatsByAssetItemSpec.Add(itemSpec, existingFormats);
                 }
 
@@ -137,14 +143,27 @@ public class ResolveCompressedAssets : Task
                     continue;
                 }
 
-                if (TryCreateCompressedAsset(asset, outputPath, format, out var compressedAsset))
+                pathTemplate ??= CreatePathTemplate(asset, outputPath);
+                relativePath ??= asset.EmbedTokens(asset.RelativePath);
+
+                if (TryCreateCompressedAsset(
+                    asset,
+                    outputPath,
+                    format,
+                    pathTemplate,
+                    relativePath,
+                    ref previousAsset,
+                    out var compressedAsset))
                 {
-                    assetsToCompress.Add(compressedAsset);
+                    var result = compressedAsset.ToTaskItem();
+                    result.SetMetadata("RelatedAssetOriginalItemSpec", asset.OriginalItemSpec);
+
+                    assetsToCompress[assetCounter++] = result;
                     existingFormats.Add(format);
 
                     Log.LogMessage(
                         "Accepted compressed asset '{0}' for '{1}'.",
-                        compressedAsset.ItemSpec,
+                        result.ItemSpec,
                         itemSpec);
                 }
                 else
@@ -158,12 +177,19 @@ public class ResolveCompressedAssets : Task
 
         Log.LogMessage(
             "Resolved {0} compressed assets for {1} candidate assets.",
-            assetsToCompress.Count,
+            assetCounter,
             matchingCandidateAssets.Count);
 
-        AssetsToCompress = [.. assetsToCompress];
+        AssetsToCompress = assetsToCompress;
 
         return !Log.HasLoggedErrors;
+    }
+
+    private static string CreatePathTemplate(StaticWebAsset asset, string outputPath)
+    {
+        var relativePath = asset.ComputePathWithoutTokens(asset.RelativePath);
+        var pathHash = FileHasher.HashString(asset.SourceId + asset.BasePath + asset.AssetKind + relativePath);
+        return Path.Combine(outputPath, $"{pathHash}-{{0}}-{asset.Fingerprint}");
     }
 
     private Dictionary<string, HashSet<string>> CollectCompressedAssets(StaticWebAsset[] candidates)
@@ -236,7 +262,14 @@ public class ResolveCompressedAssets : Task
             .Select(s => s.Trim())
             .ToArray();
 
-    private bool TryCreateCompressedAsset(StaticWebAsset asset, string outputPath, string format, out ITaskItem result)
+    private bool TryCreateCompressedAsset(
+        StaticWebAsset asset,
+        string outputPath,
+        string format,
+        string pathTemplate,
+        string relativePath,
+        ref StaticWebAsset previousAsset,
+        out StaticWebAsset result)
     {
         result = null;
 
@@ -262,34 +295,41 @@ public class ResolveCompressedAssets : Task
             return false;
         }
 
-        var originalItemSpec = asset.OriginalItemSpec;
-        var relativePath = asset.EmbedTokens(asset.RelativePath);
-
         // Make the hash name more unique by including source id, base path, asset kind and relative path.
         // This combination must be unique across all assets, so this will avoid collisions when two files on
         // the same project have the same contents, when it happens across different projects or between Build/Publish
         // assets.
-        var pathHash = FileHasher.HashString(asset.SourceId + asset.BasePath + asset.AssetKind + asset.RelativePath);
-        var fileName = $"{pathHash}-{asset.Fingerprint}{fileExtension}";
+        var fileName = $"{pathTemplate}-{asset.Fingerprint}{fileExtension}";
         var itemSpec = Path.GetFullPath(Path.Combine(OutputPath, fileName));
 
-        var res = new StaticWebAsset(asset)
+        if (previousAsset != null)
         {
-            Identity = itemSpec,
-            RelativePath = $"{relativePath}{fileExtension}",
-            OriginalItemSpec = asset.Identity,
-            RelatedAsset = asset.Identity,
-            AssetRole = "Alternative",
-            AssetTraitName = "Content-Encoding",
-            AssetTraitValue = assetTraitValue,
-            ContentRoot = outputPath,
-            // Set integrity and fingerprint to null so that they get recalculated for the compressed asset.
-            Fingerprint = null,
-            Integrity = null,
-        };
+            result = new StaticWebAsset(previousAsset)
+            {
+                Identity = itemSpec,
+                RelativePath = $"{relativePath}{fileExtension}",
+                AssetTraitValue = assetTraitValue,
+            };
+        }
+        else
+        {
+            result = new StaticWebAsset(asset)
+            {
+                Identity = itemSpec,
+                RelativePath = $"{relativePath}{fileExtension}",
+                OriginalItemSpec = asset.Identity,
+                RelatedAsset = asset.Identity,
+                AssetRole = "Alternative",
+                AssetTraitName = "Content-Encoding",
+                AssetTraitValue = assetTraitValue,
+                ContentRoot = outputPath,
+                // Set integrity and fingerprint to null so that they get recalculated for the compressed asset.
+                Fingerprint = null,
+                Integrity = null,
+            };
 
-        result = res.ToTaskItem();
-        result.SetMetadata("RelatedAssetOriginalItemSpec", originalItemSpec);
+            previousAsset = result;
+        }
 
         return true;
     }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1251,26 +1251,6 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         return result;
     }
 
-    internal static IDictionary<string, List<StaticWebAssetEndpoint>> ToAssetFileDictionary(ITaskItem[] candidateEndpoints)
-    {
-        var result = new Dictionary<string, List<StaticWebAssetEndpoint>>(candidateEndpoints.Length / 2);
-
-        foreach (var candidate in candidateEndpoints)
-        {
-            var endpoint = FromTaskItem(candidate);
-            var assetFile = endpoint.AssetFile;
-            if (!result.TryGetValue(assetFile, out var endpoints))
-            {
-                endpoints = new List<StaticWebAssetEndpoint>(5);
-                result[assetFile] = endpoints;
-            }
-            endpoints.Add(endpoint);
-        }
-
-        return result;
-    }
-
-
     internal static Dictionary<string, (StaticWebAsset, List<StaticWebAsset>)> AssetsByTargetPath(ITaskItem[] assets, string source, string assetKind)
     {
         // We return either the selected asset or a list with all the candidates that were found to be ambiguous

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1251,6 +1251,26 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         return result;
     }
 
+    internal static IDictionary<string, List<StaticWebAssetEndpoint>> ToAssetFileDictionary(ITaskItem[] candidateEndpoints)
+    {
+        var result = new Dictionary<string, List<StaticWebAssetEndpoint>>(candidateEndpoints.Length / 2);
+
+        foreach (var candidate in candidateEndpoints)
+        {
+            var endpoint = FromTaskItem(candidate);
+            var assetFile = endpoint.AssetFile;
+            if (!result.TryGetValue(assetFile, out var endpoints))
+            {
+                endpoints = new List<StaticWebAssetEndpoint>(5);
+                result[assetFile] = endpoints;
+            }
+            endpoints.Add(endpoint);
+        }
+
+        return result;
+    }
+
+
     internal static Dictionary<string, (StaticWebAsset, List<StaticWebAsset>)> AssetsByTargetPath(ITaskItem[] assets, string source, string assetKind)
     {
         // We return either the selected asset or a list with all the candidates that were found to be ambiguous

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -199,7 +199,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         return result;
     }
 
-    public static ITaskItem[] ToTaskItems(IList<StaticWebAssetEndpoint> endpoints)
+    public static ITaskItem[] ToTaskItems(ICollection<StaticWebAssetEndpoint> endpoints)
     {
         if (endpoints == null || endpoints.Count == 0)
         {
@@ -207,9 +207,10 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         }
 
         var endpointItems = new ITaskItem[endpoints.Count];
-        for (var i = 0; i < endpoints.Count; i++)
+        var i = 0;
+        foreach (var endpoint in endpoints)
         {
-            endpointItems[i] = endpoints[i].ToTaskItem();
+            endpointItems[i++] = endpoint.ToTaskItem();
         }
 
         return endpointItems;

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -147,6 +147,25 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
 
     public static IEqualityComparer<StaticWebAssetEndpoint> RouteAndAssetComparer { get; } = new RouteAndAssetEqualityComparer();
 
+    internal static IDictionary<string, List<StaticWebAssetEndpoint>> ToAssetFileDictionary(ITaskItem[] candidateEndpoints)
+    {
+        var result = new Dictionary<string, List<StaticWebAssetEndpoint>>(candidateEndpoints.Length / 2);
+
+        foreach (var candidate in candidateEndpoints)
+        {
+            var endpoint = FromTaskItem(candidate);
+            var assetFile = endpoint.AssetFile;
+            if (!result.TryGetValue(assetFile, out var endpoints))
+            {
+                endpoints = new List<StaticWebAssetEndpoint>(5);
+                result[assetFile] = endpoints;
+            }
+            endpoints.Add(endpoint);
+        }
+
+        return result;
+    }
+
     public static StaticWebAssetEndpoint[] FromItemGroup(ITaskItem[] endpoints)
     {
         var result = new StaticWebAssetEndpoint[endpoints.Length];

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
@@ -171,7 +171,13 @@ public partial class DefineStaticWebAssets : Task
 
         private void PartialUpdate(Dictionary<string, ITaskItem> inputHashes)
         {
-            var newHashes = new HashSet<string>(inputHashes.Keys);
+            var newHashes = new HashSet<string>(inputHashes.Count);
+            foreach (var kvp in inputHashes)
+            {
+                var hash = kvp.Key;
+                newHashes.Add(hash);
+            }
+
             var oldHashes = InputHashes;
 
             if (newHashes.SetEquals(oldHashes))

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveCompressedAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ResolveCompressedAssetsTest.cs
@@ -71,7 +71,7 @@ public class ResolveCompressedAssetsTest
 
         // Assert
         result.Should().BeTrue();
-        task.AssetsToCompress.Should().HaveCount(2);
+        task.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(2);
         task.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
         task.AssetsToCompress[1].ItemSpec.Should().EndWith(".br");
     }
@@ -145,7 +145,7 @@ public class ResolveCompressedAssetsTest
         var result = task.Execute();
 
         result.Should().BeTrue();
-        task.AssetsToCompress.Should().HaveCount(0);
+        task.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(0);
     }
 
     [Fact]
@@ -188,7 +188,7 @@ public class ResolveCompressedAssetsTest
 
         // Assert
         result.Should().BeTrue();
-        task.AssetsToCompress.Should().HaveCount(2);
+        task.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(2);
         task.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
         task.AssetsToCompress[1].ItemSpec.Should().EndWith(".br");
     }
@@ -233,7 +233,7 @@ public class ResolveCompressedAssetsTest
 
         // Assert
         result.Should().BeTrue();
-        task.AssetsToCompress.Should().HaveCount(2);
+        task.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(2);
         task.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
         var relativePath = task.AssetsToCompress[0].GetMetadata("RelativePath");
         relativePath.Should().EndWith(".gz");
@@ -338,7 +338,7 @@ public class ResolveCompressedAssetsTest
 
         // Assert
         buildResult.Should().BeTrue();
-        buildTask.AssetsToCompress.Should().HaveCount(2);
+        buildTask.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(2);
         buildTask.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
         buildTask.AssetsToCompress[1].ItemSpec.Should().EndWith(".br");
     }
@@ -382,7 +382,7 @@ public class ResolveCompressedAssetsTest
         var result1 = task1.Execute();
 
         result1.Should().BeTrue();
-        task1.AssetsToCompress.Should().HaveCount(1);
+        task1.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(1);
         task1.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
         task1.AssetsToCompress[0].SetMetadata("Fingerprint", "v1gz");
         task1.AssetsToCompress[0].SetMetadata("Integrity", "abcgz");
@@ -404,7 +404,7 @@ public class ResolveCompressedAssetsTest
         var result2 = task2.Execute();
 
         result2.Should().BeTrue();
-        task2.AssetsToCompress.Should().HaveCount(1);
+        task2.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(1);
         task2.AssetsToCompress[0].ItemSpec.Should().EndWith(".br");
     }
 
@@ -447,7 +447,7 @@ public class ResolveCompressedAssetsTest
         var result1 = task1.Execute();
 
         result1.Should().BeTrue();
-        task1.AssetsToCompress.Should().HaveCount(1);
+        task1.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(1);
         task1.AssetsToCompress[0].ItemSpec.Should().EndWith(".br");
         task1.AssetsToCompress[0].SetMetadata("Fingerprint", "v1br");
         task1.AssetsToCompress[0].SetMetadata("Integrity", "abcbr");
@@ -469,7 +469,7 @@ public class ResolveCompressedAssetsTest
         var result2 = task2.Execute();
 
         result2.Should().BeTrue();
-        task2.AssetsToCompress.Should().HaveCount(1);
+        task2.AssetsToCompress.TakeWhile(a => a != null).Should().HaveCount(1);
         task2.AssetsToCompress[0].ItemSpec.Should().EndWith(".gz");
     }
 }


### PR DESCRIPTION
* Removes LINQ usages.
* Avoids excessive array amortization.
* Reduces allocations