### PR TITLE
Enable SSH in GH Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,11 @@
       ]
     }
   },
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+        "version": "latest"
+    }
+  },
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/post-creation.sh",
   // Add the locally installed dotnet to the path to ensure that it is activated


### PR DESCRIPTION
This enables the ssh feature so that you can `gh cs ssh` into codespaces created for this repository.