### PR TITLE
Promote `NuGet.Client` builds during official CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -345,3 +345,7 @@ extends:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022
               os: windows
+
+        - template: /eng/pipelines/templates/jobs/promote-nuget-client.yml@self
+          parameters:
+            assetName: NuGet.Protocol

--- a/eng/pipelines/templates/jobs/promote-nuget-client.yml
+++ b/eng/pipelines/templates/jobs/promote-nuget-client.yml
@@ -36,13 +36,14 @@ jobs:
         Write-Host "Promoting build of asset ${{ parameters.assetName }} / $version..."
 
         $assets = .\.dotnet\dotnet darc get-asset --name '${{ parameters.assetName }}' --version "$version" --max-age 60 --output-format json --ci
-        $buildId = ($assets | ConvertFrom-Json)[0].build.id
+        $parsedAssets = $assets | ConvertFrom-Json
 
-        if ($buildId -eq $null) {
+        if (-not $parsedAssets -or -not $parsedAssets[0]) {
           Write-Error "No build found to promote version $version"
           exit 1
         }
 
+        $buildId = $parsedAssets[0].build.id
         try {
             $defaultChannels = .\.dotnet\dotnet darc get-default-channels --source-repo https://github.com/dotnet/sdk --branch "$(Build.SourceBranchName)" --output-format json --ci | ConvertFrom-Json
         } catch {
@@ -50,6 +51,10 @@ jobs:
             exit 0
         }
 
+        if ($defaultChannels.Count -eq 0) {
+            Write-Host "Default channels list is empty for branch $(Build.SourceBranchName) - no promotion will take place"
+            exit 0
+        }
         $targetChannel = $defaultChannels[0].channel.name
 
         Write-Host "Promoting build $buildId to channel $targetChannel"

--- a/eng/pipelines/templates/jobs/promote-nuget-client.yml
+++ b/eng/pipelines/templates/jobs/promote-nuget-client.yml
@@ -1,0 +1,57 @@
+# NuGet.Client does not flow to the VMR directly but only to dotnet/sdk where it is validated
+# Upon the version bump happens in dotnet/sdk, this job promotes that build of NuGet.Client to
+# another channel from where it flows into the VMR.
+# The sdk and nuget.client subscriptions are batched and go into the VMR in a single PR.
+# More information: https://github.com/dotnet/arcade-services/issues/4618
+
+parameters:
+- name: assetName
+  type: string
+  displayName: Name of the asset to promote
+
+jobs:
+- job: PromoteNuGetClient
+  displayName: Promote NuGet Client
+  pool:
+    name: NetCore1ESPool-Publishing-Internal
+    image: windows.vs2019.amd64
+    os: windows
+
+  steps:
+  - template: ../steps/install-darc.yml@self
+
+  - template: ../steps/get-asset-info.yml@self
+    parameters:
+      assetName: ${{ parameters.assetName }}
+
+  - task: AzureCLI@2
+    displayName: 🟣 Assign build to channel
+    inputs:
+      azureSubscription: "Darc: Maestro Production"
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        $version = '$(AssetVersion)'
+
+        Write-Host "Promoting build of asset ${{ parameters.assetName }} / $version..."
+
+        $assets = .\.dotnet\dotnet darc get-asset --name '${{ parameters.assetName }}' --version "$version" --max-age 60 --output-format json --ci
+        $buildId = ($assets | ConvertFrom-Json)[0].build.id
+
+        if ($buildId -eq $null) {
+          Write-Error "No build found to promote version $version"
+          exit 1
+        }
+
+        try {
+            $defaultChannels = .\.dotnet\dotnet darc get-default-channels --source-repo https://github.com/dotnet/sdk --branch "$(Build.SourceBranchName)" --output-format json --ci | ConvertFrom-Json
+        } catch {
+            Write-Host "No default channels found for branch $(Build.SourceBranchName) - no promotion will take place"
+            exit 0
+        }
+
+        $targetChannel = $defaultChannels[0].channel.name
+
+        Write-Host "Promoting build $buildId to channel $targetChannel"
+
+        .\.dotnet\dotnet darc add-build-to-channel --id $buildId --channel "$targetChannel" --skip-assets-publishing --ci

--- a/eng/pipelines/templates/steps/get-asset-info.yml
+++ b/eng/pipelines/templates/steps/get-asset-info.yml
@@ -1,0 +1,42 @@
+### Looks up asset information from Version.Details.xml and stores it in variables
+
+parameters:
+- name: assetName
+  type: string
+  displayName: Name of the asset to look up
+
+steps:
+- task: AzureCLI@2
+  displayName: 🟣 Get version information
+  inputs:
+    azureSubscription: "Darc: Maestro Production"
+    scriptType: ps
+    scriptLocation: inlineScript
+    inlineScript: |
+      $ErrorActionPreference = 'Stop'
+      Write-Host "Searching for details of asset ${{ parameters.assetName }}..."
+
+      $dependencies = .\.dotnet\dotnet darc get-dependencies --name '${{ parameters.assetName }}' --ci
+      $version = $dependencies | Select-String -Pattern 'Version:\s+([^\s]+)' | Select-Object -First 1
+
+      if ($version -eq $null) {
+          Write-Error "Asset ${{ parameters.assetName }} not found in the dependency list"
+          exit 1
+      }
+
+      $version -match 'Version:\s+([^\s]+)' | Out-Null
+      $version = $matches[1]
+
+      $repository = $dependencies | Select-String -Pattern 'Repo:\s+([^\s]+)' | Select-Object -First 1
+      $repository -match 'Repo:\s+([^\s]+)' | Out-Null
+      $repository = $matches[1]
+
+      $commit = $dependencies | Select-String -Pattern 'Commit:\s+([^\s]+)' | Select-Object -First 1
+      $commit -match 'Commit:\s+([^\s]+)' | Out-Null
+      $commit = $matches[1]
+
+      Write-Host "##vso[task.setvariable variable=AssetRepository]$repository"
+      Write-Host "##vso[task.setvariable variable=AssetCommit]$commit"
+      Write-Host "##vso[task.setvariable variable=AssetVersion]$version"
+
+      Write-Host "Asset ${{ parameters.assetName }} found with version $version, commit $commit, repository $repository"

--- a/eng/pipelines/templates/steps/install-darc.yml
+++ b/eng/pipelines/templates/steps/install-darc.yml
@@ -1,0 +1,18 @@
+steps:
+- powershell: |
+    $ErrorActionPreference = 'Stop'
+    . .\eng\common\tools.ps1
+    $dotnetRoot = InitializeDotNetCli -install:$true
+    $dotnet = "$dotnetRoot\dotnet.exe"
+    & "$dotnet" tool restore
+  displayName: 🟣 Install darc (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- script: |
+    set -e
+    . .\eng\common\tools.sh
+    dotnetRoot=$(InitializeDotNetCli --install)
+    dotnet="$dotnetRoot/dotnet"
+    $dotnet tool restore
+  displayName: 🟣 Install darc (Unix)
+  condition: ne(variables['Agent.OS'], 'Windows_NT')


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4618

Example promotion: https://dev.azure.com/dnceng/internal/_build/results?buildId=2683058&view=logs&j=5f875b74-e537-5180-674b-3a447f4f6772&t=9f843123-8243-5a9e-a444-41fcac18ff9a