### PR TITLE
Use pull_request_target event for GH Actions workflows

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -1,6 +1,6 @@
 name: PR Analysis
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled]
 permissions:
   contents: read

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -1,7 +1,7 @@
 name: Remove Lockdown Label from PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -13,9 +13,6 @@ jobs:
         if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'Branding')
         runs-on: ubuntu-latest
         steps:
-        -   name: Checkout repository
-            uses: actions/checkout@v2
-
         -   name: PR's only change is <VersionFeature> in eng/Versions.props
             id: only_version_feature_changed
             uses: actions/github-script@v4


### PR DESCRIPTION
This removes the annoying "2 workflows awaiting approval". We don't need to run these workflows with the "pull_request" trigger (which runs in the context of the fork and is therefore dangerous), the "pull_request_target" is enough (which runs in the context of the base branch and is safe).

We can also remove the source checkout from the remove-lockdown-label.yml since we don't read anything from the repo.