### PR TITLE
Exclude dotnet*.js files from signing-validation

### DIFF
--- a/src/SourceBuild/content/eng/SignCheckExclusionsFile.txt
+++ b/src/SourceBuild/content/eng/SignCheckExclusionsFile.txt
@@ -6,6 +6,7 @@
 *singlefilehost.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *comhost.dll;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *apphosttemplateapphostexe.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
+dotnet*.js;; DO-NOT-SIGN, https://github.com/dotnet/runtime/issues/114353#issuecomment-2784726217
 
 ;; ## PGO ##
 ;dotnet-sdk-pgo-*.tar.gz; PGO builds are unsigned


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/114353#issuecomment-2784726217

[Pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2681600&view=results)