### PR TITLE
Create SymbolPublishingExclusionsFile.txt

### DIFF
--- a/src/SourceBuild/content/eng/SymbolPublishingExclusionsFile.txt
+++ b/src/SourceBuild/content/eng/SymbolPublishingExclusionsFile.txt
@@ -1,0 +1,13 @@
+libgit2-a418d9d.so
+tools/x86_arm/mscordaccore.dll
+tools/x86_arm/mscordbi.dll
+tools/x64_arm64/mscordaccore.dll
+tools/x64_arm64/mscordbi.dll
+content/LanguageServer/linux-musl-arm64/libe_sqlite3.so
+content/LanguageServer/linux-musl-x64/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-arm64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-arm/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-x64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-arm64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-arm/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-x64/native/libe_sqlite3.so


### PR DESCRIPTION
Aggregates the exclusions from roslyn, arcade, and runtime. https://github.com/dotnet/source-build/issues/5076