### PR TITLE
Use new SB secrets variable group

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -37,7 +37,7 @@ variables:
 - template: /src/sdk/eng/pipelines/templates/variables/vmr-build.yml@self
 
 # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
-- group: DotNet-Source-Build-Bot-Secrets-MVP
+- group: Dotnet-SourceBuild-Secrets
 
 jobs:
 - template: templates/jobs/sdk-diff-tests.yml

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -34,7 +34,7 @@ parameters:
 
 variables:
   # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
-- group: DotNet-Source-Build-Bot-Secrets-MVP
+- group: Dotnet-SourceBuild-Secrets
 - name: sdkRoot
   value: '$(Build.SourcesDirectory)/src/sdk'
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/5212

The `DotNet-Source-Build-Bot-Secrets-MVP` is obsolete, pointing to a secret with an expired PAT for the source build bot. Replacing it with the new variable group that has a valid PAT.