### PR TITLE
Set OfficialBuilder when building VMR in MSFT official builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -219,7 +219,7 @@ jobs:
     value: $(commandPrefix)ci $(commandPrefix)$(cleanArgument) $(commandPrefix)prepareMachine -c ${{ parameters.configuration }}
 
   - name: baseProperties
-    value: $(officialBuildParameter) /p:VerticalName=$(Agent.JobName)
+    value: $(officialBuildProperties) /p:VerticalName=$(Agent.JobName)
 
   - name: targetProperties
     ${{ if and(ne(parameters.targetOS, ''), ne(parameters.targetArchitecture, '')) }}:

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -88,7 +88,7 @@ stages:
     - template: ../variables/vmr-build.yml
       parameters:
         vmrBranch: ${{ parameters.vmrBranch }}
-
+        buildSourceOnly: true
     jobs:
 
     ### Jobs for ultralite builds ###

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -4,6 +4,10 @@ parameters:
   type: string
   default: ''
 
+- name: buildSourceOnly
+  type: boolean
+  default: false
+
 - name: desiredSigning
   displayName: Signed/unsigned/default signing parameters
   type: string

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -52,10 +52,20 @@ variables:
   - name: ibcEnabled
     value: false
 
-- name: officialBuildParameter
-  ${{ if eq(variables['isOfficialBuild'], true) }}:
-    value: /p:OfficialBuildId=$(Build.BuildNumber)
-  ${{ else }}:
+## Do not set this when building source only to avoid including telemetry in the bootstrap artifacts
+## handed off to distro partners.
+- ${{ if ne(parameters.buildSourceOnly, true) }}:
+  - name: officialBuilderProperty
+    value: '/p:OfficialBuilder=Microsoft'
+- ${{ else }}:
+  - name: officialBuilderProperty
+    value: ''
+
+- ${{ if eq(variables['isOfficialBuild'], true) }}:
+  - name: officialBuildProperties
+    value: '/p:OfficialBuildId=$(Build.BuildNumber) $(officialBuilderProperty)'
+- ${{ else }}:
+  - name: officialBuildProperties
     value: ''
 
 - ${{ if eq(parameters.desiredSigning, 'Signed') }}:


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/48516 This property controls MS specific behavior. In this case, SDK telemetry is only included in the product if built by MSFT.