### PR TITLE
Fix minimum width of Author column in tabular output

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -191,7 +191,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                           .ThenBy(d => d.TemplateGroupInfo.Name, StringComparer.CurrentCultureIgnoreCase))
                     .DefineColumn(r => r.TemplateGroupInfo.Name, out object? nameColumn, LocalizableStrings.ColumnNameTemplateName, showAlways: true, shrinkIfNeeded: true, minWidth: 15)
                     .DefineColumn(r => r.TemplateGroupInfo.ShortNames, LocalizableStrings.ColumnNameShortName, showAlways: true)
-                    .DefineColumn(r => r.TemplateGroupInfo.Author, LocalizableStrings.ColumnNameAuthor, TabularOutputSettings.ColumnNames.Author, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
+                    .DefineColumn(r => r.TemplateGroupInfo.Author, LocalizableStrings.ColumnNameAuthor, TabularOutputSettings.ColumnNames.Author, defaultColumn: false, shrinkIfNeeded: true, minWidth: 12)
                     .DefineColumn(r => r.TemplateGroupInfo.Languages, LocalizableStrings.ColumnNameLanguage, TabularOutputSettings.ColumnNames.Language, defaultColumn: true)
                     .DefineColumn(r => r.TemplateGroupInfo.Type, LocalizableStrings.ColumnNameType, TabularOutputSettings.ColumnNames.Type, defaultColumn: false)
                     .DefineColumn(r => r.TemplateGroupInfo.Classifications, LocalizableStrings.ColumnNameTags, TabularOutputSettings.ColumnNames.Tags, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)

--- a/test/dotnet-new.IntegrationTests/DotnetNewSearchTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewSearchTests.cs
@@ -220,9 +220,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
 
-#pragma warning disable xUnit1004
-        [Theory(Skip = "https://github.com/dotnet/sdk/issues/49123")]
-#pragma warning restore xUnit1004
+        [Theory]
         [InlineData("--search --columns author --author micro")]
         [InlineData("search --columns author --author micro")]
         public void CanFilterAuthor_WithoutName(string testCase)


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49123

This PR increases the minimum width of the `Author` column in the tabular output of `dotnet new search` to prevent truncation of author names. This resolves a test failure caused by the output not containing the expected author string due to column width limitations.
