### PR TITLE
File watcher: ignore directories, allow watching non-recursively

### DIFF
--- a/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/DotNetWatcher.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Watch
                 using var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellationToken, currentRunCancellationSource.Token);
                 using var fileSetWatcher = new FileWatcher(Context.Reporter);
 
-                fileSetWatcher.WatchContainingDirectories(evaluationResult.Files.Keys);
+                fileSetWatcher.WatchContainingDirectories(evaluationResult.Files.Keys, includeSubdirectories: true);
 
                 var processTask = ProcessRunner.RunAsync(processSpec, Context.Reporter, isUserApplication: true, launchResult: null, combinedCancellationSource.Token);
 

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/FileWatcherFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.DotNet.Watch
 {
     internal static class FileWatcherFactory
     {
-        public static IDirectoryWatcher CreateWatcher(string watchedDirectory)
-            => CreateWatcher(watchedDirectory, EnvironmentVariables.IsPollingEnabled);
+        public static IDirectoryWatcher CreateWatcher(string watchedDirectory, bool includeSubdirectories)
+            => CreateWatcher(watchedDirectory, EnvironmentVariables.IsPollingEnabled, includeSubdirectories);
 
-        public static IDirectoryWatcher CreateWatcher(string watchedDirectory, bool usePollingWatcher)
+        public static IDirectoryWatcher CreateWatcher(string watchedDirectory, bool usePollingWatcher, bool includeSubdirectories)
         {
             return usePollingWatcher ?
-                new PollingDirectoryWatcher(watchedDirectory) :
-                new EventBasedDirectoryWatcher(watchedDirectory);
+                new PollingDirectoryWatcher(watchedDirectory, includeSubdirectories) :
+                new EventBasedDirectoryWatcher(watchedDirectory, includeSubdirectories);
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IDirectoryWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/Internal/FileWatcher/IDirectoryWatcher.cs
@@ -1,16 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Watch
+namespace Microsoft.DotNet.Watch;
+
+/// <summary>
+/// Watches for changes in a <see cref="WatchedDirectory"/> and its subdirectories.
+/// </summary>
+internal interface IDirectoryWatcher : IDisposable
 {
-    internal interface IDirectoryWatcher : IDisposable
-    {
-        event EventHandler<ChangedPath> OnFileChange;
+    event EventHandler<ChangedPath> OnFileChange;
 
-        event EventHandler<Exception> OnError;
+    event EventHandler<Exception> OnError;
 
-        string WatchedDirectory { get; }
+    string WatchedDirectory { get; }
 
-        bool EnableRaisingEvents { get; set; }
-    }
+    bool EnableRaisingEvents { get; set; }
 }

--- a/src/BuiltInTools/dotnet-watch/Utilities/PathUtilities.cs
+++ b/src/BuiltInTools/dotnet-watch/Utilities/PathUtilities.cs
@@ -6,9 +6,21 @@ namespace Microsoft.DotNet.Watch;
 internal static class PathUtilities
 {
     public static readonly IEqualityComparer<string> OSSpecificPathComparer = Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+    public static readonly StringComparison OSSpecificPathComparison = Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    public static string EnsureTrailingSlash(string path)
+        => (path is [.., var last] && last != Path.DirectorySeparatorChar) ? path + Path.DirectorySeparatorChar : path;
+
+    public static string NormalizeDirectorySeparators(string path)
+        => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
     public static bool ContainsPath(IReadOnlySet<string> directories, string fullPath)
     {
+        if (directories.Count == 0)
+        {
+            return false;
+        }
+
         fullPath = Path.TrimEndingDirectorySeparator(fullPath);
 
         while (true)

--- a/test/dotnet-watch.Tests/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcherTests.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Diagnostics;
+
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class FileWatcherTests(ITestOutputHelper output)
@@ -15,15 +17,16 @@ namespace Microsoft.DotNet.Watch.UnitTests
             string dir,
             ChangedPath[] expectedChanges,
             bool usePolling,
+            bool watchSubdirectories,
             Action operation)
         {
-            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling);
+            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling, includeSubdirectories: watchSubdirectories);
             if (watcher is EventBasedDirectoryWatcher dotnetWatcher)
             {
                 dotnetWatcher.Logger = m => output.WriteLine(m);
             }
 
-            var changedEv = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var operationCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var filesChanged = new HashSet<ChangedPath>();
 
             EventHandler<ChangedPath> handler = null;
@@ -42,7 +45,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 {
                     watcher.EnableRaisingEvents = false;
                     watcher.OnFileChange -= handler;
-                    changedEv.TrySetResult();
+                    operationCompletionSource.TrySetResult();
                 }
             };
 
@@ -59,81 +62,90 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             operation();
 
-            await changedEv.Task.TimeoutAfter(DefaultTimeout);
-            AssertEx.SequenceEqual(expectedChanges, filesChanged.Order(Comparer<ChangedPath>.Create((x, y) => (x.Path, x.Kind).CompareTo((y.Path, y.Kind)))));
+            var task = operationCompletionSource.Task;
+            await (Debugger.IsAttached ? task : task.TimeoutAfter(DefaultTimeout));
+
+            AssertEx.SequenceEqual(expectedChanges, filesChanged.OrderBy(x => x.Path));
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task NewFile(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            var testFileFullPath = Path.Combine(dir, "foo");
+            var file = Path.Combine(dir, "file");
 
             await TestOperation(
                 dir,
-                expectedChanges: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !usePolling
+                expectedChanges: !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || usePolling
                 ?
                 [
-                    new(testFileFullPath, ChangeKind.Update),
-                    new(testFileFullPath, ChangeKind.Add),
+                    new(file, ChangeKind.Add),
                 ]
                 :
                 [
-                    new(testFileFullPath, ChangeKind.Add),
+                    new(file, ChangeKind.Update),
+                    new(file, ChangeKind.Add),
                 ],
                 usePolling,
-                () => File.WriteAllText(testFileFullPath, string.Empty));
+                watchSubdirectories: true,
+                () => File.WriteAllText(file, string.Empty));
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task NewFileInNewDirectory(bool usePolling)
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "https://github.com/dotnet/runtime/issues/116351")]
+        [CombinatorialData]
+        public async Task NewFileInNewDirectory(bool usePolling, bool nested)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            var newDir = Path.Combine(dir, "Dir");
-            var newFile = Path.Combine(newDir, "foo");
+            var dir1 = Path.Combine(dir, "dir1");
+            var dir2 = nested ? Path.Combine(dir1, "dir2") : dir1;
+            var fileInSubdir = Path.Combine(dir2, "file_in_subdir");
 
             await TestOperation(
                 dir,
-                expectedChanges: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !usePolling
+                expectedChanges: !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || usePolling
                 ?
                 [
-                    new(newDir, ChangeKind.Add),
-                    new(newFile, ChangeKind.Update),
-                    new(newFile, ChangeKind.Add),
+                    new(fileInSubdir, ChangeKind.Add),
                 ]
                 :
                 [
-                    new(newDir, ChangeKind.Add),
+                    new(fileInSubdir, ChangeKind.Update),
+                    new(fileInSubdir, ChangeKind.Add),
                 ],
                 usePolling,
+                watchSubdirectories: true,
                 () =>
                 {
-                    Directory.CreateDirectory(newDir);
-                    File.WriteAllText(newFile, string.Empty);
+                    Directory.CreateDirectory(dir1);
+
+                    if (nested)
+                    {
+                        Directory.CreateDirectory(dir2);
+                    }
+
+                    File.WriteAllText(fileInSubdir, string.Empty);
                 });
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task ChangeFile(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            var testFileFullPath = Path.Combine(dir, "foo");
-            File.WriteAllText(testFileFullPath, string.Empty);
+            var file = Path.Combine(dir, "file");
+            File.WriteAllText(file, string.Empty);
 
             await TestOperation(
                 dir,
-                expectedChanges: [new(testFileFullPath, ChangeKind.Update)],
+                expectedChanges: [new(file, ChangeKind.Update)],
                 usePolling,
-                () => File.WriteAllText(testFileFullPath, string.Empty));
+                watchSubdirectories: true,
+                () => File.WriteAllText(file, string.Empty));
         }
 
         [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
@@ -141,8 +153,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
         public async Task MoveFile(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
-            var srcFile = Path.Combine(dir, "foo");
-            var dstFile = Path.Combine(dir, "foo2");
+            var srcFile = Path.Combine(dir, "file");
+            var dstFile = Path.Combine(dir, "file2");
 
             File.WriteAllText(srcFile, string.Empty);
 
@@ -162,40 +174,69 @@ namespace Microsoft.DotNet.Watch.UnitTests
                     new(dstFile, ChangeKind.Add),
                 ],
                 usePolling,
+                watchSubdirectories: true,
                 () => File.Move(srcFile, dstFile));
-
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // "https://github.com/dotnet/sdk/issues/49307")
-        public async Task FileInSubdirectory()
+        [Theory]
+        [CombinatorialData]
+        public async Task FileInSubdirectory(bool usePolling, bool watchSubdirectories)
         {
-            var dir = _testAssetManager.CreateTestDirectory().Path;
+            var dir = _testAssetManager.CreateTestDirectory(identifier: $"{usePolling}{watchSubdirectories}").Path;
 
             var subdir = Path.Combine(dir, "subdir");
             Directory.CreateDirectory(subdir);
 
-            var testFileFullPath = Path.Combine(subdir, "foo");
-            File.WriteAllText(testFileFullPath, string.Empty);
+            var fileInDir = Path.Combine(dir, "file_in_dir");
+            File.WriteAllText(fileInDir, string.Empty);
+
+            var fileInSubdir = Path.Combine(subdir, "file_in_subdir");
+            File.WriteAllText(fileInSubdir, string.Empty);
+
+            ChangedPath[] expectedChanges;
+
+            if (watchSubdirectories)
+            {
+                expectedChanges = !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || usePolling ?
+                [
+                    new(fileInDir, ChangeKind.Update),
+                    new(fileInSubdir, ChangeKind.Update)
+                ]
+                :
+                [
+                    new(fileInDir, ChangeKind.Update),
+                    new(fileInDir, ChangeKind.Add),
+                    new(fileInSubdir, ChangeKind.Update),
+                    new(fileInSubdir, ChangeKind.Add),
+                ];
+            }
+            else
+            {
+                expectedChanges =
+                [
+                    new(fileInDir, ChangeKind.Update),
+                ];
+            }
 
             await TestOperation(
                 dir,
-                expectedChanges:
-                [
-                    new(subdir, ChangeKind.Update),
-                    new(testFileFullPath, ChangeKind.Update)
-                ],
-                usePolling: true,
-                () => File.WriteAllText(testFileFullPath, string.Empty));
+                expectedChanges,
+                usePolling,
+                watchSubdirectories,
+                () =>
+                {
+                    File.WriteAllText(fileInSubdir, string.Empty);
+                    File.WriteAllText(fileInDir, string.Empty);
+                });
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task NoNotificationIfDisabled(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling);
+            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling, includeSubdirectories: true);
 
             var changedEv = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             watcher.OnFileChange += (_, f) => changedEv.TrySetResult(0);
@@ -217,20 +258,19 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await Assert.ThrowsAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task DisposedNoEvents(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
             var changedEv = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            using (var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling))
+            using (var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling, includeSubdirectories: true))
             {
                 watcher.OnFileChange += (_, f) => changedEv.TrySetResult();
                 watcher.EnableRaisingEvents = true;
             }
 
-            var testFileFullPath = Path.Combine(dir, "foo");
+            var file = Path.Combine(dir, "file");
 
             if (usePolling)
             {
@@ -239,47 +279,39 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 // watcher will not detect the change
                 await Task.Delay(1000);
             }
-            File.WriteAllText(testFileFullPath, string.Empty);
+            File.WriteAllText(file, string.Empty);
 
             await Assert.ThrowsAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task MultipleFiles(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            File.WriteAllText(Path.Combine(dir, "foo1"), string.Empty);
-            File.WriteAllText(Path.Combine(dir, "foo2"), string.Empty);
-            File.WriteAllText(Path.Combine(dir, "foo3"), string.Empty);
-            File.WriteAllText(Path.Combine(dir, "foo4"), string.Empty);
+            File.WriteAllText(Path.Combine(dir, "file1"), string.Empty);
+            File.WriteAllText(Path.Combine(dir, "file2"), string.Empty);
+            File.WriteAllText(Path.Combine(dir, "file3"), string.Empty);
+            File.WriteAllText(Path.Combine(dir, "file4"), string.Empty);
 
-            // On Unix the native file watcher may surface events from
-            // the recent past. Delay to avoid those.
-            // On Unix the file write time is in 1s increments;
-            // if we don't wait, there's a chance that the polling
-            // watcher will not detect the change
-            await Task.Delay(1250);
-
-            var testFileFullPath = Path.Combine(dir, "foo3");
+            var file3 = Path.Combine(dir, "file3");
 
             await TestOperation(
                 dir,
-                expectedChanges: [new(testFileFullPath, ChangeKind.Update)],
-                usePolling: true,
-                () => File.WriteAllText(testFileFullPath, string.Empty));
+                expectedChanges: [new(file3, ChangeKind.Update)],
+                usePolling,
+                watchSubdirectories: true,
+                () => File.WriteAllText(file3, string.Empty));
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task MultipleTriggers(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
-            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling);
+            using var watcher = FileWatcherFactory.CreateWatcher(dir, usePolling, includeSubdirectories: true);
 
             watcher.EnableRaisingEvents = true;
 
@@ -332,9 +364,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
             }
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/49307
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory]
+        [CombinatorialData]
         public async Task DeleteSubfolder(bool usePolling)
         {
             var dir = _testAssetManager.CreateTestDirectory(usePolling.ToString()).Path;
@@ -352,17 +383,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             await TestOperation(
                 dir,
-                expectedChanges: usePolling ?
+                expectedChanges: RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !usePolling ?
                 [
-                    new(subdir, ChangeKind.Delete),
-                    new(f1, ChangeKind.Delete),
-                    new(f2, ChangeKind.Delete),
-                    new(f3, ChangeKind.Delete),
-                ]
-                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
-                [
-                    new(subdir, ChangeKind.Add),
-                    new(subdir, ChangeKind.Delete),
                     new(f1, ChangeKind.Update),
                     new(f1, ChangeKind.Add),
                     new(f1, ChangeKind.Delete),
@@ -373,22 +395,14 @@ namespace Microsoft.DotNet.Watch.UnitTests
                     new(f3, ChangeKind.Add),
                     new(f3, ChangeKind.Delete),
                 ]
-                : RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                [
-                    new(subdir, ChangeKind.Update),
-                    new(subdir, ChangeKind.Delete),
-                    new(f1, ChangeKind.Delete),
-                    new(f2, ChangeKind.Delete),
-                    new(f3, ChangeKind.Delete),
-                ]
                 :
                 [
-                    new(subdir, ChangeKind.Delete),
                     new(f1, ChangeKind.Delete),
                     new(f2, ChangeKind.Delete),
                     new(f3, ChangeKind.Delete),
                 ],
                 usePolling,
+                watchSubdirectories: true,
                 () => Directory.Delete(subdir, recursive: true));
         }
     }

--- a/test/dotnet-watch.Tests/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcherTests.cs
@@ -94,10 +94,16 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.AnyUnix, "https://github.com/dotnet/runtime/issues/116351")]
         [CombinatorialData]
         public async Task NewFileInNewDirectory(bool usePolling, bool nested)
         {
+            if (!usePolling && !(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+            {
+                // Skip test on Unix:
+                // https://github.com/dotnet/runtime/issues/116351
+                return;
+            }
+
             var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
             var dir1 = Path.Combine(dir, "dir1");


### PR DESCRIPTION
Preparing directory watcher for watching individual files in some cases when we don't want to watch the entire directory tree (e.g. targets and props files outside of the project dir).

Fixes https://github.com/dotnet/sdk/issues/49307