### PR TITLE
[dotnet-format] Include the .NET Framework buildhost executable in the SDK.

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -113,6 +113,7 @@
 
     <ItemGroup>
       <DotnetFormatDllFiles Include="$(Pkgdotnet-format)/tools/net8.0/any/**/*.dll" />
+      <DotnetFormatDllFiles Include="$(Pkgdotnet-format)/tools/net8.0/any/**/*.exe" />
       <DotnetFormatConfigFiles Include="$(Pkgdotnet-format)/tools/net8.0/any/**/*.json" />
       <DotnetFormatConfigFiles Include="$(Pkgdotnet-format)/tools/net8.0/any/**/*.config" />
     </ItemGroup>


### PR DESCRIPTION
This is necessary for dotnet-format to load .NET Framework projects.

Backport of #45290 to release/8.0.4xx

# Description
Roslyn 4.9+ moved project loading out-of-process to a separate build host. Roslyn ships both .NET and .NET Framework build hosts in order to support framework projects. By not shipping the full framework build host dotnet-format now errors when trying to load full framework projects.

# Risk 
Low - This same change has shipped in the 9.0 SDKs and is not a change in behavior but a packaging change.

# Regression
Yes. Prior to moving to Roslyn 4.9+ full framework projects were not supported by dotnet-format and there would be no error.

# Testing
