### PR TITLE
Remove CoherentParentDependency metadata for entries both inside the VMR

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -291,7 +291,7 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>721dc7a2a59416b21fc49447d264009d708d6000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="10.0.0-preview.5.25222.12" CoherentParentDependency="Microsoft.WindowsDesktop.App.Ref">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="10.0.0-preview.5.25222.12">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>c80941dd15b7bfad555c096ef2fe190cd6eed276</Sha>
     </Dependency>
@@ -441,11 +441,11 @@
       <SourceBuild RepoName="razor" ManagedOnly="true" />
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.5.25222.5" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.5.25222.5">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>89fcfd878c4dd8c962f04832c92d3c977064b4e0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="10.0.0-preview.5.25222.12" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="10.0.0-preview.5.25222.12">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>c80941dd15b7bfad555c096ef2fe190cd6eed276</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -291,9 +291,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>721dc7a2a59416b21fc49447d264009d708d6000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="10.0.0-preview.5.25222.12">
-      <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>c80941dd15b7bfad555c096ef2fe190cd6eed276</Sha>
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="10.0.0-preview.5.25223.119">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>721dc7a2a59416b21fc49447d264009d708d6000</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="10.0.0-preview.5.25223.119">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -441,13 +441,13 @@
       <SourceBuild RepoName="razor" ManagedOnly="true" />
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.5.25222.5">
-      <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>89fcfd878c4dd8c962f04832c92d3c977064b4e0</Sha>
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.5.25223.119">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>721dc7a2a59416b21fc49447d264009d708d6000</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="10.0.0-preview.5.25222.12">
-      <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>c80941dd15b7bfad555c096ef2fe190cd6eed276</Sha>
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="10.0.0-preview.5.25223.119">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>721dc7a2a59416b21fc49447d264009d708d6000</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Web.Xdt" Version="10.0.0-preview.25223.119">
       <Uri>https://github.com/dotnet/dotnet</Uri>


### PR DESCRIPTION
Works around a Maestro flow issue where those artifacts get ignored.