### PR TITLE
Reenable tests in WorkloadTests.cs

### DIFF
--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.NET.Build.Tests
                 .BeEquivalentTo("true");
         }
 
-        [Fact(Skip="https://github.com/dotnet/sdk/issues/45516")]
+        [Fact]
         public void It_should_get_suggested_workload_by_GetRequiredWorkloads_target()
         {
             var mainProject = new TestProject()
@@ -261,7 +261,7 @@ namespace Microsoft.NET.Build.Tests
                 .BeEquivalentTo("android");
         }
 
-        [Theory(Skip="https://github.com/dotnet/sdk/issues/45516")]
+        [Theory]
         [InlineData($"{ToolsetInfo.CurrentTargetFramework}-android;{ToolsetInfo.CurrentTargetFramework}-ios", $"{ToolsetInfo.CurrentTargetFramework}-android;{ToolsetInfo.CurrentTargetFramework}-ios", "android;ios")]
         [InlineData(ToolsetInfo.CurrentTargetFramework, $"{ToolsetInfo.CurrentTargetFramework};{ToolsetInfo.CurrentTargetFramework}-android;{ToolsetInfo.CurrentTargetFramework}-ios", "android;ios")]
         [InlineData($"{ToolsetInfo.CurrentTargetFramework};{ToolsetInfo.CurrentTargetFramework}-ios", $"{ToolsetInfo.CurrentTargetFramework};{ToolsetInfo.CurrentTargetFramework}-android", "android;ios")]


### PR DESCRIPTION
Those were disabled as part of https://github.com/dotnet/sdk/pull/45500 but looks like they can be reenabled: https://github.com/dotnet/sdk/issues/45516#issuecomment-2691831312