### PR TITLE
Update tests for test templates

### DIFF
--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             string templatePackagePath = Path.Combine(
                 RepoTemplatePackages,
-                "Microsoft.DotNet.Common.ProjectTemplates." + ToolsetInfo.CurrentTargetFrameworkVersion,
+                $"Microsoft.DotNet.Common.ProjectTemplates.{ToolsetInfo.CurrentTargetFrameworkVersion}",
                 "content");
 
             var dummyLog = new NullTestOutputHelper();

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         private static readonly ImmutableArray<string> SupportedTargetFrameworks =
         [
-            "net10.0",
+            ToolsetInfo.CurrentTargetFramework
         ];
 
         private static readonly (string ProjectTemplateName, string ItemTemplateName, string[] Languages, bool SupportsTestingPlatform)[] AvailableItemTemplates =
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             string templatePackagePath = Path.Combine(
                 RepoTemplatePackages,
-                "Microsoft.DotNet.Common.ProjectTemplates.10.0",
+                "Microsoft.DotNet.Common.ProjectTemplates." + ToolsetInfo.CurrentTargetFrameworkVersion,
                 "content");
 
             var dummyLog = new NullTestOutputHelper();
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                 .WithWorkingDirectory(CreateTemporaryFolder())
                 .Execute()
-                .Should().ExitWith(0);
+                .Should().Pass();
         }
 
         [Theory]
@@ -83,16 +83,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
              .WithCustomHive(outputDirectory).WithRawArguments()
              .WithWorkingDirectory(workingDirectory)
              .Execute()
-             .Should().ExitWith(0);
+             .Should().Pass();
 
             var itemName = "test";
 
-            // Add test item to test project: dotnet new <itemTemplate> -n <test> -lang <language> -o <testProjectName>
+            // Add test item to test project: dotnet new <itemTemplate> -n <test> -lang <language> -o <outputDirectory>
             new DotnetNewCommand(_log, $"{itemTemplate} -n {itemName} -lang {language} -o {outputDirectory}")
                 .WithCustomHive(outputDirectory).WithRawArguments()
                 .WithWorkingDirectory(workingDirectory)
                 .Execute()
-                .Should().ExitWith(0);
+                .Should().Pass();
 
             if (language == Languages.FSharp)
             {
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithWorkingDirectory(outputDirectory)
                 .Execute(outputDirectory);
 
-            result.Should().ExitWith(0);
+            result.Should().Pass();
 
             result.StdOut.Should().Contain("Passed!");
             result.StdOut.Should().MatchRegex(@"Passed:\s*2");
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
              .WithCustomHive(outputDirectory).WithRawArguments()
              .WithWorkingDirectory(workingDirectory)
              .Execute()
-             .Should().ExitWith(0);
+             .Should().Pass();
 
             if (runDotnetTest)
             {
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithWorkingDirectory(outputDirectory)
                 .Execute(outputDirectory);
 
-                result.Should().ExitWith(0);
+                result.Should().Pass();
 
                 result.StdOut.Should().Contain("Passed!");
                 result.StdOut.Should().MatchRegex(@"Passed:\s*1");
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
              .WithCustomHive(outputDirectory).WithRawArguments()
              .WithWorkingDirectory(workingDirectory)
              .Execute()
-             .Should().ExitWith(0);
+             .Should().Pass();
 
             if (runDotnetTest)
             {
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithWorkingDirectory(outputDirectory)
                 .Execute(outputDirectory);
 
-                result.Should().ExitWith(0);
+                result.Should().Pass();
 
                 result.StdOut.Should().Contain("Passed!");
                 result.StdOut.Should().MatchRegex(@"Passed:\s*1");

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         static DotnetNewTestTemplatesTests()
         {
+            // This is the live location of the build
             string templatePackagePath = Path.Combine(
                 RepoTemplatePackages,
                 $"Microsoft.DotNet.Common.ProjectTemplates.{ToolsetInfo.CurrentTargetFrameworkVersion}",
@@ -57,6 +58,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             var dummyLog = new NullTestOutputHelper();
 
+            // Here we uninstall first, because we want to make sure we clean up before the installation
+            // i.e we want to make sure our installation is done
             new DotnetNewCommand(dummyLog, "uninstall", templatePackagePath)
                    .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                    .WithWorkingDirectory(CreateTemporaryFolder())
@@ -66,7 +69,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithCustomHive(CreateTemporaryFolder(folderName: "Home"))
                 .WithWorkingDirectory(CreateTemporaryFolder())
                 .Execute()
-                .Should().Pass();
+                .Should()
+                .Pass();
         }
 
         [Theory]
@@ -80,10 +84,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // Create new test project: dotnet new <projectTemplate> -n <testProjectName> -f <targetFramework> -lang <language>
             string args = $"{projectTemplate} -n {testProjectName} -f {targetFramework} -lang {language} -o {outputDirectory}";
             new DotnetNewCommand(_log, args)
-             .WithCustomHive(outputDirectory).WithRawArguments()
-             .WithWorkingDirectory(workingDirectory)
-             .Execute()
-             .Should().Pass();
+                .WithCustomHive(outputDirectory).WithRawArguments()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass();
 
             var itemName = "test";
 
@@ -92,7 +97,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 .WithCustomHive(outputDirectory).WithRawArguments()
                 .WithWorkingDirectory(workingDirectory)
                 .Execute()
-                .Should().Pass();
+                .Should()
+                .Pass();
 
             if (language == Languages.FSharp)
             {
@@ -109,6 +115,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             result.Should().Pass();
 
             result.StdOut.Should().Contain("Passed!");
+            // We created another test class (which will contain 1 test), and we already have 1 test when we created the test project.
+            // Therefore, in total we would have 2.
             result.StdOut.Should().MatchRegex(@"Passed:\s*2");
 
             Directory.Delete(outputDirectory, true);
@@ -126,10 +134,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // Create new test project: dotnet new <projectTemplate> -n <testProjectName> -f <targetFramework> -lang <language>
             string args = $"{projectTemplate} -n {testProjectName} -f {targetFramework} -lang {language} -o {outputDirectory}";
             new DotnetNewCommand(_log, args)
-             .WithCustomHive(outputDirectory).WithRawArguments()
-             .WithWorkingDirectory(workingDirectory)
-             .Execute()
-             .Should().Pass();
+                .WithCustomHive(outputDirectory).WithRawArguments()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass();
 
             if (runDotnetTest)
             {
@@ -164,10 +173,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // Create new test project: dotnet new <projectTemplate> -n <testProjectName> -f <targetFramework> -lang <language> --coverage-tool <coverageTool> --test-runner <testRunner>
             string args = $"{projectTemplate} -n {testProjectName} -f {targetFramework} -lang {language} -o {outputDirectory} --coverage-tool {coverageTool} --test-runner {testRunner}";
             new DotnetNewCommand(_log, args)
-             .WithCustomHive(outputDirectory).WithRawArguments()
-             .WithWorkingDirectory(workingDirectory)
-             .Execute()
-             .Should().Pass();
+                .WithCustomHive(outputDirectory).WithRawArguments()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass();
 
             if (runDotnetTest)
             {


### PR DESCRIPTION
This pull request updates the `DotnetNewTestTemplatesTests` integration tests to improve maintainability and align with current conventions. Key changes include replacing hardcoded framework values with dynamic ones, updating assertions for better readability, and refining comments for clarity.

### Updates to framework handling:
* Replaced hardcoded target framework (`"net10.0"`) with `ToolsetInfo.CurrentTargetFramework` in the `SupportedTargetFrameworks` array for dynamic framework compatibility. (`[test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.csL14-R14](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL14-R14)`)
* Updated the template package path to use `ToolsetInfo.CurrentTargetFrameworkVersion` instead of a hardcoded version string. (`[test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.csL55-R55](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL55-R55)`)

### Assertion improvements:
* Replaced `.Should().ExitWith(0)` with `.Should().Pass()` in multiple test methods for improved readability and alignment with FluentAssertions conventions. (`[[1]](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL69-R69)`, `[[2]](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL86-R95)`, `[[3]](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL109-R109)`, `[[4]](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL132-R140)`, `[[5]](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL170-R178)`)

### Comment refinements:
* Adjusted comments in the `ItemTemplate_CanBeInstalledAndTestArePassing` method to clarify the purpose and parameters of the `dotnet new` command. (`[test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.csL86-R95](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL86-R95)`)