### PR TITLE
Encode container image manifests in ImageBuilder via Encoder Fixes #47399

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
@@ -296,7 +296,7 @@ internal sealed partial class AuthHandshakeMessageHandler : DelegatingHandler
             return null; // try next method
         }
         _logger.LogTrace("Received '{statuscode}'.", postResponse.StatusCode);
-        TokenResponse? tokenResponse = JsonSerializer.Deserialize<TokenResponse>(postResponse.Content.ReadAsStream(cancellationToken));
+        TokenResponse? tokenResponse = JsonSerializer.Deserialize<TokenResponse>(postResponse.Content.ReadAsStream(cancellationToken), Constants.SerializerOptions);
         if (tokenResponse is { } tokenEnvelope)
         {
             var authValue = new AuthenticationHeaderValue(BearerAuthScheme, tokenResponse.ResolvedToken);
@@ -340,7 +340,7 @@ internal sealed partial class AuthHandshakeMessageHandler : DelegatingHandler
             return null; // try next method
         }
 
-        TokenResponse? token = JsonSerializer.Deserialize<TokenResponse>(tokenResponse.Content.ReadAsStream(cancellationToken));
+        TokenResponse? token = JsonSerializer.Deserialize<TokenResponse>(tokenResponse.Content.ReadAsStream(cancellationToken), Constants.SerializerOptions);
         if (token is null)
         {
             throw new ArgumentException(Resource.GetString(nameof(Strings.CouldntDeserializeJsonToken)));

--- a/src/Containers/Microsoft.NET.Build.Containers/Constants.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Constants.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Unicode;
 
 namespace Microsoft.NET.Build.Containers;
 
@@ -9,4 +12,5 @@ public static class Constants
 {
     public static readonly string Version = typeof(Registry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "";
 
+    internal static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) };
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -23,7 +23,6 @@ internal sealed class ImageBuilder
     private readonly ManifestV2 _manifest;
     private readonly ImageConfig _baseImageConfig;
     private readonly ILogger _logger;
-    private readonly JsonSerializerOptions serializerOptions = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) };
 
     /// <summary>
     /// This is a parser for ASPNETCORE_URLS based on https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/BindingAddress.cs
@@ -94,7 +93,7 @@ internal sealed class ImageBuilder
             Config = imageJsonStr,
             ImageDigest = imageDigest,
             ImageSha = imageSha,
-            Manifest = JsonSerializer.SerializeToNode(newManifest, serializerOptions)?.ToJsonString() ?? "",
+            Manifest = JsonSerializer.SerializeToNode(newManifest, Constants.SerializerOptions)?.ToJsonString() ?? "",
             ManifestDigest = newManifest.GetDigest(),
             ManifestMediaType = ManifestMediaType,
             Layers = _manifest.Layers

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using System.Text.Unicode;
 using Microsoft.Extensions.Logging;
 using Microsoft.NET.Build.Containers.Resources;
 
@@ -21,7 +23,7 @@ internal sealed class ImageBuilder
     private readonly ManifestV2 _manifest;
     private readonly ImageConfig _baseImageConfig;
     private readonly ILogger _logger;
-    private readonly serializerOptions = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) };
+    private readonly JsonSerializerOptions serializerOptions = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) };
 
     /// <summary>
     /// This is a parser for ASPNETCORE_URLS based on https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/BindingAddress.cs

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -21,6 +21,7 @@ internal sealed class ImageBuilder
     private readonly ManifestV2 _manifest;
     private readonly ImageConfig _baseImageConfig;
     private readonly ILogger _logger;
+    private readonly serializerOptions = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) };
 
     /// <summary>
     /// This is a parser for ASPNETCORE_URLS based on https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/BindingAddress.cs
@@ -91,7 +92,7 @@ internal sealed class ImageBuilder
             Config = imageJsonStr,
             ImageDigest = imageDigest,
             ImageSha = imageSha,
-            Manifest = JsonSerializer.SerializeToNode(newManifest)?.ToJsonString() ?? "",
+            Manifest = JsonSerializer.SerializeToNode(newManifest, serializerOptions)?.ToJsonString() ?? "",
             ManifestDigest = newManifest.GetDigest(),
             ManifestMediaType = ManifestMediaType,
             Layers = _manifest.Layers

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -66,7 +66,7 @@ internal sealed class ImageConfig
     internal string? GetUser() => _config["config"]?["User"]?.ToString();
     internal string[]? GetEntrypoint() => _config["config"]?["Entrypoint"]?.AsArray()?.Select(node => node!.GetValue<string>())?.ToArray();
     private string[]? GetCmd() => _config["config"]?["Entrypoint"]?.AsArray()?.Select(node => node!.GetValue<string>())?.ToArray();
-    private List<HistoryEntry> GetHistory() => _config["history"]?.AsArray().Select(node => node.Deserialize<HistoryEntry>()!).ToList() ?? new List<HistoryEntry>();
+    private List<HistoryEntry> GetHistory() => _config["history"]?.AsArray().Select(node => node.Deserialize<HistoryEntry>(Constants.SerializerOptions)!).ToList() ?? new List<HistoryEntry>();
     private string GetOs() => _config["os"]?.ToString() ?? throw new ArgumentException("Base image configuration should contain an 'os' property.");
     private string GetArchitecture() => _config["architecture"]?.ToString() ?? throw new ArgumentException("Base image configuration should contain an 'architecture' property.");
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageIndexGenerator.cs
@@ -4,6 +4,7 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers;
@@ -125,11 +126,13 @@ internal static class ImageIndexGenerator
     {
         var nullIgnoreOptions = new JsonSerializerOptions
         {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin)
         };
         // To avoid things like \u002B for '+' especially in media types ("application/vnd.oci.image.manifest.v1\u002Bjson"), we use UnsafeRelaxedJsonEscaping.
         var escapeOptions = new JsonSerializerOptions
         {
+            // This encoder already permits more characters to not be escaped, including '+'
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 

--- a/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ManifestV2.cs
@@ -50,7 +50,7 @@ public class ManifestV2
     /// <summary>
     /// Gets the digest for this manifest.
     /// </summary>
-    public string GetDigest() => KnownDigest ??= DigestUtils.GetDigest(JsonSerializer.SerializeToNode(this)?.ToJsonString() ?? string.Empty);
+    public string GetDigest() => KnownDigest ??= DigestUtils.GetDigest(JsonSerializer.SerializeToNode(this, Constants.SerializerOptions)?.ToJsonString() ?? string.Empty);
 }
 
 public record struct ManifestConfig(string mediaType, long size, string digest);

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -117,7 +117,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
 
             if (destinationKind == DestinationImageReferenceKind.LocalRegistry)
             {
-                var manifestV2 = JsonSerializer.Deserialize<ManifestV2>(manifest);
+                var manifestV2 = JsonSerializer.Deserialize<ManifestV2>(manifest, Constants.SerializerOptions);
                 if (manifestV2 == null)
                 {
                     Log.LogError(Strings.InvalidImageManifest);


### PR DESCRIPTION
Fixes #47399

@MattKotsenas @baronfel 

I wasn't really able to test this (see [here](https://github.com/dotnet/sdk/issues/47399#issuecomment-2773833159)) as I'd like, but does this look like the kind of fix you'd expect?