### PR TITLE
Remove bad assert

### DIFF
--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -164,8 +164,6 @@ internal static class TestCommandParser
         var builder = new ConfigurationBuilder();
 
         string? dotnetConfigPath = GetDotnetConfigPath(Environment.CurrentDirectory);
-        Debug.Assert(dotnetConfigPath is not null);
-
         if (!File.Exists(dotnetConfigPath))
         {
             return CliConstants.VSTest;


### PR DESCRIPTION
File.Exists just returns false if its input is null, and asserting that it shouldn't be null means that if dotnet.config isn't found (which should be _very common_), anyone using debug bits will be unable to run any dotnet command. (Commands are all initialized before any commands are executed.)

This just removes the unnecessary assert added in #48846.