### PR TITLE
Build test template projects via a pipeline to support CG

### DIFF
--- a/build/BuildTestTemplates.ps1
+++ b/build/BuildTestTemplates.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Builds a list of project files in the dogfood environment.
+.DESCRIPTION
+    This script enters the dogfood environment and builds the specified project files.
+#>
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [string] $configuration = "Release"
+)
+
+function Build-Projects {
+    $ErrorActionPreference = 'Stop'
+    $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+	
+	# Define constants for common path segments
+	$TemplateFeedPath = "template_feed\Microsoft.DotNet.Common.ProjectTemplates.10.0\content"
+	$MSTestPath = "$TemplateFeedPath\MSTest"
+	$NUnitPath = "$TemplateFeedPath\NUnit"
+	$XUnitPath = "$TemplateFeedPath\XUnit"
+	$PlaywrightMSTestPath = "$TemplateFeedPath\Playwright-MSTest"
+	$PlaywrightNUnitPath = "$TemplateFeedPath\Playwright-NUnit"
+
+	# Define the project files using the constants
+	$ProjectFiles = @(
+		# MSTest Projects
+		"$MSTestPath-CSharp\Company.TestProject1.csproj",
+		"$MSTestPath-FSharp\Company.TestProject1.fsproj",
+		"$MSTestPath-VisualBasic\Company.TestProject1.vbproj",
+		"$PlaywrightMSTestPath-CSharp\Company.TestProject1.csproj",
+		
+		# NUnit Projects
+		"$NUnitPath-CSharp\Company.TestProject1.csproj",
+		"$NUnitPath-FSharp\Company.TestProject1.fsproj",
+		"$NUnitPath-VisualBasic\Company.TestProject1.vbproj",
+		"$PlaywrightNUnitPath-CSharp\Company.TestProject1.csproj",
+		
+		# XUnit Projects
+		"$XUnitPath-CSharp\Company.TestProject1.csproj",
+		"$XUnitPath-FSharp\Company.TestProject1.fsproj",
+		"$XUnitPath-VisualBasic\Company.TestProject1.vbproj"
+	)
+
+    Write-Host "Building projects in the dogfood environment..." -ForegroundColor Cyan
+
+    # Call dogfood.ps1 directly instead of through dogfood.cmd to avoid the -NoExit parameter
+    $dogfoodPs1 = Join-Path $RepoRoot "eng\dogfood.ps1"
+
+    foreach ($projectFile in $ProjectFiles) {
+        $fullProjectPath = Join-Path $RepoRoot $projectFile
+
+        # Check if the project file exists
+        if (-not (Test-Path $fullProjectPath)) {
+            Write-Error "Project file not found at: $fullProjectPath"
+            return 1
+        }
+
+        Write-Host "Executing: dotnet build $fullProjectPath via dogfood environment" -ForegroundColor Gray
+        # Pass the command directly to the dogfood.ps1 script
+        & $dogfoodPs1 -configuration $configuration -command "dotnet", "build", $fullProjectPath
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            Write-Error "Build failed for project: $fullProjectPath with exit code: $exitCode"
+            return $exitCode
+        } else {
+            Write-Host "Build completed successfully for project: $fullProjectPath" -ForegroundColor Green
+        }
+    }
+
+    return 0
+}
+
+# Execute the function using Invoke-Command
+$exitCode = Invoke-Command -ScriptBlock ${function:Build-Projects}
+exit $exitCode

--- a/build/BuildTestTemplates.ps1
+++ b/build/BuildTestTemplates.ps1
@@ -12,39 +12,41 @@ Param(
 function Build-Projects {
     $ErrorActionPreference = 'Stop'
     $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
-	
-	# Define constants for common path segments
-	$TemplateFeedPath = "template_feed\Microsoft.DotNet.Common.ProjectTemplates.10.0\content"
-	$MSTestPath = "$TemplateFeedPath\MSTest"
-	$NUnitPath = "$TemplateFeedPath\NUnit"
-	$XUnitPath = "$TemplateFeedPath\XUnit"
-	$PlaywrightMSTestPath = "$TemplateFeedPath\Playwright-MSTest"
-	$PlaywrightNUnitPath = "$TemplateFeedPath\Playwright-NUnit"
 
-	# Define the project files using the constants
-	$ProjectFiles = @(
-		# MSTest Projects
-		"$MSTestPath-CSharp\Company.TestProject1.csproj",
-		"$MSTestPath-FSharp\Company.TestProject1.fsproj",
-		"$MSTestPath-VisualBasic\Company.TestProject1.vbproj",
-		"$PlaywrightMSTestPath-CSharp\Company.TestProject1.csproj",
-		
-		# NUnit Projects
-		"$NUnitPath-CSharp\Company.TestProject1.csproj",
-		"$NUnitPath-FSharp\Company.TestProject1.fsproj",
-		"$NUnitPath-VisualBasic\Company.TestProject1.vbproj",
-		"$PlaywrightNUnitPath-CSharp\Company.TestProject1.csproj",
-		
-		# XUnit Projects
-		"$XUnitPath-CSharp\Company.TestProject1.csproj",
-		"$XUnitPath-FSharp\Company.TestProject1.fsproj",
-		"$XUnitPath-VisualBasic\Company.TestProject1.vbproj"
-	)
+    # Define constants for common path segments
+    $TemplateFeedPath = "template_feed\Microsoft.DotNet.Common.ProjectTemplates.10.0\content"
+    $MSTestPath = "$TemplateFeedPath\MSTest"
+    $NUnitPath = "$TemplateFeedPath\NUnit"
+    $XUnitPath = "$TemplateFeedPath\XUnit"
+    $PlaywrightMSTestPath = "$TemplateFeedPath\Playwright-MSTest"
+    $PlaywrightNUnitPath = "$TemplateFeedPath\Playwright-NUnit"
+
+    # Define the project files using the constants
+    $ProjectFiles = @(
+        # MSTest Projects
+        "$MSTestPath-CSharp\Company.TestProject1.csproj",
+        "$MSTestPath-FSharp\Company.TestProject1.fsproj",
+        "$MSTestPath-VisualBasic\Company.TestProject1.vbproj",
+        "$PlaywrightMSTestPath-CSharp\Company.TestProject1.csproj",
+
+        # NUnit Projects
+        "$NUnitPath-CSharp\Company.TestProject1.csproj",
+        "$NUnitPath-FSharp\Company.TestProject1.fsproj",
+        "$NUnitPath-VisualBasic\Company.TestProject1.vbproj",
+        "$PlaywrightNUnitPath-CSharp\Company.TestProject1.csproj",
+
+        # XUnit Projects
+        "$XUnitPath-CSharp\Company.TestProject1.csproj",
+        "$XUnitPath-FSharp\Company.TestProject1.fsproj",
+        "$XUnitPath-VisualBasic\Company.TestProject1.vbproj"
+    )
 
     Write-Host "Building projects in the dogfood environment..." -ForegroundColor Cyan
 
     # Call dogfood.ps1 directly instead of through dogfood.cmd to avoid the -NoExit parameter
     $dogfoodPs1 = Join-Path $RepoRoot "eng\dogfood.ps1"
+
+    $failedProjects = @()
 
     foreach ($projectFile in $ProjectFiles) {
         $fullProjectPath = Join-Path $RepoRoot $projectFile
@@ -52,7 +54,8 @@ function Build-Projects {
         # Check if the project file exists
         if (-not (Test-Path $fullProjectPath)) {
             Write-Error "Project file not found at: $fullProjectPath"
-            return 1
+            $failedProjects += $fullProjectPath
+            continue
         }
 
         Write-Host "Executing: dotnet build $fullProjectPath via dogfood environment" -ForegroundColor Gray
@@ -61,13 +64,20 @@ function Build-Projects {
         $exitCode = $LASTEXITCODE
         if ($exitCode -ne 0) {
             Write-Error "Build failed for project: $fullProjectPath with exit code: $exitCode"
-            return $exitCode
+            $failedProjects += $fullProjectPath
         } else {
             Write-Host "Build completed successfully for project: $fullProjectPath" -ForegroundColor Green
         }
     }
 
-    return 0
+    if ($failedProjects.Count -gt 0) {
+        Write-Error "The following projects failed to build:"
+        $failedProjects | ForEach-Object { Write-Error $_ }
+        return 1
+    } else {
+        Write-Host "All projects built successfully!" -ForegroundColor Green
+        return 0
+    }
 }
 
 # Execute the function using Invoke-Command

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -104,6 +104,8 @@ jobs:
         env:
           BuildConfig: $(buildConfiguration)
           TestFullMSBuild: ${{ parameters.testFullMSBuild }}
+      - powershell: build/BuildTestTemplates.ps1
+        displayName: 🟣 Build Test Templates
     - ${{ else }}:
       - script: |
           source $(Build.SourcesDirectory)/eng/common/native/init-os-and-arch.sh


### PR DESCRIPTION
This pull request introduces a new PowerShell script to streamline the process of building test project templates in the dogfood environment and integrates it into the SDK build pipeline. Below are the key changes:

### New script for building test templates:
* [`build/BuildTestTemplates.ps1`](diffhunk://#diff-054554734db6ee2ea9f8fe56317a641b173f1cefe393651556e072bc52f8b253R1-R85): Added a PowerShell script to automate the building of test project templates for MSTest, NUnit, and XUnit in the dogfood environment. The script validates project file paths, executes builds via `dogfood.ps1`, and reports any failures.

### Pipeline integration:
* [`eng/pipelines/templates/jobs/sdk-build.yml`](diffhunk://#diff-491bd7ffb91a7b524d01bef4b986bc9405936fff64d9793716eebeb9cb7b849eR107-R108): Integrated the new `BuildTestTemplates.ps1` script into the SDK build pipeline to ensure test templates are built as part of the CI process.