### PR TITLE
Update maintenance-packages pruning versions

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net5.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net5.0.cs
@@ -20,7 +20,7 @@ internal partial class FrameworkPackages
             { "System.Formats.Asn1", "5.0.0" },
             { "System.IO.FileSystem.AccessControl", "5.0.0" },
             { "System.Net.Http.Json", "5.0.0" },
-            { "System.Reflection.DispatchProxy", "4.7.1" },
+            { "System.Reflection.DispatchProxy", "4.8.2" },
             { "System.Reflection.Metadata", "5.0.0" },
             { "System.Runtime.CompilerServices.Unsafe", "5.0.0" },
             { "System.Security.AccessControl", "5.0.0" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net6.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net6.0.cs
@@ -18,7 +18,7 @@ internal partial class FrameworkPackages
             { "System.Formats.Asn1", "6.0.0" },
             { "System.Net.Http.Json", "6.0.0" },
             { "System.Reflection.Metadata", "6.0.0" },
-            { "System.Runtime.CompilerServices.Unsafe", "6.0.0" },
+            { "System.Runtime.CompilerServices.Unsafe", "6.1.2" },
             { "System.Security.AccessControl", "6.0.0" },
             { "System.Text.Encoding.CodePages", "6.0.0" },
             { "System.Text.Encodings.Web", "6.0.0" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
@@ -17,14 +17,14 @@ internal partial class FrameworkPackages
             { "Microsoft.NETCore.App", "2.1.0" },
             { "Microsoft.VisualBasic", "10.3.0" },
             { "Microsoft.Win32.Registry", "4.5.0" },
-            { "System.Buffers", "4.5.0" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Immutable", "1.5.0" },
             { "System.ComponentModel.Annotations", "4.5.0" },
             { "System.Diagnostics.DiagnosticSource", "4.5.0" },
             { "System.IO.FileSystem.AccessControl", "4.5.0" },
             { "System.IO.Pipes.AccessControl", "4.5.0" },
-            { "System.Memory", "4.5.5" },
-            { "System.Numerics.Vectors", "4.5.0" },
+            { "System.Memory", "4.6.3" },
+            { "System.Numerics.Vectors", "4.6.1" },
             { "System.Reflection.DispatchProxy", "4.5.0" },
             { "System.Reflection.Metadata", "1.6.0" },
             { "System.Security.AccessControl", "4.5.0" },
@@ -32,8 +32,8 @@ internal partial class FrameworkPackages
             { "System.Security.Cryptography.OpenSsl", "4.5.0" },
             { "System.Security.Principal.Windows", "4.5.0" },
             { "System.Threading.Tasks.Dataflow", "4.9.0" },
-            { "System.Threading.Tasks.Extensions", "4.5.4" },
-            { "System.ValueTuple", "4.5.0" },
+            { "System.Threading.Tasks.Extensions", "4.6.3" },
+            { "System.ValueTuple", "4.6.1" },
         };
 
         internal static void Register() => FrameworkPackages.Register(Instance);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
@@ -15,7 +15,7 @@ internal partial class FrameworkPackages
         {
             { "Microsoft.CSharp", "4.6.0" },
             { "Microsoft.Win32.Registry", "4.6.0" },
-            { "System.Buffers", "4.5.1" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Immutable", "1.6.0" },
             { "System.ComponentModel.Annotations", "4.6.0" },
             { "System.Data.DataSetExtensions", "4.5.0" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
@@ -19,7 +19,7 @@ internal partial class FrameworkPackages
             { "System.ComponentModel.Annotations", "4.7.0" },
             { "System.Diagnostics.DiagnosticSource", "4.7.0" },
             { "System.IO.FileSystem.AccessControl", "4.7.0" },
-            { "System.Reflection.DispatchProxy", "4.7.0" },
+            { "System.Reflection.DispatchProxy", "4.8.2" },
             { "System.Reflection.Metadata", "1.8.0" },
             { "System.Runtime.CompilerServices.Unsafe", "4.7.1" },
             { "System.Runtime.WindowsRuntime", "4.7.0" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
@@ -98,7 +98,7 @@ internal partial class FrameworkPackages
             { "System.Threading.Thread", "4.3.0" },
             { "System.Threading.ThreadPool", "4.3.0" },
             { "System.Threading.Timer", "4.3.0" },
-            { "System.ValueTuple", "4.4.0" },
+            { "System.ValueTuple", "4.6.1" },
             { "System.Xml.ReaderWriter", "4.3.1" },
             { "System.Xml.XDocument", "4.0.11" },
             { "System.Xml.XmlDocument", "4.3.0" },

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
@@ -13,7 +13,7 @@ internal partial class FrameworkPackages
     {
         internal static FrameworkPackages Instance { get; } = new(NetStandard21, FrameworkNames.NetStandardLibrary, NETStandard20.Instance)
         {
-            { "System.Buffers", "4.5.1" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Concurrent", "4.3.0" },
             { "System.Collections.Immutable", "1.4.0" },
             { "System.ComponentModel", "4.3.0" },
@@ -22,10 +22,10 @@ internal partial class FrameworkPackages
             { "System.Diagnostics.Contracts", "4.3.0" },
             { "System.Dynamic.Runtime", "4.3.0" },
             { "System.Linq.Queryable", "4.3.0" },
-            { "System.Memory", "4.5.5" },
+            { "System.Memory", "4.6.3" },
             { "System.Net.Requests", "4.3.0" },
             { "System.Net.WebHeaderCollection", "4.3.0" },
-            { "System.Numerics.Vectors", "4.5.0" },
+            { "System.Numerics.Vectors", "4.6.1" },
             { "System.ObjectModel", "4.3.0" },
             { "System.Private.DataContractSerialization", "4.3.0" },
             { "System.Reflection.DispatchProxy", "4.5.1" },
@@ -41,7 +41,7 @@ internal partial class FrameworkPackages
             { "System.Security.Principal", "4.3.0" },
             { "System.Security.Principal.Windows", "4.4.0" },
             { "System.Threading", "4.3.0" },
-            { "System.Threading.Tasks.Extensions", "4.5.4" },
+            { "System.Threading.Tasks.Extensions", "4.6.3" },
             { "System.Threading.Tasks.Parallel", "4.3.0" },
             { "System.Xml.XDocument", "4.3.0" },
             { "System.Xml.XmlSerializer", "4.3.0" },


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/47314

This updates pruning versions for maintenance-packages.  We do so only on frameworks where they were previously pruning the version just before the maintenance-package version.