### PR TITLE
Publish scenario-tests logs for installer tests

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -56,3 +56,15 @@ steps:
       mergeTestResults: true
       publishRunAttachments: true
       testRunTitle: Tests_$(Agent.JobName)
+
+  - task: PublishTestResults@2
+    displayName: Publish Scenario Test Results
+    condition: succeededOrFailed()
+    continueOnError: true
+    inputs:
+      testRunner: xUnit
+      testResultsFiles: 'artifacts/TestResults/**/scenario-tests/*.xml'
+      searchFolder: $(Build.SourcesDirectory)
+      mergeTestResults: true
+      publishRunAttachments: true
+      testRunTitle: ScenarioTests_$(Agent.JobName)

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -23,6 +23,9 @@ public static class Config
     public static string PackagesDirectory { get; } = GetRuntimeConfig(PackagesDirectorySwitch);
     const string PackagesDirectorySwitch = RuntimeConfigSwitchPrefix + nameof(PackagesDirectory);
 
+    public static string ArtifactsTestResultsDirectory { get; } = GetRuntimeConfig(ArtifactsTestResultsDirectorySwitch);
+    const string ArtifactsTestResultsDirectorySwitch = RuntimeConfigSwitchPrefix + nameof(ArtifactsTestResultsDirectory);
+
     public static string ScenarioTestsNuGetConfigPath { get; } = GetRuntimeConfig(ScenarioTestsNuGetConfigSwitch);
     const string ScenarioTestsNuGetConfigSwitch = RuntimeConfigSwitchPrefix + nameof(ScenarioTestsNuGetConfigPath);
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -220,7 +220,7 @@ public class LinuxInstallerTests : IDisposable
         string hostLogDir = Path.Combine(Config.ArtifactsTestResultsDirectory, "scenario-tests");
         Directory.CreateDirectory(hostLogDir);
         string containerLogDir = "/logs";
-        string containerLogPath = Path.Combine(containerLogDir, $"scenario-tests-{GetSanitatizedImageName(baseImage)}.xml");
+        string containerLogPath = Path.Combine(containerLogDir, $"scenario-tests-{GetSanitizedImageName(baseImage)}.xml");
 
         string testCommand = $"dotnet {GetScenarioTestsBinaryPath()} --dotnet-root /usr/share/dotnet/ --xml {containerLogPath}";
 
@@ -399,7 +399,7 @@ public class LinuxInstallerTests : IDisposable
         return files.OrderByDescending(f => f).First();
     }
 
-    private static string GetSanitatizedImageName(string image) =>
+    private static string GetSanitizedImageName(string image) =>
         image.Replace("/", "_").Replace(":", "_").Replace(".", "_");
 
     private static async Task DownloadFileAsync(string url, string filePath)

--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -25,6 +25,9 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).PackagesDirectory">
         <Value>$(PackageArtifactsDir)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).ArtifactsTestResultsDirectory">
+        <Value>$(ArtifactsTestResultsDir)</Value>
+      </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).ScenarioTestsNuGetConfigPath">
         <Value>$(RepoRoot)src\scenario-tests\NuGet.config</Value>
       </RuntimeHostConfigurationOption>


### PR DESCRIPTION
This PR adds the scenario-tests logs to the test logs published by the installer tests.

Verification run, with scenario-tests logs publishing: https://dev.azure.com/dnceng/internal/_build/results?buildId=2679804&view=logs&j=6e593626-f6df-5699-84b9-2127a964bf7b&t=97b0b9a2-cbdb-5c20-a774-29078c722b30