### PR TITLE
real structures around package input formats for dotnet new commands

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -132,8 +132,8 @@
       The command checks if the package is installed locally, if it was not found, it searches the configured NuGet feeds.</value>
   </data>
   <data name="Command_Install_Argument_Package" xml:space="preserve">
-    <value>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+    <value>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </value>
   </data>
   <data name="Command_Install_Description" xml:space="preserve">
@@ -168,7 +168,7 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
     <value>Searches for the templates on NuGet.org.</value>
   </data>
   <data name="Command_Uninstall_Argument_Package" xml:space="preserve">
-    <value>NuGet package ID (without version) or path to folder to uninstall. 
+    <value>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</value>
   </data>
   <data name="Command_Uninstall_Description" xml:space="preserve">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
@@ -2,8 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Utils;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
@@ -16,19 +21,88 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             : base(hostBuilder, commandName, SymbolStrings.Command_Install_Description)
         {
             ParentCommand = parentCommand;
-            Arguments.Add(NameArgument);
+            Arguments.Add(PackageIdentifierArgument);
             Options.Add(InteractiveOption);
             Options.Add(AddSourceOption);
             Options.Add(ForceOption);
         }
 
-        internal static Argument<string[]> NameArgument { get; } = new("package")
+        internal static Argument<ITemplateIdentifierArgument[]> PackageIdentifierArgument { get; } = new("package")
         {
             Description = SymbolStrings.Command_Install_Argument_Package,
-            Arity = new ArgumentArity(1, 99)
+            Arity = ArgumentArity.OneOrMore,
+            CustomParser = ParseTemplateIdentifierArguments
         };
 
+        private static ITemplateIdentifierArgument[]? ParseTemplateIdentifierArguments(ArgumentResult result)
+        {
+            var templateIdentifierArguments = new List<ITemplateIdentifierArgument>();
+            foreach (var value in result.Tokens.Select(t => t.Value))
+            {
+                if (File.Exists(value))
+                {
+                    templateIdentifierArguments.Add(new FileBasedTemplateIdentifier(new FileInfo(value)));
+                }
+                else if (Directory.Exists(value) || Directory.Exists(Path.GetDirectoryName(value)))
+                {
+                    var environmentSettings = new EngineEnvironmentSettings(new Edge.DefaultTemplateEngineHost("dotnet", "1.0.0"), false, null, null, null, null);
+                    // expand the value pattern to allow for globbing, etc:
+                    foreach (var path in InstallRequestPathResolution.ExpandMaskedPath(value, environmentSettings))
+                    {
+                        templateIdentifierArguments.Add(new FileBasedTemplateIdentifier(new FileInfo(path)));
+                    }
+                }
+                else if (value.Contains("::") && ParsePackageIdentityWithVersionSeparator(value, "::") is PackageIdentity packageIdentity)
+                {
+                    Console.WriteLine(string.Format(LocalizableStrings.Colon_Separator_Deprecated, packageIdentity.Id, packageIdentity.Version is not null ? packageIdentity.Version : string.Empty));
+                    templateIdentifierArguments.Add(new PackageIdentifier(packageIdentity));
+                }
+                else if (ParsePackageIdentityWithVersionSeparator(value, "@") is PackageIdentity packageIdentityWithAt)
+                {
+                    templateIdentifierArguments.Add(new PackageIdentifier(packageIdentityWithAt));
+                }
+            }
+
+            if (templateIdentifierArguments.Count == 0) // we have an arity of One or More, so code is expecting that we error before we call the command...
+            {
+                result.AddError("No packages were found for installation. Please provide a valid package identity or path to a template package.");
+                return null;
+            }
+
+            return templateIdentifierArguments.ToArray();
+        }
+
+        private static PackageIdentity? ParsePackageIdentityWithVersionSeparator(string packageIdentity, string versionSeparator)
+        {
+            if (string.IsNullOrEmpty(packageIdentity))
+            {
+                return null;
+            }
+
+            string[] splitPackageIdentity = packageIdentity.Split(versionSeparator);
+            var (packageId, versionString) = (splitPackageIdentity.ElementAtOrDefault(0), splitPackageIdentity.ElementAtOrDefault(1));
+
+            if (string.IsNullOrEmpty(packageId))
+            {
+                throw new ArgumentException("package identity cannot be null or empty", nameof(packageId));
+            }
+
+            if (string.IsNullOrEmpty(versionString))
+            {
+                return new PackageIdentity(packageId, null);
+            }
+
+            if (!NuGetVersion.TryParse(versionString, out var version))
+            {
+                throw new ArgumentException($"Version {versionString} is not a valid Semantic Version");
+            }
+
+            return new PackageIdentity(packageId, new NuGetVersion(version));
+        }
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
         internal static Option<bool> ForceOption { get; } = SharedOptionsFactory.CreateForceOption().WithDescription(SymbolStrings.Option_Install_Force);
+#pragma warning restore SA1201 // Elements should appear in the correct order
 
         internal virtual Option<bool> InteractiveOption { get; } = SharedOptions.InteractiveOption;
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/InstallCommandArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/install/InstallCommandArgs.cs
@@ -2,30 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using NuGet.Packaging.Core;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
+    internal interface ITemplateIdentifierArgument;
+
+#pragma warning disable CS9113 // Parameter is unread.
+    internal record FileBasedTemplateIdentifier(FileInfo File) : ITemplateIdentifierArgument;
+#pragma warning restore CS9113 // Parameter is unread.
+
+#pragma warning disable CS9113 // Parameter is unread.
+    internal record PackageIdentifier(PackageIdentity Package) : ITemplateIdentifierArgument;
+#pragma warning restore CS9113 // Parameter is unread.
+
     internal class InstallCommandArgs : GlobalArgs
     {
         public InstallCommandArgs(BaseInstallCommand installCommand, ParseResult parseResult) : base(installCommand, parseResult)
         {
-            var nameResult = parseResult.GetResult(BaseInstallCommand.NameArgument);
-            if (nameResult is null || nameResult.Errors.Any())
-            {
-                throw new ArgumentException($"{nameof(parseResult)} should contain at least one argument for {nameof(BaseInstallCommand.NameArgument)}", nameof(parseResult));
-            }
-
-            TemplatePackages = parseResult.GetValue(BaseInstallCommand.NameArgument)!;
+            TemplatePackages = parseResult.GetValue(BaseInstallCommand.PackageIdentifierArgument)!;
 
             //workaround for --install source1 --install source2 case
-            if (installCommand is LegacyInstallCommand && (TemplatePackages.Contains(installCommand.Name) || installCommand.Aliases.Any(alias => TemplatePackages.Contains(alias))))
+            if (installCommand is LegacyInstallCommand)
             {
-                TemplatePackages = TemplatePackages.Where(package => installCommand.Name != package && !installCommand.Aliases.Contains(package)).ToList();
+                TemplatePackages = TemplatePackages.Where(package =>
+                {
+                    if (package is PackageIdentifier packageIdentifier)
+                    {
+                        return packageIdentifier.Package.Id != installCommand.Name && !installCommand.Aliases.Contains(packageIdentifier.Package.Id);
+                    }
+                    return true;
+                }).ToList();
             }
 
             if (!TemplatePackages.Any())
             {
-                throw new ArgumentException($"{nameof(parseResult)} should contain at least one argument for {nameof(BaseInstallCommand.NameArgument)}", nameof(parseResult));
+                throw new ArgumentException($"{nameof(parseResult)} should contain at least one argument for {nameof(BaseInstallCommand.PackageIdentifierArgument)}", nameof(parseResult));
             }
 
             Interactive = parseResult.GetValue(installCommand.InteractiveOption);
@@ -33,7 +45,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Force = parseResult.GetValue(BaseInstallCommand.ForceOption);
         }
 
-        public IReadOnlyList<string> TemplatePackages { get; }
+        public IReadOnlyList<ITemplateIdentifierArgument> TemplatePackages { get; }
 
         public bool Interactive { get; }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">ID balíčku NuGet nebo cesta ke složce nebo balíčku NuGet, který se má nainstalovat. 
+        <target state="needs-review-translation">ID balíčku NuGet nebo cesta ke složce nebo balíčku NuGet, který se má nainstalovat. 
 Pokud chcete nainstalovat balíček NuGet určité verze, použijte &lt;package ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Pokud chcete nainstalovat balíček NuGet určité verze, použijte &lt;package 
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">ID balíčku NuGet (bez verze) nebo cesta ke složce, která se má odinstalovat. 
+        <target state="needs-review-translation">ID balíčku NuGet (bez verze) nebo cesta ke složce, která se má odinstalovat. 
 Pokud je příkaz zadán bez argumentu, zobrazí seznam všech nainstalovaných balíčků šablon.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">NuGet-Paket-ID oder Pfad zum Ordner oder nuGet-Paket, das installiert werden soll. 
+        <target state="needs-review-translation">NuGet-Paket-ID oder Pfad zum Ordner oder nuGet-Paket, das installiert werden soll. 
 Um das NuGet-Paket einer bestimmten Version zu installieren, verwenden Sie &lt;Paket-ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Um das NuGet-Paket einer bestimmten Version zu installieren, verwenden Sie &lt;P
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">NuGet-Paket-ID (ohne Version) oder Pfad zum Ordner, der deinstalliert werden soll. 
+        <target state="needs-review-translation">NuGet-Paket-ID (ohne Version) oder Pfad zum Ordner, der deinstalliert werden soll. 
 Wenn der Befehl ohne Argument angegeben wird, werden alle installierten Vorlagenpakete aufgelistet.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">Id. del paquete NuGet o ruta de acceso a la carpeta o paquete NuGet que se va a instalar. 
+        <target state="needs-review-translation">Id. del paquete NuGet o ruta de acceso a la carpeta o paquete NuGet que se va a instalar. 
 Para instalar el paquete NuGet de una versión determinada, use &lt;package ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Para instalar el paquete NuGet de una versión determinada, use &lt;package ID&g
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">Id. del paquete NuGet (sin versión) o ruta de acceso a la carpeta que se va a desinstalar. 
+        <target state="needs-review-translation">Id. del paquete NuGet (sin versión) o ruta de acceso a la carpeta que se va a desinstalar. 
 Si el comando se especifica sin el argumento, muestra todos los paquetes de plantillas instalados.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">ID de package NuGet ou chemin d’accès au dossier ou au package NuGet à installer. 
+        <target state="needs-review-translation">ID de package NuGet ou chemin d’accès au dossier ou au package NuGet à installer. 
 Pour installer le package NuGet d’une certaine version, utilisez &lt;package ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Pour installer le package NuGet d’une certaine version, utilisez &lt;package I
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">ID de package NuGet (sans version) ou chemin d’accès au dossier à désinstaller. 
+        <target state="needs-review-translation">ID de package NuGet (sans version) ou chemin d’accès au dossier à désinstaller. 
 Si la commande est spécifiée sans l’argument, elle répertorie tous les packages de modèles installés.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">ID pacchetto NuGet o percorso della cartella o del pacchetto NuGet da installare. 
+        <target state="needs-review-translation">ID pacchetto NuGet o percorso della cartella o del pacchetto NuGet da installare. 
 Per installare il pacchetto NuGet di una determinata versione, usare &lt;package ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Per installare il pacchetto NuGet di una determinata versione, usare &lt;package
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">ID pacchetto NuGet (senza versione) o percorso della cartella da disinstallare. 
+        <target state="needs-review-translation">ID pacchetto NuGet (senza versione) o percorso della cartella da disinstallare. 
 Se il comando è specificato senza l'argomento, vengono elencati tutti i pacchetti modello installati.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">NuGet パッケージ ID、フォルダーのパス、またはインストールする NuGet パッケージ。
+        <target state="needs-review-translation">NuGet パッケージ ID、フォルダーのパス、またはインストールする NuGet パッケージ。
  特定のバージョンの NuGet パッケージをインストールするには、&lt;package ID&gt;::&lt;version&gt; を使用します。
 </target>
         <note />
@@ -86,9 +86,9 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">NuGet パッケージ ID (バージョンなし) またはアンインストールするフォルダーへのパス。
+        <target state="needs-review-translation">NuGet パッケージ ID (バージョンなし) またはアンインストールするフォルダーへのパス。
  引数なしでコマンドを指定した場合、インストールされているすべてのテンプレート パッケージが一覧表示されます。</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">설치할 NuGet 패키지 ID 또는 폴더 또는 NuGet 패키지의 경로입니다. 
+        <target state="needs-review-translation">설치할 NuGet 패키지 ID 또는 폴더 또는 NuGet 패키지의 경로입니다. 
 특정 버전의 NuGet 패키지를 설치하려면 &lt;package ID&gt;::&lt;version&gt;을 사용하세요.
 </target>
         <note />
@@ -86,9 +86,9 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">NuGet 패키지 ID(버전 없음) 또는 제거할 폴더 경로입니다. 
+        <target state="needs-review-translation">NuGet 패키지 ID(버전 없음) 또는 제거할 폴더 경로입니다. 
 인수 없이 명령을 지정하면 설치된 모든 템플릿 패키지가 나열됩니다.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">Identyfikator pakietu NuGet lub ścieżka do folderu lub pakietu NuGet do zainstalowania. 
+        <target state="needs-review-translation">Identyfikator pakietu NuGet lub ścieżka do folderu lub pakietu NuGet do zainstalowania. 
 Aby zainstalować pakiet NuGet określonej wersji, użyj &lt;package ID&gt;::&lt;version&gt;. 
 </target>
         <note />
@@ -86,9 +86,9 @@ Aby zainstalować pakiet NuGet określonej wersji, użyj &lt;package ID&gt;::&lt
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">Identyfikator pakietu NuGet (bez wersji) lub ścieżka do folderu do odinstalowania. 
+        <target state="needs-review-translation">Identyfikator pakietu NuGet (bez wersji) lub ścieżka do folderu do odinstalowania. 
 Jeśli polecenie zostanie określone bez argumentu, zostanie wyświetlona lista wszystkich zainstalowanych pakietów szablonów.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">ID do pacote NuGet ou caminho para a pasta ou pacote NuGet a ser instalado. 
+        <target state="needs-review-translation">ID do pacote NuGet ou caminho para a pasta ou pacote NuGet a ser instalado. 
 Para instalar o pacote NuGet de determinada versão, utilize &lt;package ID&gt;::&lt;version&gt;.
 </target>
         <note />
@@ -86,9 +86,9 @@ Para instalar o pacote NuGet de determinada versão, utilize &lt;package ID&gt;:
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">ID do pacote NuGet (sem versão) ou caminho para a pasta a ser desinstalada. 
+        <target state="needs-review-translation">ID do pacote NuGet (sem versão) ou caminho para a pasta a ser desinstalada. 
 Se o comando for especificado sem o argumento, ele listará todos os pacotes de modelos instalados.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">Идентификатор пакета NuGet или путь к папке или пакету NuGet для установки. 
+        <target state="needs-review-translation">Идентификатор пакета NuGet или путь к папке или пакету NuGet для установки. 
 Чтобы установить пакет NuGet определенной версии, используйте &lt;package ID&gt;::&lt;version&gt;
 </target>
         <note />
@@ -86,9 +86,9 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">Идентификатор пакета NuGet (без версии) или путь к папке для удаления. 
+        <target state="needs-review-translation">Идентификатор пакета NuGet (без версии) или путь к папке для удаления. 
 Если эта команда указана без аргумента, она перечислит все установленные пакеты шаблонов.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">Yüklenecek NuGet paket kimliği veya klasör yolu ya da NuGet paketi. 
+        <target state="needs-review-translation">Yüklenecek NuGet paket kimliği veya klasör yolu ya da NuGet paketi. 
 Belirli bir sürümün NuGet paketini yüklemek için &lt;package ID&gt;::&lt;version&gt; kullanın.
 </target>
         <note />
@@ -86,9 +86,9 @@ Belirli bir sürümün NuGet paketini yüklemek için &lt;package ID&gt;::&lt;ve
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">NuGet paket kimliği (sürüm olmadan) veya kaldırılacak klasörün yolu. 
+        <target state="needs-review-translation">NuGet paket kimliği (sürüm olmadan) veya kaldırılacak klasörün yolu. 
 Eğer komut bağımsız değişken olmadan belirtilirse yüklü tüm şablon paketlerini listeler.</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">要安装的文件夹或 NuGet 包的 NuGet 包 ID 或路径。
+        <target state="needs-review-translation">要安装的文件夹或 NuGet 包的 NuGet 包 ID 或路径。
 要安装特定版本的 NuGet 包，请使用 &lt;package ID&gt;::&lt;version&gt;。
 </target>
         <note />
@@ -86,9 +86,9 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">要卸载的文件夹的 NuGet 包 ID (没有版本)或路径。
+        <target state="needs-review-translation">要卸载的文件夹的 NuGet 包 ID (没有版本)或路径。
 如果在不使用参数的情况下指定命令，则它将列出安装的所有模板包。</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
@@ -27,10 +27,10 @@
         <note />
       </trans-unit>
       <trans-unit id="Command_Install_Argument_Package">
-        <source>NuGet package ID or path to folder or NuGet package to install. 
-To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;version&gt;.
+        <source>NuGet package ID or path to folder or NuGet package to install.
+To install the NuGet package of certain version, use &lt;package ID&gt;@&lt;version&gt;.
 </source>
-        <target state="translated">要安裝之資料夾或 NuGet 套件的 NuGet 套件識別碼或路徑。
+        <target state="needs-review-translation">要安裝之資料夾或 NuGet 套件的 NuGet 套件識別碼或路徑。
 若要安裝特定版本的 NuGet 套件，請使用 &lt;package ID&gt;::&lt;version&gt;。
 </target>
         <note />
@@ -86,9 +86,9 @@ To install the NuGet package of certain version, use &lt;package ID&gt;::&lt;ver
         <note />
       </trans-unit>
       <trans-unit id="Command_Uninstall_Argument_Package">
-        <source>NuGet package ID (without version) or path to folder to uninstall. 
+        <source>NuGet package ID (without version) or path to folder to uninstall.
 If command is specified without the argument, it lists all the template packages installed.</source>
-        <target state="translated">要解除安裝之資料夾的 NuGet 套件識別碼 (沒有版本) 或路徑。
+        <target state="needs-review-translation">要解除安裝之資料夾的 NuGet 套件識別碼 (沒有版本) 或路徑。
 如果指定的命令沒有引數，則其會列出所有已安裝的範本套件。</target>
         <note />
       </trans-unit>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -254,7 +254,7 @@ namespace Microsoft.TemplateEngine.Cli
                         Reporter.Output.WriteCommand(Example.For<UninstallCommand>(templateArgs.ParseResult).WithArgument(BaseUninstallCommand.NameArgument, templatePackage.DisplayName));
                         Reporter.Output.WriteLine();
                         Reporter.Output.WriteLine(LocalizableStrings.TemplateCreator_Hint_Install);
-                        Reporter.Output.WriteCommand(Example.For<InstallCommand>(templateArgs.ParseResult).WithArgument(BaseInstallCommand.NameArgument, templatePackage.DisplayName));
+                        Reporter.Output.WriteCommand(Example.For<InstallCommand>(templateArgs.ParseResult).WithArgument(BaseInstallCommand.PackageIdentifierArgument, templatePackage.DisplayName));
                         Reporter.Output.WriteLine();
                     }
                     return NewCommandStatus.NotFound;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageDisplay.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageDisplay.cs
@@ -47,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 if (!versionCheckResult.IsLatestVersion)
                 {
-                    string displayString = $"{versionCheckResult.TemplatePackage?.Identifier}::{versionCheckResult.TemplatePackage?.Version}";         // the package::version currently installed
+                    string displayString = $"{versionCheckResult.TemplatePackage?.Identifier}@{versionCheckResult.TemplatePackage?.Version}";         // the package@version currently installed
                     _reporterOutput.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateAvailable, displayString);
 
                     _reporterOutput.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader);
@@ -55,7 +55,7 @@ namespace Microsoft.TemplateEngine.Cli
                         Example
                             .For<NewCommand>(args.ParseResult)
                             .WithSubcommand<InstallCommand>()
-                            .WithArgument(BaseInstallCommand.NameArgument, $"{versionCheckResult.TemplatePackage?.Identifier}::{versionCheckResult.LatestVersion}"));
+                            .WithArgument(BaseInstallCommand.PackageIdentifierArgument, $"{versionCheckResult.TemplatePackage?.Identifier}@{versionCheckResult.LatestVersion}"));
                     _reporterOutput.WriteLine();
                 }
             }
@@ -68,7 +68,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal void DisplayBuiltInPackagesCheckResult(string packageId, string version, string provider, ICommandArgs args)
         {
-            _reporterOutput.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable, $"{packageId}::{version}", provider);
+            _reporterOutput.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable, $"{packageId}@{version}", provider);
             _reporterOutput.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage);
             _reporterOutput.WriteCommand(
                 Example
@@ -157,7 +157,7 @@ namespace Microsoft.TemplateEngine.Cli
                                   LocalizableStrings.TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled,
                                   packageToInstall).Bold().Red());
                         _reporterError.WriteLine(LocalizableStrings.TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled_Hint, BaseInstallCommand.ForceOption.Name);
-                        _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.NameArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
+                        _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.PackageIdentifierArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
 
                         break;
                     case InstallerErrorCode.UpdateUninstallFailed:
@@ -186,7 +186,7 @@ namespace Microsoft.TemplateEngine.Cli
                                        LocalizableStrings.TemplatePackageCoordinator_Install_Error_VulnerablePackageTip,
                                        packageToInstall,
                                        SharedOptions.ForceOption.Name).Bold());
-                                    _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.NameArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
+                                    _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.PackageIdentifierArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
                                     break;
 
                                 case UpdateResult updateRequest when updateRequest.Vulnerabilities.Any():
@@ -199,7 +199,7 @@ namespace Microsoft.TemplateEngine.Cli
                                         packageToInstall,
                                         SharedOptions.ForceOption.Name).Bold());
                                     _reporterError.WriteCommand(Example.For<UninstallCommand>(parseResult).WithArgument(BaseUninstallCommand.NameArgument, packageToInstall));
-                                    _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.NameArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
+                                    _reporterError.WriteCommand(Example.For<InstallCommand>(parseResult).WithArgument(BaseInstallCommand.PackageIdentifierArgument, packageToInstall).WithOption(BaseInstallCommand.ForceOption));
                                     break;
 
                                 default:
@@ -303,12 +303,12 @@ namespace Microsoft.TemplateEngine.Cli
                     Example
                         .For<NewCommand>(args.ParseResult)
                         .WithSubcommand<InstallCommand>()
-                        .WithArgument(BaseInstallCommand.NameArgument, $"<package>::<version>"));
+                        .WithArgument(BaseInstallCommand.PackageIdentifierArgument, $"<package>@<version>"));
                 Reporter.Output.WriteCommand(
                       Example
                           .For<NewCommand>(args.ParseResult)
                           .WithSubcommand<InstallCommand>()
-                          .WithArgument(BaseInstallCommand.NameArgument, $"{displayableResults.First().Identifier}::{displayableResults.First().LatestVersion}"));
+                          .WithArgument(BaseInstallCommand.PackageIdentifierArgument, $"{displayableResults.First().Identifier}@{displayableResults.First().LatestVersion}"));
                 Reporter.Output.WriteLine();
                 Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader);
                 Reporter.Output.WriteCommand(

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -95,13 +95,13 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                  Example
                      .For<NewCommand>(commandArgs.ParseResult)
                      .WithSubcommand<InstallCommand>()
-                     .WithArgument(BaseInstallCommand.NameArgument));
+                     .WithArgument(BaseInstallCommand.PackageIdentifierArgument));
                 Reporter.Output.WriteLine(LocalizableStrings.Generic_ExampleHeader);
                 Reporter.Output.WriteCommand(
                    Example
                        .For<NewCommand>(commandArgs.ParseResult)
                        .WithSubcommand<InstallCommand>()
-                       .WithArgument(BaseInstallCommand.NameArgument, packageIdToShow));
+                       .WithArgument(BaseInstallCommand.PackageIdentifierArgument, packageIdToShow));
                 return NewCommandStatus.Success;
             }
             return NewCommandStatus.NotFound;

--- a/src/Cli/dotnet/CommonArguments.cs
+++ b/src/Cli/dotnet/CommonArguments.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli
                 Arity = requireArgument ? ArgumentArity.ExactlyOne : ArgumentArity.ZeroOrOne,
             };
 
-        private static PackageIdentity? ParsePackageIdentityWithVersionSeparator(string packageIdentity, char versionSeparator = '@')
+        internal static PackageIdentity? ParsePackageIdentityWithVersionSeparator(string packageIdentity, char versionSeparator = '@')
         {
             if (string.IsNullOrEmpty(packageIdentity))
             {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Contains("my-custom-source1", args.AdditionalSources);
             Assert.Contains("my-custom-source2", args.AdditionalSources);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Fact]
@@ -84,14 +84,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
             Assert.True(args.Interactive);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
 
             parseResult = myCommand.Parse($"new install source");
             args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.False(args.Interactive);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Fact]
@@ -105,14 +105,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
             Assert.True(args.Force);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
 
             parseResult = myCommand.Parse($"new install source");
             args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.False(args.Force);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Fact]
@@ -125,8 +125,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstallCommandArgs args = new((InstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.TemplatePackages.Count);
-            Assert.Contains("source1", args.TemplatePackages);
-            Assert.Contains("source2", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Theory]
@@ -145,7 +145,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Single(args.AdditionalSources);
             Assert.Contains("my-custom-source", args.AdditionalSources);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
             Assert.True(args.Interactive);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Theory]
@@ -176,8 +176,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstallCommandArgs args = new((LegacyInstallCommand)parseResult.CommandResult.Command, parseResult);
 
             Assert.Equal(2, args.TemplatePackages.Count);
-            Assert.Contains("source1", args.TemplatePackages);
-            Assert.Contains("source2", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Theory]
@@ -196,7 +196,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Contains("my-custom-source1", args.AdditionalSources);
             Assert.Contains("my-custom-source2", args.AdditionalSources);
             Assert.Single(args.TemplatePackages);
-            Assert.Contains("source", args.TemplatePackages);
+            Assert.Contains(new PackageIdentifier(new("source", null)), args.TemplatePackages);
         }
 
         [Theory]
@@ -235,7 +235,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             };
 
             ParseResult parseResult = rootCommand.Parse("dotnet new install source");
-            Assert.Equal("dotnet new install my-source", Example.For<NewCommand>(parseResult).WithSubcommand<InstallCommand>().WithArgument(BaseInstallCommand.NameArgument, "my-source"));
+            Assert.Equal("dotnet new install my-source", Example.For<NewCommand>(parseResult).WithSubcommand<InstallCommand>().WithArgument(BaseInstallCommand.PackageIdentifierArgument, "my-source"));
         }
 
     }


### PR DESCRIPTION
This is a refactoring for the template engine around the allowed inputs for the package-to-install argument. It also changes some user-facing strings to unify on the `package@version` syntax where appropriate.