### PR TITLE
Fix truncated symbols paths in log output from CreateSdkSymbolsLayout

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSdkSymbolsLayout.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSdkSymbolsLayout.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                     string debugId = GetDebugId(guid, file);
                     if (!allPdbGuids.ContainsKey(debugId))
                     {
-                        filesWithoutPDBs.Add(file.Substring(SdkLayoutPath.Length + 1));
+                        filesWithoutPDBs.Add(file.Substring(SdkLayoutPath.Length));
                     }
                     else
                     {


### PR DESCRIPTION
I noticed in this [PR](https://github.com/dotnet/sdk/pull/48129) that the `Did not find PDBs for the following SDK files:` diagnostic message from the CreateSdkSymbolsLayout task was truncated.  

```
/__w/1/vmr/eng/finish-source-only.proj(95,5): warning : Did not find PDBs for the following SDK files:
/__w/1/vmr/eng/finish-source-only.proj(95,5): warning : dk/10.0.100-preview.4.25203.1/Microsoft.ApplicationInsights.dll
/__w/1/vmr/eng/finish-source-only.proj(95,5): warning : dk/10.0.100-preview.4.25203.1/DotnetTools/dotnet-watch/10.0.100-preview.4.25203.1/tools/net10.0/any/Microsoft.ApplicationInsights.dll
```

