### PR TITLE
Remove the TestSdkRpm

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateRPMs.targets
+++ b/src/Installer/redist-installer/targets/GenerateRPMs.targets
@@ -12,7 +12,7 @@
                             GenerateRpmsInner" />
 
   <Target Name="GenerateRpmsInner"
-          DependsOnTargets="TestFPMTool;BuildRpms;TestSdkRpm"
+          DependsOnTargets="TestFPMTool;BuildRpms"
           Condition=" '$(IsRPMBasedDistro)' == 'True' "
           Outputs="@(GeneratedInstallers)" />
 
@@ -148,16 +148,6 @@
       <SDKTokenValue Include="%SDK_RPM_NETSTANDARD_TARGETINGPACK_DEPENDENCY%">
         <ReplacementString></ReplacementString>
       </SDKTokenValue>
-    </ItemGroup>
-
-    <ItemGroup>
-      <TestSdkRpmTaskEnvironmentVariables Include="PATH=$(RpmInstalledDirectory)$(PathListSeparator)$(PATH)" />
-      <TestSdkRpmTaskEnvironmentVariables Include="TEST_ARTIFACTS=$(TestArtifactsDir)" />
-      <TestSdkRpmTaskEnvironmentVariables Include="TEST_PACKAGES=$(TestPackagesDir)" />
-      <TestSdkRpmTaskEnvironmentVariables Include="PreviousStageProps=$(NextStagePropsPath)" />
-
-      <!-- Consumed By Publish -->
-      <!--<GeneratedInstallers Include="$(SdkRPMInstallerFile)" />-->
     </ItemGroup>
 
     <ReplaceFileContents InputFiles="$(AfterInstallHostScriptTemplateFile)"
@@ -310,53 +300,6 @@
              Importance="High" />
   </Target>
 
-  <Target Name="TestSdkRpm"
-          Condition="  '$(CLIBUILD_SKIP_TESTS)' != 'true' and '$(IsRPMBasedDistro)' == 'True' and '$(FPMPresent)' == 'True' "
-          Inputs="$(DownloadedNetCoreAppTargetingPackInstallerFile);
-                  $(DownloadedNetStandardTargetingPackInstallerFile);
-                  $(DownloadedNetCoreAppHostPackInstallerFile);
-                  $(DownloadedAspNetTargetingPackInstallerFile);
-                  $(DownloadedRuntimeDepsInstallerFile);
-                  $(DownloadedSharedHostInstallerFile);
-                  $(DownloadedHostFxrInstallerFile);
-                  $(DownloadedSharedFrameworkInstallerFile);
-                  $(DownloadedAspNetCoreSharedFxInstallerFile);
-                  $(SdkRPMInstallerFile);
-                  $(RpmTestResultsXmlFile);"
-          Outputs="$(RpmTestResultsXmlFile)">
-
-    <!-- Install Dependencies and SDK Packages -->
-    <Exec Command="sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc" />
-    <Exec Command="sudo rpm -Uv $(DownloadedRuntimeDepsInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedNetCoreAppHostPackInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedNetCoreAppTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedNetStandardTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedAspNetTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedSharedHostInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedHostFxrInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(DownloadedSharedFrameworkInstallerFile)" />
-    <!-- Ignore dependencies, which may have an incoherent dependency on dotnet-runtime -->
-    <Exec Command="sudo rpm -Uv --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
-    <Exec Command="sudo rpm -Uv $(SdkRPMInstallerFile)" />
-
-    <!-- Run End-2-end Tests https://github.com/dotnet/core-sdk/issues/1174
-    <DotNetRestore ProjectPath="$(EndToEndTestProject)"
-                   ToolPath="$(RpmInstalledDirectory)" />
-    <DotNetTest ProjectPath="$(EndToEndTestProject)"
-                EnvironmentVariables="@(TestSdkRpmTaskEnvironmentVariables)"
-                ToolPath="$(RpmInstalledDirectory)" />-->
-    
-    <!-- Clean up Packages -->
-    <Exec Command="sudo rpm -ev --nodeps $(SdkRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(AspNetCoreSharedFxRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(SharedFxRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(HostFxrRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(SharedHostRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(AspNetTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetStandardTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppHostPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(RuntimeDepsPackageName)" />
-  </Target>
+  <!-- Removed the TestSdkRpm task as it would fail when the installed package exactly matched the upgrade package -->
 
 </Project>


### PR DESCRIPTION
It fails when upgrading the exact matching version.
This task and code don't exist in the main branch
Per Nikola, this is not high value as the infra for this doesn't change in servicing
The right way to test this would be to spin the test off into its own container which is not worth doing in servicing.
release/9.0.1xx CI builds are currently broken because of this.