### PR TITLE
Add the test verifying property functions used in dotnet console/webapp don't need a reflection

### DIFF
--- a/test/Microsoft.NET.Build.Tests/EvaluatorFastPathTests.cs
+++ b/test/Microsoft.NET.Build.Tests/EvaluatorFastPathTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Tests
+{
+    public class EvaluatorFastPathTests : SdkTest
+    {
+        public EvaluatorFastPathTests(ITestOutputHelper log) : base(log)
+        {
+
+        }
+
+        [Fact]
+        public void FastPathDoesNotNeedReflection()
+        {
+            var testAsset = _testAssetsManager
+                .CopyTestAsset("MSBuildBareBonesProject")
+                .WithSource();
+            var command = new MSBuildCommand(testAsset, string.Empty);
+            command
+                .WithEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection", "true")
+                .WithWorkingDirectory(testAsset.Path);
+            command
+                .ExecuteWithoutRestore()
+                .Should()
+                .Pass();
+
+            var logPath = Path.Combine(testAsset.Path, "PropertyFunctionsRequiringReflection");
+            File.Exists(logPath).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("console")]
+        [InlineData("webapp")]
+        public void EnsureDotnetCommonProjectPropertyFunctionsOnFastPath(string alias)
+        {
+            var testDir = _testAssetsManager.CreateTestDirectory().Path;
+
+            new DotnetNewCommand(Log, alias)
+                .WithoutCustomHive()
+                .WithWorkingDirectory(testDir)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetBuildCommand(Log)
+                .WithWorkingDirectory(testDir)
+                .WithEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection", "true")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var logPath = Path.Combine(testDir, "PropertyFunctionsRequiringReflection");
+            // Functions from Microsoft.Build.Utilities.ToolLocationHelper are pending to add fast path, tracked by https://github.com/dotnet/msbuild/issues/10411.
+            // This verification should be changed to no log file created once it is done.
+            var toolLocationHelper_GetPlatformSDKLocation = "ReceiverType=Microsoft.Build.Utilities.ToolLocationHelper; ObjectInstanceType=; MethodName=GetPlatformSDKLocation(String, String)";
+            var toolLocationHelper_GetPlatformSDKDisplayName = "ReceiverType=Microsoft.Build.Utilities.ToolLocationHelper; ObjectInstanceType=; MethodName=GetPlatformSDKDisplayName(String, String)";
+            var lines = File.ReadAllLines(logPath);
+            var allOnFastPathWithExceptions = lines.All(l => (toolLocationHelper_GetPlatformSDKLocation.Equals(l) || toolLocationHelper_GetPlatformSDKDisplayName.Equals(l)));
+            allOnFastPathWithExceptions.Should().BeTrue();
+        }
+    }
+}

--- a/test/TestAssets/TestProjects/MSBuildBareBonesProject/BareBones.proj
+++ b/test/TestAssets/TestProjects/MSBuildBareBonesProject/BareBones.proj
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <MajorMinorVersion>$([System.Version]::Parse('17.12.11.10').ToString(2))</MajorMinorVersion>
+    <String_Replace>$([System.Text.RegularExpressions.Regex]::Replace('abc123def', 'abc', ''))</String_Replace>
+    <String_Equals>$([System.String]::new('Hi').Equals('Hi'))</String_Equals>
+    <FileName>$([System.IO.Path]::GetFileNameWithoutExtension('C:\folder\file.txt'))</FileName>
+    <NumberToString>$([System.Int32]::new(123).ToString('mm')</NumberToString>
+    <Directory>$([Microsoft.Build.Evaluation.IntrinsicFunctions]::NormalizeDirectory('C:/folder1/./folder2/'))</Directory>
+    <IsWindows>$([Microsoft.Build.Evaluation.IntrinsicFunctions]::IsOSPlatform('Windows'))</IsWindows>
+    <!-- Functions from Microsoft.Build.Utilities.ToolLocationHelper are pending to add fast path, tracked by https://github.com/dotnet/msbuild/issues/10411.
+    Comment out this for testing once it's done.
+    <PlatformSdkLocation>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation('Windows', ''))</PlatformSdkLocation>
+    <PlatformDisplayName>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKDisplayName('Windows', ''))</PlatformDisplayName>
+    -->
+  </PropertyGroup>
+
   <Target Name="SayHello">
     <Message Importance="high" Text="Hello, from MSBuild!" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10406

ToolLocationHelper property functions still require reflection and it's tracked by https://github.com/dotnet/msbuild/issues/10411. For other functions the test is covered.
| ReceiverType | ObjectInstanceType | MethodName |
| --- | --- | --- |
| Microsoft.Build.Utilities.ToolLocationHelper| | GetPlatformSDKLocation(String, String) |
| Microsoft.Build.Utilities.ToolLocationHelper| | GetPlatformSDKDisplayName(String, String) |