### PR TITLE
Temporarily update pool for internal builds

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -244,9 +244,9 @@ variables:
       value: NetCore1ESPool-Internal
   - ${{ else }}:
     - name: defaultPoolName
-      value: $(DncEngInternalBuildPool)
+      value: NetCore1ESPool-Internal
     - name: shortStackPoolName
-      value: $(DncEngInternalBuildPool)
+      value: NetCore1ESPool-Internal
   - name: poolImage_Linux
     value: build.ubuntu.2204.amd64
   - name: poolImage_LinuxArm64


### PR DESCRIPTION
Do not use the calculated pool for internal builds, which has half the cores for release branches.