### PR TITLE
Fix reporting rude edits

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -416,11 +416,13 @@ namespace Microsoft.DotNet.Watch
                 // Rude edits in projects that caused restart of a project that can be restarted automatically
                 // will be reported only as verbose output.
                 var projectsRestartedDueToRudeEdits = updates.ProjectsToRestart
-                    .Where(e => runningProjectInfos.TryGetValue(e.Key, out var info) && info.RestartWhenChangesHaveNoEffect)
+                    .Where(e => IsAutoRestartEnabled(e.Key))
                     .SelectMany(e => e.Value)
                     .ToHashSet();
 
-                var projectsRebuiltDueToRudeEdits = updates.ProjectsToRebuild.ToHashSet();
+                var projectsRebuiltDueToRudeEdits = updates.ProjectsToRebuild
+                    .Where(IsAutoRestartEnabled)
+                    .ToHashSet();
 
                 foreach (var (projectId, diagnostics) in updates.RudeEdits)
                 {
@@ -436,6 +438,9 @@ namespace Microsoft.DotNet.Watch
                     }
                 }
             }
+
+            bool IsAutoRestartEnabled(ProjectId id)
+                => runningProjectInfos.TryGetValue(id, out var info) && info.RestartWhenChangesHaveNoEffect;
 
             void ReportDiagnostic(Diagnostic diagnostic, MessageDescriptor descriptor, string prefix = "")
             {

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.Watch
     {
         public readonly IncrementalMSBuildWorkspace Workspace;
         public readonly EnvironmentOptions EnvironmentOptions;
-        private readonly GlobalOptions _options;
         private readonly IReporter _reporter;
         private readonly WatchHotReloadService _hotReloadService;
 
@@ -41,11 +40,10 @@ namespace Microsoft.DotNet.Watch
 
         private bool _isDisposed;
 
-        public CompilationHandler(IReporter reporter, EnvironmentOptions environmentOptions, GlobalOptions options, CancellationToken shutdownCancellationToken)
+        public CompilationHandler(IReporter reporter, EnvironmentOptions environmentOptions, CancellationToken shutdownCancellationToken)
         {
             _reporter = reporter;
             EnvironmentOptions = environmentOptions;
-            _options = options;
             Workspace = new IncrementalMSBuildWorkspace(reporter);
             _hotReloadService = new WatchHotReloadService(Workspace.CurrentSolution.Services, () => ValueTask.FromResult(GetAggregateCapabilities()));
             _shutdownCancellationToken = shutdownCancellationToken;
@@ -251,6 +249,7 @@ namespace Microsoft.DotNet.Watch
         }
 
         public async ValueTask<(ImmutableDictionary<ProjectId, string> projectsToRebuild, ImmutableArray<RunningProject> terminatedProjects)> HandleManagedCodeChangesAsync(
+            bool autoRestart,
             Func<IEnumerable<string>, CancellationToken, Task> restartPrompt,
             CancellationToken cancellationToken)
         {
@@ -261,8 +260,8 @@ namespace Microsoft.DotNet.Watch
                (from project in currentSolution.Projects
                 let runningProject = GetCorrespondingRunningProject(project, runningProjects)
                 where runningProject != null
-                let autoRestart = _options.NonInteractive || runningProject.ProjectNode.IsAutoRestartEnabled()
-                select (project.Id, info: new WatchHotReloadService.RunningProjectInfo() { RestartWhenChangesHaveNoEffect = autoRestart }))
+                let autoRestartProject = autoRestart || runningProject.ProjectNode.IsAutoRestartEnabled()
+                select (project.Id, info: new WatchHotReloadService.RunningProjectInfo() { RestartWhenChangesHaveNoEffect = autoRestartProject }))
                 .ToImmutableDictionary(e => e.Id, e => e.info);
 
             var updates = await _hotReloadService.GetUpdatesAsync(currentSolution, runningProjectInfos, cancellationToken);
@@ -276,41 +275,43 @@ namespace Microsoft.DotNet.Watch
                 return (ImmutableDictionary<ProjectId, string>.Empty, []);
             }
 
-            ImmutableDictionary<string, ImmutableArray<RunningProject>> projectsToUpdate;
-            lock (_runningProjectsAndUpdatesGuard)
+            if (updates.ProjectUpdates.Any())
             {
-                // Adding the updates makes sure that all new processes receive them before they are added to running processes.
-                _previousUpdates = _previousUpdates.AddRange(updates.ProjectUpdates);
-
-                // Capture the set of processes that do not have the currently calculated deltas yet.
-                projectsToUpdate = _runningProjects;
-            }
-
-            // Apply changes to all running projects, even if they do not have a static project dependency on any project that changed.
-            // The process may load any of the binaries using MEF or some other runtime dependency loader.
-
-            await ForEachProjectAsync(projectsToUpdate, async (runningProject, cancellationToken) =>
-            {
-                try
+                ImmutableDictionary<string, ImmutableArray<RunningProject>> projectsToUpdate;
+                lock (_runningProjectsAndUpdatesGuard)
                 {
-                    using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(runningProject.ProcessExitedSource.Token, cancellationToken);
-                    var applySucceded = await runningProject.DeltaApplier.ApplyManagedCodeUpdates(updates.ProjectUpdates, processCommunicationCancellationSource.Token) != ApplyStatus.Failed;
-                    if (applySucceded)
+                    // Adding the updates makes sure that all new processes receive them before they are added to running processes.
+                    _previousUpdates = _previousUpdates.AddRange(updates.ProjectUpdates);
+
+                    // Capture the set of processes that do not have the currently calculated deltas yet.
+                    projectsToUpdate = _runningProjects;
+                }
+
+                // Apply changes to all running projects, even if they do not have a static project dependency on any project that changed.
+                // The process may load any of the binaries using MEF or some other runtime dependency loader.
+
+                await ForEachProjectAsync(projectsToUpdate, async (runningProject, cancellationToken) =>
+                {
+                    try
                     {
-                        runningProject.Reporter.Report(MessageDescriptor.HotReloadSucceeded);
-                        if (runningProject.BrowserRefreshServer is { } server)
+                        using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(runningProject.ProcessExitedSource.Token, cancellationToken);
+                        var applySucceded = await runningProject.DeltaApplier.ApplyManagedCodeUpdates(updates.ProjectUpdates, processCommunicationCancellationSource.Token) != ApplyStatus.Failed;
+                        if (applySucceded)
                         {
-                            runningProject.Reporter.Verbose("Refreshing browser.");
-                            await server.RefreshBrowserAsync(cancellationToken);
+                            runningProject.Reporter.Report(MessageDescriptor.HotReloadSucceeded);
+                            if (runningProject.BrowserRefreshServer is { } server)
+                            {
+                                runningProject.Reporter.Verbose("Refreshing browser.");
+                                await server.RefreshBrowserAsync(cancellationToken);
+                            }
                         }
                     }
-                }
-                catch (OperationCanceledException) when (runningProject.ProcessExitedSource.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    runningProject.Reporter.Verbose("Hot reload canceled because the process exited.", emoji: "🔥");
-                }
-            }, cancellationToken);
-
+                    catch (OperationCanceledException) when (runningProject.ProcessExitedSource.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        runningProject.Reporter.Verbose("Hot reload canceled because the process exited.", emoji: "🔥");
+                    }
+                }, cancellationToken);
+            }
 
             if (updates.ProjectsToRestart.IsEmpty)
             {
@@ -420,8 +421,10 @@ namespace Microsoft.DotNet.Watch
                     .SelectMany(e => e.Value)
                     .ToHashSet();
 
+                // Project with rude edit that doesn't impact running project is only listed in ProjectsToRebuild.
+                // Such projects are always auto-rebuilt whether or not there is any project to be restarted that needs a confirmation.
                 var projectsRebuiltDueToRudeEdits = updates.ProjectsToRebuild
-                    .Where(IsAutoRestartEnabled)
+                    .Where(p => !updates.ProjectsToRestart.ContainsKey(p))
                     .ToHashSet();
 
                 foreach (var (projectId, diagnostics) in updates.RudeEdits)

--- a/src/BuiltInTools/dotnet-watch/HotReload/RestartPrompt.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/RestartPrompt.cs
@@ -5,14 +5,14 @@ namespace Microsoft.DotNet.Watch
 {
     internal sealed class RestartPrompt(IReporter reporter, ConsoleInputReader requester, bool? noPrompt)
     {
-        private bool? _restartImmediatelySessionPreference = noPrompt;
+        public bool? AutoRestartPreference { get; private set; } = noPrompt;
 
         public async ValueTask<bool> WaitForRestartConfirmationAsync(string question, CancellationToken cancellationToken)
         {
-            if (_restartImmediatelySessionPreference.HasValue)
+            if (AutoRestartPreference.HasValue)
             {
                 reporter.Output("Restarting");
-                return _restartImmediatelySessionPreference.Value;
+                return AutoRestartPreference.Value;
             }
 
             var key = await requester.GetKeyAsync(
@@ -30,11 +30,11 @@ namespace Microsoft.DotNet.Watch
                     return false;
 
                 case ConsoleKey.A:
-                    _restartImmediatelySessionPreference = true;
+                    AutoRestartPreference = true;
                     return true;
 
                 case ConsoleKey.V:
-                    _restartImmediatelySessionPreference = false;
+                    AutoRestartPreference = false;
                     return false;
             }
 

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -105,6 +105,47 @@ namespace Microsoft.DotNet.Watch.UnitTests
             App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
         }
 
+        [Fact]
+        public async Task AutoRestartOnRudeEditAfterRestartPrompt()
+        {
+            var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
+                .WithSource();
+
+            var programPath = Path.Combine(testAsset.Path, "Program.cs");
+
+            App.Start(testAsset, [], testFlags: TestFlags.ReadKeyFromStdin);
+
+            await App.AssertWaitingForChanges();
+            App.Process.ClearOutput();
+
+            // rude edit: adding virtual method
+            UpdateSourceFile(programPath, src => src.Replace("/* member placeholder */", "public virtual void F() {}"));
+
+            await App.AssertOutputLineStartsWith("  ❔ Do you want to restart your app? Yes (y) / No (n) / Always (a) / Never (v)", failure: _ => false);
+
+            App.AssertOutputContains("⌚ Restart is needed to apply the changes.");
+            App.AssertOutputContains($"❌ {programPath}(33,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
+            App.Process.ClearOutput();
+
+            App.SendKey('a');
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            App.Process.ClearOutput();
+
+            // rude edit: deleting virtual method
+            UpdateSourceFile(programPath, src => src.Replace("public virtual void F() {}", ""));
+
+            await App.AssertOutputLineStartsWith(MessageDescriptor.WaitingForChanges, failure: _ => false);
+
+            App.AssertOutputContains("⌚ Restart is needed to apply the changes");
+            App.AssertOutputContains($"⌚ [auto-restart] {programPath}(33,1): error ENC0033: Deleting method 'F()' requires restarting the application.");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
+            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+        }
+
         [Theory]
         [CombinatorialData]
         public async Task AutoRestartOnNoEffectEdit(bool nonInteractive)

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -760,7 +760,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.AssertOutputLineStartsWith("  ❔ Do you want to restart these projects? Yes (y) / No (n) / Always (a) / Never (v)");
 
             App.AssertOutputContains("dotnet watch ⌚ Restart is needed to apply the changes.");
-            App.AssertOutputContains("error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
+            App.AssertOutputContains($"dotnet watch ❌ {serviceSourcePath}(36,1): error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
             App.AssertOutputContains("dotnet watch ⌚ Affected projects:");
             App.AssertOutputContains("dotnet watch ⌚   WatchAspire.ApiService");
             App.Process.ClearOutput();

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -27,7 +27,7 @@ public class CompilationHandlerTests(ITestOutputHelper logger) : DotNetWatchTest
             reporter);
 
         var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: false);
-        var handler = new CompilationHandler(reporter, environmentOptions, new GlobalOptions(), CancellationToken.None);
+        var handler = new CompilationHandler(reporter, environmentOptions, CancellationToken.None);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);
 


### PR DESCRIPTION
Last change caused misreporting rude edits in some cases. Fix and add tests.
Also switch to auto-restart mode when user replies "Always" on rude edit prompt.