### PR TITLE
Keep artifact directory

### DIFF
--- a/src/SourceBuild/content/eng/allowed-sb-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-sb-binaries.txt
@@ -4,7 +4,7 @@
 # If importing a file, include the relative path to the file
 
 # Well known non-checked in infrastructure
-artifacts/*/BinaryToolKit/
+artifacts/
 .dotnet/
 .git/
 .packages/


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4988

Exclude the complete artifacts directory from the binary removal tool.