### PR TITLE
Add default for dotnet reference list Fixes #48555

### DIFF
--- a/src/Cli/dotnet/Commands/Hidden/Add/Package/AddPackageCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Hidden/Add/Package/AddPackageCommandParser.cs
@@ -41,7 +41,7 @@ internal static class AddPackageCommandParser
             }
             else
             {
-                return new PackageAddCommand(parseResult, parseResult.GetValue(AddCommandParser.ProjectArgument)).Execute();
+                return new PackageAddCommand(parseResult, parseResult.GetValue(AddCommandParser.ProjectArgument) ?? Directory.GetCurrentDirectory()).Execute();
             }
         });
 

--- a/src/Cli/dotnet/Commands/Reference/List/ReferenceListCommand.cs
+++ b/src/Cli/dotnet/Commands/Reference/List/ReferenceListCommand.cs
@@ -20,7 +20,8 @@ internal class ReferenceListCommand : CommandBase
 
         _fileOrDirectory = parseResult.HasOption(ReferenceCommandParser.ProjectOption) ?
             parseResult.GetValue(ReferenceCommandParser.ProjectOption) :
-            parseResult.GetValue(ListCommandParser.SlnOrProjectArgument);
+            parseResult.GetValue(ListCommandParser.SlnOrProjectArgument) ??
+            Directory.GetCurrentDirectory();
     }
 
     public override int Execute()


### PR DESCRIPTION
Fixes #48555

This was a very good bug report, very easy to reproduce. My first look suggested that it was just the HasOption issue, but that was only half of the problem; there was an issue with what the default of the argument should be that I hadn't expected. In particular, there was a default "built into" System.CommandLine's Argument, and since that argument wasn't added to reference list (intentionally, as it wasn't supposed to be supported long-term), accessing it returned null. I fixed that by coalescing that to the current directory, that has the intended behavior.

Before:
```
>dotnet list reference
There are no Project to Project references in project C:\bugs\temp\.

>dotnet reference list
Could not find project or directory ``.
```

After:
```
>dotnet reference list
There are no Project to Project references in project C:\bugs\temp.

>dotnet reference list --project temp.csproj
There are no Project to Project references in project temp.csproj.
```

The one shift I noticed is that it lost a DirectorySeparatorChar. It shouldn't matter, I think, since it loads the directory as DirectoryInfo and grabs all *proj under that, but I can change that if you're aware of a way that that breaks things.