### PR TITLE
Stop Format redistributing MSBuild

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -199,7 +199,7 @@
          Additionally, set the MinimumVSVersion for the installer UI that's required for targeting NetCurrent -->
     <MicrosoftBuildVersion>17.15.0-preview-25265-101</MicrosoftBuildVersion>
     <MicrosoftBuildLocalizationVersion>17.15.0-preview-25265-101</MicrosoftBuildLocalizationVersion>
-    <MicrosoftBuildMinimumVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">17.11.4</MicrosoftBuildMinimumVersion>
+    <MicrosoftBuildMinimumVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">17.11.31</MicrosoftBuildMinimumVersion>
     <MinimumVSVersion>17.13</MinimumVSVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -33,7 +33,14 @@
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
+
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <!-- Suppress transitive dependencies of MSBuildWorkspace on MSBuild to avoid unnecessary copies -->
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="All" />
 
     <!-- Loaded dynamically -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />


### PR DESCRIPTION
Bump MSBuild's baseline version to a patched 17.11 and stop having format drop MSBuild assemblies in its folder--they should never be used from there.
