### PR TITLE
Upgrade scancode to 32.3.3 and downgrade click to 8.1.8

### DIFF
--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -5,12 +5,13 @@ set -euo pipefail
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-SCANCODE_VERSION="32.3.2"
+SCANCODE_VERSION="32.3.3"
 
 pyEnvPath="/tmp/scancode-env"
 python3 -m venv $pyEnvPath
 source $pyEnvPath/bin/activate
 pip install scancode-toolkit==$SCANCODE_VERSION
+pip install click==8.1.8
 deactivate
 
 # Setup a script which executes scancode in the virtual environment

--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -24,4 +24,3 @@ deactivate
 EOF
 
 chmod +x /usr/local/bin/scancode
- 

--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -24,3 +24,4 @@ deactivate
 EOF
 
 chmod +x /usr/local/bin/scancode
+ 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5159

License scan test failed due to an outdated attribute mapping in the scancode toolkit. The attribute `is_hidden` has been renamed to `hidden`, but this change has not yet been included in the latest version of the scancode toolkit.