### PR TITLE
Fix incorrect index in MSTest template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/template.json
@@ -234,7 +234,7 @@
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "id": "openInEditor",
       "args": {
-        "files": "2"
+        "files": "1"
       },
       "continueOnError": true
     }


### PR DESCRIPTION
Fix typo introduced in    https://github.com/dotnet/sdk/pull/47768 we want to open the second file, and the index is 0 based.