### PR TITLE
Source package cleanup

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,4 +78,33 @@
     </KnownFrameworkReference>
   </ItemGroup>
 
+  <!--
+    Common content for all SDK source packages.
+  -->
+
+  <PropertyGroup Condition="'$(IsSourcePackage)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddEditorConfigToSourcePackage;_AddLinkedCompileItemsToSourcePackage</TargetsForTfmSpecificContentInPackage>
+    <PackageDescription>
+      $(PackageDescription)
+
+      The source code included in this package is subject to arbitrary changes in future versions. 
+      Updating a reference to this package to a newer version of the package may require changes in the referencing project.
+      No compatibility guarantees are provided.
+    </PackageDescription>
+  </PropertyGroup>
+
+  <!-- Include SourcePackage.editorconfig in all source packages. -->
+  <Target Name="_AddEditorConfigToSourcePackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)eng\SourcePackage.editorconfig" PackagePath="contentFiles/cs/$(TargetFramework)/.editorconfig" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Include linked files. Arcade SDK only includes files in the project directory. -->
+  <Target Name="_AddLinkedCompileItemsToSourcePackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(Compile)" Condition="'%(Compile.Link)' != ''" PackagePath="contentFiles/cs/$(TargetFramework)/%(Compile.Link)" BuildAction="Compile"/>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/eng/SourcePackage.editorconfig
+++ b/eng/SourcePackage.editorconfig
@@ -1,0 +1,18 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+# We don't want any analyzer diagnostics to be reported for people consuming this as a source package.
+dotnet_analyzer_diagnostic.severity = none
+
+generated_code = true
+
+# The above configurations don't apply to compiler warnings.  Requiring all params to be documented
+# is not something we require for this project, so suppressing it directly here.
+dotnet_diagnostic.CS1573.severity = none
+
+# As above, we need to specifically disable compiler warnings that we don't want to break downstream
+# builds
+dotnet_diagnostic.IDE0005.severity = none

--- a/src/BuiltInTools/AspireService/.editorconfig
+++ b/src/BuiltInTools/AspireService/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+
+# IDE0240: Remove redundant nullable directive
+# The directive needs to be included since all sources in a source package are considered generated code
+# when referenced from a project via package reference.
+dotnet_diagnostic.IDE0240.severity = none

--- a/src/BuiltInTools/AspireService/AspireServerService.cs
+++ b/src/BuiltInTools/AspireService/AspireServerService.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
+++ b/src/BuiltInTools/AspireService/Contracts/IAspireServerEvents.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;

--- a/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
+++ b/src/BuiltInTools/AspireService/Helpers/CertGenerator.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/ExceptionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
+++ b/src/BuiltInTools/AspireService/Helpers/HttpContextExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
+++ b/src/BuiltInTools/AspireService/Helpers/LoggerProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/src/BuiltInTools/AspireService/Helpers/SocketConnectionManager.cs
+++ b/src/BuiltInTools/AspireService/Helpers/SocketConnectionManager.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;

--- a/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
+++ b/src/BuiltInTools/AspireService/Helpers/SocketUtilities.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
+++ b/src/BuiltInTools/AspireService/Helpers/WebSocketConnection.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/BuiltInTools/AspireService/Models/ErrorResponse.cs
+++ b/src/BuiltInTools/AspireService/Models/ErrorResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Text.Json.Serialization;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Models/InfoResponse.cs
+++ b/src/BuiltInTools/AspireService/Models/InfoResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Text.Json.Serialization;
 
 namespace Aspire.Tools.Service;

--- a/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
+++ b/src/BuiltInTools/AspireService/Models/RunSessionRequest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;

--- a/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
+++ b/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 

--- a/src/BuiltInTools/HotReloadAgent.Data/.editorconfig
+++ b/src/BuiltInTools/HotReloadAgent.Data/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+
+# IDE0240: Remove redundant nullable directive
+# The directive needs to be included since all sources in a source package are considered generated code
+# when referenced from a project via package reference.
+dotnet_diagnostic.IDE0240.severity = none

--- a/src/BuiltInTools/HotReloadAgent.Data/AgentEnvironmentVariables.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/AgentEnvironmentVariables.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.DotNet.HotReload;
 
 internal static class AgentEnvironmentVariables

--- a/src/BuiltInTools/HotReloadAgent.Data/AgentMessageSeverity.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/AgentMessageSeverity.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.DotNet.HotReload;
 
 internal enum AgentMessageSeverity : byte

--- a/src/BuiltInTools/HotReloadAgent.Data/ResponseLoggingLevel.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/ResponseLoggingLevel.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.DotNet.HotReload;
 
 internal enum ResponseLoggingLevel : byte

--- a/src/BuiltInTools/HotReloadAgent.Data/StaticAssetUpdate.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/StaticAssetUpdate.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.DotNet.HotReload;
 
 internal readonly struct StaticAssetUpdate(

--- a/src/BuiltInTools/HotReloadAgent.Data/UpdateDelta.cs
+++ b/src/BuiltInTools/HotReloadAgent.Data/UpdateDelta.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.DotNet.HotReload;

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/.editorconfig
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+
+# IDE0240: Remove redundant nullable directive
+# The directive needs to be included since all sources in a source package are considered generated code
+# when referenced from a project via package reference.
+dotnet_diagnostic.IDE0240.severity = none

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/NamedPipeContract.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/NamedPipeContract.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 
+#nullable enable
+
 using System;
 using System.Buffers;
 using System.Buffers.Binary;

--- a/src/BuiltInTools/HotReloadAgent/.editorconfig
+++ b/src/BuiltInTools/HotReloadAgent/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+
+# IDE0240: Remove redundant nullable directive
+# The directive needs to be included since all sources in a source package are considered generated code
+# when referenced from a project via package reference.
+dotnet_diagnostic.IDE0240.severity = none

--- a/src/BuiltInTools/HotReloadAgent/AgentReporter.cs
+++ b/src/BuiltInTools/HotReloadAgent/AgentReporter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
Adds editorconfig settings that improve consumption of source packages built in the repo (Aspire, dotnet-watch agent).

Include editorconfig file in all source packages that designates all source files in the package generated. This allows the consuming project to use different naming conventions.

Add #nullable enable to all source files in source packages. Generated source files are required to declare nullability rules.

See also https://github.com/dotnet/roslyn/pull/78534