### PR TITLE
Add /t:CompareCliSnapshots and /t:UpdateCliSnapshots

### DIFF
--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -97,4 +97,12 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
+  <Target Name="UpdateCompletionTestsSnapshots">
+    <Message Text="Copying CompletionTests snapshots from $(ArtifactsBinDir)redist\$(Configuration)\snapshots to $(MSBuildProjectDirectory)\CompletionTests\snapshots" Importance="high" />
+    <ItemGroup>
+      <SnapshotFiles Include="$(ArtifactsBinDir)redist\$(Configuration)\snapshots\**\*.verified.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(SnapshotFiles)" DestinationFolder="$(MSBuildProjectDirectory)\CompletionTests\snapshots\%(RecursiveDir)"/>
+  </Target>
+
 </Project>

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -97,12 +97,17 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Target Name="UpdateCompletionTestsSnapshots">
-    <Message Text="Copying CompletionTests snapshots from $(ArtifactsBinDir)redist\$(Configuration)\snapshots to $(MSBuildProjectDirectory)\CompletionTests\snapshots" />
+  <Target Name="CompareCliSnapshots">
     <ItemGroup>
       <SnapshotFiles Include="$(ArtifactsBinDir)redist\$(Configuration)\snapshots\**\*.received.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(SnapshotFiles)" DestinationFiles="@(SnapshotFiles->'$(MSBuildProjectDirectory)\CompletionTests\snapshots\%(RecursiveDir)%(Filename).verified%(Extension)')" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="@(SnapshotFiles)" DestinationFolder="$(MSBuildThisFileDirectory)CompletionTests\snapshots\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 
+  <Target Name="UpdateCliSnapshots">
+    <ItemGroup>
+      <SnapshotFiles Include="$(MSBuildThisFileDirectory)CompletionTests\snapshots\**\*.received.*" />
+    </ItemGroup>
+    <Move SourceFiles="@(SnapshotFiles)" DestinationFiles="@(SnapshotFiles->Replace('received', 'verified'))" />
+  </Target>
 </Project>

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -98,11 +98,11 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="UpdateCompletionTestsSnapshots">
-    <Message Text="Copying CompletionTests snapshots from $(ArtifactsBinDir)redist\$(Configuration)\snapshots to $(MSBuildProjectDirectory)\CompletionTests\snapshots" Importance="high" />
+    <Message Text="Copying CompletionTests snapshots from $(ArtifactsBinDir)redist\$(Configuration)\snapshots to $(MSBuildProjectDirectory)\CompletionTests\snapshots" />
     <ItemGroup>
-      <SnapshotFiles Include="$(ArtifactsBinDir)redist\$(Configuration)\snapshots\**\*.verified.*" />
+      <SnapshotFiles Include="$(ArtifactsBinDir)redist\$(Configuration)\snapshots\**\*.received.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(SnapshotFiles)" DestinationFolder="$(MSBuildProjectDirectory)\CompletionTests\snapshots\%(RecursiveDir)"/>
+    <Copy SourceFiles="@(SnapshotFiles)" DestinationFiles="@(SnapshotFiles->'$(MSBuildProjectDirectory)\CompletionTests\snapshots\%(RecursiveDir)%(Filename).verified%(Extension)')" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
The current behavior for updating completion snapshots can be a bit tedious, it would be nice if a target existed to copy the files, similar to `/t:UpdateXlf`