### PR TITLE
[10.0.1xx-preview4] Propagate DotNetReleaseShipping to the vertical manifests

### DIFF
--- a/src/SourceBuild/content/eng/Publishing.props
+++ b/src/SourceBuild/content/eng/Publishing.props
@@ -60,6 +60,7 @@
         <IsShipping Condition="'%(ProducedPackage.NonShipping)' == 'true'">false</IsShipping>
         <Kind>Package</Kind>
         <PackageId>%(Identity)</PackageId>
+        <ManifestArtifactData Condition="'%(ProducedPackage.DotNetReleaseShipping)' != ''">DotNetReleaseShipping=%(ProducedPackage.DotNetReleaseShipping)</ManifestArtifactData>
       </ProducedPackage>
       <ProducedPackage>
         <ShippingFolder Condition="'%(ProducedPackage.NonShipping)' != 'true'">Shipping</ShippingFolder>
@@ -76,6 +77,7 @@
       <Artifact Include="@(ProducedAsset->'$(ArtifactsAssetsDir)%(Identity)')">
         <Kind>Blob</Kind>
         <RelativeBlobPath>%(ProducedAsset.Identity)</RelativeBlobPath>
+        <ManifestArtifactData Condition="'%(ProducedAsset.DotNetReleaseShipping)' != ''">DotNetReleaseShipping=%(ProducedAsset.DotNetReleaseShipping)</ManifestArtifactData>
       </Artifact>
     </ItemGroup>
 


### PR DESCRIPTION
Make sure that we propagate the `DotNetReleaseShipping` attribute from the individual repo manifests to the vertical manifests (and the final merged manifest) so staging can stage the right assets.

Fixes dotnet/source-build#5119
Fixes https://github.com/dotnet/source-build/issues/5117