### PR TITLE
[StaticWebAssets] Compress generated html file

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/OverrideHtmlAssetPlaceholders.cs
+++ b/src/StaticWebAssetsSdk/Tasks/OverrideHtmlAssetPlaceholders.cs
@@ -98,7 +98,9 @@ public partial class OverrideHtmlAssetPlaceholders : Task
                         fileWrites.Add(outputPath);
                     }
 
-                    htmlCandidates.Add(new TaskItem(outputPath, item.CloneCustomMetadata()));
+                    var newItem = new TaskItem(outputPath, item.CloneCustomMetadata());
+                    newItem.RemoveMetadata("OriginalItemSpec");
+                    htmlCandidates.Add(newItem);
                 }
             }
         }


### PR DESCRIPTION
- Remove `OriginalItemSpec` from generated html asset. It results in `RelatedAssetOriginalItemSpec` not being set and thus correct `RelatedAsset` is used when deciding which file to compress https://github.com/dotnet/sdk/blob/main/src/StaticWebAssetsSdk/Tasks/Utils/AssetToCompress.cs#L15
- Read and assert gzip and brotli compressed html assets in test

Fixes https://github.com/dotnet/aspnetcore/issues/61937