### PR TITLE
Local dev props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ obj/
 .tools/
 .packages/
 
+# Locally-customizable build props import
+/LocalDev.Build.props
+/LocalDev.Packages.props
+
 # OS X Device Services Store
 .DS_Store
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -96,4 +96,9 @@
 
   <Import Project="build/GenerateResxSource.targets" />
 
+  <!-- Import any local dev properties if they exist. -->
+  <PropertyGroup>
+    <LocalDevPropsPath>$(MSBuildThisFileDirectory)LocalDev.Build.props</LocalDevPropsPath>
+  </PropertyGroup>
+  <Import Project="$(LocalDevPropsPath)" Condition="Exists('$(LocalDevPropsPath)') AND '$(SkipLocalDevSettings)' != 'true'" />
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -157,4 +157,10 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildMinimumVersion)" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="$(MicrosoftBuildMinimumVersion)" />
   </ItemGroup>
+
+  <!-- Import any local dev packages if they exist. -->
+  <PropertyGroup>
+    <LocalDevPackagesPath>$(MSBuildThisFileDirectory)LocalDev.Packages.props</LocalDevPackagesPath>
+  </PropertyGroup>
+  <Import Project="$(LocalDevPackagesPath)" Condition="Exists('$(LocalDevPackagesPath)') AND '$(SkipLocalDevSettings)' != 'true'" />
 </Project>

--- a/documentation/local-dev/roslyn/LocalDev.Build.props
+++ b/documentation/local-dev/roslyn/LocalDev.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <!-- If \LocalDev.Build.props exists, it will be loaded and merged with Directory.Build.props, allowing for local adhoc build customizations. -->
+  <PropertyGroup>
+    <RoslynRoot>$(MSBuildThisFileDirectory)..\roslyn</RoslynRoot>
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(RoslynRoot)\artifacts\packages\Debug\Shipping</RestoreAdditionalProjectSources>
+
+    <!--
+      Keep downloaded packages in .\packages to avoid corrupting the shared global packages cache, but do allow the
+      use of the shared cache as a fallback folder so packages already downloaded do not need to be downloaded again.
+    -->
+    <RestorePackagesPath>$(MSBuildThisFileDirectory).packages\</RestorePackagesPath>
+    <RestoreFallbackFolders>$(UserProfile)\.nuget\packages</RestoreFallbackFolders>
+  </PropertyGroup>
+
+  <!-- RECOMMENDED: Add a target which prints a message saying that this file has been imported. -->
+  <Target Name="DisplayMessageIfLocalDevPropsDefined" BeforeTargets="BeforeCompile">
+    <Message Text="$(MSBuildProjectName) $(TargetFramework): Imported local dev properties from $(MSBuildThisFileFullPath)." Importance="high" />
+  </Target>
+</Project>

--- a/documentation/local-dev/roslyn/LocalDev.Packages.props
+++ b/documentation/local-dev/roslyn/LocalDev.Packages.props
@@ -1,0 +1,24 @@
+<Project>
+  <!-- If \LocalDev.Packages.props exists, it will be loaded and merged with Directory.Packages.props, allowing for local adhoc build customizations. -->
+  <PropertyGroup>
+    <!-- Use the local version of Roslyn -->
+    <RoslynVersion>4.14.0-dev</RoslynVersion>
+    <RoslynAnalyzers>3.12.0-dev</RoslynAnalyzers>
+
+    <MicrosoftNetCompilersToolsetVersion>$(RoslynVersion)</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetFrameworkPackageVersion>$(RoslynVersion)</MicrosoftNetCompilersToolsetFrameworkPackageVersion>
+    <MicrosoftCodeAnalysisPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpCodeStylePackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpCodeStylePackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>$(RoslynAnalyzers)</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+  </PropertyGroup>
+
+  <!-- RECOMMENDED: Add a target which prints a message saying that this file has been imported. -->
+  <Target Name="DisplayMessageIfLocalDevPackagesDefined" BeforeTargets="BeforeCompile">
+    <Message Text="$(MSBuildProjectName) $(TargetFramework): Imported local dev packages from $(MSBuildThisFileFullPath)." Importance="high" />
+  </Target>
+</Project>

--- a/documentation/local-dev/roslyn/readme.md
+++ b/documentation/local-dev/roslyn/readme.md
@@ -1,0 +1,37 @@
+# Instructions for Roslyn developers
+
+1. Check out a working copy of dotnet/roslyn, e.g. to the directory next to this repo's root `..\roslyn`.
+   Make sure the current working directory is the checkout of this repo.
+
+2. Copy LocalDev.Build.props to the root and set `RoslynRoot` property in the copied file to local Roslyn repo.
+
+    `cp documentation\local-dev\roslyn\LocalDev.Build.props LocalDev.Build.props`
+
+3. Copy LocalDev.Packages.props.roslyn to the root
+
+    `cp documentation\local-dev\roslyn\LocalDev.Packages.props LocalDev.Packages.props`
+
+4. Build Roslyn with:
+
+    `..\roslyn\Build.cmd -restore -pack`
+
+5. Clear the customized packages cache in `.packages`
+
+    `git clean -dxf .packages/`
+
+6. Restore packages
+
+7. Open solution and work normally
+
+8. Following another change to Roslyn.sln, repeat steps 4-6 to pick up those changes in sdk.
+
+Tip to speed up restore if .\packages starts containing more than just the Roslyn development packages. Clear the
+packages cache, and restore packages without using the customized local developer settings to update the per-user
+NuGet global package cache with the default packages used for Conversations. Then run a second restore to pick up
+just the local development packages for Roslyn.
+
+```
+git clean -dxf .packages/
+restore /p:SkipLocalDevSettings=true
+restore
+```


### PR DESCRIPTION
Adds infrastructure that makes it easier to consume locally built Roslyn packages.

Adding `LocalDev.Build.props` and `LocalDev.Packages.props` to the repo root redirects package restore to `.packages` dir and sets version of Roslyn packages (or any other package) to locally built one. 

Based on @sharwell's work in another repository.