### PR TITLE
dotnet test for MTP: Support TestTfmsInParallel

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -95,4 +95,6 @@ internal static class ProjectProperties
     internal const string RunArguments = "RunArguments";
     internal const string RunWorkingDirectory = "RunWorkingDirectory";
     internal const string AppDesignerFolder = "AppDesignerFolder";
+    internal const string TestTfmsInParallel = "TestTfmsInParallel";
+    internal const string BuildInParallel = "BuildInParallel";
 }

--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -17,7 +17,7 @@ internal static class MSBuildUtility
 {
     private const string dotnetTestVerb = "dotnet-test";
 
-    public static (IEnumerable<NonParallelizedTestModuleGroup> Projects, bool IsBuiltOrRestored) GetProjectsFromSolution(string solutionFilePath, BuildOptions buildOptions)
+    public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, bool IsBuiltOrRestored) GetProjectsFromSolution(string solutionFilePath, BuildOptions buildOptions)
     {
         SolutionModel solutionModel = SlnFileFactory.CreateFromFileOrDirectory(solutionFilePath, includeSolutionFilterFiles: true, includeSolutionXmlFiles: true);
 
@@ -25,7 +25,7 @@ internal static class MSBuildUtility
 
         if (!isBuiltOrRestored)
         {
-            return (Array.Empty<NonParallelizedTestModuleGroup>(), isBuiltOrRestored);
+            return (Array.Empty<ParallelizableTestModuleGroupWithSequentialInnerModules>(), isBuiltOrRestored);
         }
 
         string rootDirectory = solutionFilePath.HasExtension(".slnf") ?
@@ -35,25 +35,25 @@ internal static class MSBuildUtility
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
         var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
-        ConcurrentBag<NonParallelizedTestModuleGroup> projects = GetProjectsProperties(collection, solutionModel.SolutionProjects.Select(p => Path.Combine(rootDirectory, p.FilePath)), buildOptions);
+        ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = GetProjectsProperties(collection, solutionModel.SolutionProjects.Select(p => Path.Combine(rootDirectory, p.FilePath)), buildOptions);
         logger?.ReallyShutdown();
 
         return (projects, isBuiltOrRestored);
     }
 
-    public static (IEnumerable<NonParallelizedTestModuleGroup> Projects, bool IsBuiltOrRestored) GetProjectsFromProject(string projectFilePath, BuildOptions buildOptions)
+    public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, bool IsBuiltOrRestored) GetProjectsFromProject(string projectFilePath, BuildOptions buildOptions)
     {
         bool isBuiltOrRestored = BuildOrRestoreProjectOrSolution(projectFilePath, buildOptions);
 
         if (!isBuiltOrRestored)
         {
-            return (Array.Empty<NonParallelizedTestModuleGroup>(), isBuiltOrRestored);
+            return (Array.Empty<ParallelizableTestModuleGroupWithSequentialInnerModules>(), isBuiltOrRestored);
         }
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
         var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
-        IEnumerable<NonParallelizedTestModuleGroup> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, buildOptions.NoLaunchProfile);
+        IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, buildOptions.NoLaunchProfile);
         logger?.ReallyShutdown();
 
         return (projects, isBuiltOrRestored);
@@ -117,16 +117,16 @@ internal static class MSBuildUtility
         return result == (int)BuildResultCode.Success;
     }
 
-    private static ConcurrentBag<NonParallelizedTestModuleGroup> GetProjectsProperties(ProjectCollection projectCollection, IEnumerable<string> projects, BuildOptions buildOptions)
+    private static ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> GetProjectsProperties(ProjectCollection projectCollection, IEnumerable<string> projects, BuildOptions buildOptions)
     {
-        var allProjects = new ConcurrentBag<NonParallelizedTestModuleGroup>();
+        var allProjects = new ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules>();
 
         Parallel.ForEach(
             projects,
             new ParallelOptions { MaxDegreeOfParallelism = buildOptions.DegreeOfParallelism },
             (project) =>
             {
-                IEnumerable<NonParallelizedTestModuleGroup> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project, projectCollection, buildOptions.NoLaunchProfile);
+                IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project, projectCollection, buildOptions.NoLaunchProfile);
                 foreach (var projectMetadata in projectsMetadata)
                 {
                     allProjects.Add(projectMetadata);

--- a/src/Cli/dotnet/Commands/Test/Models.cs
+++ b/src/Cli/dotnet/Commands/Test/Models.cs
@@ -9,22 +9,21 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 /// <summary>
 /// Groups test modules that should NOT be run in parallel.
-/// Parallelization here refers only to the inner test modules.
-/// Note that multiple NonParallelizedTestModuleGroups can be run in parallel.
+/// The whole group is still parallelizable with other groups, just that the inner modules are run sequentially.
 /// This class serves only the purpose of disabling parallelizing of TFMs when user sets TestTfmsInParallel to false.
 /// For a single TFM project, we will use the constructor with a single module. Meaning it will be parallelized.
 /// For a multi TFM project:
-/// - If parallelization is enabled, we will create multiple NonParallelizedTestModuleGroups, each with a single module.
-/// - If parallelization is not enabled, we will create a single NonParallelizedTestModuleGroup with all modules.
+/// - If parallelization is enabled, we will create multiple ParallelizableTestModuleGroupWithSequentialInnerModuless, each with a single module.
+/// - If parallelization is not enabled, we will create a single ParallelizableTestModuleGroupWithSequentialInnerModules with all modules.
 /// </summary>
-internal sealed class NonParallelizedTestModuleGroup : IEnumerable<TestModule>
+internal sealed class ParallelizableTestModuleGroupWithSequentialInnerModules : IEnumerable<TestModule>
 {
-    public NonParallelizedTestModuleGroup(List<TestModule> modules)
+    public ParallelizableTestModuleGroupWithSequentialInnerModules(List<TestModule> modules)
     {
         Modules = modules;
     }
 
-    public NonParallelizedTestModuleGroup(TestModule module)
+    public ParallelizableTestModuleGroupWithSequentialInnerModules(TestModule module)
     {
         // This constructor is used when there is only one module.
         Module = module;
@@ -58,10 +57,10 @@ internal sealed class NonParallelizedTestModuleGroup : IEnumerable<TestModule>
 
     internal struct Enumerator : IEnumerator<TestModule>
     {
-        private readonly NonParallelizedTestModuleGroup _group;
+        private readonly ParallelizableTestModuleGroupWithSequentialInnerModules _group;
         private int _index = -1;
 
-        public Enumerator(NonParallelizedTestModuleGroup group)
+        public Enumerator(ParallelizableTestModuleGroupWithSequentialInnerModules group)
         {
             _group = group;
         }

--- a/src/Cli/dotnet/Commands/Test/Models.cs
+++ b/src/Cli/dotnet/Commands/Test/Models.cs
@@ -1,10 +1,113 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
+
+/// <summary>
+/// Groups test modules that should NOT be run in parallel.
+/// Parallelization here refers only to the inner test modules.
+/// Note that multiple NonParallelizedTestModuleGroups can be run in parallel.
+/// This class serves only the purpose of disabling parallelizing of TFMs when user sets TestTfmsInParallel to false.
+/// For a single TFM project, we will use the constructor with a single module. Meaning it will be parallelized.
+/// For a multi TFM project:
+/// - If parallelization is enabled, we will create multiple NonParallelizedTestModuleGroups, each with a single module.
+/// - If parallelization is not enabled, we will create a single NonParallelizedTestModuleGroup with all modules.
+/// </summary>
+internal sealed class NonParallelizedTestModuleGroup : IEnumerable<TestModule>
+{
+    public NonParallelizedTestModuleGroup(List<TestModule> modules)
+    {
+        Modules = modules;
+    }
+
+    public NonParallelizedTestModuleGroup(TestModule module)
+    {
+        // This constructor is used when there is only one module.
+        Module = module;
+    }
+
+    public List<TestModule>? Modules { get; }
+
+    public TestModule? Module { get; }
+
+    public TestModule[] GetVSTestAndNotMTPModules()
+    {
+        if (Modules is not null)
+        {
+            return Modules.Where(module => !module.IsTestingPlatformApplication).ToArray();
+        }
+
+        if (!Module.IsTestingPlatformApplication)
+        {
+            return [Module];
+        }
+
+        return Array.Empty<TestModule>();
+    }
+
+    public Enumerator GetEnumerator()
+        => new Enumerator(this);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    IEnumerator<TestModule> IEnumerable<TestModule>.GetEnumerator() => GetEnumerator();
+
+    internal struct Enumerator : IEnumerator<TestModule>
+    {
+        private readonly NonParallelizedTestModuleGroup _group;
+        private int _index = -1;
+
+        public Enumerator(NonParallelizedTestModuleGroup group)
+        {
+            _group = group;
+        }
+
+        public TestModule Current
+        {
+            get
+            {
+                if (_index < 0)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                if (_group.Modules is not null)
+                {
+                    return _group.Modules[_index];
+                }
+
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                return _group.Module;
+            }
+        }
+
+        object IEnumerator.Current => Current;
+
+        public void Dispose() { }
+
+        public bool MoveNext()
+        {
+            _index++;
+
+            if (_group.Modules is not null)
+            {
+                return _index < _group.Modules.Count;
+            }
+
+            return _index == 0;
+        }
+
+        public void Reset() => _index = -1;
+    }
+}
 
 internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, bool IsTestingPlatformApplication, bool IsTestProject, ProjectLaunchSettingsModel? LaunchSettings);
 

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -119,33 +119,65 @@ internal static class SolutionAndProjectUtility
         return string.IsNullOrEmpty(fileDirectory) ? Directory.GetCurrentDirectory() : fileDirectory;
     }
 
-    public static IEnumerable<TestModule> GetProjectProperties(string projectFilePath, ProjectCollection projectCollection, bool noLaunchProfile)
+    public static IEnumerable<NonParallelizedTestModuleGroup> GetProjectProperties(string projectFilePath, ProjectCollection projectCollection, bool noLaunchProfile)
     {
-        var projects = new List<TestModule>();
+        var projects = new List<NonParallelizedTestModuleGroup>();
         ProjectInstance projectInstance = EvaluateProject(projectCollection, projectFilePath, null);
 
         var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
         var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
+
         Logger.LogTrace(() => $"Loaded project '{Path.GetFileName(projectFilePath)}' with TargetFramework '{targetFramework}', TargetFrameworks '{targetFrameworks}', IsTestProject '{projectInstance.GetPropertyValue(ProjectProperties.IsTestProject)}', and '{ProjectProperties.IsTestingPlatformApplication}' is '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}'.");
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
             if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
             {
-                projects.Add(module);
+                projects.Add(new NonParallelizedTestModuleGroup(module));
             }
         }
         else
         {
-            var frameworks = targetFrameworks.Split(CliConstants.SemiColon, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var framework in frameworks)
+            if (!bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.TestTfmsInParallel), out bool testTfmsInParallel) &&
+                !bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.BuildInParallel), out testTfmsInParallel))
             {
-                projectInstance = EvaluateProject(projectCollection, projectFilePath, framework);
-                Logger.LogTrace(() => $"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
+                // TestTfmsInParallel takes precedence over BuildInParallel.
+                // If, for some reason, we cannot parse either property as bool, we default to true.
+                testTfmsInParallel = true;
+            }
 
-                if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
+            var frameworks = targetFrameworks.Split(CliConstants.SemiColon, StringSplitOptions.RemoveEmptyEntries);
+            if (testTfmsInParallel)
+            {
+                foreach (var framework in frameworks)
                 {
-                    projects.Add(module);
+                    projectInstance = EvaluateProject(projectCollection, projectFilePath, framework);
+                    Logger.LogTrace(() => $"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
+
+                    if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
+                    {
+                        projects.Add(new NonParallelizedTestModuleGroup(module));
+                    }
+                }
+            }
+            else
+            {
+                List<TestModule>? innerModules = null;
+                foreach (var framework in frameworks)
+                {
+                    projectInstance = EvaluateProject(projectCollection, projectFilePath, framework);
+                    Logger.LogTrace(() => $"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
+
+                    if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
+                    {
+                        innerModules ??= new List<TestModule>(frameworks.Length);
+                        innerModules.Add(module);
+                    }
+                }
+
+                if (innerModules is not null)
+                {
+                    projects.Add(new NonParallelizedTestModuleGroup(innerModules));
                 }
             }
         }

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -119,9 +119,9 @@ internal static class SolutionAndProjectUtility
         return string.IsNullOrEmpty(fileDirectory) ? Directory.GetCurrentDirectory() : fileDirectory;
     }
 
-    public static IEnumerable<NonParallelizedTestModuleGroup> GetProjectProperties(string projectFilePath, ProjectCollection projectCollection, bool noLaunchProfile)
+    public static IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> GetProjectProperties(string projectFilePath, ProjectCollection projectCollection, bool noLaunchProfile)
     {
-        var projects = new List<NonParallelizedTestModuleGroup>();
+        var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
         ProjectInstance projectInstance = EvaluateProject(projectCollection, projectFilePath, null);
 
         var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
@@ -133,7 +133,7 @@ internal static class SolutionAndProjectUtility
         {
             if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
             {
-                projects.Add(new NonParallelizedTestModuleGroup(module));
+                projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
             }
         }
         else
@@ -156,7 +156,7 @@ internal static class SolutionAndProjectUtility
 
                     if (GetModuleFromProject(projectInstance, projectCollection.Loggers, noLaunchProfile) is { } module)
                     {
-                        projects.Add(new NonParallelizedTestModuleGroup(module));
+                        projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
                     }
                 }
             }
@@ -177,7 +177,7 @@ internal static class SolutionAndProjectUtility
 
                 if (innerModules is not null)
                 {
-                    projects.Add(new NonParallelizedTestModuleGroup(innerModules));
+                    projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(innerModules));
                 }
             }
         }

--- a/src/Cli/dotnet/Commands/Test/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationActionQueue.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal class TestApplicationActionQueue
 {
-    private readonly Channel<NonParallelizedTestModuleGroup> _channel;
+    private readonly Channel<ParallelizableTestModuleGroupWithSequentialInnerModules> _channel;
     private readonly List<Task> _readers;
 
     private int? _aggregateExitCode;
@@ -16,7 +16,7 @@ internal class TestApplicationActionQueue
 
     public TestApplicationActionQueue(int degreeOfParallelism, BuildOptions buildOptions, Func<TestApplication, Task<int>> action)
     {
-        _channel = Channel.CreateUnbounded<NonParallelizedTestModuleGroup>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+        _channel = Channel.CreateUnbounded<ParallelizableTestModuleGroupWithSequentialInnerModules>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
         _readers = [];
 
         for (int i = 0; i < degreeOfParallelism; i++)
@@ -25,7 +25,7 @@ internal class TestApplicationActionQueue
         }
     }
 
-    public void Enqueue(NonParallelizedTestModuleGroup testApplication)
+    public void Enqueue(ParallelizableTestModuleGroupWithSequentialInnerModules testApplication)
     {
         if (!_channel.Writer.TryWrite(testApplication))
         {

--- a/src/Cli/dotnet/Commands/Test/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationActionQueue.cs
@@ -7,25 +7,25 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal class TestApplicationActionQueue
 {
-    private readonly Channel<TestApplication> _channel;
+    private readonly Channel<NonParallelizedTestModuleGroup> _channel;
     private readonly List<Task> _readers;
 
     private int? _aggregateExitCode;
 
     private static readonly Lock _lock = new();
 
-    public TestApplicationActionQueue(int degreeOfParallelism, Func<TestApplication, Task<int>> action)
+    public TestApplicationActionQueue(int degreeOfParallelism, BuildOptions buildOptions, Func<TestApplication, Task<int>> action)
     {
-        _channel = Channel.CreateUnbounded<TestApplication>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+        _channel = Channel.CreateUnbounded<NonParallelizedTestModuleGroup>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
         _readers = [];
 
         for (int i = 0; i < degreeOfParallelism; i++)
         {
-            _readers.Add(Task.Run(async () => await Read(action)));
+            _readers.Add(Task.Run(async () => await Read(action, buildOptions)));
         }
     }
 
-    public void Enqueue(TestApplication testApplication)
+    public void Enqueue(NonParallelizedTestModuleGroup testApplication)
     {
         if (!_channel.Writer.TryWrite(testApplication))
         {
@@ -48,37 +48,41 @@ internal class TestApplicationActionQueue
         _channel.Writer.Complete();
     }
 
-    private async Task Read(Func<TestApplication, Task<int>> action)
+    private async Task Read(Func<TestApplication, Task<int>> action, BuildOptions buildOptions)
     {
-        await foreach (var testApp in _channel.Reader.ReadAllAsync())
+        await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync())
         {
-            int result = await action(testApp);
-
-            lock (_lock)
+            foreach (var module in nonParallelizedGroup)
             {
-                if (_aggregateExitCode is null)
+                var testApp = new TestApplication(module, buildOptions);
+                int result = await action(testApp);
+                testApp.Dispose();
+                lock (_lock)
                 {
-                    // This is the first result we are getting.
-                    // So we assign the exit code, regardless of whether it's failure or success.
-                    _aggregateExitCode = result;
-                }
-                else if (_aggregateExitCode.Value != result)
-                {
-                    if (_aggregateExitCode == ExitCode.Success)
+                    if (_aggregateExitCode is null)
                     {
-                        // The current result we are dealing with is the first failure after previous Success.
-                        // So we assign the current failure.
+                        // This is the first result we are getting.
+                        // So we assign the exit code, regardless of whether it's failure or success.
                         _aggregateExitCode = result;
                     }
-                    else if (result != ExitCode.Success)
+                    else if (_aggregateExitCode.Value != result)
                     {
-                        // If we get a new failure result, which is different from a previous failure, we use GenericFailure.
-                        _aggregateExitCode = ExitCode.GenericFailure;
-                    }
-                    else
-                    {
-                        // The current result is a success, but we already have a failure.
-                        // So, we keep the failure exit code.
+                        if (_aggregateExitCode == ExitCode.Success)
+                        {
+                            // The current result we are dealing with is the first failure after previous Success.
+                            // So we assign the current failure.
+                            _aggregateExitCode = result;
+                        }
+                        else if (result != ExitCode.Success)
+                        {
+                            // If we get a new failure result, which is different from a previous failure, we use GenericFailure.
+                            _aggregateExitCode = ExitCode.GenericFailure;
+                        }
+                        else
+                        {
+                            // The current result is a success, but we already have a failure.
+                            // So, we keep the failure exit code.
+                        }
                     }
                 }
             }

--- a/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
@@ -15,7 +15,7 @@ internal sealed class TestModulesFilterHandler(TestApplicationActionQueue action
     private readonly TestApplicationActionQueue _actionQueue = actionQueue;
     private readonly TerminalTestReporter _output = output;
 
-    public bool RunWithTestModulesFilter(ParseResult parseResult, BuildOptions buildOptions)
+    public bool RunWithTestModulesFilter(ParseResult parseResult)
     {
         // If the module path pattern(s) was provided, we will use that to filter the test modules
         string testModules = parseResult.GetValue(TestingPlatformOptions.TestModulesFilterOption);
@@ -48,7 +48,7 @@ internal sealed class TestModulesFilterHandler(TestApplicationActionQueue action
 
         foreach (string testModule in testModulePaths)
         {
-            var testApp = new TestApplication(new TestModule(new RunProperties(testModule, null, null), null, null, true, true, null), buildOptions);
+            var testApp = new NonParallelizedTestModuleGroup(new TestModule(new RunProperties(testModule, null, null), null, null, true, true, null));
             // Write the test application to the channel
             _actionQueue.Enqueue(testApp);
         }

--- a/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/TestModulesFilterHandler.cs
@@ -48,7 +48,7 @@ internal sealed class TestModulesFilterHandler(TestApplicationActionQueue action
 
         foreach (string testModule in testModulePaths)
         {
-            var testApp = new NonParallelizedTestModuleGroup(new TestModule(new RunProperties(testModule, null, null), null, null, true, true, null));
+            var testApp = new ParallelizableTestModuleGroupWithSequentialInnerModules(new TestModule(new RunProperties(testModule, null, null), null, null, true, true, null));
             // Write the test application to the channel
             _actionQueue.Enqueue(testApp);
         }

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
@@ -49,9 +49,10 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
 
         InitializeOutput(degreeOfParallelism, parseResult, testOptions.IsHelp);
 
-        InitializeActionQueue(degreeOfParallelism, testOptions, testOptions.IsHelp);
-
         BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult, degreeOfParallelism);
+
+        InitializeActionQueue(degreeOfParallelism, testOptions, buildOptions);
+
         _msBuildHandler = new(buildOptions, _actionQueue, _output);
         TestModulesFilterHandler testModulesFilterHandler = new(_actionQueue, _output);
 
@@ -59,7 +60,7 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
 
         if (testOptions.HasFilterMode)
         {
-            if (!testModulesFilterHandler.RunWithTestModulesFilter(parseResult, buildOptions))
+            if (!testModulesFilterHandler.RunWithTestModulesFilter(parseResult))
             {
                 return ExitCode.GenericFailure;
             }
@@ -98,15 +99,15 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
         _isRetry = arguments.Contains("--retry-failed-tests");
     }
 
-    private void InitializeActionQueue(int degreeOfParallelism, TestOptions testOptions, bool isHelp)
+    private void InitializeActionQueue(int degreeOfParallelism, TestOptions testOptions, BuildOptions buildOptions)
     {
-        if (isHelp)
+        if (testOptions.IsHelp)
         {
-            InitializeHelpActionQueue(degreeOfParallelism, testOptions);
+            InitializeHelpActionQueue(degreeOfParallelism, testOptions, buildOptions);
         }
         else
         {
-            InitializeTestExecutionActionQueue(degreeOfParallelism, testOptions);
+            InitializeTestExecutionActionQueue(degreeOfParallelism, testOptions, buildOptions);
         }
     }
 
@@ -138,9 +139,9 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
         _output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, _isDiscovery, isHelp, _isRetry);
     }
 
-    private void InitializeHelpActionQueue(int degreeOfParallelism, TestOptions testOptions)
+    private void InitializeHelpActionQueue(int degreeOfParallelism, TestOptions testOptions, BuildOptions buildOptions)
     {
-        _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
+        _actionQueue = new(degreeOfParallelism, buildOptions, async (TestApplication testApp) =>
         {
             testApp.HelpRequested += OnHelpRequested;
             testApp.ErrorReceived += _eventHandlers.OnErrorReceived;
@@ -150,9 +151,9 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
         });
     }
 
-    private void InitializeTestExecutionActionQueue(int degreeOfParallelism, TestOptions testOptions)
+    private void InitializeTestExecutionActionQueue(int degreeOfParallelism, TestOptions testOptions, BuildOptions buildOptions)
     {
-        _actionQueue = new(degreeOfParallelism, async (TestApplication testApp) =>
+        _actionQueue = new(degreeOfParallelism, buildOptions, async (TestApplication testApp) =>
         {
             testApp.HandshakeReceived += _eventHandlers.OnHandshakeReceived;
             testApp.DiscoveredTestsReceived += _eventHandlers.OnDiscoveredTestsReceived;
@@ -198,7 +199,6 @@ internal partial class TestingPlatformCommand : CliCommand, ICustomHelp
 
     private void CleanUp()
     {
-        _msBuildHandler?.Dispose();
         _eventHandlers?.Dispose();
     }
 }

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
@@ -1,0 +1,103 @@
+﻿using System.Diagnostics;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+namespace TestProjectWithNetFM
+{
+	internal class Program
+	{
+		public static async Task<int> Main(string[] args)
+		{
+			// To attach to the children
+			ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+			testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+			ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
+			return await testApplication.RunAsync();
+		}
+	}
+
+	public class DummyTestAdapter : ITestFramework, IDataProducer
+	{
+		public string Uid => nameof(DummyTestAdapter);
+
+		public string Version => "2.0.0";
+
+		public string DisplayName => nameof(DummyTestAdapter);
+
+		public string Description => nameof(DummyTestAdapter);
+
+		public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+		public Type[] DataTypesProduced => new[]
+		{
+			typeof(TestNodeUpdateMessage)
+		};
+
+		public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+			=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+		public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+			=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+		public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+		{
+			var currentProcess = Process.GetCurrentProcess();
+			var processPath = currentProcess.MainModule?.FileName;
+			if (processPath is null)
+			{
+				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+				{
+					Uid = "Test0",
+					DisplayName = "Test0",
+					Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception("Process path is null"), "")),
+				}));
+
+				context.Complete();
+				return;
+			}
+
+			if (!processPath.Contains("TestProjectWithMultipleTFMsParallelization"))
+			{
+				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+				{
+					Uid = "Test0",
+					DisplayName = "Test0",
+					Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception($"Process path is unexpected. Found: '{processPath}'."), "")),
+				}));
+
+				context.Complete();
+				return;	
+			}
+
+			await Task.Delay(5000);
+			
+			var processes = Process.GetProcessesByName(currentProcess.ProcessName);
+			if (processes.Where(p => p.Id != Process.GetCurrentProcess().Id && p.MainModule is not null && p.MainModule.FileName.Contains("TestProjectWithMultipleTFMsParallelization")).Any())
+			{
+				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+				{
+					Uid = "Test0",
+					DisplayName = "Test0",
+					Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+				}));
+			}
+			else
+			{
+				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+				{
+					Uid = "Test0",
+					DisplayName = "Test0",
+					Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception("This is run in parallel!"), "")),
+				}));
+			}
+
+			await Task.Delay(5000);
+
+			
+			context.Complete();
+		}
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
@@ -65,26 +65,25 @@ namespace TestProjectWithNetFM
 			var pathPrefix = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
 			if (processes.Where(p => p.Id != Process.GetCurrentProcess().Id && p.MainModule is not null && p.MainModule.FileName.StartsWith(pathPrefix!)).Any())
 			{
-				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
-				{
-					Uid = "Test0",
-					DisplayName = "Test0",
-					Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
-				}));
+                await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+                {
+                    Uid = "Test0",
+                    DisplayName = "Test0",
+                    Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception("This is run in parallel!"), "")),
+                }));
 			}
 			else
 			{
-				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
-				{
-					Uid = "Test0",
-					DisplayName = "Test0",
-					Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception("This is run in parallel!"), "")),
-				}));
-			}
+                await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+                {
+                    Uid = "Test0",
+                    DisplayName = "Test0",
+                    Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+                }));
+            }
 
 			await Task.Delay(5000);
 
-			
 			context.Complete();
 		}
 	}

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/Program.cs
@@ -59,23 +59,11 @@ namespace TestProjectWithNetFM
 				return;
 			}
 
-			if (!processPath.Contains("TestProjectWithMultipleTFMsParallelization"))
-			{
-				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
-				{
-					Uid = "Test0",
-					DisplayName = "Test0",
-					Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception($"Process path is unexpected. Found: '{processPath}'."), "")),
-				}));
-
-				context.Complete();
-				return;	
-			}
-
 			await Task.Delay(5000);
 			
 			var processes = Process.GetProcessesByName(currentProcess.ProcessName);
-			if (processes.Where(p => p.Id != Process.GetCurrentProcess().Id && p.MainModule is not null && p.MainModule.FileName.Contains("TestProjectWithMultipleTFMsParallelization")).Any())
+			var pathPrefix = Path.GetDirectoryName(Path.GetDirectoryName(processPath));
+			if (processes.Where(p => p.Id != Process.GetCurrentProcess().Id && p.MainModule is not null && p.MainModule.FileName.StartsWith(pathPrefix!)).Any())
 			{
 				await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
 				{

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>$(CurrentTargetFramework);net9.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<LangVersion>latest</LangVersion>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProjectWithMultipleTFMsParallelization.sln
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/TestProjectWithMultipleTFMsParallelization.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35505.181
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{D2E321F2-3513-99DE-C37E-6D48D15F404D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2E321F2-3513-99DE-C37E-6D48D15F404D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3D7914D1-7D03-4FFB-8D0F-7FFA6B6BA6A0}
+	EndGlobalSection
+EndGlobal

--- a/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/dotnet.config
+++ b/test/TestAssets/TestProjects/TestProjectWithMultipleTFMsParallelization/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -117,9 +117,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 {
                     result.StdOut
                         .Should().Contain("Test run summary: Failed!")
-                        .And.Contain("total: 1")
+                        .And.Contain("total: 2")
                         .And.Contain("succeeded: 0")
-                        .And.Contain("failed: 1")
+                        .And.Contain("failed: 2")
                         .And.Contain("skipped: 0")
                         .And.Contain("This is run in parallel!");
                 }


### PR DESCRIPTION
Fixes #47496

TestTfmsInParallel was already supported in MTP with the old `dotnet test` as we are hooking into existing VSTest infrastructure. This brings feature parity.