### PR TITLE
Reduce specific test executions times

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -11,22 +11,12 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
+        // Reduced set of test cases that still verify the compatibility matrix
         [Theory]
         [InlineData("net45", "Full", "netstandard1.0 netstandard1.1 net45", true, true)]
-        [InlineData("net451", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 net45 net451", true, true)]
-        [InlineData("net46", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 net45 net451 net46", true, true)]
-        [InlineData("net461", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
         [InlineData("net462", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461 net462", true, true)]
-        [InlineData("netstandard1.0", "Full", "netstandard1.0", true, true)]
-        [InlineData("netstandard1.1", "Full", "netstandard1.0 netstandard1.1", true, true)]
-        [InlineData("netstandard1.2", "Full", "netstandard1.0 netstandard1.1 netstandard1.2", true, true)]
-        [InlineData("netstandard1.3", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3", true, true)]
-        [InlineData("netstandard1.4", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4", true, true)]
-        [InlineData("netstandard1.5", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5", true, true)]
         [InlineData("netstandard1.6", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6", true, true)]
         [InlineData("netstandard2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0", true, true)]
-        [InlineData("netcoreapp1.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0", true, true)]
-        [InlineData("netcoreapp1.1", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0 netcoreapp1.1", true, true)]
         [InlineData("netcoreapp2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
 
         [InlineData("netstandard2.0", "OptIn", "net45 net451 net46 net461", true, true)]
@@ -46,31 +36,53 @@ namespace Microsoft.NET.Build.Tests
                 return;
             }
 
-            foreach (string dependencyTarget in rawDependencyTargets.Split(',', ';', ' ').ToList())
-            {
-                TestProject dependencyProject = GetTestProject(ConstantStringValues.DependencyDirectoryNamePrefix + dependencyTarget.Replace('.', '_'), dependencyTarget, true);
-                TestPackageReference dependencyPackageReference = new(
-                    dependencyProject.Name,
-                    "1.0.0",
-                    ConstantStringValues.ConstructNuGetPackageReferencePath(dependencyProject, identifier: referencerTarget + testDescription + rawDependencyTargets));
+            var dependencyPackageReferences = new List<TestPackageReference>();
 
-                //  Skip creating the NuGet package if not running on Windows; or if the NuGet package already exists
-                //        https://github.com/dotnet/sdk/issues/335
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dependencyProject.BuildsOnNonWindows)
+            // Process all dependencies in parallel
+            Parallel.ForEach(
+                rawDependencyTargets.Split(',', ';', ' ').Where(s => !string.IsNullOrWhiteSpace(s)), 
+                new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+                dependencyTarget => 
                 {
-                    if (!dependencyPackageReference.NuGetPackageExists())
+                    // Create the dependency project and package
+                    TestProject dependencyProject = GetTestProject(
+                        ConstantStringValues.DependencyDirectoryNamePrefix + dependencyTarget.Replace('.', '_'), 
+                        dependencyTarget, 
+                        true);
+                        
+                    TestPackageReference dependencyPackageReference = new(
+                        dependencyProject.Name,
+                        "1.0.0",
+                        ConstantStringValues.ConstructNuGetPackageReferencePath(dependencyProject, identifier: referencerTarget + testDescription + rawDependencyTargets));
+
+                    // Create package if it doesn't exist
+                    if (!dependencyPackageReference.NuGetPackageExists() &&
+                        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dependencyProject.BuildsOnNonWindows))
                     {
-                        //  Create the NuGet packages
-                        var dependencyTestAsset = _testAssetsManager.CreateTestProject(dependencyProject, identifier: referencerTarget + testDescription + rawDependencyTargets);
-                        var dependencyRestoreCommand = dependencyTestAsset.GetRestoreCommand(Log, relativePath: dependencyProject.Name).Execute().Should().Pass();
-                        var dependencyProjectDirectory = Path.Combine(dependencyTestAsset.TestRoot, dependencyProject.Name);
+                        if (!dependencyPackageReference.NuGetPackageExists()) // Double-check after lock
+                        {
+                            var dependencyTestAsset = _testAssetsManager.CreateTestProject(
+                                dependencyProject,
+                                identifier: referencerTarget + testDescription + rawDependencyTargets);
 
-                        var dependencyPackCommand = new PackCommand(Log, dependencyProjectDirectory);
-                        var dependencyPackResult = dependencyPackCommand.Execute().Should().Pass();
+                            dependencyTestAsset.GetRestoreCommand(Log, relativePath: dependencyProject.Name)
+                                .Execute().Should().Pass();
+
+                            var dependencyProjectDirectory = Path.Combine(
+                                dependencyTestAsset.TestRoot,
+                                dependencyProject.Name);
+
+                            new PackCommand(Log, dependencyProjectDirectory)
+                                .Execute().Should().Pass();
+                        }
+
                     }
+                });
 
-                    referencerProject.PackageReferences.Add(dependencyPackageReference);
-                }
+            // Add all references to the referencer project
+            foreach (var dependencyPackageReference in dependencyPackageReferences)
+            {
+                referencerProject.PackageReferences.Add(dependencyPackageReference);
             }
 
             //  Skip running tests if no NuGet packages are referenced

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -11,7 +11,6 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        // Reduced set of test cases that still verify the compatibility matrix
         [Theory]
         [InlineData("net45", "Full", "netstandard1.0 netstandard1.1 net45", true, true)]
         [InlineData("net462", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461 net462", true, true)]
@@ -59,7 +58,7 @@ namespace Microsoft.NET.Build.Tests
                     if (!dependencyPackageReference.NuGetPackageExists() &&
                         (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dependencyProject.BuildsOnNonWindows))
                     {
-                        if (!dependencyPackageReference.NuGetPackageExists()) // Double-check after lock
+                        if (!dependencyPackageReference.NuGetPackageExists())
                         {
                             var dependencyTestAsset = _testAssetsManager.CreateTestProject(
                                 dependencyProject,

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyProjectReferenceCompat.cs
@@ -11,20 +11,9 @@ namespace Microsoft.NET.Build.Tests
 
         [Theory]
         [InlineData("net45", "Full", "netstandard1.0 netstandard1.1 net45", true, true)]
-        [InlineData("net451", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 net45 net451", true, true)]
-        [InlineData("net46", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 net45 net451 net46", true, true)]
-        [InlineData("net461", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461", true, true)]
         [InlineData("net462", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 net45 net451 net46 net461 net462", true, true)]
-        [InlineData("netstandard1.0", "Full", "netstandard1.0", true, true)]
-        [InlineData("netstandard1.1", "Full", "netstandard1.0 netstandard1.1", true, true)]
-        [InlineData("netstandard1.2", "Full", "netstandard1.0 netstandard1.1 netstandard1.2", true, true)]
-        [InlineData("netstandard1.3", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3", true, true)]
-        [InlineData("netstandard1.4", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4", true, true)]
-        [InlineData("netstandard1.5", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5", true, true)]
         [InlineData("netstandard1.6", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6", true, true)]
         [InlineData("netstandard2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0", true, true)]
-        [InlineData("netcoreapp1.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0", true, true)]
-        [InlineData("netcoreapp1.1", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netcoreapp1.0 netcoreapp1.1", true, true)]
         [InlineData("netcoreapp2.0", "Full", "netstandard1.0 netstandard1.1 netstandard1.2 netstandard1.3 netstandard1.4 netstandard1.5 netstandard1.6 netstandard2.0 netcoreapp1.0 netcoreapp1.1 netcoreapp2.0", true, true)]
 
         public void Project_reference_compat(string referencerTarget, string testIDPostFix, string rawDependencyTargets,

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -96,7 +96,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_links_simple_app_without_analysis_warnings_and_it_runs(string targetFramework)
         {
             foreach (var trimMode in new[] { "copyused", "link" })
@@ -248,7 +248,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void PrepareForILLink_can_set_IsTrimmable(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1192,7 +1192,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_runs_incrementally(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1295,7 +1295,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_does_not_include_leftover_artifacts_on_second_run(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1381,7 +1381,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_removes_symbols_when_debugger_support_is_disabled(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1409,7 +1409,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_accepts_option_to_remove_symbols(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1660,7 +1660,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [MemberData(nameof(SupportedTfms), MemberType = typeof(PublishTestUtils))]
+        [MemberData(nameof(Net8Plus), MemberType = typeof(PublishTestUtils))]
         public void ILLink_dont_display_time_awareness_message_on_incremental_build(string targetFramework)
         {
             var projectName = "HelloWorld";


### PR DESCRIPTION
I have a PR that splits tests by individual test rather than test class to help identify the slowest tests. There were two test work items that ran significantly longer than all others at 28m and 22m (next closest was 15m). Running the tests I identified some optimizations to make in the nuget tests and reduced matrix for the illink tests.

https://github.com/dotnet/sdk/pull/44898#issuecomment-2795421025

For the nuget tests, I did two things:

1. Parallelized the test as it was taking five seconds for each iteration through but looping 10+ times. 
2. I removed some of the downlevel instances of these tests as the cleanest way to save time

For the ILLink tests, I just took any test that took over 50s and made it target net8+ since the others are no longer in support.