### PR TITLE
Allow `@` as separator in `#:package`

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -186,7 +186,7 @@ Other directives result in a warning, reserving them for future use.
 #:sdk Microsoft.NET.Sdk.Web
 #:property TargetFramework net11.0
 #:property LangVersion preview
-#:package System.CommandLine 2.0.0-*
+#:package System.CommandLine@2.0.0-*
 ```
 
 The value must be separated from the name of the directive by white space and any leading and trailing white space is not considered part of the value.

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -407,6 +407,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                 #:sdk Third 3.0=a/b
                 #:package P1 1.0/a=b
                 #:package P2 2.0/a=b
+                #:package P3@1.0 ab
                 """,
             expectedProject: $"""
                 <Project Sdk="First/1.0=a/b">
@@ -429,6 +430,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                   <ItemGroup>
                     <PackageReference Include="P1" Version="1.0/a=b" />
                     <PackageReference Include="P2" Version="2.0/a=b" />
+                    <PackageReference Include="P3" Version="1.0 ab" />
                   </ItemGroup>
 
                 </Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/47990.