### PR TITLE
Implement auto-restarting on rude edit or no-effect change

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable CS0618 // TODO: https://github.com/dotnet/sdk/pull/48752
-#pragma warning disable CS0612 // TODO: https://github.com/dotnet/sdk/pull/48752
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.Build.Graph;
@@ -18,7 +15,7 @@ namespace Microsoft.DotNet.Watch
     {
         public readonly IncrementalMSBuildWorkspace Workspace;
         public readonly EnvironmentOptions EnvironmentOptions;
-
+        private readonly GlobalOptions _options;
         private readonly IReporter _reporter;
         private readonly WatchHotReloadService _hotReloadService;
 
@@ -44,10 +41,11 @@ namespace Microsoft.DotNet.Watch
 
         private bool _isDisposed;
 
-        public CompilationHandler(IReporter reporter, EnvironmentOptions environmentOptions, CancellationToken shutdownCancellationToken)
+        public CompilationHandler(IReporter reporter, EnvironmentOptions environmentOptions, GlobalOptions options, CancellationToken shutdownCancellationToken)
         {
             _reporter = reporter;
             EnvironmentOptions = environmentOptions;
+            _options = options;
             Workspace = new IncrementalMSBuildWorkspace(reporter);
             _hotReloadService = new WatchHotReloadService(Workspace.CurrentSolution.Services, () => ValueTask.FromResult(GetAggregateCapabilities()));
             _shutdownCancellationToken = shutdownCancellationToken;
@@ -259,40 +257,24 @@ namespace Microsoft.DotNet.Watch
             var currentSolution = Workspace.CurrentSolution;
             var runningProjects = _runningProjects;
 
-            var runningProjectIds = currentSolution.Projects
-                .Where(project => project.FilePath != null && runningProjects.ContainsKey(project.FilePath))
-                .Select(project => project.Id)
-                .ToImmutableHashSet();
+            var runningProjectInfos =
+               (from project in currentSolution.Projects
+                let runningProject = GetCorrespondingRunningProject(project, runningProjects)
+                where runningProject != null
+                let autoRestart = _options.NonInteractive || runningProject.ProjectNode.IsAutoRestartEnabled()
+                select (project.Id, info: new WatchHotReloadService.RunningProjectInfo() { RestartWhenChangesHaveNoEffect = autoRestart }))
+                .ToImmutableDictionary(e => e.Id, e => e.info);
 
-            var updates = await _hotReloadService.GetUpdatesAsync(currentSolution, runningProjectIds, cancellationToken);
-            var anyProcessNeedsRestart = !updates.ProjectIdsToRestart.IsEmpty;
+            var updates = await _hotReloadService.GetUpdatesAsync(currentSolution, runningProjectInfos, cancellationToken);
 
-            await DisplayResultsAsync(updates, cancellationToken);
+            await DisplayResultsAsync(updates, runningProjectInfos, cancellationToken);
 
-            if (updates.Status is ModuleUpdateStatus.None or ModuleUpdateStatus.Blocked)
+            if (updates.Status is WatchHotReloadService.Status.NoChangesToApply or WatchHotReloadService.Status.Blocked)
             {
                 // If Hot Reload is blocked (due to compilation error) we ignore the current
                 // changes and await the next file change.
                 return (ImmutableDictionary<ProjectId, string>.Empty, []);
             }
-
-            if (updates.Status == ModuleUpdateStatus.RestartRequired)
-            {
-                if (!anyProcessNeedsRestart)
-                {
-                    return (ImmutableDictionary<ProjectId, string>.Empty, []);
-                }
-
-                await restartPrompt.Invoke(updates.ProjectIdsToRestart.Select(id => currentSolution.GetProject(id)!.Name), cancellationToken);
-
-                // Terminate all tracked processes that need to be restarted,
-                // except for the root process, which will terminate later on.
-                var terminatedProjects = await TerminateNonRootProcessesAsync(updates.ProjectIdsToRestart.Select(id => currentSolution.GetProject(id)!.FilePath!), cancellationToken);
-
-                return (updates.ProjectIdsToRebuild.ToImmutableDictionary(keySelector: id => id, elementSelector: id => currentSolution.GetProject(id)!.FilePath!), terminatedProjects);
-            }
-
-            Debug.Assert(updates.Status == ModuleUpdateStatus.Ready);
 
             ImmutableDictionary<string, ImmutableArray<RunningProject>> projectsToUpdate;
             lock (_runningProjectsAndUpdatesGuard)
@@ -329,35 +311,61 @@ namespace Microsoft.DotNet.Watch
                 }
             }, cancellationToken);
 
-            return (ImmutableDictionary<ProjectId, string>.Empty, []);
+
+            if (updates.ProjectsToRestart.IsEmpty)
+            {
+                return (ImmutableDictionary<ProjectId, string>.Empty, []);
+            }
+
+            // Terminate projects that need restarting.
+
+            var projectsToPromptForRestart =
+                (from projectId in updates.ProjectsToRestart.Keys
+                 where !runningProjectInfos[projectId].RestartWhenChangesHaveNoEffect // equivallent to auto-restart
+                 select currentSolution.GetProject(projectId)!.Name).ToList();
+
+            if (projectsToPromptForRestart is not [])
+            {
+                await restartPrompt.Invoke(projectsToPromptForRestart, cancellationToken);
+            }
+
+            // Terminate all tracked processes that need to be restarted,
+            // except for the root process, which will terminate later on.
+            var terminatedProjects = await TerminateNonRootProcessesAsync(updates.ProjectsToRestart.Select(e => currentSolution.GetProject(e.Key)!.FilePath!), cancellationToken);
+            var projectsToRebuild = updates.ProjectsToRebuild.ToImmutableDictionary(keySelector: id => id, elementSelector: id => currentSolution.GetProject(id)!.FilePath!);
+
+            return (projectsToRebuild, terminatedProjects);
         }
 
-        private async ValueTask DisplayResultsAsync(WatchHotReloadService.Updates updates, CancellationToken cancellationToken)
+        private static RunningProject? GetCorrespondingRunningProject(Project project, ImmutableDictionary<string, ImmutableArray<RunningProject>> runningProjects)
         {
-            var anyProcessNeedsRestart = !updates.ProjectIdsToRestart.IsEmpty;
+            if (project.FilePath == null || !runningProjects.TryGetValue(project.FilePath, out var projectsWithPath))
+            {
+                return null;
+            }
 
+            // msbuild workspace doesn't set TFM if the project is not multi-targeted
+            var tfm = WatchHotReloadService.GetTargetFramework(project);
+            if (tfm == null)
+            {
+                return projectsWithPath[0];
+            }
+
+            return projectsWithPath.SingleOrDefault(p => string.Equals(p.ProjectNode.GetTargetFramework(), tfm, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private async ValueTask DisplayResultsAsync(WatchHotReloadService.Updates2 updates, ImmutableDictionary<ProjectId, WatchHotReloadService.RunningProjectInfo> runningProjectInfos, CancellationToken cancellationToken)
+        {
             switch (updates.Status)
             {
-                case ModuleUpdateStatus.None:
+                case WatchHotReloadService.Status.ReadyToApply:
+                    break;
+
+                case WatchHotReloadService.Status.NoChangesToApply:
                     _reporter.Report(MessageDescriptor.NoCSharpChangesToApply);
                     break;
 
-                case ModuleUpdateStatus.Ready:
-                    break;
-
-                case ModuleUpdateStatus.RestartRequired:
-                    if (anyProcessNeedsRestart)
-                    {
-                        _reporter.Output("Unable to apply hot reload, restart is needed to apply the changes.");
-                    }
-                    else
-                    {
-                        _reporter.Verbose("Rude edits detected but do not affect any running process");
-                    }
-
-                    break;
-
-                case ModuleUpdateStatus.Blocked:
+                case WatchHotReloadService.Status.Blocked:
                     _reporter.Output("Unable to apply hot reload due to compilation errors.");
                     break;
 
@@ -365,79 +373,91 @@ namespace Microsoft.DotNet.Watch
                     throw new InvalidOperationException();
             }
 
-            // Diagnostics include syntactic errors, semantic warnings/errors and rude edit warnigns/errors for members being updated.
+            if (!updates.ProjectsToRestart.IsEmpty)
+            {
+                _reporter.Output("Restart is needed to apply the changes.");
+            }
 
-            var diagnosticsToDisplay = new List<string>();
+            var diagnosticsToDisplayInApp = new List<string>();
 
             // Display errors first, then warnings:
-            Display(MessageSeverity.Error);
-            Display(MessageSeverity.Warning);
+            ReportCompilationDiagnostics(DiagnosticSeverity.Error);
+            ReportCompilationDiagnostics(DiagnosticSeverity.Warning);
+            ReportRudeEdits();
 
-            void Display(MessageSeverity severity)
+            // report or clear diagnostics in the browser UI
+            await ForEachProjectAsync(
+                _runningProjects,
+                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowserAsync([.. diagnosticsToDisplayInApp], cancellationToken).AsTask() ?? Task.CompletedTask,
+                cancellationToken);
+
+            void ReportCompilationDiagnostics(DiagnosticSeverity severity)
             {
-                foreach (var diagnostic in updates.Diagnostics)
+                foreach (var diagnostic in updates.CompilationDiagnostics)
                 {
-                    MessageDescriptor descriptor;
-
-                    if (diagnostic.Id == "ENC0118")
-                    {
-                        // Changing '<entry-point>' might not have any effect until the application is restarted.
-                        descriptor = MessageDescriptor.ApplyUpdate_ChangingEntryPoint;
-                    }
-                    else if (diagnostic.Id == "ENC1005")
-                    {
-                        // TODO: This warning is overreported in cases when the solution contains projects that are not rebuilt (up-to-date)
-                        // and a document is updated that is linked to such a project and another "active" project.
-                        // E.g. multi-tfm projects where only one TFM is currently built/running.
-
-                        // Warning: The current content of source file 'D:\Temp\App\Program.cs' does not match the built source.
-                        // Any changes made to this file while debugging won't be applied until its content matches the built source.
-                        descriptor = MessageDescriptor.ApplyUpdate_FileContentDoesNotMatchBuiltSource;
-                    }
-                    else if (diagnostic.Id == "CS8002")
+                    if (diagnostic.Id == "CS8002")
                     {
                         // TODO: This is not a useful warning. Compiler shouldn't be reporting this on .NET/
                         // Referenced assembly '...' does not have a strong name"
                         continue;
                     }
-                    else
-                    {
-                        // Use the default severity of the diagnostic as it conveys impact on Hot Reload
-                        // (ignore warnings as errors and other severity configuration).
-                        descriptor = diagnostic.DefaultSeverity switch
-                        {
-                            DiagnosticSeverity.Error => MessageDescriptor.ApplyUpdate_Error,
-                            DiagnosticSeverity.Warning => MessageDescriptor.ApplyUpdate_Warning,
-                            _ => MessageDescriptor.ApplyUpdate_Verbose,
-                        };
-                    }
 
-                    if (descriptor.Severity != severity)
+                    if (diagnostic.DefaultSeverity != severity)
                     {
                         continue;
                     }
 
-                    // Do not report rude edits as errors/warnings if no running process is affected.
-                    if (!anyProcessNeedsRestart && diagnostic.Id is ['E', 'N', 'C', >= '0' and <= '9', ..])
-                    {
-                        descriptor = descriptor with { Severity = MessageSeverity.Verbose };
-                    }
+                    ReportDiagnostic(diagnostic, GetMessageDescriptor(diagnostic));
+                }
+            }
 
-                    var display = CSharpDiagnosticFormatter.Instance.Format(diagnostic);
-                    _reporter.Report(descriptor, display);
+            void ReportRudeEdits()
+            {
+                // Rude edits in projects that caused restart of a project that can be restarted automatically
+                // will be reported only as verbose output.
+                var projectsRestartedDueToRudeEdits = updates.ProjectsToRestart
+                    .Where(e => runningProjectInfos.TryGetValue(e.Key, out var info) && info.RestartWhenChangesHaveNoEffect)
+                    .SelectMany(e => e.Value)
+                    .ToImmutableHashSet();
 
-                    if (descriptor.TryGetMessage(prefix: null, [display], out var message))
+                foreach (var (projectId, diagnostics) in updates.RudeEdits)
+                {
+                    foreach (var diagnostic in diagnostics)
                     {
-                        diagnosticsToDisplay.Add(message);
+                        var descriptor = GetMessageDescriptor(diagnostic);
+                        var prefix = "";
+
+                        if (projectsRestartedDueToRudeEdits.Contains(projectId))
+                        {
+                            descriptor = descriptor with { Severity = MessageSeverity.Verbose };
+                            prefix = "[auto-restart] ";
+                        }
+
+                        ReportDiagnostic(diagnostic, descriptor, prefix);
                     }
                 }
             }
 
-            // report or clear diagnostics in the browser UI
-            await ForEachProjectAsync(
-                _runningProjects,
-                (project, cancellationToken) => project.BrowserRefreshServer?.ReportCompilationErrorsInBrowserAsync(diagnosticsToDisplay.ToImmutableArray(), cancellationToken).AsTask() ?? Task.CompletedTask,
-                cancellationToken);
+            void ReportDiagnostic(Diagnostic diagnostic, MessageDescriptor descriptor, string prefix = "")
+            {
+                var display = CSharpDiagnosticFormatter.Instance.Format(diagnostic);
+                _reporter.Report(descriptor, prefix, [display]);
+
+                if (descriptor.TryGetMessage(prefix, [display], out var message))
+                {
+                    diagnosticsToDisplayInApp.Add(message);
+                }
+            }
+
+            // Use the default severity of the diagnostic as it conveys impact on Hot Reload
+            // (ignore warnings as errors and other severity configuration).
+            static MessageDescriptor GetMessageDescriptor(Diagnostic diagnostic)
+                => diagnostic.DefaultSeverity switch
+                {
+                    DiagnosticSeverity.Error => MessageDescriptor.ApplyUpdate_Error,
+                    DiagnosticSeverity.Warning => MessageDescriptor.ApplyUpdate_Warning,
+                    _ => MessageDescriptor.ApplyUpdate_Verbose,
+                };
         }
 
         public async ValueTask<bool> HandleStaticAssetChangesAsync(IReadOnlyList<ChangedFile> files, ProjectNodeMap projectMap, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReloadDotNetWatcher.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Watch
                     }
 
                     var projectMap = new ProjectNodeMap(evaluationResult.ProjectGraph, Context.Reporter);
-                    compilationHandler = new CompilationHandler(Context.Reporter, Context.EnvironmentOptions, shutdownCancellationToken);
+                    compilationHandler = new CompilationHandler(Context.Reporter, Context.EnvironmentOptions, Context.Options, shutdownCancellationToken);
                     var scopedCssFileHandler = new ScopedCssFileHandler(Context.Reporter, projectMap, browserConnector);
                     var projectLauncher = new ProjectLauncher(Context, projectMap, browserConnector, compilationHandler, iteration);
                     var outputDirectories = GetProjectOutputDirectories(evaluationResult.ProjectGraph);

--- a/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/IReporter.cs
@@ -74,7 +74,10 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor IgnoringChangeInHiddenDirectory = new("Ignoring change in hidden directory '{0}': {1} '{2}'", "⌚", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor IgnoringChangeInOutputDirectory = new("Ignoring change in output directory: {0} '{1}'", "⌚", MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor FileAdditionTriggeredReEvaluation = new("File addition triggered re-evaluation.", "⌚", MessageSeverity.Verbose, s_id++);
-        public static readonly MessageDescriptor NoCSharpChangesToApply = new ("No C# changes to apply.", "⌚", MessageSeverity.Output, s_id++);
+        public static readonly MessageDescriptor NoCSharpChangesToApply = new("No C# changes to apply.", "⌚", MessageSeverity.Output, s_id++);
+        public static readonly MessageDescriptor Exited = new("Exited", "⌚", MessageSeverity.Output, s_id++);
+        public static readonly MessageDescriptor ExitedWithUnknownErrorCode = new("Exited with unknown error code", "❌", MessageSeverity.Error, s_id++);
+        public static readonly MessageDescriptor ExitedWithErrorCode = new("Exited with error code {0}", "❌", MessageSeverity.Error, s_id++);
     }
 
     internal interface IReporter

--- a/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/ProcessRunner.cs
@@ -154,15 +154,15 @@ namespace Microsoft.DotNet.Watch
                 {
                     if (exitCode == 0)
                     {
-                        reporter.Output("Exited");
+                        reporter.Report(MessageDescriptor.Exited);
                     }
                     else if (exitCode == null)
                     {
-                        reporter.Error("Exited with unknown error code");
+                        reporter.Report(MessageDescriptor.ExitedWithUnknownErrorCode);
                     }
                     else
                     {
-                        reporter.Error($"Exited with error code {exitCode}");
+                        reporter.Report(MessageDescriptor.ExitedWithErrorCode, exitCode);
                     }
                 }
 

--- a/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/ProjectGraphNodeExtensions.cs
@@ -45,6 +45,9 @@ internal static class ProjectGraphNodeExtensions
     public static IEnumerable<string> GetCapabilities(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetItems("ProjectCapability").Select(item => item.EvaluatedInclude);
 
+    public static bool IsAutoRestartEnabled(this ProjectGraphNode projectNode)
+        => bool.TryParse(projectNode.ProjectInstance.GetPropertyValue("HotReloadAutoRestart"), out var result) && result;
+
     public static IEnumerable<ProjectGraphNode> GetTransitivelyReferencingProjects(this IEnumerable<ProjectGraphNode> projects)
     {
         var visited = new HashSet<ProjectGraphNode>();

--- a/test/TestAssets/TestProjects/WatchHotReloadApp/Program.cs
+++ b/test/TestAssets/TestProjects/WatchHotReloadApp/Program.cs
@@ -30,4 +30,4 @@ while (true)
     await Task.Delay(1000);
 }
 
-class C { }
+class C { /* member placeholder */ }

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -67,6 +67,83 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.AssertOutputLineStartsWith("Changed!");
         }
 
+        [Theory]
+        [CombinatorialData]
+        public async Task AutoRestartOnRudeEdit(bool nonInteractive)
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
+                .WithSource();
+
+            if (!nonInteractive)
+            {
+                testAsset = testAsset
+                    .WithProjectChanges(project =>
+                    {
+                        project.Root.Descendants()
+                            .First(e => e.Name.LocalName == "PropertyGroup")
+                            .Add(XElement.Parse("""
+                                <HotReloadAutoRestart>true</HotReloadAutoRestart>
+                                """));
+                    });
+            }
+
+            var programPath = Path.Combine(testAsset.Path, "Program.cs");
+
+            App.Start(testAsset, nonInteractive ? ["--non-interactive"] : []);
+
+            await App.AssertWaitingForChanges();
+            App.Process.ClearOutput();
+
+            // rude edit: adding virtual method
+            UpdateSourceFile(programPath, src => src.Replace("/* member placeholder */", "public virtual void F() {}"));
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+
+            App.AssertOutputContains("⌚ Restart is needed to apply the changes");
+            App.AssertOutputContains($"❌ [auto-restart] {programPath}(33,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task AutoRestartOnNoEffectEdit(bool nonInteractive)
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
+                .WithSource();
+
+            if (!nonInteractive)
+            {
+                testAsset = testAsset
+                    .WithProjectChanges(project =>
+                    {
+                        project.Root.Descendants()
+                            .First(e => e.Name.LocalName == "PropertyGroup")
+                            .Add(XElement.Parse("""
+                            <HotReloadAutoRestart>true</HotReloadAutoRestart>
+                            """));
+                    });
+            }
+
+            var programPath = Path.Combine(testAsset.Path, "Program.cs");
+
+            App.Start(testAsset, nonInteractive ? ["--non-interactive"] : []);
+
+            await App.AssertWaitingForChanges();
+            App.Process.ClearOutput();
+
+            // rude edit: adding virtual method
+            UpdateSourceFile(programPath, src => src.Replace("Started", "<Updated>"));
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+
+            App.AssertOutputContains("⌚ Restart is needed to apply the changes");
+            App.AssertOutputContains($"⚠ [auto-restart] {programPath}(16,19): warning ENC0118: Changing 'top-level code' might not have any effect until the application is restarted.");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            App.AssertOutputContains("<Updated>");
+        }
+
         /// <summary>
         /// Unchanged project doesn't build. Wait for source change and rebuild.
         /// </summary>
@@ -682,7 +759,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             await App.AssertOutputLineStartsWith("  ❔ Do you want to restart these projects? Yes (y) / No (n) / Always (a) / Never (v)");
 
-            App.AssertOutputContains("dotnet watch ⌚ Unable to apply hot reload, restart is needed to apply the changes.");
+            App.AssertOutputContains("dotnet watch ⌚ Restart is needed to apply the changes.");
             App.AssertOutputContains("error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
             App.AssertOutputContains("dotnet watch ⌚ Affected projects:");
             App.AssertOutputContains("dotnet watch ⌚   WatchAspire.ApiService");

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -120,8 +120,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
                         project.Root.Descendants()
                             .First(e => e.Name.LocalName == "PropertyGroup")
                             .Add(XElement.Parse("""
-                            <HotReloadAutoRestart>true</HotReloadAutoRestart>
-                            """));
+                                <HotReloadAutoRestart>true</HotReloadAutoRestart>
+                                """));
                     });
             }
 

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
 
             App.AssertOutputContains("⌚ Restart is needed to apply the changes");
-            App.AssertOutputContains($"❌ [auto-restart] {programPath}(33,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
+            App.AssertOutputContains($"⌚ [auto-restart] {programPath}(33,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
             App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
             App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
         }
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
 
             App.AssertOutputContains("⌚ Restart is needed to apply the changes");
-            App.AssertOutputContains($"⚠ [auto-restart] {programPath}(16,19): warning ENC0118: Changing 'top-level code' might not have any effect until the application is restarted.");
+            App.AssertOutputContains($"⌚ [auto-restart] {programPath}(16,19): warning ENC0118: Changing 'top-level code' might not have any effect until the application is restarted.");
             App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
             App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
             App.AssertOutputContains("<Updated>");

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -27,7 +27,7 @@ public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTest
             reporter);
 
         var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: false);
-        var handler = new CompilationHandler(reporter, environmentOptions, CancellationToken.None);
+        var handler = new CompilationHandler(reporter, environmentOptions, new GlobalOptions(), CancellationToken.None);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);
 

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -526,7 +526,6 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         Log("Waiting for change handled ...");
         await changeHandled.WaitAsync(w.ShutdownSource.Token);
 
-        w.Reporter.ProcessOutput.Contains("verbose ⌚ Rude edits detected but do not affect any running process");
         w.Reporter.ProcessOutput.Contains($"verbose ❌ {serviceSourceA2}(1,12): error ENC0003: Updating 'attribute' requires restarting the application.");
     }
 

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -503,6 +503,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
         var changeHandled = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadChangeHandled);
         var sessionStarted = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadSessionStarted);
+        var applyUpdateVerbose = w.Reporter.RegisterSemaphore(MessageDescriptor.ApplyUpdate_Verbose);
 
         // let the host process start:
         Log("Waiting for changes...");
@@ -516,6 +517,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await sessionStarted.WaitAsync(w.ShutdownSource.Token);
 
         // Terminate the process:
+        Log($"Terminating process {runningProject.ProjectNode.GetDisplayName()} ...");
         await w.Service.ProjectLauncher.TerminateProcessAsync(runningProject, CancellationToken.None);
 
         // rude edit in A (changing assembly level attribute):
@@ -526,7 +528,8 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         Log("Waiting for change handled ...");
         await changeHandled.WaitAsync(w.ShutdownSource.Token);
 
-        w.Reporter.ProcessOutput.Contains($"verbose ❌ {serviceSourceA2}(1,12): error ENC0003: Updating 'attribute' requires restarting the application.");
+        Log("Waiting for verbose rude edit reported ...");
+        await applyUpdateVerbose.WaitAsync(w.ShutdownSource.Token);
     }
 
     public enum DirectoryKind


### PR DESCRIPTION
Using APIs added in https://github.com/dotnet/roslyn/pull/78220, implements auto-restart of a project that has `HotReloadAutoRestart` property set, or any project if `--non-interactive` is passed on command line.
dotnet-watch automatically terminates associated processes, rebuilds and re-launches the project whenever a rude edit or no-effect change is detected.