### PR TITLE
Add dotnet-suggest to the skip list in JoinVerticalsAssetSelector.cs

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ManifestAssets/JoinVerticalsAssetSelector.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ManifestAssets/JoinVerticalsAssetSelector.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.ManifestAssets
             return
                 // Skip packages with stable version
                 // - this can be removed after this issue is resolved: https://github.com/dotnet/source-build/issues/4892
+                StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.AssetId, "dotnet-suggest") ||
                 StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.AssetId, "Microsoft.Diagnostics.NETCore.Client") ||
                 StringComparer.OrdinalIgnoreCase.Equals(assetVerticalMatch.AssetId, "Microsoft.NET.Sdk.Aspire.Manifest-8.0.100");
         }


### PR DESCRIPTION
dotnet-suggest has a stable version number (in the SemVer sense) so we need to skip it for now.

Fixes https://github.com/dotnet/source-build/issues/5060