### PR TITLE
Add back Microsoft.NET.Workload.Emscripten.Current.Manifest.10.0.100-Transport package

### DIFF
--- a/src/Workloads/Manifests/Directory.Build.props
+++ b/src/Workloads/Manifests/Directory.Build.props
@@ -9,14 +9,16 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShipping Condition="'$(MSBuildProjectName)' == 'Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest'">false</IsShipping>
+    <IsShippingPackage>$(IsShipping)</IsShippingPackage>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <PropertyGroup>
     <_workloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PrereleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</_workloadVersionSuffix>
-    <_workloadVersionSuffix>$(_workloadVersionSuffix.TrimEnd('.'))</_workloadVersionSuffix>
+    <_workloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PrereleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</_workloadVersionSuffix>
     <PackageId>$(MSBuildProjectName)-$(BuiltinWorkloadFeatureBand)$(_workloadVersionSuffix)</PackageId>
+    <PackageId Condition="'$(MSBuildProjectName)' == 'Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest'">Microsoft.NET.Workload.Emscripten.Current.Manifest-$(BuiltinWorkloadFeatureBand).Transport</PackageId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Workloads/Manifests/Directory.Build.targets
+++ b/src/Workloads/Manifests/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <Target Name="LayoutManifest" DependsOnTargets="Pack">
+  <Target Name="LayoutManifest" DependsOnTargets="Pack" Condition="'$(IsShipping)' == 'true'">
     <PropertyGroup>
       <_manifestTargetDirectory>$(ManifestDirectory)$(BuiltinWorkloadFeatureBand)\$(MSBuildProjectName.Replace('.Manifest', '').ToLower())\$(Version)</_manifestTargetDirectory>
     </PropertyGroup>

--- a/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest.proj
+++ b/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest.proj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <!-- empty package to flow the version of the manifest -->
+</Project>


### PR DESCRIPTION
I thought this wasn't needed anymore but some repos still depend on it (but for seemingly no reason, will follow-up on that separately).