### PR TITLE
[StaticWebAssets] Add the cache files to the list of written files so they get deleted during clean

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -244,6 +244,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAsset Include="@(_CompressionBuildStaticWebAsset)" />
       <StaticWebAssetEndpoint Include="@(_CompressionBuildStaticWebAssetEndpoint)" />
       <_CompressionCurrentProjectBuildAssets Include="@(StaticWebAsset)" />
+      <FileWrites Include="@(_ResolveBuildCompressedStaticWebAssetsCachePath)" />
     </ItemGroup>
 
     <ApplyCompressionNegotiation

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets
@@ -165,6 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAsset Include="@(_JSModuleStaticWebAsset)" />
       <StaticWebAssetEndpoint Remove="@(_FilteredJSModuleStaticWebAssetEndpointWithProperty)" />
       <StaticWebAssetEndpoint Include="@(_FilteredJSModuleStaticWebAssetEndpointWithProperty)" />
+      <FileWrites Include="$(_ResolveJsInitializerModuleStaticWebAssetsCachePath)" />
     </ItemGroup>
 
   </Target>
@@ -496,6 +497,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Remove the items from their original groups since they've now become a StaticWebAsset -->
       <Content Remove="@(_JsFileModuleStaticWebAsset->'%(OriginalItemSpec)')" />
       <None Remove="@(_JsFileModuleStaticWebAsset->'%(OriginalItemSpec)')" />
+
+      <FileWrites Include="$(_ResolveJSModuleStaticWebAssetsRazorCachePath)" />
+      <FileWrites Include="$(_ResolveJSModuleStaticWebAssetsCshtmlCachePath)" />
     </ItemGroup>
 
   </Target>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -707,6 +707,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       </StaticWebAssetDiscoveryPattern>
 
       <Content Remove="@(StaticWebAsset)" />
+
+      <FileWrites Include="$(_ResolveProjectStaticWebAssetsCachePath)" />
     </ItemGroup>
 
   </Target>

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
@@ -165,6 +165,8 @@ public partial class DefineStaticWebAssets : Task
             GlobalPropertiesHash = propertiesHash;
             FingerprintPatternsHash = fingerprintPatternsHash;
             PropertyOverridesHash = propertyOverridesHash;
+            CachedAssets.Clear();
+            CachedCopyCandidates.Clear();
             InputHashes = [.. inputsByHash.Keys];
             _inputByHash = inputsByHash;
         }

--- a/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -605,6 +605,8 @@ for path 'candidate.js'");
 
             Assert.False(cache.IsUpToDate());
             Assert.Same(inputHashes, cache.OutOfDateInputs());
+            Assert.Empty(cache.CachedAssets);
+            Assert.Empty(cache.CachedCopyCandidates);
         }
 
         [Fact]


### PR DESCRIPTION
* Fix an issue when we need to ignore the cache.
* Make sure cache files are removed during `dotnet clean`.