### PR TITLE
ensure that single-rid container publishes populate all container information

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -41,6 +41,8 @@
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
       <ContainerRuntimeIdentifiers Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(ContainerRuntimeIdentifiers)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifiers)</ContainerRuntimeIdentifiers>
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(ContainerRuntimeIdentifiers)' == ''">linux-$(NETCoreSdkPortableRuntimeIdentifier.Split('-')[1])</ContainerRuntimeIdentifier>
+      <!-- We want to save customer provided ContainerBaseImage to later set ContainerUser. -->
+      <_InitialContainerBaseImage>$(ContainerBaseImage)</_InitialContainerBaseImage>
     </PropertyGroup>
 
     <ItemGroup>
@@ -193,13 +195,13 @@
            For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <_ContainerIsTargetingWindows>false</_ContainerIsTargetingWindows>
       <_ContainerIsTargetingWindows Condition="$(ContainerRuntimeIdentifier.StartsWith('win'))">true</_ContainerIsTargetingWindows>
-
+      
       <!-- Set the WorkingDirectory depending on the RID -->
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and !$(_ContainerIsTargetingWindows)">/app/</ContainerWorkingDirectory>
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and $(_ContainerIsTargetingWindows)">C:\app\</ContainerWorkingDirectory>
 
-      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' == ''">true</_ContainerIsUsingMicrosoftDefaultImages>
-      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' != ''">false</_ContainerIsUsingMicrosoftDefaultImages>
+      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(_InitialContainerBaseImage)' == ''">true</_ContainerIsUsingMicrosoftDefaultImages>
+      <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(_InitialContainerBaseImage)' != ''">false</_ContainerIsUsingMicrosoftDefaultImages>
     </PropertyGroup>
 
       <!-- We only set a default user when the base image is Microsoft-authored, and we're targeting a version of those images that supports a nonroot user -->
@@ -349,7 +351,8 @@
           _SkipContainerPublishing=$(_SkipContainerPublishing);
           ContainerImageFormat=$(_SingleImageContainerFormat);
           _IsMultiRIDBuild=false;
-          _IsSingleRIDBuild=true
+          _IsSingleRIDBuild=true;
+          _InitialContainerBaseImage=$(_InitialContainerBaseImage)
         "/>
       <_rids Remove ="$(_rids)" />
     </ItemGroup>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -67,7 +67,9 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage">
+  <!-- This Target is called early on in the chain for both single-RID and multi-RID containers - but for single-RID it's important
+       that we ensure all of the data necessary to create a single-RID container is computed after we exit this target. -->
+  <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage;_ComputeContainerExecutionArgs">
     <PropertyGroup Label="VS defaults">
       <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
       <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>
@@ -177,24 +179,25 @@
   <PropertyGroup>
     <PublishContainerDependsOn>
       _ContainerVerifySDKVersion;
+      _ContainerEstablishRIDNess;
       ComputeContainerConfig;
       _CheckContainersPackage
     </PublishContainerDependsOn>
   </PropertyGroup>
 
   <!-- These args are relevant to container execution and are per-RID by nature. Therefore they're a direct dependency of the _PublishSingleContainer
-       target and not computed at the outer layer. -->
-  <Target Name="_ComputeContainerExecutionArgs">
+       target and not computed at the outer, multi-RID build layer. -->
+  <Target Name="_ComputeContainerExecutionArgs" Condition="'$(_IsSingleRIDBuild)' == 'true'">
     <PropertyGroup>
       <!-- The Container RID should default to the RID used for the entire build (to ensure things run on the platform they are built for), but the user knows best and so should be able to set it explicitly.
            For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <_ContainerIsTargetingWindows>false</_ContainerIsTargetingWindows>
       <_ContainerIsTargetingWindows Condition="$(ContainerRuntimeIdentifier.StartsWith('win'))">true</_ContainerIsTargetingWindows>
-    
+
       <!-- Set the WorkingDirectory depending on the RID -->
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and !$(_ContainerIsTargetingWindows)">/app/</ContainerWorkingDirectory>
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and $(_ContainerIsTargetingWindows)">C:\app\</ContainerWorkingDirectory>
-      
+
       <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' == ''">true</_ContainerIsUsingMicrosoftDefaultImages>
       <_ContainerIsUsingMicrosoftDefaultImages Condition="'$(ContainerBaseImage)' != ''">false</_ContainerIsUsingMicrosoftDefaultImages>
     </PropertyGroup>
@@ -245,7 +248,9 @@
       Text="The $(_ContainersPackageIdentity) NuGet package is explicitly referenced but the current SDK can natively publish the project as a container. Consider removing the package reference to $(_ContainersPackageIdentity) because it is no longer needed." />
   </Target>
 
-  <Target Name="_PublishSingleContainer" DependsOnTargets="_ComputeContainerExecutionArgs" Returns="@(GeneratedContainer)">
+  <!-- There is an implicit dependency here in that both of ComputeContainerConfig and _ComputeContainerExecutionArgs must have been run, but because we call this Target
+       in a few different ways we can't express that dependency directly here. -->
+  <Target Name="_PublishSingleContainer" Returns="@(GeneratedContainer)">
     <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' == ''">
       <DotNetHostDirectory>$(NetCoreRoot)</DotNetHostDirectory>
       <DotNetHostFileName>dotnet</DotNetHostFileName>
@@ -342,14 +347,16 @@
           ContainerGenerateLabels=$(ContainerGenerateLabels);
           ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest);
           _SkipContainerPublishing=$(_SkipContainerPublishing);
-          ContainerImageFormat=$(_SingleImageContainerFormat)
+          ContainerImageFormat=$(_SingleImageContainerFormat);
+          _IsMultiRIDBuild=false;
+          _IsSingleRIDBuild=true
         "/>
       <_rids Remove ="$(_rids)" />
     </ItemGroup>
 
     <MSBuild
         Projects="@(_InnerBuild)"
-        Targets="Publish;_ParseItemsForPublishingSingleContainer;_PublishSingleContainer"
+        Targets="Publish;_ParseItemsForPublishingSingleContainer;_ComputeContainerExecutionArgs;_PublishSingleContainer"
         BuildInParallel="$([MSBuild]::ValueOrDefault('$(ContainerPublishInParallel)', 'true'))">
         <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />
     </MSBuild>
@@ -401,11 +408,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishContainer"
-  DependsOnTargets="$(PublishContainerDependsOn)"
-  Condition="'$(IsPublishable)' == 'true' AND '$(EnableSdkContainerSupport)' == 'true'"
-  Returns="@(GeneratedContainer)"
-  >
+  <Target Name="_ContainerEstablishRIDNess">
     <PropertyGroup>
       <_IsMultiTFMBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</_IsMultiTFMBuild>
       <!-- we are multi-RID if:
@@ -415,10 +418,17 @@
       <_HasCRIDsAndNoCRID Condition="'$(ContainerRuntimeIdentifiers)' != '' and '$(ContainerRuntimeIdentifier)' == ''">true</_HasCRIDsAndNoCRID>
       <_HasRIDs Condition="'$(RuntimeIdentifiers)' != ''">true</_HasRIDs>
       <_NoCRIDsOrCRIDorRID Condition="'$(ContainerRuntimeIdentifiers)' == '' and '$(ContainerRuntimeIdentifier)' == '' and '$(RuntimeIdentifier)' == ''">true</_NoCRIDsOrCRIDorRID>
+      <!-- these two are load-bearing for other comparisons - see _ComputeContainerExecutionArgs -->
       <_IsMultiRIDBuild Condition="'$(BuildingInsideVisualStudio)' != 'true' and ('$(_HasCRIDsAndNoCRID)' == true or ('$(_HasRIDs)' == 'true' and '$(_NoCRIDsOrCRIDorRID)' == 'true'))">true</_IsMultiRIDBuild>
       <_IsSingleRIDBuild Condition="'$(_IsMultiRIDBuild)' == ''">true</_IsSingleRIDBuild>
     </PropertyGroup>
+  </Target>
 
+  <Target Name="PublishContainer"
+  DependsOnTargets="$(PublishContainerDependsOn)"
+  Condition="'$(IsPublishable)' == 'true' AND '$(EnableSdkContainerSupport)' == 'true'"
+  Returns="@(GeneratedContainer)"
+  >
     <!-- Call _PublishMultiArchContainers if we are in a multi-rid build, and call _PublishSingleContainer if we are in a single-RID build -->
     <CallTarget Condition="'$(_IsMultiRIDBuild)' == 'true' " Targets="_PublishMultiArchContainers">
       <Output TaskParameter="TargetOutputs" ItemName="GeneratedContainer" />

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -22,6 +22,7 @@ public class TargetsTests
         {
             [prop] = value.ToString(),
             [ContainerRuntimeIdentifier] = $"{os}-x64",
+            ["_IsSingleRIDBuild"] = "true",
 
         }, projectName: $"{nameof(CanDeferContainerAppCommand)}_{prop}_{value}_{string.Join("_", expectedAppCommandArgs)}");
         using var _ = d;
@@ -310,7 +311,8 @@ public class TargetsTests
             ["TargetFrameworkIdentifier"] = ".NETCoreApp",
             ["TargetFrameworkVersion"] = tfm,
             ["TargetFramework"] = "net" + tfm.TrimStart('v'),
-            ["ContainerRuntimeIdentifier"] = rid
+            ["ContainerRuntimeIdentifier"] = rid,
+            ["_IsSingleRIDBuild"] = "true",
         }, projectName: $"{nameof(CanComputeContainerUser)}_{tfm}_{rid}_{expectedUser}");
         using var _ = d;
         var instance = project.CreateProjectInstance(ProjectInstanceSettings.None);

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -27,7 +27,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanDeferContainerAppCommand)}_{prop}_{value}_{string.Join("_", expectedAppCommandArgs)}");
         using var _ = d;
         var instance = project.CreateProjectInstance(ProjectInstanceSettings.None);
-        instance.Build([ _ComputeContainerExecutionArgs ], []);
+        instance.Build([ ComputeContainerConfig ], []);
         var computedAppCommand = instance.GetItems(ContainerAppCommand).Select(i => i.EvaluatedInclude);
 
         // The test was not testing anything previously, as the list returned was zero length,
@@ -316,7 +316,7 @@ public class TargetsTests
         }, projectName: $"{nameof(CanComputeContainerUser)}_{tfm}_{rid}_{expectedUser}");
         using var _ = d;
         var instance = project.CreateProjectInstance(ProjectInstanceSettings.None);
-        instance.Build(new[] { _ComputeContainerExecutionArgs }, new[] { logger }, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
+        instance.Build(new[] { ComputeContainerConfig }, new[] { logger }, null, out var outputs).Should().BeTrue(String.Join(Environment.NewLine, logger.Errors));
         var computedTag = instance.GetProperty("ContainerUser")?.EvaluatedValue;
         computedTag.Should().Be(expectedUser);
     }


### PR DESCRIPTION
Fixes #48579

This is a proposed change to the container targets to ensure that for single-rid containers the existing `ComputecontainerConfig` contract holds.

NOTE: we need to add a test verifying that all the run-time-related information is present for single-rid builds after calling the ComputeContainerConfig target so that we don't regress this in the future.

For a single-RID container publish:
![image](https://github.com/user-attachments/assets/3a47ac64-9241-4487-8ae3-065f9b0f71f5)
Here you can see that by the time ComputeContainerConfig is completed the execution-time properties have been set.

For a multi-RID container publish, the 'outer' parts are computed:
![image](https://github.com/user-attachments/assets/abe21139-99bc-4dcf-b5e2-bca05391e890)

And then the per-RID parts are just-in-time called before each RID's container publish:
![image](https://github.com/user-attachments/assets/36ca82b8-39b1-44e0-8b72-b8a20cfbb4db)
