### PR TITLE
Don't flow OutputPath global property in dotnet-sdk.proj

### DIFF
--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -26,15 +26,13 @@
     -->
     <InstallerRuntimeIdentifiers>linux-$(TargetArchitecture)</InstallerRuntimeIdentifiers>
     <IsShippingPackage>true</IsShippingPackage>
+    <!-- The PublishToDisk target which depends on ResolveProjectReferences is invoked with OutputPath as an global property
+         which would flow to redist.csproj or sdk-tasks.csproj. -->
+    <_GlobalPropertiesToRemoveFromProjectReferences>$(_GlobalPropertiesToRemoveFromProjectReferences);OutputPath</_GlobalPropertiesToRemoveFromProjectReferences>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- The PublishToDisk target which depends on ResolveProjectReferences is invoked with OutputPath as an global property
-         which would flow to redist.csproj. -->
-    <ProjectReference Include="..\redist\redist.csproj" ReferenceOutputAssembly="false" GlobalPropertiesToRemove="OutputPath" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <ProjectReference Include="..\redist\redist.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" />
   </ItemGroup>
 


### PR DESCRIPTION
Noticed in https://github.com/dotnet/dotnet/pull/374 -> dotnet-sdk.proj imports sdk-tasks.targets which defines a P2P to sdk-tasks.csproj which incorrectly receives the globally set OutputPath property.

The PublishToDisk target receives the globally set OutputPath property that signals where to publish the files to. This property should never flow to referenced projects as that would result in a race.

@jkoritzinsky I think it would've been better to choose a different property name for PublishToDisk or mark the property as never to flow to P2Ps (that's what this PR does).