### PR TITLE
[workloads] Update maui,ios,android baselines to preview3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -315,7 +315,7 @@
     <AspireFeatureBand>8.0.100</AspireFeatureBand>
     <MicrosoftNETSdkAspireManifest80100PackageVersion>8.2.2</MicrosoftNETSdkAspireManifest80100PackageVersion>
     <MauiFeatureBand>10.0.100-preview.3</MauiFeatureBand>
-    <MauiWorkloadManifestVersion>10.0.0-preview.3.25203.16</MauiWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>10.0.0-preview.3.25208.1</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>36.0.0-preview.3.22</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>18.2.10695-net10-p3</XamarinIOSWorkloadManifestVersion>
     <XamarinMacCatalystWorkloadManifestVersion>18.2.10695-net10-p3</XamarinMacCatalystWorkloadManifestVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -314,13 +314,13 @@
   <PropertyGroup Label="Workload manifest package versions">
     <AspireFeatureBand>8.0.100</AspireFeatureBand>
     <MicrosoftNETSdkAspireManifest80100PackageVersion>8.2.2</MicrosoftNETSdkAspireManifest80100PackageVersion>
-    <MauiFeatureBand>10.0.100-preview.1</MauiFeatureBand>
-    <MauiWorkloadManifestVersion>10.0.0-preview.1.25122.6</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>35.99.0-preview.1.140</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>18.2.10322-net10-p1</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>18.2.10322-net10-p1</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>15.2.10322-net10-p1</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>18.2.10322-net10-p1</XamarinTvOSWorkloadManifestVersion>
+    <MauiFeatureBand>10.0.100-preview.3</MauiFeatureBand>
+    <MauiWorkloadManifestVersion>10.0.0-preview.3.25203.16</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>36.0.0-preview.3.22</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>18.2.10695-net10-p3</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>18.2.10695-net10-p3</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>15.2.10695-net10-p3</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>18.2.10695-net10-p3</XamarinTvOSWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup Label="Pinned dependency">
     <!-- This package is not being produced outside of the 2.0 branch of corefx and should not change. -->


### PR DESCRIPTION
Update the baseline versions for .NET MAUI, iOS and Android so it references more recent workloads (preview 3).