### PR TITLE
macOS Installer: Update relese notes link

### DIFF
--- a/src/Installer/redist-installer/packaging/osx/resources/cs.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/cs.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs"> Dokumentace.NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Dokumentace SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Poznámky k verzi</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Poznámky k verzi</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/de.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/de.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET-Dokumentation</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK-Dokumentation</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Versionshinweise</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Versionshinweise</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/en.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/en.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Release Notes</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/es.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/es.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Documentación de .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Documentación de SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Notas de la versión</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Notas de la versión</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutoriales</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/fr.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/fr.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Documentation .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Kit de développement logiciel (SDK) de documentation</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Notes de publication</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Notes de publication</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutoriels</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/it.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/it.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Documentazione .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">documentazione SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Note sulla versione</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Note sulla versione</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Esercitazioni</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/ja.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/ja.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET ドキュメント</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK ドキュメント</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">リリース ノート</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">リリース ノート</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">チュートリアル</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/ko.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/ko.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET 설명서</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK 설명서</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">릴리스 정보</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">릴리스 정보</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">자습서</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/pl.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/pl.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Dokumentacja platformy .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Dokumentacja zestawu SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Informacje o wersji</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Informacje o wersji</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Samouczki</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/pt-br.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/pt-br.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Documentação do .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Documentação do SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Notas sobre a versão</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Notas sobre a versão</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutoriais</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/ru.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/ru.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">Документация по .NET</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">Документация по SDK</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Заметки о выпуске</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Заметки о выпуске</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Руководства</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/tr.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/tr.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">Release Notes</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/zh-hans.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/zh-hans.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET 文档</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK 文档</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">发行说明</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">发行说明</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">教程</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/packaging/osx/resources/zh-hant.lproj/conclusion.html
+++ b/src/Installer/redist-installer/packaging/osx/resources/zh-hant.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a id="dotnetdocumentation" href="https://aka.ms/dotnet-docs">.NET 文件</a></li>
                 <li><a id="sdkdocumentation" href="https://aka.ms/dotnet-cli-docs">SDK 文件</a></li>
-                <li><a id="releasenotes" href="https://aka.ms/dotnet7-release-notes">版本資訊</a></li>
+                <li><a id="releasenotes" href="https://aka.ms/dotnet{DOTNETSDKVERSIONMAJOR}-release-notes">版本資訊</a></li>
                 <li><a id="tutorials" href="https://aka.ms/dotnet-tutorials">教學課程</a></li>
             </ul>
         </div>

--- a/src/Installer/redist-installer/targets/GeneratePKG.targets
+++ b/src/Installer/redist-installer/targets/GeneratePKG.targets
@@ -110,6 +110,9 @@
       <ResourcesReplacement Include="{DOTNETSDKVERSION}">
         <ReplacementString>$(Version)</ReplacementString>
       </ResourcesReplacement>
+      <ResourcesReplacement Include="{DOTNETSDKVERSIONMAJOR}">
+        <ReplacementString>$(VersionMajor)</ReplacementString>
+      </ResourcesReplacement>
       <ResourcesReplacement Include="{DOTNETRUNTIMEVERSION}">
         <ReplacementString>$(MicrosoftNETCoreAppRuntimePackageVersion)</ReplacementString>
       </ResourcesReplacement>


### PR DESCRIPTION
Fixes #47648 

## Description
The macOS installer wizard links to the .NET 7 release notes for all versions. It should instead link to the respective version being installed. 

## Risk
Low - This has no impact on usability, but rather provides accurate information to the user. 

## Regression
Yes, this used to be correct on .NET 7 but isn't anymore. 

## Testing
I can test if needed but would need access to a Mac machine. 