### PR TITLE
Remove PGO legs from SDK official build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -145,33 +145,6 @@ extends:
                 _SignType: real
               dependsOn: Official_windows_x64
               downloadManifestMsiPackages: true
-            ### PGO ###
-            - categoryName: PGO
-              pgoInstrument: true
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-            - categoryName: PGO
-              pgoInstrument: true
-              targetArchitecture: x86
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-            - categoryName: PGO
-              pgoInstrument: true
-              targetArchitecture: arm64
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
 
       ############### LINUX ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
@@ -265,21 +238,6 @@ extends:
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: /p:OSName=linux-musl
-              runTests: false
-            ### PGO ###
-            - categoryName: PGO
-              pgoInstrument: true
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties)
-              runTests: false
-            - categoryName: PGO
-              pgoInstrument: true
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties)
               runTests: false
 
       ############### MACOS ###############


### PR DESCRIPTION
Now that our optimization tooling repo consumes assets from the VMR, we don't need to run the PGO legs in the SDK official build at all.

Remove them now (instead of waiting for the assetless official build work) so we can clean up the PGO logic in the VMR.