### PR TITLE
sln-add: Don't add solution folders outside the scope of solution directory

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Sln.Add
             {
                 string relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionFileFullPath), projectPath);
                 // Add fallback solution folder if relative path does not contain `..`.
-                string relativeSolutionFolder =  relativePath.Split(Path.DirectorySeparatorChar).Any(p => p == "..")
+                string relativeSolutionFolder = (relativePath.StartsWith("..") || Path.IsPathRooted(relativePath))
                     ? string.Empty : Path.GetDirectoryName(relativePath);
 
                 if (!_inRoot && solutionFolder is null && !string.IsNullOrEmpty(relativeSolutionFolder))

--- a/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-sln/add/Program.cs
@@ -100,8 +100,8 @@ namespace Microsoft.DotNet.Tools.Sln.Add
             foreach (var projectPath in projectPaths)
             {
                 string relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionFileFullPath), projectPath);
-                // Add fallback solution folder if relative path does not contain `..`.
-                string relativeSolutionFolder = (relativePath.StartsWith("..") || Path.IsPathRooted(relativePath))
+                // Add auto-generated solution folder if relative path exists in the solution directory
+                string relativeSolutionFolder = (relativePath.Split(Path.DirectorySeparatorChar).Any(p => p == "..") || Path.IsPathRooted(relativePath))
                     ? string.Empty : Path.GetDirectoryName(relativePath);
 
                 if (!_inRoot && solutionFolder is null && !string.IsNullOrEmpty(relativeSolutionFolder))


### PR DESCRIPTION
Fixes #48608 

# Description
When adding a project to a solution file, solution folders are automatically generated with the relative path (relative to the solution file path). When adding projects outside the scope of the solution working directory, solution folders with invalid names are created (e.g., `..`, `:`, etc).

This was addressed in #46456 but didn't consider paths in different volumes. 

# Risk
Low - this doesn't alter existing behavior but rather considers a previously not considered edge case.

# Regression 
Yes - this worked before 9.0.2xx

# Testing
Adding automated tests is difficult as it involves mounting several volumes, but manual tests were performed.

 ## Expected behavior
![image](https://github.com/user-attachments/assets/18b71ecb-849d-47b9-a4ad-a996c8f82401)

## Current behavior
![image](https://github.com/user-attachments/assets/38130c0f-01bf-4f09-a967-733ef8ca3a18)

