### PR TITLE
draft: hack together arbitrary container layer support for SDK Containers

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/BuiltImage.cs
@@ -26,7 +26,7 @@ internal readonly struct BuiltImage
     /// <summary>
     /// Gets image manifest.
     /// </summary>
-    internal required string Manifest { get; init; } 
+    internal required string Manifest { get; init; }
 
     /// <summary>
     /// Gets manifest digest.
@@ -41,7 +41,7 @@ internal readonly struct BuiltImage
     /// <summary>
     /// Gets image layers.
     /// </summary>
-    internal List<ManifestLayer>? Layers { get; init; }
+    internal List<(ManifestLayer, LayerKind)>? Layers { get; init; }
 
     /// <summary>
     /// Gets image OS.
@@ -60,8 +60,8 @@ internal readonly struct BuiltImage
     {
         get
         {
-            List<ManifestLayer> layersNode = Layers ?? throw new NotImplementedException("Tried to get layer information but there is no layer node?");
-            foreach (ManifestLayer layer in layersNode)
+            List<(ManifestLayer, LayerKind)> layersNode = Layers ?? throw new NotImplementedException("Tried to get layer information but there is no layer node?");
+            foreach ((ManifestLayer layer, _) in layersNode)
             {
                 yield return new(layer.mediaType, layer.digest, layer.size);
             }

--- a/src/Containers/Microsoft.NET.Build.Containers/ContentStore.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContentStore.cs
@@ -37,7 +37,7 @@ internal static class ContentStore
     {
         string digest = descriptor.Digest;
 
-        Debug.Assert(digest.StartsWith("sha256:", StringComparison.Ordinal));
+        Debug.Assert(digest.StartsWith("sha256:", StringComparison.Ordinal), $"digest {digest} does not start with sha256:");
 
         string contentHash = digest.Substring("sha256:".Length);
 

--- a/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/DigestUtils.cs
@@ -37,4 +37,20 @@ internal sealed class DigestUtils
 
         return Convert.ToHexStringLower(hash);
     }
+
+    internal static bool IsValidDigest(string digest)
+    {
+        if (string.IsNullOrEmpty(digest))
+        {
+            return false;
+        }
+
+        if (!digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string sha = GetShaFromDigest(digest);
+        return sha.Length == SHA256.HashSizeInBytes * 2;
+    }
 }

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -201,7 +201,7 @@ internal class Layer
 
         string layerMediaType = manifestMediaType switch
         {
-             // TODO: configurable? gzip always?
+            // TODO: configurable? gzip always?
             SchemaTypes.DockerManifestV2 => SchemaTypes.DockerLayerGzip,
             SchemaTypes.OciManifestV1 => SchemaTypes.OciLayerGzipV1,
             _ => throw new ArgumentException(Resource.FormatString(nameof(Strings.UnrecognizedMediaType), manifestMediaType))

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -186,6 +186,8 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFramewor
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFrameworkVersion.set -> void
 override Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.Execute() -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.AdditionalLayers.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.AdditionalLayers.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageTag.get -> string!

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -25,6 +25,8 @@ Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.PortType.tcp = 0 -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.PortType.udp = 1 -> Microsoft.NET.Build.Containers.PortType
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.AdditionalLayers.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.AdditionalLayers.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageTag.get -> string!
@@ -100,6 +102,7 @@ override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolName.get -> str
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateCommandLineCommands() -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateFullPathToTool() -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GetProcessStartInfo(string! pathToTool, string! commandLineCommands, string! responseFileSwitch) -> System.Diagnostics.ProcessStartInfo!
+override Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.Execute() -> bool
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ContainerEnvironmentVariables.set -> void
@@ -145,4 +148,3 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.get
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.SdkVersion.set -> void
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFrameworkVersion.get -> string!
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFrameworkVersion.set -> void
-override Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.Execute() -> bool

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateImageIndex.cs
@@ -84,7 +84,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
         var telemetry = new Telemetry(sourceImageReference, destinationImageReference, Log);
 
         await ImagePublisher.PublishImageAsync(multiArchImage, sourceImageReference, destinationImageReference, Log, telemetry, cancellationToken)
-            .ConfigureAwait(false); 
+            .ConfigureAwait(false);
 
         return !Log.HasLoggedErrors;
     }
@@ -127,7 +127,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
                 imageDigest = manifestV2.Config.digest;
                 imageSha = DigestUtils.GetShaFromDigest(imageDigest);
                 layers = manifestV2.Layers;
-            }     
+            }
 
             images[i] = new BuiltImage()
             {
@@ -137,7 +137,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
                 Manifest = manifest,
                 ManifestDigest = manifestDigest,
                 ManifestMediaType = manifestMediaType,
-                Layers = layers,
+                Layers = layers?.Select(l => (l, LayerKind.BaseImage)).ToList(),
                 OS = os,
                 Architecture = architecture
             };
@@ -159,7 +159,7 @@ public sealed partial class CreateImageIndex : Microsoft.Build.Utilities.Task, I
         {
             Log.LogError(Strings.ImageConfigMissingArchitecture);
             return (string.Empty, string.Empty);
-        } 
+        }
         var os = configJson["os"]?.ToString();
         if (os is null)
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -174,6 +174,8 @@ partial class CreateNewImage
     /// </summary>
     public bool SkipPublishing { get; set; }
 
+    public ITaskItem[] AdditionalLayers { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 
@@ -236,5 +238,7 @@ partial class CreateNewImage
         GenerateDigestLabel = false;
 
         TaskResources = Resource.Manager;
+
+        AdditionalLayers = Array.Empty<ITaskItem>();
     }
 }

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -287,7 +287,8 @@
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
                     SkipPublishing="$(_SkipContainerPublishing)"
                     GenerateLabels="$(ContainerGenerateLabels)"
-                    GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"> <!-- The RID graph path is provided as a property by the SDK. -->
+                    GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"
+                    AdditionalLayers="@(ContainerAdditionalLayer)">
 
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />


### PR DESCRIPTION
Putting this up as a checkpoint - this works now. 

Add

```xml
	<ItemGroup Condition="$(RuntimeIdentifier) == 'linux-x64'">
		<ContainerAdditionalLayer Include="sha256:5d07f997927bfbc756cee47f7bb55825a1315fae3d1d9697411b3fe478058ddf" 
			Registry="docker.io" 
			Repository="appdynamics/dotnet-core-agent"
			MediaType="application/vnd.docker.image.rootfs.diff.tar.gzip"
			Size="13558922" />
	</ItemGroup>
	<ItemGroup Condition="$(RuntimeIdentifier) == 'linux-arm64'">
		<ContainerAdditionalLayer Include="sha256:6b24f8c3a780589d68e6f09b3b45dcb499b446db54727d89b73ea5e4e1d081eb" 
		Registry="docker.io" 
		Repository="appdynamics/dotnet-core-agent"
		MediaType="application/vnd.docker.image.rootfs.diff.tar.gzip"
		Size="13576182" />
	</ItemGroup>
```

to a project file and publish for various RIDs to see it working.