### PR TITLE
Adjust dotnet test UX (for MTP)

### DIFF
--- a/test/TestAssets/TestProjects/TestAppSimpleWithRetry/TestAppSimpleWithRetry.csproj
+++ b/test/TestAssets/TestProjects/TestAppSimpleWithRetry/TestAppSimpleWithRetry.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <!-- Use of crash dump is to ensure we are testing the UX in case a test host controller exists -->
+	<TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --retry-failed-tests 3 --crashdump</TestingPlatformCommandLineArguments>
+	<EnableMSTestRunner>true</EnableMSTestRunner>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="$(MSTestVersion)" />
+	<PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$(MicrosoftTestingPlatformVersion)" />
+	<PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestAppSimpleWithRetry/TestClass1.cs
+++ b/test/TestAssets/TestProjects/TestAppSimpleWithRetry/TestClass1.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class TestClass1
+{
+    [TestMethod]
+    public void TestMethod1()
+    {
+        if (Environment.GetCommandLineArgs().Any(arg => arg.Contains("Retries") && !arg.EndsWith("2")))
+        {
+            Assert.Fail("Failing...");
+        }
+    }
+}

--- a/test/TestAssets/TestProjects/TestAppSimpleWithRetry/dotnet.config
+++ b/test/TestAssets/TestProjects/TestAppSimpleWithRetry/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"


### PR DESCRIPTION
Related to #45927

Previously, we were calling AssemblyRunStarted twice for a single assembly for the case where a test host controller is involved (e.g, an extension such as crash dump, etc). In this case, both the test host and test host controller will handshake with us. This PR modifies the logic to only call AssemblyRunStarted when we are handshaking with the test host. I'm also refactoring a bit the retry logic.