### PR TITLE
Add --os and --arch in VMR build script

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -243,11 +243,11 @@ jobs:
 
   - name: targetProperties
     ${{ if and(ne(parameters.targetOS, ''), ne(parameters.targetArchitecture, '')) }}:
-      value: /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      value: -os ${{ parameters.targetOS }} -arch ${{ parameters.targetArchitecture }}
     ${{ elseif ne(parameters.targetOS, '') }}:
-      value: /p:TargetOS=${{ parameters.targetOS }}
+      value: -os ${{ parameters.targetOS }}
     ${{ else }}:
-      value: /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      value: -arch ${{ parameters.targetArchitecture }}
 
   ### Signing
   - name: _SignDiagnosticFilesArgs

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -13,6 +13,8 @@ usage()
   echo "  --binaryLog                     Create MSBuild binary log (short: -bl)"
   echo "  --configuration <value>         Build configuration: 'Debug' or 'Release' (short: -c)"
   echo "  --rid, --target-rid <value>     Overrides the rid that is produced by the build. e.g. alpine.3.18-arm64, fedora.37-x64, freebsd.13-arm64, ubuntu.19.10-x64"
+  echo "  --os, --target-os <value>       Target operating system: e.g. linux, osx, freebsd. Note: this is the base OS name, not the distro"
+  echo "  --arch, --target-arch <value>   Target architecture: e.g. x64, x86, arm64, arm, riscv64"
   echo "  --verbosity <value>             Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --with-system-libs <libs>       Use system versions of these libraries. Combine with a plus. eg brotli+libunwind+rapidjson+zlib"
   echo ""
@@ -87,8 +89,6 @@ projects=''
 ci=false
 exclude_ci_binary_log=false
 prepare_machine=false
-target_rid=
-system_libs=
 
 properties=()
 while [[ $# > 0 ]]; do
@@ -103,11 +103,19 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     -rid|-target-rid)
-      target_rid=$2
+      properties+=( "/p:TargetRid=$2" )
+      shift
+      ;;
+    -os|-target-os)
+      properties+=( "/p:TargetOS=$2" )
+      shift
+      ;;
+    -arch|-target-arch)
+      properties+=( "/p:TargetArchitecture=$2" )
       shift
       ;;
     -with-system-libs)
-      system_libs=$2
+      properties+=( "/p:UseSystemLibs=$2" )
       shift
       ;;
     -verbosity|-v)
@@ -291,12 +299,6 @@ fi
 source $scriptroot/eng/common/native/init-os-and-arch.sh
 source $scriptroot/eng/common/native/init-distro-rid.sh
 initDistroRidGlobal "$os" "$arch" ""
-if [[ -n "$target_rid" ]]; then
-  properties+=( "/p:TargetRid=$target_rid" )
-fi
-if [[ -n "$system_libs" ]]; then
-  properties+=( "/p:UseSystemLibs=$system_libs" )
-fi
 
 # Source-only settings
 if [[ "$sourceOnly" == "true" ]]; then

--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -3,6 +3,9 @@ Param(
   # Common settings
   [switch][Alias('bl')]$binaryLog,
   [string][Alias('c')]$configuration = "Release",
+  [string][Alias('rid')]$targetRid,
+  [string][Alias('os')]$targetOS,
+  [string][Alias('arch')]$targetArch,
   [string][Alias('v')]$verbosity = "minimal",
 
   # Actions
@@ -23,9 +26,12 @@ Param(
 
 function Get-Usage() {
   Write-Host "Common settings:"
-  Write-Host "  -binaryLog              Output binary log (short: -bl)"
-  Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c). [Default: Release]"
-  Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -binaryLog                   Output binary log (short: -bl)"
+  Write-Host "  -configuration <value>       Build configuration: 'Debug' or 'Release' (short: -c). [Default: Release]"
+  Write-Host "  -rid, -targetRid <value>     Overrides the rid that is produced by the build. e.g. win-arm64, win-x64"
+  Write-Host "  -os, -targetOS <value>       Target operating system: e.g. windows."
+  Write-Host "  -arch, -targetArch <value>   Target architecture: e.g. x64, x86, arm64, arm, riscv64"
+  Write-Host "  -verbosity <value>           Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   Write-Host ""
 
   Write-Host "Actions:"
@@ -69,6 +75,18 @@ if ($test) {
 # Override project if specified on cmd-line
 if ($projects) {
   $project = $projects
+}
+
+if ($targetRid) {
+  $arguments += "/p:TargetRid=$targetRid"
+}
+
+if ($targetOS) {
+  $arguments += "/p:TargetOS=$targetOS"
+}
+
+if ($targetArch) {
+  $arguments += "/p:TargetArchitecture=$targetArch"
 }
 
 if ($sign) {


### PR DESCRIPTION
Usage goes from:

```sh
./build.sh --clean-while-building -sb --rid fedora-riscv64 -p:TargetOS=linux -p:TargetArchitecture=riscv64 -p:Crossbuild=true 
```

to:

```sh
./build.sh --clean-while-building -sb -rid fedora-riscv64 --os linux --arch riscv64 --cross
```