### PR TITLE
[release/8.0.4xx] Containers - Retry on download blob

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -237,6 +237,11 @@ internal static class ContainerBuilder
                 cancellationToken)).ConfigureAwait(false);
             logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, destinationImageReference.RemoteRegistry.RegistryName);
         }
+        catch (UnableToDownloadFromRepositoryException)
+        {
+            logger.LogError(Resource.FormatString(nameof(Strings.UnableToDownloadFromRepository)), sourceImageReference);
+            return 1;
+        }
         catch (UnableToAccessRepositoryException)
         {
             logger.LogError(Resource.FormatString(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName));

--- a/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -215,6 +215,11 @@ internal static class ContainerBuilder
             await containerRegistry.LoadAsync(builtImage, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
             logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, containerRegistry);
         }
+        catch (UnableToDownloadFromRepositoryException)
+        {
+            logger.LogError(Resource.FormatString(nameof(Strings.UnableToDownloadFromRepository)), sourceImageReference);
+            return 1;
+        }
         catch (Exception ex)
         {
             logger.LogError(Resource.FormatString(nameof(Strings.RegistryOutputPushFailed), ex.Message));
@@ -236,11 +241,6 @@ internal static class ContainerBuilder
                 destinationImageReference,
                 cancellationToken)).ConfigureAwait(false);
             logger.LogInformation(Strings.ContainerBuilder_ImageUploadedToRegistry, destinationImageReference, destinationImageReference.RemoteRegistry.RegistryName);
-        }
-        catch (UnableToDownloadFromRepositoryException)
-        {
-            logger.LogError(Resource.FormatString(nameof(Strings.UnableToDownloadFromRepository)), sourceImageReference);
-            return 1;
         }
         catch (UnableToAccessRepositoryException)
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToDownloadFromRepositoryException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToDownloadFromRepositoryException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Containers;
+
+internal sealed class UnableToDownloadFromRepositoryException : Exception
+{
+    public UnableToDownloadFromRepositoryException(string repository)
+        : base($"The download of the image from repository { repository } has failed.")
+    {
+    }
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -107,6 +107,10 @@ internal static class ImagePublisher
             await loadFunc(image, sourceImageReference, destinationImageReference, cancellationToken).ConfigureAwait(false);
             Log.LogMessage(MessageImportance.High, Strings.ContainerBuilder_ImageUploadedToLocalDaemon, destinationImageReference, localRegistry);
         }
+        catch (UnableToDownloadFromRepositoryException)
+        {
+            Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToDownloadFromRepository), sourceImageReference);
+        }
         catch (ContainerHttpException e)
         {
             Log.LogErrorFromException(e, true);
@@ -144,10 +148,6 @@ internal static class ImagePublisher
                 destinationImageReference,
                 cancellationToken).ConfigureAwait(false);
             Log.LogMessage(MessageImportance.High, successMessage, destinationImageReference, destinationImageReference.RemoteRegistry!.RegistryName);
-        }
-        catch (UnableToAccessRepositoryException)
-        {
-            Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
         }
         catch (ContainerHttpException e)
         {

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -149,6 +149,10 @@ internal static class ImagePublisher
                 cancellationToken).ConfigureAwait(false);
             Log.LogMessage(MessageImportance.High, successMessage, destinationImageReference, destinationImageReference.RemoteRegistry!.RegistryName);
         }
+        catch (UnableToAccessRepositoryException)
+        {
+            Log.LogErrorWithCodeFromResources(nameof(Strings.UnableToAccessRepository), destinationImageReference.Repository, destinationImageReference.RemoteRegistry!.RegistryName);
+        }
         catch (ContainerHttpException e)
         {
             Log.LogErrorFromException(e, true);

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -408,15 +408,22 @@ internal sealed class Registry
             return localPath;
         }
 
-        // No local copy, so download one
-        using Stream responseStream = await _registryAPI.Blob.GetStreamAsync(repository, descriptor.Digest, cancellationToken).ConfigureAwait(false);
-
         string tempTarballPath = ContentStore.GetTempFile();
-        using (FileStream fs = File.Create(tempTarballPath))
-        {
-            await responseStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
-        }
 
+        try
+        {
+            // No local copy, so download one
+            using Stream responseStream = await _registryAPI.Blob.GetStreamAsync(repository, descriptor.Digest, cancellationToken).ConfigureAwait(false);
+
+            using (FileStream fs = File.Create(tempTarballPath))
+            {
+                await responseStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception)
+        {
+            throw new UnableToDownloadFromRepositoryException(repository);
+        }
         cancellationToken.ThrowIfCancellationRequested();
 
         File.Move(tempTarballPath, localPath, overwrite: true);

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -75,7 +75,7 @@ internal sealed class Registry
     private const string DockerHubRegistry2 = "registry.hub.docker.com";
     private static readonly int s_defaultChunkSizeBytes = 1024 * 64;
     private const int MaxDownloadRetries = 5;
-    private const int FixedDownloadDelayInSeconds = 1;
+    private readonly Func<TimeSpan> _retryDelayProvider;
 
     private readonly ILogger _logger;
     private readonly IRegistryAPI _registryAPI;
@@ -88,7 +88,7 @@ internal sealed class Registry
     /// </summary>
     public string RegistryName { get; }
 
-    internal Registry(string registryName, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null) :
+    internal Registry(string registryName, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null, Func<TimeSpan>? retryDelayProvider = null) :
         this(new Uri($"https://{registryName}"), logger, registryAPI, settings)
     { }
 
@@ -97,7 +97,7 @@ internal sealed class Registry
     { }
 
 
-    internal Registry(Uri baseUri, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null) :
+    internal Registry(Uri baseUri, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null, Func<TimeSpan>? retryDelayProvider = null) :
         this(baseUri, logger, new RegistryApiFactory(registryAPI), settings)
     { }
 
@@ -105,7 +105,7 @@ internal sealed class Registry
         this(baseUri, logger, new RegistryApiFactory(mode), settings)
     { }
 
-    private Registry(Uri baseUri, ILogger logger, RegistryApiFactory factory, RegistrySettings? settings = null)
+    private Registry(Uri baseUri, ILogger logger, RegistryApiFactory factory, RegistrySettings? settings = null, Func<TimeSpan>? retryDelayProvider = null)
     {
         RegistryName = DeriveRegistryName(baseUri);
 
@@ -119,6 +119,8 @@ internal sealed class Registry
         _logger = logger;
         _settings = settings ?? new RegistrySettings(RegistryName);
         _registryAPI = factory.Create(RegistryName, BaseUri, logger, _settings.IsInsecure);
+
+        _retryDelayProvider = retryDelayProvider ?? (() => TimeSpan.FromSeconds(1));
     }
 
     private static string DeriveRegistryName(Uri baseUri)
@@ -439,7 +441,7 @@ internal sealed class Registry
                 _logger.LogTrace("Download attempt {0}/{1} for repository '{2}' failed. Error: {3}", retryCount, MaxDownloadRetries, repository, ex.ToString());
     
                 // Wait before retrying
-                await Task.Delay(TimeSpan.FromSeconds(FixedDownloadDelayInSeconds), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(_retryDelayProvider(), cancellationToken).ConfigureAwait(false);
             }
         }
     

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -845,6 +845,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to CONTAINER1018: Unable to download image from the repository &apos;{0}&apos;..
+        /// </summary>
+        internal static string UnableToDownloadFromRepository {
+            get {
+                return ResourceManager.GetString("UnableToDownloadFromRepository", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to CONTAINER2021: Unknown AppCommandInstruction &apos;{0}&apos;. Valid instructions are {1}..
         /// </summary>
         internal static string UnknownAppCommandInstruction {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -461,6 +461,10 @@
     <value>CONTAINER1015: Unable to access the repository '{0}' at tag '{1}' in the registry '{2}'. Please confirm that this name and tag are present in the registry.</value>
     <comment>{StrBegin="CONTAINER1015: "}</comment>
   </data>
+  <data name="UnableToDownloadFromRepository" xml:space="preserve">
+    <value>CONTAINER1018: Unable to download image from the repository '{0}'.</value>
+    <comment>{StrBegins="CONTAINER1018:" }</comment>
+  </data>
   <data name="UnableToAccessRepository" xml:space="preserve">
     <value>CONTAINER1016: Unable to access the repository '{0}' in the registry '{1}'. Please confirm your credentials are correct and that you have access to this repository and registry.</value>
     <comment>{StrBegin="CONTAINER1016:" }</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: Nelze získat přístup k úložišti „{0}“ v registru „{1}“. Ověřte prosím správnost vašich přihlašovacích údajů a to, že máte přístup k tomuto úložišti a registru.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: Neznámé AppCommandInstruction „{0}“. Platné pokyny jsou {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: Auf das Repository "{0}" in der Registrierung "{1}" kann nicht zugegriffen werden. Vergewissern Sie sich, dass Ihre Anmeldeinformationen korrekt sind und dass Sie Zugriff auf dieses Repository und die Registrierung haben.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: Unbekannte AppCommandInstruction "{0}". Gültige Anweisungen sind {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: no se puede acceder al repositorio ''{0}'' en el registro ''{1}''. Confirme que las credenciales son correctas y que tiene acceso a este repositorio y registro.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: AppCommandInstruction ''{0}desconocido. Las instrucciones válidas son {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: nous n’avons pas pu accéder au référentiel '{0}' dans le Registre '{1}'. Confirmez que vos informations d’identification sont correctes et que vous avez accès à ce référentiel et à ce Registre.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: instruction de commande d'application inconnue '{0}'. Les instructions valides sont {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: impossibile accedere al repository '{0}' nel Registro di sistema '{1}'. Verificare che le credenziali siano corrette e di avere accesso a questo repository e registro.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: appCommandInstruction '{0}'sconosciuta. Istruzioni valide sono {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: レジストリ '{1}' のリポジトリ '{0}' にアクセスできません。資格情報が正しいこと、およびこのリポジトリとレジストリへのアクセス権があることを確認してください。</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: 不明な AppCommandInstruction '{0}'。有効な手順は {1} です。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: '{1}' 레지스트리의 '{0}' 리포지토리에 액세스할 수 없습니다. 자격 증명이 올바르고 이 리포지토리 및 레지스트리에 액세스할 수 있는지 확인하세요.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: 알 수 없는 AppCommandInstruction '{0}'. 올바른 지침은 {1}입니다.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: nie można uzyskać dostępu do repozytorium „{0}” w rejestrze „{1}”. Upewnij się, że poświadczenia są poprawne oraz że masz dostęp do tego repozytorium i rejestru.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: Nieznana instrukcja AppCommandInstruction „{0}”. Prawidłowe instrukcje to{1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: não é possível acessar o repositório ''{0}'' no registro ''{1}''. Confirme se suas credenciais estão corretas e se você tem acesso a este repositório e ao Registro.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: AppCommandInstruction desconhecido '{0}'. As instruções válidas são {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: не удается получить доступ к репозиторию "{0}" в реестре "{1}". Убедитесь, что ваши учетные данные верны и что у вас есть доступ к этому репозиторию и реестру.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: неизвестный элемент AppCommandInstruction "{0}". Допустимые инструкции: {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: '{1}' kayıt defterindeki '{0}' deposuna erişilemedi. Lütfen kimlik bilgilerinizin doğru olduğunu ve bu depoya ve kayıt defterine erişiminiz olduğunu onaylayın.</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: AppCommandInstruction '{0}' bilinmiyor. Geçerli yönergeler {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: 无法访问注册表“{1}”中的存储库“{0}”。请确认你的凭据正确无误，并且你有权访问此存储库和注册表。</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: AppCommandInstruction“{0}”未知。有效的说明为 {1}。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -429,6 +429,11 @@
         <target state="translated">CONTAINER1016: 無法存取登錄 '{1}' 中的存放庫 '{0}'。請確認您的認證正確，且您擁有此存放庫和登錄的存取權。</target>
         <note>{StrBegin="CONTAINER1016:" }</note>
       </trans-unit>
+      <trans-unit id="UnableToDownloadFromRepository">
+        <source>CONTAINER1018: Unable to download image from the repository '{0}'.</source>
+        <target state="new">CONTAINER1018: Unable to download image from the repository '{0}'.</target>
+        <note>{StrBegins="CONTAINER1018:" }</note>
+      </trans-unit>
       <trans-unit id="UnknownAppCommandInstruction">
         <source>CONTAINER2021: Unknown AppCommandInstruction '{0}'. Valid instructions are {1}.</source>
         <target state="translated">CONTAINER2021: 未知的 AppCommandInstruction '{0}'。有效的指示為 {1}。</target>

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -4,6 +4,8 @@
 using System.Formats.Tar;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using FakeItEasy;
+using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Build.Containers.LocalDaemons;
 using Microsoft.NET.Build.Containers.Resources;
@@ -1429,9 +1431,10 @@ public class EndToEndTests : IDisposable
     }
 
     [DockerAvailableFact]
-    public async Task CheckErrorMessageWhenSourceRepositoryThrows()
+    public async void CheckDownloadErrorMessageWhenSourceRepositoryThrows()
     {
-        ILogger logger = _loggerFactory.CreateLogger(nameof(CheckErrorMessageWhenSourceRepositoryThrows));
+        var loggerFactory = new TestLoggerFactory(_testOutput);
+        var logger = loggerFactory.CreateLogger(nameof(CheckDownloadErrorMessageWhenSourceRepositoryThrows));
         string rid = "win-x64";
         string publishDirectory = BuildLocalApp(tfm: ToolsetInfo.CurrentTargetFramework, rid: rid);
 
@@ -1457,23 +1460,38 @@ public class EndToEndTests : IDisposable
 
         // Load the image into the local registry
         var sourceReference = new SourceImageReference(registry, "some_random_image", DockerRegistryManager.Net8ImageTag);
-        var destinationReference = new DestinationImageReference(registry, NewImageName(), new[] { rid });
-        var sawMyException = false;
-        try
-        {
-            await new DockerCli(_loggerFactory).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
-        }
-        catch (UnableToDownloadFromRepositoryException e)
-        {
-            sawMyException = true;
-            Assert.Contains("The download of the image from repository some_random_image has failed", e.ToString());
-        }
-        Assert.True(sawMyException);
+        string archivePath = Path.Combine(TestSettings.TestArtifactsDirectory, nameof(CheckDownloadErrorMessageWhenSourceRepositoryThrows));
+        var destinationReference = new DestinationImageReference(new ArchiveFileRegistry(archivePath), NewImageName(), new[] { rid });
+
+        (var taskLog, var errors) = SetupTaskLog();
+        var telemetry = new Telemetry(sourceReference, destinationReference, taskLog);
+
+        await ImagePublisher.PublishImageAsync(builtImage, sourceReference, destinationReference, taskLog, telemetry, CancellationToken.None)
+                .ConfigureAwait(false);
+
+        // Assert the error message
+        Assert.True(taskLog.HasLoggedErrors);
+        Assert.NotNull(errors);
+        Assert.Single(errors);
+        Assert.Contains("Unable to download image from the repository", errors[0]);
 
         static string[] DecideEntrypoint(string rid, string appName, string workingDir)
         {
             var binary = rid.StartsWith("win", StringComparison.Ordinal) ? $"{appName}.exe" : appName;
             return new[] { $"{workingDir}/{binary}" };
+        }
+
+        static (Microsoft.Build.Utilities.TaskLoggingHelper, List<string?> errors) SetupTaskLog()
+        {
+            // We can use any Task, we just need TaskLoggingHelper
+            Tasks.CreateNewImage cni = new();
+            List<string?> errors = new();
+            IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+            A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => errors.Add(e.Message));
+            A.CallTo(() => buildEngine.LogErrorEvent(A<BuildErrorEventArgs>.Ignored)).Invokes((BuildErrorEventArgs e) => errors.Add(e.Message));
+            A.CallTo(() => buildEngine.LogMessageEvent(A<BuildMessageEventArgs>.Ignored)).Invokes((BuildMessageEventArgs e) => errors.Add(e.Message));
+            cni.BuildEngine = buildEngine;
+            return (cni.Log, errors);
         }
     }
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1428,6 +1428,55 @@ public class EndToEndTests : IDisposable
         }
     }
 
+    [DockerAvailableFact]
+    public async Task CheckErrorMessageWhenSourceRepositoryThrows()
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(CheckErrorMessageWhenSourceRepositoryThrows));
+        string rid = "win-x64";
+        string publishDirectory = BuildLocalApp(tfm: ToolsetInfo.CurrentTargetFramework, rid: rid);
+
+        // Build the image
+        Registry registry = new(DockerRegistryManager.BaseImageSource, logger, RegistryMode.Push);
+        ImageBuilder? imageBuilder = await registry.GetImageManifestAsync(
+            DockerRegistryManager.RuntimeBaseImage,
+            DockerRegistryManager.Net8PreviewWindowsSpecificImageTag,
+            rid,
+            ToolsetUtils.RidGraphManifestPicker,
+            cancellationToken: default).ConfigureAwait(false);
+        Assert.NotNull(imageBuilder);
+
+        Layer l = Layer.FromDirectory(publishDirectory, "C:\\app", true, imageBuilder.ManifestMediaType);
+
+        imageBuilder.AddLayer(l);
+        imageBuilder.SetWorkingDirectory("C:\\app");
+
+        string[] entryPoint = DecideEntrypoint(rid, "MinimalTestApp", "C:\\app");
+        imageBuilder.SetEntrypointAndCmd(entryPoint, Array.Empty<string>());
+
+        BuiltImage builtImage = imageBuilder.Build();
+
+        // Load the image into the local registry
+        var sourceReference = new SourceImageReference(registry, "some_random_image", DockerRegistryManager.Net8ImageTag);
+        var destinationReference = new DestinationImageReference(registry, NewImageName(), new[] { rid });
+        var sawMyException = false;
+        try
+        {
+            await new DockerCli(_loggerFactory).LoadAsync(builtImage, sourceReference, destinationReference, default).ConfigureAwait(false);
+        }
+        catch (UnableToDownloadFromRepositoryException e)
+        {
+            sawMyException = true;
+            Assert.Contains("The download of the image from repository some_random_image has failed", e.ToString());
+        }
+        Assert.True(sawMyException);
+
+        static string[] DecideEntrypoint(string rid, string appName, string workingDir)
+        {
+            var binary = rid.StartsWith("win", StringComparison.Ordinal) ? $"{appName}.exe" : appName;
+            return new[] { $"{workingDir}/{binary}" };
+        }
+    }
+
     [DockerAvailableFact(checkContainerdStoreAvailability: true)]
     public void EnforcesOciSchemaForMultiRIDTarballOutput()
     {

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -556,7 +556,7 @@ public class RegistryTests : IDisposable
             .ThrowsAsync(new Exception("Simulated failure 2")) // Second attempt fails
             .ReturnsAsync(new MemoryStream(new byte[] { 1, 2, 3 })); // Third attempt succeeds
 
-        Registry registry = new(repoName, logger, mockRegistryAPI.Object);
+        Registry registry = new(repoName, logger, mockRegistryAPI.Object, null, () => TimeSpan.Zero);
 
         // Act
         var result = await registry.DownloadBlobAsync(repoName, descriptor, cancellationToken);

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -558,16 +558,56 @@ public class RegistryTests : IDisposable
 
         Registry registry = new(repoName, logger, mockRegistryAPI.Object, null, () => TimeSpan.Zero);
 
-        // Act
-        var result = await registry.DownloadBlobAsync(repoName, descriptor, cancellationToken);
+        string? result = null;
+        try
+        {
+            // Act
+            result = await registry.DownloadBlobAsync(repoName, descriptor, cancellationToken);
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.True(File.Exists(result)); // Ensure the file was successfully downloaded
-        mockRegistryAPI.Verify(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken), Times.Exactly(3)); // Verify retries
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(File.Exists(result)); // Ensure the file was successfully downloaded
+            mockRegistryAPI.Verify(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken), Times.Exactly(3)); // Verify retries
+        }
+        finally
+        {
+            // Cleanup
+            if (result != null)
+            {
+                File.Delete(result);
+            }
+        }
+    }
 
-        //Cleanup
-        File.Delete(result);
+    [Fact]
+    public async Task DownloadBlobAsync_ThrowsAfterMaxRetries()
+    {
+        // Arrange
+        var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_ThrowsAfterMaxRetries));
+
+        var repoName = "testRepo";
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
+        var cancellationToken = CancellationToken.None;
+
+        var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);
+        // Simulate 5 failures (assuming your retry logic attempts 5 times before throwing)
+        mockRegistryAPI
+            .SetupSequence(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken))
+            .ThrowsAsync(new Exception("Simulated failure 1"))
+            .ThrowsAsync(new Exception("Simulated failure 2"))
+            .ThrowsAsync(new Exception("Simulated failure 3"))
+            .ThrowsAsync(new Exception("Simulated failure 4"))
+            .ThrowsAsync(new Exception("Simulated failure 5"));
+
+        Registry registry = new(repoName, logger, mockRegistryAPI.Object, null, () => TimeSpan.Zero);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnableToDownloadFromRepositoryException>(async () =>
+        {
+            await registry.DownloadBlobAsync(repoName, descriptor, cancellationToken);
+        });
+
+        mockRegistryAPI.Verify(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken), Times.Exactly(5));
     }
 
     private static NextChunkUploadInformation ChunkUploadSuccessful(Uri requestUri, Uri uploadUrl, int? contentLength, HttpStatusCode code = HttpStatusCode.Accepted)

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -546,7 +546,7 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_RetriesOnFailure));
 
         var repoName = "testRepo";
-        var descriptor = new Descriptor("application/octet-stream", "sha256:testdigest", 1234);
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
         var cancellationToken = CancellationToken.None;
 
         var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);
@@ -565,6 +565,9 @@ public class RegistryTests : IDisposable
         Assert.NotNull(result);
         Assert.True(File.Exists(result)); // Ensure the file was successfully downloaded
         mockRegistryAPI.Verify(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken), Times.Exactly(3)); // Verify retries
+
+        //Cleanup
+        File.Delete(result);
     }
 
     private static NextChunkUploadInformation ChunkUploadSuccessful(Uri requestUri, Uri uploadUrl, int? contentLength, HttpStatusCode code = HttpStatusCode.Accepted)


### PR DESCRIPTION
Fixes #48940

### Description/Customer Impact

When building images we often have to pull base image layers from remote sources. These layers can be quite large, and so network interruption can cause the entire build to report failure. Typically we try to retry these operations (e.g. the Copy Task in MSBuild itself), so we should do the same here. 

We're forced to use pretty naive retries (operation-level, not chunk-level) because the OCI HTTP API and many popular registries do not support chunked requests well.

### Changes made
1. Copied logic for improved logging in `DownloadBlobAsync` in case of failure from https://github.com/dotnet/sdk/pull/44953 (too many commits, something goes wrong when try git cherry-pick)
2. Modified `Registry.DownloadBlobAsync` by adding a retry mechanism

### Testing
Added unit test for retry mechanism. 

### Risk
**Low** - tests have been added and the mechanism is very simple.