### PR TITLE
[HotReloadAgent] Update `MetadataUpdateHandlerInvoker` to be nullable friendly

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.Data/StaticAssetUpdate.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/StaticAssetUpdate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.DotNet.HotReload;
 
 internal readonly struct StaticAssetUpdate(

--- a/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
@@ -327,7 +327,7 @@ internal sealed class MetadataUpdateHandlerInvoker(AgentReporter reporter)
 
         static void Visit(Assembly[] assemblies, Assembly assembly, List<Assembly> sortedAssemblies, HashSet<string> visited)
         {
-            string assemblyIdentifier;
+            string? assemblyIdentifier;
 
             try
             {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/61272

```
PS> dotnet build .\src\Components\WebAssembly\WebAssembly\src\Microsoft.AspNetCore.Components.WebAssembly.csproj
Restore complete (1.3s)
  Microsoft.JSInterop succeeded (0.6s) → artifacts\bin\Microsoft.JSInterop\Debug\net10.0\Microsoft.JSInterop.dll
  Microsoft.JSInterop.WebAssembly succeeded (0.6s) → artifacts\bin\Microsoft.JSInterop.WebAssembly\Debug\net10.0\Microsoft.JSInterop.WebAssembly.dll
  Microsoft.AspNetCore.Components succeeded (1.4s) → artifacts\bin\Microsoft.AspNetCore.Components\Debug\net10.0\Microsoft.AspNetCore.Components.dll
  Microsoft.AspNetCore.Components.Forms succeeded (0.9s) → artifacts\bin\Microsoft.AspNetCore.Components.Forms\Debug\net10.0\Microsoft.AspNetCore.Components.Forms.dll
  Microsoft.AspNetCore.Components.Web succeeded (0.8s) → artifacts\bin\Microsoft.AspNetCore.Components.Web\Debug\net10.0\Microsoft.AspNetCore.Components.Web.dll
  Microsoft.AspNetCore.Components.WebAssembly failed with 1 error(s) (0.7s)
    C:\Nuget\microsoft.dotnet.hotreload.agent\10.0.100-preview.5.25252.107\contentFiles\cs\netstandard2.1\MetadataUpdateHandlerInvoker.cs(334,38): error CS8600: Converting null literal or possible null value to non-nullable type.

Build failed with 1 error(s) in 5.6s
```