### PR TITLE
Fix source-only jobs to not test in UB

### DIFF
--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -96,8 +96,9 @@ stages:
           pool: ${{ parameters.pool_Linux }}
         buildSourceOnly: true
         ${{ if eq(parameters.useMicrosoftBuildAssetsForTests, false) }}:
-          runTests: false
           extraProperties: "/p:DisableDevBuildAsDefaultForSourceOnly=true"
+        ${{ else }}:
+          runTests: false
         buildFromArchive: ${{ leg.buildFromArchive }}
         runOnline: ${{ leg.runOnline }}
         useMonoRuntime: ${{ leg.useMonoRuntime }}


### PR DESCRIPTION
The source-only jobs are failing in the UB pipeline because they are attempting to test in the same job as the build occurs. Testing is supposed to be disabled in those jobs as it happens later in a separate stage. Fixed the logic to correctly set this state.