### PR TITLE
Remove xliff-tasks from source-mappings.json

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -681,25 +681,6 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>c5cfa8a7850acb4de6480be562b8ab1f7e32ed26</Sha>
     </Dependency>
-    <!--
-      Aspire isn't really a toolset dependency. However, it only inserts a baseline manifest in sdk,
-      and if you squint at it, this means we can say that its specific dependency versions don't matter to sdk.
-      It also doesn't currently ship 9.0 preview versions, meaning the version is locked to the latest shipped from 8.0 era.
-      Avoiding this as a product dependency avoids a long coherency path (aspnetcore->extensions->aspire->sdk).
-      **It is** of course possible that an incoherent aspire means that aspire depends on versions of extensions that
-      aren't shipping, or those extensions packages depend on aspnetcore packages that won't ship. However, given the cost
-      of maintaining this coherency path is high. This being toolset means that aspire is responsible for its own coherency.
-    -->
-    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-8.0.100" Version="8.2.2">
-      <Uri>https://github.com/dotnet/aspire</Uri>
-      <Sha>5fa9337a84a52e9bd185d04d156eccbdcf592f74</Sha>
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.aspire" Version="8.2.2-preview.1.24521.5">
-      <Uri>https://github.com/dotnet/aspire</Uri>
-      <Sha>5fa9337a84a52e9bd185d04d156eccbdcf592f74</Sha>
-      <SourceBuild RepoName="aspire" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.Testing.Platform" Version="1.7.0-preview.25217.2">
       <Uri>https://github.com/microsoft/testfx</Uri>
       <Sha>b1ee076771c0c039b9393e5adc51e4d6b11538be</Sha>

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -177,17 +177,6 @@
             "defaultRemote": "https://github.com/dotnet/xdt"
         },
         {
-            // TODO: Remove the xliff-tasks mapping once the synchronization flags it as unused
-            // We no longer synchronize it but we can't remove it yet until
-            // it disappears from all of the Version.Details.xml files.
-            // https://github.com/dotnet/source-build/issues/4359
-            "name": "xliff-tasks",
-            "defaultRemote": "https://github.com/dotnet/xliff-tasks",
-            "ignoreDefaults": true,
-            "exclude": [ "**/*" ],
-            "disableSynchronization": true
-        },
-        {
             "name": "winforms",
             "defaultRemote": "https://github.com/dotnet/winforms",
             "exclude": [


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4359

It needed removing aspire from Version.Details.xml which is fine since we don't actually synchronize it into the VMR anymore.