### PR TITLE
Lift VMR's eng/versions.props to PSB in source only builds

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -42,4 +42,13 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <OctokitVersion>10.0.0</OctokitVersion>
   </PropertyGroup>
+
+   <PropertyGroup>
+     <PreviouslySourceBuiltPackageVersionsPropsFile>$(PreviouslySourceBuiltPackagesPath)PackageVersions.props</PreviouslySourceBuiltPackageVersionsPropsFile>
+   </PropertyGroup>
+ 
+   <!-- For source only builds, override the version props with previously built artifacts.
+        If a version should be pinned, declare it after this import. -->
+   <Import Project="$(PreviouslySourceBuiltPackageVersionsPropsFile)"
+           Condition="Exists('$(PreviouslySourceBuiltPackageVersionsPropsFile)') and '$(DotNetBuildSourceOnly)' == 'true'"/>
 </Project>

--- a/src/SourceBuild/content/eng/tools/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Don't use these feeds when testing. Projects under this directory are referenced by
        test projects. This makes sure that the feeds aren't used. -->
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(PreviouslySourceBuiltReferencePackagesDir);$(PrebuiltPackagesPath);$(PreviouslySourceBuiltPackagesPath)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(PrebuiltPackagesPath);$(PreviouslySourceBuiltPackagesPath)</RestoreSources>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4976.