### PR TITLE
Update the scope of dpkg failure suppressions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -334,13 +334,20 @@ public class LinuxInstallerTests : IDisposable
         sb.AppendLine("# Install the installer packages and Microsoft.DotNet.ScenarioTests.SdkTemplateTests tool");
         sb.Append("RUN");
 
-        // TODO: remove --force-all after deps image issue has been resolved - https://github.com/dotnet/dotnet-docker/issues/6271
-        string packageInstallationCommand = packageType == PackageType.Deb ? "dpkg -i --force-all" : "rpm -i";
+        string packageInstallationCommand = packageType == PackageType.Deb ? "dpkg -i" : "rpm -i";
         bool useAndOperator = false;
         foreach (string package in packageList)
         {
+            string options = "";
+            // TODO: remove --force-depends after deps image issue has been resolved - https://github.com/dotnet/dotnet-docker/issues/6271
+            if (packageType == PackageType.Deb &&
+                package.Contains("dotnet-runtime-deps-"))
+            {
+                options = " --force-depends";
+            }
+
             sb.AppendLine(" \\");
-            sb.Append($"    {(useAndOperator ? "&&" : "")} {packageInstallationCommand} {package}");
+            sb.Append($"    {(useAndOperator ? "&&" : "")} {packageInstallationCommand}{options} {package}");
             useAndOperator = true;
         }
         sb.AppendLine("");


### PR DESCRIPTION
This PR scales down the suppressions of potential `dpkg` command failures. Instead of suppressing all failures, we will only suppress dependency failures of the DEPS package, which is a known issue and tracked with https://github.com/dotnet/dotnet-docker/issues/6271

Full validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2689026&view=results