### PR TITLE
Support binlog in build/restore of file-based programs

### DIFF
--- a/src/Cli/dotnet/Commands/Restore/RestoreCommand.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoreCommand.cs
@@ -24,15 +24,17 @@ public static class RestoreCommand
 
         result.ShowHelpOrErrorIfAppropriate();
 
-        string[] fileArgument = result.GetValue(RestoreCommandParser.SlnOrProjectOrFileArgument) ?? [];
+        string[] args = result.GetValue(RestoreCommandParser.SlnOrProjectOrFileArgument) ?? [];
+
+        LoggerUtility.SeparateBinLogArguments(args, out var binLogArgs, out var nonBinLogArgs);
 
         string[] forwardedOptions = result.OptionValuesToBeForwarded(RestoreCommandParser.GetCommand()).ToArray();
 
-        if (fileArgument is [{ } arg] && VirtualProjectBuildingCommand.IsValidEntryPointPath(arg))
+        if (nonBinLogArgs is [{ } arg] && VirtualProjectBuildingCommand.IsValidEntryPointPath(arg))
         {
             return new VirtualProjectBuildingCommand(
                     entryPointFileFullPath: Path.GetFullPath(arg),
-                    msbuildArgs: forwardedOptions,
+                    msbuildArgs: [.. forwardedOptions, ..binLogArgs],
                     verbosity: result.GetValue(CommonOptions.VerbosityOption),
                     interactive: result.GetValue(CommonOptions.InteractiveMsBuildForwardOption))
             {
@@ -41,7 +43,7 @@ public static class RestoreCommand
             };
         }
 
-        return CreateForwarding(["-target:Restore", .. forwardedOptions, .. fileArgument], msbuildPath);
+        return CreateForwarding(["-target:Restore", .. forwardedOptions, .. args], msbuildPath);
     }
 
     public static MSBuildForwardingApp CreateForwarding(IEnumerable<string> msbuildArgs, string? msbuildPath = null)

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -515,24 +515,12 @@ public class RunCommand
         // bl information to synchronize the restore and build logger configurations
         var applicationArguments = parseResult.GetValue(RunCommandParser.ApplicationArguments)?.ToList();
 
-        var binlogArgs = new List<string>();
-        var nonBinLogArgs = new List<string>();
-        foreach (var arg in applicationArguments ?? [])
-        {
-            if (LoggerUtility.IsBinLogArgument(arg))
-            {
-                binlogArgs.Add(arg);
-            }
-            else
-            {
-                nonBinLogArgs.Add(arg);
-            }
-        }
+        LoggerUtility.SeparateBinLogArguments(applicationArguments, out var binLogArgs, out var nonBinLogArgs);
 
         var restoreArgs = parseResult.OptionValuesToBeForwarded(RunCommandParser.GetCommand()).ToList();
-        if (binlogArgs.Count > 0)
+        if (binLogArgs.Count > 0)
         {
-            restoreArgs.AddRange(binlogArgs);
+            restoreArgs.AddRange(binLogArgs);
         }
 
         var command = new RunCommand(

--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -61,20 +61,7 @@ internal static class MSBuildUtility
 
     public static BuildOptions GetBuildOptions(ParseResult parseResult, int degreeOfParallelism)
     {
-        var binLogArgs = new List<string>();
-        var otherArgs = new List<string>();
-
-        foreach (var arg in parseResult.UnmatchedTokens)
-        {
-            if (LoggerUtility.IsBinLogArgument(arg))
-            {
-                binLogArgs.Add(arg);
-            }
-            else
-            {
-                otherArgs.Add(arg);
-            }
-        }
+        LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(TestCommandParser.GetCommand())
             .Concat(binLogArgs);

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -61,6 +61,23 @@ internal static class LoggerUtility
         return new FacadeLogger(dispatcher);
     }
 
+    internal static void SeparateBinLogArguments(IEnumerable<string>? args, out List<string> binLogArgs, out List<string> nonBinLogArgs)
+    {
+        binLogArgs = new List<string>();
+        nonBinLogArgs = new List<string>();
+        foreach (var arg in args ?? [])
+        {
+            if (IsBinLogArgument(arg))
+            {
+                binLogArgs.Add(arg);
+            }
+            else
+            {
+                nonBinLogArgs.Add(arg);
+            }
+        }
+    }
+
     internal static bool IsBinLogArgument(string arg)
     {
         const StringComparison comp = StringComparison.OrdinalIgnoreCase;

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -573,6 +573,27 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().BeEquivalentTo(["msbuild.binlog", "msbuild-dotnet-run.binlog"]);
     }
 
+    [Theory, CombinatorialData]
+    public void BinaryLog_Build([CombinatorialValues("restore", "build")] string command, bool beforeFile)
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), s_program);
+
+        string[] args = beforeFile
+            ? [command, "-bl", "Program.cs"]
+            : [command, "Program.cs", "-bl"];
+
+        new DotnetCommand(Log, args)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DirectoryInfo(testInstance.Path)
+            .EnumerateFiles("*.binlog", SearchOption.TopDirectoryOnly)
+            .Select(f => f.Name)
+            .Should().BeEquivalentTo(["msbuild.binlog"]);
+    }
+
     [Theory]
     [InlineData("-bl")]
     [InlineData("-BL")]


### PR DESCRIPTION
Without this PR, `dotnet build -bl Program.cs` is not supported because both args (`-bl` and `Program.cs`) are treated as the "project file" argument (that's a pre-existing behavior, even for project-based programs, but for them all unknown arguments are forwarded to msbuild.exe, which we can't do when using msbuild APIs). This PR makes build/restore extract `-bl` arguments just like the `dotnet run` command does.