### PR TITLE
[StaticWebAsset] Fix label not being correctly updated and add a unit test

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
@@ -21,12 +21,12 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
     public override bool Execute()
     {
         var assets = StaticWebAsset.ToAssetDictionary(Assets);
-        var candidateEndpoints = StaticWebAssetEndpoint.FromItemGroup(CandidateEndpoints);
 
-        var endpoints = new List<StaticWebAssetEndpoint>();
+        var result = CandidateEndpoints;
 
-        foreach (var candidateEndpoint in candidateEndpoints)
+        for (var i = 0; i < CandidateEndpoints.Length; i++)
         {
+            var candidateEndpoint = StaticWebAssetEndpoint.FromTaskItem(CandidateEndpoints[i]);
             if (assets.TryGetValue(candidateEndpoint.AssetFile, out var asset))
             {
                 // We need to adjust the path to include the base path for the asset, since this is going to be used
@@ -43,27 +43,32 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
                 {
                     candidateEndpoint.Route = StaticWebAsset.CombineNormalizedPaths("", asset.BasePath, candidateEndpoint.Route, '/');
 
-                    for (var i = 0; i < candidateEndpoint.EndpointProperties.Length; i++)
+                    for (var j = 0; j < candidateEndpoint.EndpointProperties.Length; j++)
                     {
-                        ref var property = ref candidateEndpoint.EndpointProperties[i];
+                        ref var property = ref candidateEndpoint.EndpointProperties[j];
                         if (string.Equals(property.Name, "label", StringComparison.OrdinalIgnoreCase))
                         {
                             property.Value = StaticWebAsset.CombineNormalizedPaths("", asset.BasePath, property.Value, '/');
+                            // We need to do this because we are modifying the properties in place.
+                            // We could instead do candidateEndpoint.EndpointProperties = candidateEndpoint.EndpointProperties
+                            // but that's more obscure than this.
+                            candidateEndpoint.MarkProperiesAsModified();
                         }
                     }
 
                     Log.LogMessage(MessageImportance.Low, "Adding endpoint {0} for asset {1} with updated route {2}.", candidateEndpoint.Route, candidateEndpoint.AssetFile, candidateEndpoint.Route);
 
-                    endpoints.Add(candidateEndpoint);
+                    result[i] = candidateEndpoint.ToTaskItem();
                 }
             }
             else
             {
                 Log.LogMessage(MessageImportance.Low, "Skipping endpoint {0} because the asset {1} was not found.", candidateEndpoint.Route, candidateEndpoint.AssetFile);
+                result[i] = null;
             }
         }
 
-        Endpoints = StaticWebAssetEndpoint.ToTaskItems(endpoints);
+        Endpoints = result;
 
         return true;
     }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -139,6 +139,12 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         }
     }
 
+    internal void MarkProperiesAsModified()
+    {
+        _modified = true;
+        _endpointPropertiesModified = true;
+    }
+
     public static IEqualityComparer<StaticWebAssetEndpoint> RouteAndAssetComparer { get; } = new RouteAndAssetEqualityComparer();
 
     public static StaticWebAssetEndpoint[] FromItemGroup(ITaskItem[] endpoints)

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsTest.cs
@@ -38,6 +38,35 @@ public class ComputeEndpointsForReferenceStaticWebAssetsTest
     }
 
     [Fact]
+    public void UpdatesLabelAsNecessary_ForChosenEndpoints()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var task = new ComputeEndpointsForReferenceStaticWebAssets
+        {
+            BuildEngine = buildEngine.Object,
+            Assets = [CreateCandidate(Path.Combine("wwwroot", "candidate.js"), "MyPackage", "Discovered", "candidate.js", "All", "All")],
+            CandidateEndpoints = [CreateCandidateEndpoint("candidate.js", Path.Combine("wwwroot", "candidate.js"), addLabel: true)]
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        result.Should().Be(true);
+        task.Endpoints.Should().ContainSingle();
+        task.Endpoints[0].ItemSpec.Should().Be("base/candidate.js");
+        task.Endpoints[0].GetMetadata("AssetFile").Should().Be(Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")));
+        var properties = StaticWebAssetEndpointProperty.FromMetadataValue(task.Endpoints[0].GetMetadata("EndpointProperties"));
+        properties.Should().ContainSingle();
+        properties[0].Name.Should().Be("label");
+        properties[0].Value.Should().Be("base/label-value");
+    }
+
+    [Fact]
     public void FiltersOutEndpointsForAssetsNotFound()
     {
         var errorMessages = new List<string>();
@@ -60,7 +89,7 @@ public class ComputeEndpointsForReferenceStaticWebAssetsTest
 
         // Assert
         result.Should().Be(true);
-        task.Endpoints.Should().ContainSingle();
+        task.Endpoints.Where(e => e != null).Should().ContainSingle();
         task.Endpoints[0].ItemSpec.Should().Be("base/candidate.js");
         task.Endpoints[0].GetMetadata("AssetFile").Should().Be(Path.GetFullPath(Path.Combine("wwwroot", "candidate.js")));
     }
@@ -103,12 +132,15 @@ public class ComputeEndpointsForReferenceStaticWebAssetsTest
         return result.ToTaskItem();
     }
 
-    private static ITaskItem CreateCandidateEndpoint(string route, string assetFile)
+    private static ITaskItem CreateCandidateEndpoint(string route, string assetFile, bool addLabel = false)
     {
         return new StaticWebAssetEndpoint
         {
             Route = route,
             AssetFile = Path.GetFullPath(assetFile),
+            EndpointProperties = addLabel
+                ? [new StaticWebAssetEndpointProperty { Name = "label", Value = "label-value" }]
+                : [],
         }.ToTaskItem();
     }
 }


### PR DESCRIPTION
* Reuses the input array for output
* Avoids allocating an array for processing the inputs
* Fixes an issue where the label property was not correctly updated for reference assets