### PR TITLE
Flow enablePoison parameter to VMR build

### DIFF
--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -99,6 +99,7 @@ stages:
           extraProperties: "/p:DisableDevBuildAsDefaultForSourceOnly=true"
         ${{ else }}:
           runTests: false
+        enablePoison: ${{ leg.enablePoison }}
         buildFromArchive: ${{ leg.buildFromArchive }}
         runOnline: ${{ leg.runOnline }}
         useMonoRuntime: ${{ leg.useMonoRuntime }}


### PR DESCRIPTION
The `CentOSStream9_Offline_PreviousSourceBuiltSdk_Validation_x64` leg is failing in the `Microsoft.DotNet.SourceBuild.Tests.PoisonTests.VerifyUsage` test with the following error:

`System.InvalidOperationException : Poison report '/__w/1/s/artifacts/prebuilt-report/poison-usage.xml' does not exist.`

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2698546) (internal link)

This occurs because the `CentOSStream9_Offline_PreviousSourceBuiltSdk_x64` leg which ran the build was supposed to enable poison reporting but did not do so. This is because I accidentally omitted some YAML configuration from https://github.com/dotnet/sdk/pull/48703 that I had done my testing with. 