### PR TITLE
[StaticWebAssets] Ensure HtmlAssetPlaceholders are executed before ServiceWorker

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.HtmlAssetPlaceholders.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.HtmlAssetPlaceholders.targets
@@ -23,8 +23,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ResolveHtmlAssetPlaceholdersBuildConfiguration
      -->
     <ResolveBuildRelatedStaticWebAssetsDependsOn>
-      $(ResolveBuildRelatedStaticWebAssetsDependsOn);
       ResolveHtmlAssetPlaceholdersBuildStaticWebAssets;
+      $(ResolveBuildRelatedStaticWebAssetsDependsOn)
     </ResolveBuildRelatedStaticWebAssetsDependsOn>
     <ResolveCompressedFilesDependsOn>
       $(ResolveCompressedFilesDependsOn);
@@ -50,8 +50,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ResolveHtmlAssetPlaceholdersPublishConfiguration
      -->
     <ResolvePublishRelatedStaticWebAssetsDependsOn>
-      $(ResolvePublishRelatedStaticWebAssetsDependsOn);
-      ResolveHtmlAssetPlaceholdersPublishStaticWebAssets
+      ResolveHtmlAssetPlaceholdersPublishStaticWebAssets;
+      $(ResolvePublishRelatedStaticWebAssetsDependsOn)
     </ResolvePublishRelatedStaticWebAssetsDependsOn>
     <ResolvePublishCompressedStaticWebAssetsDependsOn>
       $(ResolvePublishCompressedStaticWebAssetsDependsOn);


### PR DESCRIPTION
The `ResolveHtmlAssetPlaceholdersBuildStaticWebAssets` needs to run before `ResolveBuildServiceWorkerStaticWebAssetsConfiguration` so that service worker targets get correct HTML StaticWebAssets.

Related to https://github.com/dotnet/sdk/pull/46233