### PR TITLE
Ignore .slnx

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -32,6 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.user</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.*proj</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.sln</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/*.slnx</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.vssscc</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/.DS_Store</DefaultItemExcludes>
 


### PR DESCRIPTION
Fixes #48728

# Description
As mentioned in the issue, when opening a .sln file in a directory that contains a .slnx file, the .slnx file is displayed as content in the project. It should be ignored the same way .sln files are. 

# Risk 
Low - This shouldn't alter behavior.

# Regression
No - This started occurring following new support for slnx

# Testing
Manual testing was done.