### PR TITLE
Remove Test condition from tools RestoreSources

### DIFF
--- a/src/SourceBuild/content/eng/tools/Directory.Build.props
+++ b/src/SourceBuild/content/eng/tools/Directory.Build.props
@@ -2,10 +2,8 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
-  <!-- Don't use these feeds when testing. Projects under this directory are referenced by
-       test projects. This makes sure that the feeds aren't used. -->
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(Test)' != 'true'">$(PrebuiltPackagesPath);$(PreviouslySourceBuiltPackagesPath)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(PrebuiltPackagesPath);$(PreviouslySourceBuiltPackagesPath)</RestoreSources>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The condition on running tests isn't necessary anymore as the SBRP package feed isn't an input to the tools anymore. That was the original reason for the condition.