### PR TITLE
Fix restore failures in SourceBuild Stage2

### DIFF
--- a/src/SourceBuild/patches/runtime/0002-dont-use-baseos-as-rid.patch
+++ b/src/SourceBuild/patches/runtime/0002-dont-use-baseos-as-rid.patch
@@ -1,0 +1,48 @@
+From 14e1f3562b60ae979b3993ee538ca54b34bad328 Mon Sep 17 00:00:00 2001
+From: Jeremy Koritzinsky <jekoritz@microsoft.com>
+Date: Wed, 16 Apr 2025 15:22:59 -0700
+Subject: [PATCH] Don't use BaseOS as the RID for publishing NativeAOT'd assets
+ when OutputRID is the SDK's RID
+
+This fixes SourceBuild Stage2 failures in https://github.com/dotnet/sdk/pull/48523
+
+Backport: https://github.com/dotnet/runtime/pull/114755
+---
+ src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj | 6 +++++-
+ src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj   | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj b/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
+index 3b996b78fb0416..d49edad34c479c 100644
+--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
++++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
+@@ -3,7 +3,11 @@
+   <PropertyGroup>
+     <_IsPublishing>true</_IsPublishing>
+     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+-    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
++    <!--
++      If the output RID isn't the current SDK RID and we have a "base" RID, then the output RID isn't known to the SDK.
++      In that case, we need to set the RuntimeIdentifier to the base RID so the SDK can find a runtime pack for publishing.
++    -->
++    <RuntimeIdentifier Condition="'$(OutputRID)' != '$(NETCoreSdkRuntimeIdentifier)' and '$(BaseOS)' != '' ">$(BaseOS)</RuntimeIdentifier>
+     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
+     <SelfContained>true</SelfContained>
+     <PublishTrimmed>true</PublishTrimmed>
+diff --git a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+index 54953da6834124..8e81546a2770a1 100644
+--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
++++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+@@ -3,7 +3,11 @@
+   <PropertyGroup>
+     <_IsPublishing>true</_IsPublishing>
+     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+-    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
++    <!--
++      If the output RID isn't the current SDK RID and we have a "base" RID, then the output RID isn't known to the SDK.
++      In that case, we need to set the RuntimeIdentifier to the base RID so the SDK can find a runtime pack for publishing.
++    -->
++    <RuntimeIdentifier Condition="'$(OutputRID)' != '$(NETCoreSdkRuntimeIdentifier)' and '$(BaseOS)' != '' ">$(BaseOS)</RuntimeIdentifier>
+     <PublishDir>$(RuntimeBinDir)crossgen2-published/</PublishDir>
+     <SelfContained>true</SelfContained>
+     <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
Only use BaseOS when we're restoring for an SDK that isn't for the current RID (so we use the right RID in stage2).