### PR TITLE
[RuntimeInteference.targets] add property to opt out of R2R error message

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -216,11 +216,11 @@ Copyright (c) .NET Foundation. All rights reserved.
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="SelfContained"/>
 
-    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
+    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true' and '$(AllowReadyToRunWithoutRuntimeIdentifier)' != 'true'"
                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                  FormatArguments="PublishReadyToRun"/>
 
-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true'"
+    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(_IsPublishing)' == 'true' and '$(AllowPublishSingleFileWithoutRuntimeIdentifier)' != 'true'"
                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
                 FormatArguments="PublishSingleFile"/>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/36047
Context: https://github.com/dotnet/android/issues/10062

We have experimental support for CoreCLR+R2R on Android. Android is also unique in that a default build can target multiple RIDs via:

    <RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>

Unfortunately, targeting 4 RIDs like this results in:

    dotnet/sdk/10.0.100-preview.4.25180.3/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5):
    error NETSDK1191: A runtime identifier for the property 'PublishReadyToRun' couldn't be inferred. Specify a rid explicitly

But simply skipping this error message allows the build to succeed, and R2R successfully runs on all 4 RIDs.

Just like in https://github.com/dotnet/sdk/pull/36047, I introduced a new `$(AllowReadyToRunWithoutRuntimeIdentifier)` property to opt out of this error message.

I also added `$(AllowPublishSingleFileWithoutRuntimeIdentifier)`, to give the same flexibility in the future.