### PR TITLE
Remove `testfx` from VMR source mappings

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -159,10 +159,6 @@
             "defaultRemote": "https://github.com/dotnet/templating"
         },
         {
-            "name": "testfx",
-            "defaultRemote": "https://github.com/microsoft/testfx"
-        },
-        {
             "name": "vstest",
             "defaultRemote": "https://github.com/microsoft/vstest",
             "exclude": [


### PR DESCRIPTION
The repo was never brought in