### PR TITLE
Add GitHub Action workflow to update man pages

### DIFF
--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -1,0 +1,39 @@
+name: Update man-pages workflow
+on:
+  schedule:
+    - cron: "42 3 1/15 * *"   # Trigger every 15 days at 03:42
+    #- cron: "0,5,10,15,20,25,30,35,40,45,50,55 * * * *"  # For testing
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-man-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Update man-pages
+        run: |
+          set -euo pipefail
+
+          rm ./documentation/manpages/sdk/*
+
+          ./documentation/manpages/tool/run_docker.sh
+
+          if [[ -n $(git status -s) ]]; then
+            git config user.name 'TODO'
+            git config user.email 'TODO@example.com'
+            date=$(date +%F)
+            git add .
+            title="Update man pages"
+            branch=update-man-page-$date
+            git checkout -b $branch
+            git commit -a -m "$title"
+            git push -u origin $branch --force
+            gh pr create --base main --head $branch --title "$title" --body "Auto-generated"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -24,16 +24,17 @@ jobs:
           ./documentation/manpages/tool/run_docker.sh
 
           if [[ -n $(git status -s) ]]; then
-            git config user.name 'TODO'
-            git config user.email 'TODO@example.com'
+            git config user.name 'github-actions'
+            git config user.email 'github-actions@github.com'
             date=$(date +%F)
             git add .
-            title="Update man pages"
+            title="[automated] Update man pages"
+            body="This action is executed twice a month to automatically update the manpages based on the latest changes to the dotnet/docs repo"
             branch=update-man-page-$date
             git checkout -b $branch
             git commit -a -m "$title"
             git push -u origin $branch --force
-            gh pr create --base main --head $branch --title "$title" --body "Auto-generated"
+            gh pr create --base main --head $branch --title "$title" --body "$body"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/documentation/manpages/tool/update-man-pages.sh
+++ b/documentation/manpages/tool/update-man-pages.sh
@@ -55,4 +55,4 @@ ls docs-main/docs/core/tools/dotnet*.md | while read -r file;
       "$file" -o "${command_name}"."${man_page_section}"
 done
 
-# rm -rf docs-main
+rm -rf docs-main


### PR DESCRIPTION
This repo contains man pages. They are generated from another repo, and need to be updated manually. Generally, someone updates them once a year or so, and often it's too late for GA:

- https://github.com/dotnet/sdk/pull/36447
- https://github.com/dotnet/sdk/pull/29032

So automate the update using GitHub Actions.