### PR TITLE
Exclude `*.whl/**/*.exe` and `libbinaryen.dylib` from VMR SignCheck

### DIFF
--- a/src/SourceBuild/content/eng/SignCheckExclusionsFile.txt
+++ b/src/SourceBuild/content/eng/SignCheckExclusionsFile.txt
@@ -25,5 +25,9 @@ ILCompiler.Build.Tasks.dll;; IGNORE-STRONG-NAME, https://github.com/dotnet/sourc
 ;; ## MACH-O ##
 *.dwarf;; Debugging symbols, https://github.com/dotnet/source-build/issues/4994#issuecomment-2768803544
 
+;; ## ESRP Signing Issues ##
+*.exe;*.whl;The .whl files are not supported by ESRP, https://github.com/dotnet/emsdk/commit/3ac196ac425223d11490e759c2641256ce746f21
+libbinaryen.dylib;; fails to sign via ESRP, https://github.com/dotnet/emsdk/commit/3ac196ac425223d11490e759c2641256ce746f21
+
 ;; ## DAC Signed Files ##
 ;; Exclusions for these files are added dynamically when running the VMR Signing Validation task on a non-release branch.


### PR DESCRIPTION
VMR SignCheck is reporting the following files as unsigned. These files cannot be signed due to ESRP issues, so they need to be added to the exclusions file.

```
libbinaryen.dylib
cli-32.exe
cli-64.exe
cli-arm64.exe
cli.exe
gui-32.exe
gui-64.exe
gui-arm64.exe
gui.exe
t32.exe
t64-arm.exe
t64.exe
w32.exe
w64-arm.exe
w64.exe
```