### PR TITLE
Remove source-build-lite pipeline

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -11,7 +11,7 @@ parameters:
 - name: scope
   type: string
   values:
-  # run several legs e.g. win/linux/mac for basic testing
+  # run 1 leg for smoke tests
   - lite
   # run everything
   - full

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -11,8 +11,6 @@ parameters:
 - name: scope
   type: string
   values:
-  # run 1 leg for smoke tests
-  - ultralite
   # run several legs e.g. win/linux/mac for basic testing
   - lite
   # run everything
@@ -83,7 +81,7 @@ stages:
 
     jobs:
 
-    ### Jobs for ultralite builds ###
+    ### Jobs for lite builds ###
     - template: ../jobs/vmr-build.yml
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
@@ -101,8 +99,8 @@ stages:
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
 
-    ### Additional jobs for lite/full builds ###
-    - ${{ if in(parameters.scope, 'lite', 'full') }}:
+    ### Additional jobs for full build ###
+    - ${{ if in(parameters.scope, 'full') }}:
 
       - template: ../jobs/vmr-build.yml
         parameters:
@@ -140,184 +138,181 @@ stages:
           useMonoRuntime: false              # 🚫
           withPreviousSDK: true              # ✅
 
-      ### Additional jobs for full build ###
-      - ${{ if in(parameters.scope, 'full') }}:
+      # This AlmaLinux leg is intended to build with the min supported glibc version
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.almaLinuxName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.almaLinuxContainer }}
+          targetRid: ${{ variables.almaLinuxX64Rid }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: true        # ✅
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        # This AlmaLinux leg is intended to build with the min supported glibc version
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.almaLinuxName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.almaLinuxContainer }}
-            targetRid: ${{ variables.almaLinuxX64Rid }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.alpineName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.alpineContainer }}
+          targetRid: ${{ variables.alpineX64Rid }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: true        # ✅
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.alpineName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.alpineContainer }}
-            targetRid: ${{ variables.alpineX64Rid }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.centOSStreamContainer }}
+          buildFromArchive: true             # ✅
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: true             # ✅
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          artifactsRid: ${{ variables.centOSStreamX64Rid }}
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.centOSStreamContainer }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: true                    # ✅
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: true              # ✅
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            artifactsRid: ${{ variables.centOSStreamX64Rid }}
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: true                    # ✅
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: true              # ✅
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.centOSStreamContainer }}
+          buildFromArchive: true             # ✅
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: true        # ✅
+          runOnline: false                   # 🚫
+          useMonoRuntime: true               # ✅
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: true             # ✅
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: true               # ✅
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.fedoraContainer }}
+          buildFromArchive: true             # ✅
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedoraContainer }}
-            buildFromArchive: true             # ✅
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.ubuntuContainer }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.ubuntuContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: arm64
+          pool: ${{ parameters.pool_LinuxArm64 }}
+          container: ${{ variables.ubuntuArmContainer }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: arm64
-            pool: ${{ parameters.pool_LinuxArm64 }}
-            container: ${{ variables.ubuntuArmContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.fedoraContainer }}
+          buildFromArchive: false            # 🚫
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: false       # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
+          reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
 
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.fedoraContainer }}
-            buildFromArchive: false            # 🚫
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: false       # 🚫
-            runOnline: false                   # 🚫
-            useMonoRuntime: false              # 🚫
-            withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
-
-        - template: ../jobs/vmr-build.yml
-          parameters:
-            # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-            buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
-            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-            vmrBranch: ${{ variables.VmrBranch }}
-            architecture: x64
-            pool: ${{ parameters.pool_Linux }}
-            container: ${{ variables.centOSStreamContainer }}
-            buildFromArchive: true             # ✅
-            buildSourceOnly: true              # ✅
-            enablePoison: false                # 🚫
-            excludeOmniSharpTests: true        # ✅
-            runOnline: false                   # 🚫
-            useMonoRuntime: true               # ✅
-            withPreviousSDK: false             # 🚫
-            reuseBuildArtifactsFrom: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+          buildName: ${{ format('{0}_Mono_Offline_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          vmrBranch: ${{ variables.VmrBranch }}
+          architecture: x64
+          pool: ${{ parameters.pool_Linux }}
+          container: ${{ variables.centOSStreamContainer }}
+          buildFromArchive: true             # ✅
+          buildSourceOnly: true              # ✅
+          enablePoison: false                # 🚫
+          excludeOmniSharpTests: true        # ✅
+          runOnline: false                   # 🚫
+          useMonoRuntime: true               # ✅
+          withPreviousSDK: false             # 🚫
+          reuseBuildArtifactsFrom: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
 
 #### VERTICAL BUILD ####
 - ${{ if not(parameters.isSourceOnlyBuild) }}:

--- a/eng/pipelines/vmr-build-pr-internal.yml
+++ b/eng/pipelines/vmr-build-pr-internal.yml
@@ -55,8 +55,6 @@ stages:
       isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
       ${{ if contains(variables['Build.DefinitionName'], '-full') }}:
         scope: full
-      ${{ elseif eq(variables.isSourceOnlyBuild, 'true') }}:
-        scope: ultralite
       ${{ else }}:
         scope: lite
 

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -63,8 +63,6 @@ stages:
       isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
       ${{ if contains(variables['Build.DefinitionName'], '-full') }}:
         scope: full
-      ${{ elseif eq(variables.isSourceOnlyBuild, 'true') }}:
-        scope: ultralite
       ${{ else }}:
         scope: lite
 

--- a/src/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/pr.yml
@@ -22,9 +22,6 @@ variables:
 - name: isSourceOnlyBuildLite
   value: ${{ contains(variables['Build.DefinitionName'], '-source-build-lite') }}
 
-- name: isScheduleTrigger
-  value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
-
 - name: isPRTrigger
   value: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
 
@@ -40,11 +37,7 @@ stages:
     isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
     ${{ if eq(variables.isScheduleTrigger, 'true') }}:
       scope: full
-    ${{ elseif eq(variables.isSourceOnlyBuildLite, 'true') }}:
-      scope: lite
-    ${{ elseif and(eq(variables.isPRTrigger, 'true'), eq(variables.isSourceOnlyBuild, 'true')) }}:
-      scope: ultralite
-    ${{ elseif and(eq(variables.isPRTrigger, 'true'), ne(variables.isSourceOnlyBuild, 'true')) }}:
+    ${{ elseif eq(variables.isPRTrigger, 'true') }}:
       scope: lite
     ${{ else }}:
       scope: full

--- a/src/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/pr.yml
@@ -19,8 +19,8 @@ variables:
 - name: isSourceOnlyBuild
   value: ${{ contains(variables['Build.DefinitionName'], '-source-build') }}
 
-- name: isSourceOnlyBuildLite
-  value: ${{ contains(variables['Build.DefinitionName'], '-source-build-lite') }}
+- name: isScheduleTrigger
+  value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
 
 - name: isPRTrigger
   value: ${{ eq(variables['Build.Reason'], 'PullRequest') }}

--- a/src/SourceBuild/content/eng/pipelines/sb-ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-ci.yml
@@ -17,9 +17,6 @@ variables:
 - name: isSourceOnlyBuild
   value: ${{ contains(variables['Build.DefinitionName'], '-source-build') }}
 
-- name: isSourceOnlyBuildLite
-  value: ${{ contains(variables['Build.DefinitionName'], '-source-build-lite') }}
-
 - name: isScheduleTrigger
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
 
@@ -68,11 +65,7 @@ extends:
         isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
         ${{ if eq(variables.isScheduleTrigger, 'true') }}:
           scope: full
-        ${{ elseif eq(variables.isSourceOnlyBuildLite, 'true') }}:
-          scope: lite
-        ${{ elseif and(eq(variables.isPRTrigger, 'true'), eq(variables.isSourceOnlyBuild, 'true')) }}:
-          scope: ultralite
-        ${{ elseif and(eq(variables.isPRTrigger, 'true'), ne(variables.isSourceOnlyBuild, 'true')) }}:
+        ${{ elseif eq(variables.isPRTrigger, 'true') }}:
           scope: lite
         ${{ else }}:
           scope: full


### PR DESCRIPTION
Removes references to the SB lite pipeline, which has now been deleted

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2710897&view=results)