### PR TITLE
Use host RID for crossgen2 during source-build

### DIFF
--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -8,7 +8,6 @@
                                     '$(DotNetBuildUseMonoRuntime)' != 'true'">true</IsCrossgenSupported>
 
     <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
-    <Crossgen2Rid Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SharedFrameworkRid)</Crossgen2Rid>
 
     <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(Crossgen2Rid)</RuntimeNETCrossgenPackageName>
   </PropertyGroup>


### PR DESCRIPTION
This allows us to use crossgen2 during sb cross-build https://github.com/am11/dotnet-riscv/actions/runs/14917917641.