### PR TITLE
Remove dead code in UsageReport

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UsageReport/AnnotatedUsage.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UsageReport/AnnotatedUsage.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport
 
         public string Project { get; set; }
         public string SourceBuildPackageIdCreator { get; set; }
-        public string ProdConPackageIdCreator { get; set; }
         public bool EndsUpInOutput { get; set; }
         public bool TestProjectByHeuristic { get; set; }
         public bool TestProjectOnlyByHeuristic { get; set; }
@@ -26,7 +25,6 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport
             Usage.ToXml().Attributes(),
             Project.ToXAttributeIfNotNull(nameof(Project)),
             SourceBuildPackageIdCreator.ToXAttributeIfNotNull(nameof(SourceBuildPackageIdCreator)),
-            ProdConPackageIdCreator.ToXAttributeIfNotNull(nameof(ProdConPackageIdCreator)),
             TestProjectByHeuristic.ToXAttributeIfTrue(nameof(TestProjectByHeuristic)),
             TestProjectOnlyByHeuristic.ToXAttributeIfTrue(nameof(TestProjectOnlyByHeuristic)),
             IsDirectDependency.ToXAttributeIfTrue(nameof(IsDirectDependency)),

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -60,7 +60,6 @@
 
     <PackageReportDataFile>$(PackageReportDir)prebuilt-usage.xml</PackageReportDataFile>
     <ProjectAssetsJsonArchiveFile>$(PackageReportDir)all-project-assets-json-files.zip</ProjectAssetsJsonArchiveFile>
-    <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.ReplaceTextInFile" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
@@ -948,7 +947,6 @@
 
     <WriteUsageReports DataFile="$(PackageReportDataFile)"
                        PackageVersionPropsSnapshots="@(PackageVersionPropsSavedSnapshotFile)"
-                       ProdConBuildManifestFile="$(ProdConManifestFile)"
                        PoisonedReportFile="$(PoisonedReportFile)"
                        OutputDirectory="$(PackageReportDir)" />
 


### PR DESCRIPTION
The "ProdCon" infra isn't used anymore and should be deleted.