### PR TITLE
Change ci.yml -> sb-ci.yml

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/sb-ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-ci.yml
@@ -1,33 +1,16 @@
 # This yml is used by these pipelines and triggers:
-# NOTE: the triggers are defined in the Azure DevOps UI as they are too complex
-#
-# - dotnet-source-build (public)
-#   https://dev.azure.com/dnceng-public/public/_build?definitionId=240
-#   - PR: ultralite build
-#   - CI: release/*, every batched commit, full build
-#   - Schedule: main only, full build
-#
-# - dotnet-unified-build (public)
-#   https://dev.azure.com/dnceng-public/public/_build?definitionId=278
-#   - PR: lite build
-#   - CI: release/* only, every batched commit, full build
-#   - Schedule: main only, full build
 #
 # - dotnet-source-build (internal)
 #   https://dev.azure.com/dnceng/internal/_build?definitionId=1219
-#   - PR: ultralite build
 #   - CI: release/* and internal/release/* only, every batched commit, full build
-#   - Schedule: main only, full build
-#
-# - dotnet-source-build-lite (internal)
-#   https://dev.azure.com/dnceng/internal/_build?definitionId=1299
-#   - PR: release/* and main only, lite build, on-demand trigger
-#   - CI: main only, every batched commit, lite build
-#
-# - dotnet-unified-build (internal)
-#   https://dev.azure.com/dnceng/internal/_build?definitionId=1330
-#   - PR: lite build
-#   - CI: release/*, internal/release/* and main only, every batched commit, full build
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+      - release/*
+      - internal/release/*
 
 variables:
 # enable source-only build for pipelines that contain the -source-build string


### PR DESCRIPTION
This allows us to repoint the SB pipeline at this YAML file, meaning that we can manage triggers for UB, which uses ci.yml, via YAML files rather than the UI. Updated comments to reflect where this file will be used.