### PR TITLE
[GitHub Actions] Add synchronize Event

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -1,7 +1,7 @@
 name: PR Analysis
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    types: [opened, synchronize, labeled, unlabeled]
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
For automated PRs, conflicts often need to be resolved. After resolving conflicts, new commits need to trigger the workflow again to ensure all label statuses and other checks pass. This is the reason for adding the synchronize event.

![image](https://github.com/user-attachments/assets/a8d9fa3c-a9c8-49b8-b979-c49aaefe65e9)
