### PR TITLE
gitignore: .received target completion snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ cmake/
 # Test results
 **/*.trx
 /TestResults
+/test/dotnet.Tests/CompletionTests/snapshots/**/**.received.*
 
 # Live Unit Testing
 *.lutconfig


### PR DESCRIPTION
Extends #48396 to avoid automatically commiting .received snapshots.