### PR TITLE
Fix build ordering issue when dotnet-sdk depends on redist

### DIFF
--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
@@ -24,12 +24,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <RuntimeAnalyzersContent Include="$(ArtifactsBinDir)Microsoft.Net.Sdk.AnalyzerRedirecting\$(Configuration)\net472\**\*.*" DeploymentSubpath="AnalyzerRedirecting" />
-      <RuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.NetCore.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="NetCoreAnalyzers" />
-      <RuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.WindowsDesktop.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="WindowsDesktopAnalyzers" />
-      <RuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.AspNetCore.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="AspNetCoreAnalyzers" />
-      <RuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk\analyzers\**\*.*" DeploymentSubpath="SDKAnalyzers" />
-      <RuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk.Web\analyzers\**\*.*" DeploymentSubpath="WebSDKAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.NetCore.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="NetCoreAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.WindowsDesktop.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="WindowsDesktopAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.AspNetCore.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="AspNetCoreAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk\analyzers\**\*.*" DeploymentSubpath="SDKAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk.Web\analyzers\**\*.*" DeploymentSubpath="WebSDKAnalyzers" />
+      <RedirectingRuntimeAnalyzersContent Include="$(ArtifactsBinDir)Microsoft.Net.Sdk.AnalyzerRedirecting\$(Configuration)\net472\**\*.*" DeploymentSubpath="AnalyzerRedirecting" />
+    </ItemGroup>
+
+    <Error Condition="'@(RedistRuntimeAnalyzersContent)' == ''" Text="The 'RedistRuntimeAnalyzersContent' items are empty. This shouldn't happen!" />
+    <Error Condition="'@(RedirectingRuntimeAnalyzersContent)' == ''" Text="The 'RedirectingRuntimeAnalyzersContent' items are empty. This shouldn't happen!" />
+
+    <ItemGroup>
+      <RuntimeAnalyzersContent Include="@(RedistRuntimeAnalyzersContent);@(RedirectingRuntimeAnalyzersContent)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(RuntimeAnalyzersContent)"

--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -29,7 +29,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\redist\redist.csproj" ReferenceOutputAssembly="false" />
+    <!-- The PublishToDisk target which depends on ResolveProjectReferences is invoked with OutputPath as an global property
+         which would flow to redist.csproj. -->
+    <ProjectReference Include="..\redist\redist.csproj" ReferenceOutputAssembly="false" GlobalPropertiesToRemove="OutputPath" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +44,7 @@
     <ManpagesDirectory>$(RepoRoot)documentation/manpages/sdk</ManpagesDirectory>
   </PropertyGroup>
 
-  <Target Name="PublishToDisk">
+  <Target Name="PublishToDisk" DependsOnTargets="ResolveProjectReferences">
     <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
 
     <ItemGroup>
@@ -52,6 +54,7 @@
     </ItemGroup>
 
     <!-- Create layout: Binaries -->
+    <Error Condition="'@(CLISdkFiles)' == ''" Text="The 'CLISdkFiles' items are empty. This shouldn't happen!" />
     <Copy
       DestinationFiles="@(CLISdkFiles->'$(OutputPath)/sdk/%(RecursiveDir)%(Filename)%(Extension)')"
       SourceFiles="@(CLISdkFiles)"
@@ -60,6 +63,7 @@
       UseHardlinksIfPossible="False" />
 
     <!-- Create layout: Templates -->
+    <Error Condition="'@(TemplatesFiles)' == ''" Text="The 'TemplatesFiles' items are empty. This shouldn't happen!" />
     <Copy
       DestinationFiles="@(TemplatesFiles->'$(OutputPath)/templates/%(RecursiveDir)%(Filename)%(Extension)')"
       SourceFiles="@(TemplatesFiles)"
@@ -68,6 +72,7 @@
       UseHardlinksIfPossible="False" />
 
     <!-- Create layout: Workload Manifests -->
+    <Error Condition="'@(ManifestFiles)' == ''" Text="The 'ManifestFiles' items are empty. This shouldn't happen!" />
     <Copy
       DestinationFiles="@(ManifestFiles->'$(OutputPath)/sdk-manifests/%(RecursiveDir)%(Filename)%(Extension)')"
       SourceFiles="@(ManifestFiles)"

--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -194,14 +194,9 @@
     <!-- Move symbols to separate folder, they are not included in the layout but are published separately -->
     <Move SourceFiles="@(PdbsToMove)"
           DestinationFiles="@(PdbsToMove->'$(ArtifactsSymStoreDirectory)/sdk/$(Version)/%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
 
-  <Target Name="ChmodLayout"
-        AfterTargets="CrossgenLayout"
-        Condition=" '$(OSName)' != 'win' ">
-
-    <Exec Command="find $(InstallerOutputDirectory) -type d -exec chmod 755 {} \;" />
-    <Exec Command="find $(InstallerOutputDirectory) -type f -exec chmod 644 {} \;" />
+    <Exec Command="find $(InstallerOutputDirectory) -type d -exec chmod 755 {} \;" Condition="'$(OSName)' != 'win'" />
+    <Exec Command="find $(InstallerOutputDirectory) -type f -exec chmod 644 {} \;" Condition="'$(OSName)' != 'win'" />
   </Target>
 
 </Project>

--- a/src/Layout/redist/targets/GenerateArchives.targets
+++ b/src/Layout/redist/targets/GenerateArchives.targets
@@ -2,7 +2,7 @@
 
   <Target Name="GenerateArchives"
           DependsOnTargets="GenerateInstallerLayout"
-          AfterTargets="Build">
+          AfterTargets="AfterBuild">
     <!-- When running in Docker under a Windows host, tar is warning "file changed as we read it" for several files and returning exit code 1.
          So this flag allows that to be ignored. -->
     <PropertyGroup Condition="'$(IgnoreTarExitCode)' == ''">

--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -83,7 +83,7 @@
                             LayoutWorkloadUserLocalMarker;
                             CrossgenLayout;
                             ReplaceBundledRuntimePackFilesWithSymbolicLinks"
-          AfterTargets="Build" />
+          AfterTargets="AfterBuild" />
 
   <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is
        necessary for the msi/pkg to install correctly and put the content under that sub path. -->

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -546,6 +546,6 @@
                             RetargetTools;
                             RemoveResourcesFromDotnetDeps;
                             ChmodPublishDir"
-          AfterTargets="Build" />
+          AfterTargets="AfterBuild" />
 
 </Project>

--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -378,7 +378,7 @@
   </Target>
 
   <Target Name="GenerateMsis"
-          AfterTargets="Build"
+          AfterTargets="AfterBuild"
           DependsOnTargets="$(GenerateMsisDependsOn)" />
 
 </Project>

--- a/src/Layout/redist/targets/GeneratePKG.targets
+++ b/src/Layout/redist/targets/GeneratePKG.targets
@@ -226,7 +226,7 @@
   </Target>
 
   <Target Name="GeneratePkgs"
-          AfterTargets="Build"
+          AfterTargets="AfterBuild"
           DependsOnTargets="GenerateSdkPkg;GenerateSdkProductArchive" />
 
 </Project>

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -4,7 +4,7 @@
     <TestHostFolder>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</TestHostFolder>
   </PropertyGroup>
 
-  <Target Name="OverlaySdkOnLKG" AfterTargets="Build" DependsOnTargets="GenerateInstallerLayout">
+  <Target Name="OverlaySdkOnLKG" AfterTargets="AfterBuild" DependsOnTargets="GenerateInstallerLayout">
     <PropertyGroup>
       <_DotNetHiveRoot>$(DOTNET_INSTALL_DIR)</_DotNetHiveRoot>
       <_DotNetHiveRoot Condition="'$(_DotNetHiveRoot)' == ''">$(RepoRoot).dotnet/</_DotNetHiveRoot>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/48785

The DependsOnTargets was missing