### PR TITLE
Support --no-launch-profile-arguments in dotnet test for MTP

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -90,6 +90,7 @@ internal static class MSBuildUtility
             parseResult.GetValue(TestingPlatformOptions.NoBuildOption),
             parseResult.HasOption(CommonOptions.VerbosityOption) ? parseResult.GetValue(CommonOptions.VerbosityOption) : null,
             parseResult.GetValue(TestingPlatformOptions.NoLaunchProfileOption),
+            parseResult.GetValue(TestingPlatformOptions.NoLaunchProfileArgumentsOption),
             degreeOfParallelism,
             otherArgs,
             msbuildArgs);

--- a/src/Cli/dotnet/Commands/Test/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/Options.cs
@@ -7,4 +7,12 @@ internal record TestOptions(string Architecture, bool HasFilterMode, bool IsHelp
 
 internal record PathOptions(string ProjectPath, string SolutionPath, string DirectoryPath);
 
-internal record BuildOptions(PathOptions PathOptions, bool HasNoRestore, bool HasNoBuild, VerbosityOptions? Verbosity, bool NoLaunchProfile, int DegreeOfParallelism, List<string> UnmatchedTokens, IEnumerable<string> MSBuildArgs);
+internal record BuildOptions(
+    PathOptions PathOptions,
+    bool HasNoRestore,
+    bool HasNoBuild,
+    VerbosityOptions? Verbosity,
+    bool NoLaunchProfile,
+    bool NoLaunchProfileArguments,
+    int DegreeOfParallelism, List<string> UnmatchedTokens,
+    IEnumerable<string> MSBuildArgs);

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -75,8 +75,8 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
                 processStartInfo.EnvironmentVariables[entry.Key] = value;
             }
 
-            // TODO: Support --no-launch-profile-arguments
-            if (!string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
+            if (!_buildOptions.NoLaunchProfileArguments &&
+                !string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {
                 processStartInfo.Arguments = $"{processStartInfo.Arguments} {Module.LaunchSettings.CommandLineArgs}";
             }

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -242,6 +242,7 @@ internal static class TestCommandParser
         command.Options.Add(TestingPlatformOptions.NoBuildOption);
         command.Options.Add(TestingPlatformOptions.NoAnsiOption);
         command.Options.Add(TestingPlatformOptions.NoLaunchProfileOption);
+        command.Options.Add(TestingPlatformOptions.NoLaunchProfileArgumentsOption);
         command.Options.Add(TestingPlatformOptions.NoProgressOption);
         command.Options.Add(TestingPlatformOptions.OutputOption);
 

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
@@ -68,6 +68,11 @@ internal static class TestingPlatformOptions
         Arity = ArgumentArity.Zero
     };
 
+    public static readonly CliOption<bool> NoLaunchProfileArgumentsOption = new("--no-launch-profile-arguments")
+    {
+        Description = CliCommandStrings.CommandOptionNoLaunchProfileArgumentsDescription
+    };
+
     public static readonly CliOption<bool> NoProgressOption = new("--no-progress")
     {
         Description = CliCommandStrings.CmdNoProgressDescription,

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTests.cs
@@ -138,6 +138,24 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
+        public void RunTestProjectWithTestsAndNoLaunchSettingsArguments_ShouldReturnExitCodeSuccess(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithLaunchSettings", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(
+                                        TestingPlatformOptions.ConfigurationOption.Name, configuration,
+                                        TestingPlatformOptions.NoLaunchProfileArgumentsOption.Name, "true");
+
+            result.StdOut.Should()
+                .Contain("FAILED to find argument from launchSettings.json");
+        }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
         public void RunMultipleTestProjectsWithFailingTests_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())


### PR DESCRIPTION
Fixes #47548

This brings parity with `dotnet run`, and this can be useful for cases where a user wants to put `--filter` in launchSettings for local development, and still ensure it's not picked up by accident in CI scenarios.