### PR TITLE
--interactive should actually default to true in user-facing situations.

### DIFF
--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -133,7 +133,7 @@ internal static class CommonOptions
              Description = CliStrings.CommandInteractiveOptionDescription,
              Arity = acceptArgument ? ArgumentArity.ZeroOrOne : ArgumentArity.Zero,
              // this default is called when no tokens/options are passed on the CLI args
-             DefaultValueFactory = (ar) => IsCIEnvironmentOrRedirected()
+             DefaultValueFactory = (ar) => !IsCIEnvironmentOrRedirected()
          };
 
     public static CliOption<bool> InteractiveMsBuildForwardOption = InteractiveOption(acceptArgument: true).ForwardAsSingle(b => $"-property:NuGetInteractive={(b ? "true" : "false")}");

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -414,7 +414,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
         }
 
-        private const string NugetInteractiveProperty = "-property:NuGetInteractive=true";
+        private const string NugetInteractiveProperty = "-property:NuGetInteractive=false";
 
         /// <summary>
         /// Validates that options that the "run" command forwards to "build" command are forwarded by dotnet-watch.

--- a/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLineOptionsTests.cs
@@ -424,7 +424,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData(new[] { "--framework", "net9.0" }, new[] { "-property:TargetFramework=net9.0", NugetInteractiveProperty })]
         [InlineData(new[] { "--runtime", "arm64" }, new[] { "-property:RuntimeIdentifier=arm64", "-property:_CommandLineDefinedRuntimeIdentifier=true", NugetInteractiveProperty })]
         [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
-        [InlineData(new[] { "--interactive" }, new[] { NugetInteractiveProperty })]
+        [InlineData(new[] { "--interactive" }, new[] { "-property:NuGetInteractive=true" })]
         [InlineData(new[] { "--no-restore" }, new[] { NugetInteractiveProperty, "-restore:false" })]
         [InlineData(new[] { "--sc" }, new[] { NugetInteractiveProperty, "-property:SelfContained=True", "-property:_CommandLineDefinedSelfContained=true" })]
         [InlineData(new[] { "--self-contained" }, new[] { NugetInteractiveProperty, "-property:SelfContained=True", "-property:_CommandLineDefinedSelfContained=true" })]

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo"];
 
-        const string NugetInteractiveProperty = "-property:NuGetInteractive=true";
+        const string NugetInteractiveProperty = "-property:NuGetInteractive=false";
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetCleanInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetCleanInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private const string NugetInteractiveProperty = "-property:NuGetInteractive=true";
+        private const string NugetInteractiveProperty = "-property:NuGetInteractive=false";
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-verbosity:normal", "-target:Clean", NugetInteractiveProperty];
 
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetOsArchOptions.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetOsArchOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo"];
-        private const string NugetInteractiveProperty = "-property:NuGetInteractive=true";
+        private const string NugetInteractiveProperty = "-property:NuGetInteractive=false";
         private static readonly string[] DefaultArgs = ["-restore", "-consoleloggerparameters:Summary", NugetInteractiveProperty];
 
         private static readonly string WorkingDirectory =

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPackInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPackInvocation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-restore", "-target:pack"];
         private static readonly string[] ExpectedNoBuildPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-target:pack"];
-        private readonly string[] ExpectedProperties = ["--property:_IsPacking=true", "-property:NuGetInteractive=true"];
+        private readonly string[] ExpectedProperties = ["--property:_IsPacking=true", "-property:NuGetInteractive=false"];
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo"];
-        private static readonly string[] ExpectedProperties = ["--property:_IsPublishing=true", "-property:NuGetInteractive=true"];
+        private static readonly string[] ExpectedProperties = ["--property:_IsPublishing=true"];
 
         [Theory]
         [InlineData(new string[] { }, new string[] { })]

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo"];
         private static readonly string[] ExpectedProperties = ["--property:_IsPublishing=true"];
+        private static readonly string NuGetDisabledProperty = "-property:NuGetInteractive=false";
 
         [Theory]
         [InlineData(new string[] { }, new string[] { })]
@@ -56,7 +57,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
                 command.GetArgumentTokensToMSBuild()
                     .Should()
-                    .BeEquivalentTo([.. ExpectedPrefix, "-restore", "-target:Publish", .. ExpectedProperties, .. expectedAdditionalArgs]);
+                    .BeEquivalentTo([.. ExpectedPrefix, "-restore", "-target:Publish", .. ExpectedProperties, .. expectedAdditionalArgs, NuGetDisabledProperty]);
             });
         }
 
@@ -68,14 +69,23 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var command = PublishCommand.FromArgs(args, msbuildPath);
 
-            command.SeparateRestoreCommand
-                   .GetArgumentTokensToMSBuild()
+            var restoreTokens =
+                command.SeparateRestoreCommand
+                   .GetArgumentTokensToMSBuild();
+            output.WriteLine("restore tokens:");
+            output.WriteLine(string.Join(" ", restoreTokens));
+            restoreTokens
                    .Should()
-                   .BeEquivalentTo([.. ExpectedPrefix, "-target:Restore", "-tlp:verbosity=quiet", .. ExpectedProperties]);
+                   .BeEquivalentTo([.. ExpectedPrefix, "-target:Restore", "-tlp:verbosity=quiet", .. ExpectedProperties, NuGetDisabledProperty]);
 
-            command.GetArgumentTokensToMSBuild()
+            var buildTokens =
+                command.GetArgumentTokensToMSBuild();
+            output.WriteLine("build tokens:");
+            output.WriteLine(string.Join(" ", buildTokens));
+
+            buildTokens
                    .Should()
-                   .BeEquivalentTo([.. ExpectedPrefix, "-nologo", "-target:Publish", .. ExpectedProperties, .. expectedAdditionalArgs]);
+                   .BeEquivalentTo([.. ExpectedPrefix, "-nologo", "-target:Publish", .. ExpectedProperties, .. expectedAdditionalArgs, NuGetDisabledProperty]);
         }
 
         [Fact]
@@ -90,7 +100,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetArgumentTokensToMSBuild()
                    .Should()
-                   .BeEquivalentTo([.. ExpectedPrefix, "-target:Publish", .. ExpectedProperties, "-property:NoBuild=true"]);
+                   .BeEquivalentTo([.. ExpectedPrefix, "-target:Publish", .. ExpectedProperties, "-property:NoBuild=true", NuGetDisabledProperty]);
         }
 
         [Fact]
@@ -101,7 +111,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetArgumentTokensToMSBuild()
                .Should()
-               .BeEquivalentTo([.. ExpectedPrefix, "-restore", "-target:Publish", .. ExpectedProperties, "--property:Prop1=prop1", "--property:Prop2=prop2"]);
+               .BeEquivalentTo([.. ExpectedPrefix, "-restore", "-target:Publish", .. ExpectedProperties, "--property:Prop1=prop1", "--property:Prop2=prop2", NuGetDisabledProperty]);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
         private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-target:Restore"];
+        private static readonly string NuGetDisabledProperty = "-property:NuGetInteractive=false";
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetRestoreInvocation));
 
@@ -49,7 +50,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 RestoreCommand.FromArgs(args, msbuildPath)
                     .GetArgumentTokensToMSBuild()
                     .Should()
-                    .BeEquivalentTo([.. ExpectedPrefix, .. expectedAdditionalArgs]);
+                    .BeEquivalentTo([.. ExpectedPrefix, .. expectedAdditionalArgs, NuGetDisabledProperty]);
             });
         }
     }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetRestoreInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-target:Restore", "-property:NuGetInteractive=true"];
+        private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-target:Restore"];
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetRestoreInvocation));
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRunInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
         private static readonly string[] ConstantRestoreArgs = ["-nologo", "-verbosity:quiet"];
+        private static readonly string NuGetDisabledProperty = "-property:NuGetInteractive=false";
 
         public ITestOutputHelper Log { get; }
 
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     var command = RunCommand.FromArgs(args);
                     command.RestoreArgs
                         .Should()
-                        .BeEquivalentTo([.. ConstantRestoreArgs, .. expectedArgs]);
+                        .BeEquivalentTo([.. ConstantRestoreArgs, .. expectedArgs, NuGetDisabledProperty]);
                 });
             }
             finally

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetRunInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private static readonly string[] ConstantRestoreArgs = ["-nologo", "-verbosity:minimal", "-property:NuGetInteractive=true"];
+        private static readonly string[] ConstantRestoreArgs = ["-nologo", "-verbosity:quiet"];
 
         public ITestOutputHelper Log { get; }
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetTestInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetTestInvocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     [Collection(TestConstants.UsesStaticTelemetryState)]
     public class GivenDotnetTestInvocation : IClassFixture<NullCurrentSessionIdFixture>
     {
-        private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-restore", "-nologo", "-target:VSTest", "-property:NuGetInteractive=true"];
+        private static readonly string[] ExpectedPrefix = ["-maxcpucount", "-verbosity:m", "-tlp:default=auto", "-nologo", "-restore", "-nologo", "-target:VSTest", "-property:NuGetInteractive=false"];
 
         private static readonly string WorkingDirectory =
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetTestInvocation));

--- a/test/dotnet.Tests/CommandTests/Package/Remove/GivenDotnetRemovePackage.cs
+++ b/test/dotnet.Tests/CommandTests/Package/Remove/GivenDotnetRemovePackage.cs
@@ -18,7 +18,7 @@ Arguments:
   <PACKAGE_NAME>    The package reference to remove.
 
 Options:
-  --interactive     Allows the command to stop and wait for user input or action (for example to complete authentication). [default: True]
+  --interactive     Allows the command to stop and wait for user input or action (for example to complete authentication). [default: False]
   -?, -h, --help    Show command line help.";
 
         private Func<string, string> RemoveCommandHelpText = (defaultVal) => $@"Description:

--- a/test/dotnet.Tests/CommandTests/Reference/Add/AddReferenceParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Reference/Add/AddReferenceParserTests.cs
@@ -39,15 +39,6 @@ namespace Microsoft.DotNet.Tests.ParserTests
         }
 
         [Fact]
-        public void AddReferenceDoesHaveInteractiveFlagByDefault()
-        {
-            var result = Parser.Instance.Parse("dotnet add reference my.csproj");
-
-            result.GetValue<bool>(ReferenceAddCommandParser.InteractiveOption)
-                .Should().BeTrue();
-        }
-
-        [Fact]
         public void AddReferenceWithoutArgumentResultsInAnError()
         {
             var result = Parser.Instance.Parse("dotnet add reference");

--- a/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
+++ b/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
@@ -19,7 +19,7 @@ Arguments:
 Options:
   -f, --framework <FRAMEWORK>  Add the reference only when targeting a specific framework.
   --interactive                Allows the command to stop and wait for user input or action (for example to complete
-                               authentication). [default: True]
+                               authentication). [default: False]
   --project                    The project file to operate on. If a file is not specified, the command will search the
                                current directory for one.
   -?, -h, --help               Show command line help.";

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -698,23 +698,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItDoesShowImportantLevelMessageByDefault()
-        {
-            var testAppName = "MSBuildTestApp";
-            var testInstance = _testAssetsManager.CopyTestAsset(testAppName)
-                .WithSource()
-                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeRestoreToProject);
-
-            var result = new DotnetCommand(Log, "run")
-                .WithWorkingDirectory(testInstance.Path)
-                .Execute();
-
-            // this message should show because interactivity (and therefore nuget auth) is the default
-            result.Should().Pass()
-                .And.HaveStdOutContaining("Important text");
-        }
-
-        [Fact]
         public void ItDoesNotShowImportantLevelMessageByDefaultWhenInteractivityDisabled()
         {
             var testAppName = "MSBuildTestApp";


### PR DESCRIPTION
Ok this is embarrassing but when I did the `--interactive` defaulting I defaulted it to the wrong way around.  _Thankfully_ because today users have to pass `--interactive` to get the benefits there wasn't actually a regression. 

I've fixed the conditional and updated the test baselines - the main changes here are that all of our CI tests have the `false` default because it's either a CI/CD system environment _or_ the test is running redirected - so we really only have local testing to prove that this works:

![image](https://github.com/user-attachments/assets/b8036936-f13a-46f8-8c7a-c1f5604fdfdd)
