### PR TITLE
Enable arm64 DEB tests

### DIFF
--- a/eng/pipelines/templates/stages/vmr-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-validation.yml
@@ -81,7 +81,7 @@ stages:
   - job: ValidateInstallers_Linux_arm64
     displayName: Validate Installers - Linux arm64
     pool: ${{ parameters.pool_LinuxArm64 }}
-    timeoutInMinutes: 30
+    timeoutInMinutes: 60
     steps:
     - template: ../steps/vmr-validate-installers.yml
       parameters:

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -31,17 +31,12 @@ steps:
 
 - ${{ if eq(parameters.OS, 'Linux') }}:
   - script: |
-      extraBuildProperties="/p:TestRpmPackages=true"
-      if [[ '${{ parameters.targetArchitecture }}' == 'x64' ]]; then
-        # At the moment Deb packages are only available for x64
-        extraBuildProperties="$extraBuildProperties /p:TestDebPackages=true"
-      fi
-
       ./build.sh \
       --ci \
       -t \
       --projects test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
-      $extraBuildProperties
+      /p:TestRpmPackages=true \
+      /p:TestDebPackages=true
     displayName: Validate installer packages
     workingDirectory: $(Build.SourcesDirectory)
 


### PR DESCRIPTION
We have a full set of arm64 DEB packages. This PR enables installer testing on Debian arm64 distros.

Arm64 tests are slower and they are now running close to the current timeout limit of 30 minutes. This PR also increases the timeout to 60 minutes.

Verification run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2682358&view=results