### PR TITLE
Stop copying PSB reference packages

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -178,6 +178,8 @@
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
     <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>
+    <PreviouslySourceBuiltReferencePackagesDirName>SourceBuildReferencePackages</PreviouslySourceBuiltReferencePackagesDirName>
+    <PreviouslySourceBuiltReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrebuiltSourceBuiltPackagesPath)', '$(PreviouslySourceBuiltReferencePackagesDirName)'))</PreviouslySourceBuiltReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
 

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -269,7 +269,7 @@
           DestinationFolder="$(SourceBuiltLayoutDir)"
           UseSymbolicLinksIfPossible="true" />
     <Copy SourceFiles="@(ReferencePackageToBundle)"
-          DestinationFolder="$(SourceBuiltLayoutDir)SourceBuildReferencePackages"
+          DestinationFolder="$(SourceBuiltLayoutDir)$(PreviouslySourceBuiltReferencePackagesDirName)"
           UseSymbolicLinksIfPossible="true" />
 
     <!-- Content of the .version file to include in the tarball -->

--- a/src/SourceBuild/content/eng/init-source-only.proj
+++ b/src/SourceBuild/content/eng/init-source-only.proj
@@ -47,32 +47,9 @@
           Condition="'@(SourceBuiltPrebuiltsTarballFile)' != ''" />
   </Target>
 
-  <!-- Copy SBRP packages to reference packages location. -->
-  <Target Name="CopySourceBuiltReferencePackages"
-          DependsOnTargets="UnpackSourceBuiltArtifactsArchive"
-          Inputs="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages"
-          Outputs="$(ReferencePackagesDir)">
-    <ItemGroup>
-      <UnpackedSourceBuildReferencePackage Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*" />
-    </ItemGroup>
-
-    <!-- When building iteratively (e.g. making infra changes), the directory may already exist and needs to be cleaned up. -->
-    <RemoveDir Directories="$(ReferencePackagesDir)" />
-
-    <!-- Either move or copy the unpacked SBRP packages.
-         Don't move when the packages directory is externally provided. -->
-    <Move SourceFiles="@(UnpackedSourceBuildReferencePackage)"
-          DestinationFolder="$(ReferencePackagesDir)"
-          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
-    <Copy SourceFiles="@(UnpackedSourceBuildReferencePackage)"
-          DestinationFolder="$(ReferencePackagesDir)"
-          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' != ''" />
-  </Target>
-
   <Target Name="UnpackTarballs"
           DependsOnTargets="UnpackSourceBuiltArtifactsArchive;
-                            UnpackSourceBuiltPrebuiltsArchive;
-                            CopySourceBuiltReferencePackages" />
+                            UnpackSourceBuiltPrebuiltsArchive" />
 
   <!-- Build the custom msbuild sdk resolver. -->
   <Target Name="BuildMSBuildSdkResolver"
@@ -96,8 +73,8 @@
   <Target Name="ExtractToolsetPackages" DependsOnTargets="UnpackTarballs">
     <ItemGroup>
       <ToolsetPackage Include="Microsoft.DotNet.Arcade.Sdk" SourceFolder="$(PrebuiltSourceBuiltPackagesPath)" Version="$(ARCADE_BOOTSTRAP_VERSION)" />
-      <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(ReferencePackagesDir)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
-      <ToolsetPackage Include="Microsoft.Build.Traversal" SourceFolder="$(ReferencePackagesDir)" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
+      <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(PreviouslySourceBuiltReferencePackagesDir)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
+      <ToolsetPackage Include="Microsoft.Build.Traversal" SourceFolder="$(PreviouslySourceBuiltReferencePackagesDir)" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
     </ItemGroup>
 
     <Unzip SourceFiles="%(ToolsetPackage.SourceFolder)%(ToolsetPackage.Identity).%(ToolsetPackage.Version).nupkg"

--- a/src/SourceBuild/content/eng/tools/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Don't use these feeds when testing. Projects under this directory are referenced by
        test projects. This makes sure that the feeds aren't used. -->
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(ReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(PreviouslySourceBuiltReferencePackagesDir);$(PrebuiltPackagesPath);$(PrebuiltSourceBuiltPackagesPath)</RestoreSources>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4978

init-source-build.proj was updated to no longer copy the reference packages out of PSB.  Instead the two places where they are required now reference them directly from the PSB folder.  Aside from fixing https://github.com/dotnet/source-build/issues/4978, this provides the added benefit that SBRP itself will build with no PSB reference packages available to it.  This is a nice safety check to ensure it is able to build self-contained.