### PR TITLE
Copy files for MSI layout from the post-crossgen'd location

### DIFF
--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -87,7 +87,7 @@
 
   <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is
        necessary for the msi/pkg to install correctly and put the content under that sub path. -->
-  <Target Name="PrepareIntermediateSdkInstallerOutput" DependsOnTargets="GenerateSdkLayout">
+  <Target Name="PrepareIntermediateSdkInstallerOutput" DependsOnTargets="GenerateInstallerLayout">
     <PropertyGroup>
       <IntermediateSdkInstallerOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'sdk-installer', '$(Configuration)'))</IntermediateSdkInstallerOutputPath>
     </PropertyGroup>

--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -94,7 +94,7 @@
 
     <!-- Create "SDK Internal" layout. -->
     <ItemGroup>
-      <SdkOutputFile Include="$(OutputPath)**\*" />
+      <SdkOutputFile Include="$(InstallerOutputDirectory)**\*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(SdkOutputFile)"


### PR DESCRIPTION
Fixes internal issue reported where the .NET 10.0.100 Preview 4 SDK didn't have R2Rd Roslyn in the Exe/Msi installers.