### PR TITLE
Fix publishing workload pack msi packages in SDK official build

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -35,6 +35,13 @@
     <Artifact Update="$(ArtifactsShippingPackagesDir)dotnet-sdk-pgo-*" Visibility="External" />
   </ItemGroup>
 
+  <!-- temporarily remove the .Msi workload pack nugets in the SDK official build until we switch to the VMR, but keep the manifest .Msi packages -->
+  <ItemGroup Condition="'$(DotNetBuild)' != 'true'">
+    <MsiPackages Include="$(ArtifactsShippingPackagesDir)*.Msi.*.nupkg" />
+    <MsiPackages Remove="$(ArtifactsShippingPackagesDir)*.Manifest-*.Msi.*.nupkg" />
+    <Artifact Remove="@(MsiPackages)" />
+  </ItemGroup>
+
   <Target Name="GetNonStableProductVersion">
     <!-- Retrieve the non-stable product version. -->
     <MSBuild Projects="$(RepoRoot)src\Layout\redist\redist.csproj"


### PR DESCRIPTION
We'll keep them in runtime/emsdk for now until we switch to the VMR.