### PR TITLE
Exclude directories in aspnetcore .tgz files in asset comparison

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -10,6 +10,12 @@
     "justification": "mscordaccoree's version is baked into the file name and varies build to build."
   },
   {
+    "issueType": "ExtraPackageContent",
+    "idMatch": ".*microsoft-(signalr|dotnet-js-interop).*.tgz",
+    "descriptionMatch": "^package/(dist/(browser/|cjs/|esm/|webworker/)?|src/)$",
+    "justification": "aspnetcore and VMR are using different linux distros and node versions, the .tgz from the VMR has separate entries for directories."
+  },
+  {
     "issueType": "MissingPackageContent",
     "idMatch": ".*\\.Msi\\.(arm64|x64|x86)",
     "descriptionMatch": "(useSharedDesignerContext.txt|THIRD-PARTY-NOTICES.TXT)",


### PR DESCRIPTION
The VMR-built .tgz contains directories as separate entries in the archive.