### PR TITLE
Add / in between skipped tests and retrie tests

### DIFF
--- a/src/Cli/dotnet/Commands/Test/Terminal/NonAnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/NonAnsiTerminal.cs
@@ -202,6 +202,7 @@ internal sealed class NonAnsiTerminal : ITerminal
 
             if (retried > 0)
             {
+                Append('/');
                 SetColor(TerminalColor.Gray);
                 Append('r');
                 Append(retried.ToString(CultureInfo.CurrentCulture));


### PR DESCRIPTION
Non ansi progress renders like this:

[+320/x0/?4r2] ....
But it should render like this

[+320/x0/?4/r2] ...

Related to https://github.com/dotnet/sdk/issues/45927