### PR TITLE
Baseline SOS.Hosting in vmr-msft-comparison-baseline.json

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -245,7 +245,7 @@
   },
   {
     "issueType": "MissingNonShipping",
-    "idMatch": "SOS\\.InstallHelper",
+    "idMatch": "SOS\\.Hosting",
     "justification": "Diagnostics does a minimal build in the VMR"
   },
   {


### PR DESCRIPTION
It got added in https://github.com/dotnet/diagnostics/commit/a3d92233188234c569db2b40be27052d428bd24a#diff-e5a20850af9dc53b52bcae314510a946f59e1c8e6319d3ffa71909b0ebb97b24R6

I noticed we had a duplicate entry for SOS.InstallHelper so I just changed that one :)