### PR TITLE
Bring back PublishDotnetWatch

### DIFF
--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -4,6 +4,8 @@
   <Import Project="..\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
   <Import Project="..\HotReloadAgent.Data\Microsoft.DotNet.HotReload.Agent.Data.projitems" Label="Shared" />
 
+  <Import Project="$(RepoRoot)\src\Layout\redist\targets\PublishDotnetWatch.targets" />
+
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>exe</OutputType>
@@ -43,5 +45,12 @@
     <ProjectReference Include="..\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" TargetPath="hotreload\Microsoft.Extensions.DotNetDeltaApplier.dll" CopyToOutputDirectory="PreserveNewest" />
     <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <!--
+    Publish the dotnet-watch binaries to the redist directory (artifacts\bin\redist\{config}\dotnet\sdk\{version}\DotnetTools).
+    These files are used for layout generation in redist project.
+    Tests are also running dotnet.exe from redist artifacts.
+  -->
+  <Target Name="PublishToRedist" DependsOnTargets="PublishDotnetWatchToRedist" BeforeTargets="AfterBuild" />
 
 </Project>

--- a/src/Layout/redist/targets/Directory.Build.targets
+++ b/src/Layout/redist/targets/Directory.Build.targets
@@ -10,6 +10,7 @@
 
   <ImportGroup Condition="'$(GenerateSdkBundleOnly)' != 'true'">
     <Import Project="BundledSdks.targets" />
+    <Import Project="PublishDotnetWatch.targets" />
     <Import Project="BundledDotnetTools.targets" />
     <Import Project="GenerateBundledVersions.targets" />
     <Import Project="GeneratePackagePruneData.targets" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -415,34 +415,6 @@
                                    AssetPath="%(NuPkgContentForMSBuildExtensionsRelativePaths.Identity)" />
   </Target>
 
-  <Target Name="PublishDotnetWatchToRedist">
-    <ItemGroup>
-      <_DotnetWatchBuildOutput Include="$(ArtifactsBinDir)dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**"/>
-
-      <!--
-        To reduce the size of the SDK, we use the compiler dependencies that are located in the `Roslyn/bincore` location
-        instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
-        dotnet-watch executable.
-
-        We make an exception for the Microsoft.CodeAnalysis binaries deployed with the MSBuildWorkspace BuildHosts, since those don't
-        have any logic to pick up Roslyn from another location. Those can be addressed a different way which tracked in
-        https://github.com/dotnet/roslyn/issues/70945.
-      -->
-      <_DotnetWatchInputFile Include="@(_DotnetWatchBuildOutput)"
-                             Condition="('%(Filename)' != 'Microsoft.CodeAnalysis' and
-                                         '%(Filename)' != 'Microsoft.CodeAnalysis.resources' and
-                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp' and
-                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp.resources') or
-                                        $([MSBuild]::ValueOrDefault('%(FullPath)', '').Contains('BuildHost'))" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_DotnetWatchInputFile)"
-          DestinationFiles="@(_DotnetWatchInputFile->'$(OutputPath)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true">
-      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
-    </Copy>
-  </Target>
-
   <Target Name="CopyKnownWorkloadManifestFile">
     <ItemGroup>
       <WorkloadManifestFilesContent Include="$([MSBuild]::ValueOrDefault('%(BundledManifests.Identity)', '').ToLowerInvariant())" />

--- a/src/Layout/redist/targets/PublishDotnetWatch.targets
+++ b/src/Layout/redist/targets/PublishDotnetWatch.targets
@@ -1,0 +1,34 @@
+<Project>
+  <Target Name="PublishDotnetWatchToRedist">
+    <PropertyGroup>
+      <DotnetWatchRedistOutputDirectory>$(ArtifactsDir)bin\redist\$(Configuration)\dotnet\sdk\$(Version)\DotnetTools\dotnet-watch\</DotnetWatchRedistOutputDirectory>
+      <DotnetWatchRedistOutputSubdirectory>$(Version)\tools\$(SdkTargetFramework)\any\</DotnetWatchRedistOutputSubdirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_DotnetWatchBuildOutput Include="$(ArtifactsDir)bin\dotnet-watch\$(Configuration)\$(SdkTargetFramework)\**"/>
+
+      <!--
+        To reduce the size of the SDK, we use the compiler dependencies that are located in the `Roslyn/bincore` location
+        instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
+        dotnet-watch executable.
+
+        We make an exception for the Microsoft.CodeAnalysis binaries deployed with the MSBuildWorkspace BuildHosts, since those don't
+        have any logic to pick up Roslyn from another location. Those can be addressed a different way which tracked in
+        https://github.com/dotnet/roslyn/issues/70945.
+      -->
+      <_DotnetWatchInputFile Include="@(_DotnetWatchBuildOutput)"
+                             Condition="('%(Filename)' != 'Microsoft.CodeAnalysis' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.resources' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp.resources') or
+                                        $([MSBuild]::ValueOrDefault('%(FullPath)', '').Contains('BuildHost'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_DotnetWatchInputFile)"
+          DestinationFiles="@(_DotnetWatchInputFile->'$(DotnetWatchRedistOutputDirectory)$(DotnetWatchRedistOutputSubdirectory)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+</Project>


### PR DESCRIPTION
Revert parts of https://github.com/dotnet/sdk/pull/47767, which broke inner dev loop for dotnet-watch tests.
dotnet-watch project build needs to deploy to redist directory, so that any updates to dotnet-watch are picked up by dotnet-watch tests.