### PR TITLE
Handle name conflict between project name and referenced package in GenerateDepsFile

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -262,6 +262,11 @@ namespace Microsoft.NET.Build.Tasks
 
             List<ModifiableRuntimeLibrary> runtimeLibraries = new();
 
+            if (_includeMainProjectInDepsFile)
+            {
+                runtimeLibraries.Add(GetProjectRuntimeLibrary());
+            }
+
             runtimeLibraries.AddRange(GetRuntimePackLibraries());
 
             foreach (var library in _dependencyLibraries.Values
@@ -297,11 +302,6 @@ namespace Microsoft.NET.Build.Tasks
                     serviceable: false));
 
                 runtimeLibraries.Add(runtimeLibrary);
-            }
-
-            if (_includeMainProjectInDepsFile)
-            {
-                runtimeLibraries.Add(GetProjectRuntimeLibrary());
             }
 
             /*

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -262,11 +262,6 @@ namespace Microsoft.NET.Build.Tasks
 
             List<ModifiableRuntimeLibrary> runtimeLibraries = new();
 
-            if (_includeMainProjectInDepsFile)
-            {
-                runtimeLibraries.Add(GetProjectRuntimeLibrary());
-            }
-
             runtimeLibraries.AddRange(GetRuntimePackLibraries());
 
             foreach (var library in _dependencyLibraries.Values
@@ -302,6 +297,11 @@ namespace Microsoft.NET.Build.Tasks
                     serviceable: false));
 
                 runtimeLibraries.Add(runtimeLibrary);
+            }
+
+            if (_includeMainProjectInDepsFile)
+            {
+                runtimeLibraries.Add(GetProjectRuntimeLibrary());
             }
 
             /*
@@ -518,7 +518,7 @@ namespace Microsoft.NET.Build.Tasks
 
             return new ModifiableRuntimeLibrary(new RuntimeLibrary(
                 type: "project",
-                name: _mainProjectInfo.Name,
+                name: GetUniqueLibraryName(_mainProjectInfo.Name, "Project"),
                 version: _mainProjectInfo.Version,
                 hash: string.Empty,
                 runtimeAssemblyGroups: runtimeAssemblyGroups,
@@ -918,7 +918,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 // Reference names can conflict with PackageReference names, so
                 // ensure that the Reference names are unique when creating libraries
-                name = GetUniqueReferenceName(reference.Name);
+                name = GetUniqueLibraryName(reference.Name);
 
                 ReferenceLibraryNames.Add(reference, name);
                 _usedLibraryNames.Add(name);
@@ -927,11 +927,11 @@ namespace Microsoft.NET.Build.Tasks
             return name;
         }
 
-        private string GetUniqueReferenceName(string name)
+        private string GetUniqueLibraryName(string name, string qualifier = "Reference")
         {
             if (_usedLibraryNames.Contains(name))
             {
-                string startingName = $"{name}.Reference";
+                string startingName = $"{name}.{qualifier}";
                 name = startingName;
 
                 int suffix = 1;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Security.Cryptography;
 using Microsoft.Build.Utilities;
 using Microsoft.Extensions.DependencyModel;
 
@@ -154,6 +155,24 @@ public class NETFramework
                 var dependencyContext = new DependencyContextJsonReader().Read(depsJsonFileStream);
                 dependencyContext.RuntimeLibraries.Any(l => l.Name.Equals("Nerdbank.GitVersioning")).Should().BeFalse();
             }
+        }
+
+        [Fact]
+        public void ProjectNameCanMatchPackageReferenceName()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "Newtonsoft.Json",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+
+            testProject.PackageReferences.Add(new TestPackageReference("Newtonsoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()));
+            testProject.AdditionalProperties["PackageId"] = "Newtonsoft.Json*";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().Pass();
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
Fix bug introduced in #46218 and caught in dotnet/dotnet#614.