### PR TITLE
Reenable CheckTargetFrameworkDisplayName test

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -810,7 +810,7 @@ namespace Microsoft.NET.Build.Tests
             }
         }
 
-        [Theory(Skip = "https://github.com/dotnet/sdk/issues/45148")]
+        [Theory]
         [InlineData("netcoreapp3.1", ".NET Core 3.1")]
         [InlineData("netcoreapp2.1", ".NET Core 2.1")]
         [InlineData("netstandard2.1", ".NET Standard 2.1")]

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -855,11 +855,11 @@ class Program
                 .Should()
                 .Pass();
 
-            var exePath = Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, testProject.Name + ".dll");
-            var result = new DotnetCommand(Log, "exec", exePath)
+            var result = new DotnetCommand(Log, "run", "/tl:off")
+                .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
                 .Execute();
             result.Should().Pass();
-            result.StdOut.Should().BeEquivalentTo(expectedFrameworkDisplayName);
+            result.StdOut.StripTerminalLoggerProgressIndicators().Should().BeEquivalentTo(expectedFrameworkDisplayName);
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -855,11 +855,11 @@ class Program
                 .Should()
                 .Pass();
 
-            var result = new DotnetCommand(Log, "run", "/tl:off")
-                .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
+            var exePath = Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, testProject.Name + ".dll");
+            var result = new DotnetCommand(Log, "exec", exePath)
                 .Execute();
             result.Should().Pass();
-            result.StdOut.StripTerminalLoggerProgressIndicators().Should().BeEquivalentTo(expectedFrameworkDisplayName);
+            result.StdOut.Should().BeEquivalentTo(expectedFrameworkDisplayName);
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -855,11 +855,11 @@ class Program
                 .Should()
                 .Pass();
 
-            var result = new DotnetCommand(Log, "run")
-                .WithWorkingDirectory(Path.Combine(testAsset.Path, testProject.Name))
+            var exePath = Path.Combine(buildCommand.GetOutputDirectory(testProject.TargetFrameworks).FullName, testProject.Name + ".dll");
+            var result = new DotnetCommand(Log, "exec", exePath)
                 .Execute();
             result.Should().Pass();
-            result.StdOut.StripTerminalLoggerProgressIndicators().Should().BeEquivalentTo(expectedFrameworkDisplayName);
+            result.StdOut.Should().BeEquivalentTo(expectedFrameworkDisplayName);
         }
     }
 }


### PR DESCRIPTION
Fixed #45148

When using the `dotnet run` command to execute the project, the standard output is processed by `StripTerminalLoggerProgressIndicators`. This step can clean up progress indicators from the output but might also affect the format and content of the output. By using the `dotnet exec` command to directly execute the built `DLL`, the standard output is compared directly to the expected framework display name.