### PR TITLE
Remove comment from Console template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ConsoleApplication-CSharp/Program.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/ConsoleApplication-CSharp/Program.cs
@@ -1,6 +1,3 @@
-﻿#if (csharpFeature_TopLevelProgram)
-// See https://aka.ms/new-console-template for more information
-#endif
 #if (!csharpFeature_ImplicitUsings)
 using System;
 


### PR DESCRIPTION
Putting this up for discussion given it's been multiple major releases since we introduced top-level statements as the default I think it's worth considering removing this comment from the console template to make the C# file cleaner.

@baronfel @claudiaregio @stephentoub @timheuer