### PR TITLE
Disable loading code style analyzers when building from VS

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,4 +78,21 @@
     </KnownFrameworkReference>
   </ItemGroup>
 
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);RemoveCodeStyleAnalyzers</CoreCompileDependsOn>
+  </PropertyGroup>
+
+  <!--
+    CodeStyle analyzers inserted in the SDK might not be compatible with the current public version of Visual Studio,
+    which causes failures when building from the IDE.
+  -->
+  <Target Name="RemoveCodeStyleAnalyzers" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="
+                '%(FileName)' == 'Microsoft.CodeAnalysis.CodeStyle' or
+                '%(FileName)' == 'Microsoft.CodeAnalysis.CodeStyle.Fixes' or
+                '%(FileName)' == 'Microsoft.CodeAnalysis.CSharp.CodeStyle' or
+                '%(FileName)' == 'Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes'"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -85,6 +85,8 @@
   <!--
     CodeStyle analyzers inserted in the SDK might not be compatible with the current public version of Visual Studio,
     which causes failures when building from the IDE.
+
+    TODO: enable once they version independently: https://github.com/dotnet/sdk/issues/48578
   -->
   <Target Name="RemoveCodeStyleAnalyzers" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
     <ItemGroup>


### PR DESCRIPTION
Allows using Visual Studio from dogfood environment while Roslyn version is higher than what's available in the latest VS msbuild.

Fixes VS-only build issues like
```
Analyzer assembly 'C:\sdk5\artifacts\bin\redist\Debug\dotnet\sdk\10.0.100-dev\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll' cannot be used because it references version '...' of the compiler, which is newer than the currently running version '...'.
```