### PR TITLE
Remove unnecessary CA2022 suppressions

### DIFF
--- a/src/RazorSdk/Tool/Client.cs
+++ b/src/RazorSdk/Tool/Client.cs
@@ -171,9 +171,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
-#pragma warning disable CA2022 // Avoid inexact read
-                        await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
-#pragma warning restore CA2022
+                        _ = await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }
                     catch (OperationCanceledException)

--- a/src/RazorSdk/Tool/Client.cs
+++ b/src/RazorSdk/Tool/Client.cs
@@ -171,6 +171,8 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
+                        // Stream.ReadExactlyAsync with a zero-length buffer will not update the state of the pipe.
+                        // We need to trigger a state update without actually reading the data.
                         _ = await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }

--- a/src/RazorSdk/Tool/ConnectionHost.cs
+++ b/src/RazorSdk/Tool/ConnectionHost.cs
@@ -107,9 +107,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
-#pragma warning disable CA2022 // Avoid inexact read
-                        await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
-#pragma warning restore CA2022
+                        _ = await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }
                     catch (OperationCanceledException)

--- a/src/RazorSdk/Tool/ConnectionHost.cs
+++ b/src/RazorSdk/Tool/ConnectionHost.cs
@@ -107,6 +107,8 @@ namespace Microsoft.NET.Sdk.Razor.Tool
                     try
                     {
                         ServerLogger.Log($"Before poking pipe {Identifier}.");
+                        // Stream.ReadExactlyAsync with a zero-length buffer will not update the state of the pipe.
+                        // We need to trigger a state update without actually reading the data.
                         _ = await Stream.ReadAsync(Array.Empty<byte>(), 0, 0, cancellationToken);
                         ServerLogger.Log($"After poking pipe {Identifier}.");
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4322

- Remove all the unnecessary CA2022 suppressions.
- Keep `Stream.ReadAsync` method.
In the code, we need to trigger a state update on a `Pipestream` without actualy reading data. Using `Stream.ReadExactlyAsync` with a zero-length buffer will not update the state of the pipe: https://github.com/dotnet/sdk/pull/47904#discussion_r2020793538