### PR TITLE
Do not use live shims for tools packages in VMR

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -54,9 +54,11 @@
           Condition="'$(RunTestsAsTool)' == 'true' And '$(CanRunTestAsTool)' == 'true'"/>
 
   <!-- Update KnownFrameworkReferences to target the right version of the runtime -->
+  <!-- We cannot use live shims when building tool packs in VMR - only package for current arch is available. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                           and $(MicrosoftNETCoreAppRefPackageVersion.StartsWith('$(_TargetFrameworkVersionWithoutV)'))
-                          and '$(MSBuildProjectName)' != 'sdk-tasks'">
+                          and '$(MSBuildProjectName)' != 'sdk-tasks'
+                          and ('$(DotNetBuild)' != 'true' or '$(PackAsToolShimRuntimeIdentifiers)' == '')">
     <FrameworkReference
         Update="Microsoft.NETCore.App"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"

--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -23,7 +23,7 @@
       These identifiers are for generating the shim'd core executables for signing. Not all options
       from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
     -->
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true' OR '$(TargetOsName)' == 'win'">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
 
     <!-- Avoid https://github.com/dotnet/arcade/issues/9305 -->
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>

--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -23,7 +23,7 @@
       These identifiers are for generating the shim'd core executables for signing. Not all options
       from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
     -->
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true' OR '$(TargetOsName)' == 'win'">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true'">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
 
     <!-- Avoid https://github.com/dotnet/arcade/issues/9305 -->
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>

--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -23,8 +23,7 @@
       These identifiers are for generating the shim'd core executables for signing. Not all options
       from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
     -->
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true' and $(SignableShimRuntimeIdentifier.Contains('$(TargetRid)'))">$(TargetRid)</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
 
     <!-- Avoid https://github.com/dotnet/arcade/issues/9305 -->
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4944

We don't have all live shims when building in VMR. The fix is to restore shared framework and not use the live one, as only one architecture is available.

Verified in a local build.