### PR TITLE
[StaticWebAssets] Add file to FileWrites even when the content is the same in OverrideHtmlAssetPlaceholders

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/OverrideHtmlAssetPlaceholders.cs
+++ b/src/StaticWebAssetsSdk/Tasks/OverrideHtmlAssetPlaceholders.cs
@@ -93,10 +93,8 @@ public partial class OverrideHtmlAssetPlaceholders : Task
                     htmlFilesToRemove.Add(item);
 
                     string outputPath = Path.Combine(OutputPath, FileHasher.HashString(item.ItemSpec) + item.GetMetadata("Extension"));
-                    if (this.PersistFileIfChanged(Encoding.UTF8.GetBytes(outputContent), outputPath))
-                    {
-                        fileWrites.Add(outputPath);
-                    }
+                    this.PersistFileIfChanged(Encoding.UTF8.GetBytes(outputContent), outputPath);
+                    fileWrites.Add(outputPath);
 
                     var newItem = new TaskItem(outputPath, item.CloneCustomMetadata());
                     newItem.RemoveMetadata("OriginalItemSpec");


### PR DESCRIPTION
Fixes bug with incremental clean.
We need to mark the file as "written to" even if we skipped the write because the content was the same.