### PR TITLE
Inner loop improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,10 @@
 
   <PropertyGroup>
     <SdkSrcRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src'))</SdkSrcRoot>
+    <TestHostFolder>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'redist', '$(Configuration)'))</TestHostFolder>
+    <TestHostDotNetRoot>$([MSBuild]::NormalizeDirectory('$(TestHostFolder)', 'dotnet'))</TestHostDotNetRoot>
+    <TestHostDotNetTool>$(TestHostDotNetRoot)$([System.IO.Path]::GetFileName('$(DotNetTool)'))</TestHostDotNetTool>
+
     <PackageProjectUrl>https://github.com/dotnet/sdk</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <LangVersion>Preview</LangVersion>

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -54,4 +54,33 @@
     <ProjectReference Include="..\DotNetWatchTasks\DotNetWatchTasks.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework;TargetFrameworks" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <!-- Publish dotnet-watch files to the redist testhost folder so that in innerloop, redist doesn't need to be built again. -->
+  <Target Name="PublishDotnetWatchToTestHost" BeforeTargets="AfterBuild">
+    <ItemGroup>
+      <!--
+        To reduce the size of the SDK, we use the compiler dependencies that are located in the `Roslyn/bincore` location
+        instead of shipping our own copies in the dotnet-watch tool. These assemblies will be resolved by path in the
+        dotnet-watch executable.
+
+        We make an exception for the Microsoft.CodeAnalysis binaries deployed with the MSBuildWorkspace BuildHosts, since those don't
+        have any logic to pick up Roslyn from another location. Those can be addressed a different way which tracked in
+        https://github.com/dotnet/roslyn/issues/70945.
+
+        Keep excluded files in sync with the list in GenerateLayout.targets.
+      -->
+      <_DotnetWatchInputFile Include="$(TargetDir)**"
+                             Condition="('%(Filename)' != 'Microsoft.CodeAnalysis' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.resources' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp' and
+                                         '%(Filename)' != 'Microsoft.CodeAnalysis.CSharp.resources') or
+                                        $([MSBuild]::ValueOrDefault('%(FullPath)', '').Contains('BuildHost'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_DotnetWatchInputFile)"
+          DestinationFiles="@(_DotnetWatchInputFile->'$(TestHostDotNetRoot)sdk\$(Version)\DotnetTools\dotnet-watch\$(Version)\tools\$(SdkTargetFramework)\any\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
 </Project>

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <TestHostFolder>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</TestHostFolder>
-  </PropertyGroup>
-
   <Target Name="OverlaySdkOnLKG" AfterTargets="AfterBuild" DependsOnTargets="GenerateInstallerLayout">
     <PropertyGroup>
       <_DotNetHiveRoot>$(DOTNET_INSTALL_DIR)</_DotNetHiveRoot>
@@ -18,12 +14,12 @@
                        Exclude="$(_DotNetHiveRoot)sdk\**\*;
                                 $(_DotNetHiveRoot)templates\**\*;
                                 $(_DotNetHiveRoot)host\**\*"/>
-      <OverlaySDKFile Include="@(_OverlaySDKFile->'$(TestHostFolder)%(RecursiveDir)%(Filename)%(Extension)')" Source="%(Identity)" />
+      <OverlaySDKFile Include="@(_OverlaySDKFile->'$(TestHostDotNetRoot)%(RecursiveDir)%(Filename)%(Extension)')" Source="%(Identity)" />
     </ItemGroup>
 
     <ItemGroup>
       <_InstallerOutputFile Include="$(RedistInstallerLayoutPath)**\*" />
-      <InstallerOutputFile Include="@(_InstallerOutputFile->'$(TestHostFolder)%(RecursiveDir)%(Filename)%(Extension)')" Source="%(Identity)" />
+      <InstallerOutputFile Include="@(_InstallerOutputFile->'$(TestHostDotNetRoot)%(RecursiveDir)%(Filename)%(Extension)')" Source="%(Identity)" />
       <!-- Use available live built artifacts instead of stage0 files. -->
       <InstallerOutputFile Include="@(OverlaySDKFile)" Exclude="@(InstallerOutputFile)" />
     </ItemGroup>
@@ -53,10 +49,10 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(WorkloadManifestContent)"
-          DestinationFiles="@(WorkloadManifestContent->'$(TestHostFolder)sdk-manifests\$(VersionBand)\%(RecursiveDir)%(Filename)%(Extension)')" />
+          DestinationFiles="@(WorkloadManifestContent->'$(TestHostDotNetRoot)sdk-manifests\$(VersionBand)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <Copy SourceFiles="@(WorkloadPackContent)"
-          DestinationFiles="@(WorkloadPackContent->'$(TestHostFolder)packs\%(RecursiveDir)%(Filename)%(Extension)')" />
+          DestinationFiles="@(WorkloadPackContent->'$(TestHostDotNetRoot)packs\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -61,7 +61,7 @@
       <ResultsStdOutPath>@(TestToRun->'%(ResultsStdOutPath)')</ResultsStdOutPath>
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
-      <TestArgs>$(TestArgs) -dotnetPath $(ArtifactsBinDir)redist\$(Configuration)\dotnet\dotnet</TestArgs>
+      <TestArgs>$(TestArgs) -dotnetPath $(TestHostDotNetTool)</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
@@ -70,7 +70,7 @@
 
     <!-- Run "dotnet new" (which will just display usage and available templates) in order to print first time
          use message so that it doesn't interfere with tests which check the output of commands. -->
-    <Exec Command="$(ArtifactsBinDir)redist\$(Configuration)\dotnet\dotnet new" />
+    <Exec Command="$(TestHostDotNetTool) new" />
 
     <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
           WorkingDirectory="$(TestLocalToolFolder)"

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -135,7 +135,6 @@
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure";$(HelixPostCommands)</HelixPostCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "Get-ChildItem -Recurse -File -Filter '*hangdump.dmp' | Copy-Item -Destination $env:HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
       <HelixPostCommands Condition="$(IsPosixShell)">find "$HELIX_WORKITEM_UPLOAD_ROOT/../../.." -name '*hangdump.dmp' -exec cp {} "$HELIX_WORKITEM_UPLOAD_ROOT" \%3B;$(HelixPostCommands)</HelixPostCommands>
-      <TestDotnetRoot>$(RepoRoot)artifacts\bin\redist\$(Configuration)\dotnet</TestDotnetRoot>
       <TestDotnetVersion>$(Version)</TestDotnetVersion>
       <MSBuildSdkResolverDir>$(RepoRoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
       <HelixStage0Targz>$(RepoRoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
@@ -144,7 +143,7 @@
 
     <TarGzFileCreateFromDirectory
         Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' "
-        SourceDirectory="$(TestDotnetRoot)"
+        SourceDirectory="$(TestHostDotNetRoot)"
         DestinationArchive="$(HelixStage0Targz)"
         OverwriteDestination="true" />
 
@@ -158,8 +157,8 @@
         <Destination>d</Destination>
       </HelixCorrelationPayload>
 
-      <HelixCorrelationPayload Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(TestDotnetRoot)">
-        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+      <HelixCorrelationPayload Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(TestHostDotNetRoot)">
+        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
         <Destination>d</Destination>
       </HelixCorrelationPayload>
 
@@ -174,13 +173,13 @@
       </HelixCorrelationPayload>
 
       <HelixCorrelationPayload Include="SDKTestRunPackages.zip">
-        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
         <Destination>d/.nuget</Destination>
         <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages.zip</Uri>
       </HelixCorrelationPayload>
 
       <HelixCorrelationPayload Include="SDKTestRunPackages2.zip">
-        <PayloadDirectory>$(TestDotnetRoot)</PayloadDirectory>
+        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
         <Destination>d/.nuget</Destination>
         <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages2.zip</Uri>
       </HelixCorrelationPayload>

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -18,7 +18,7 @@
 
     <!-- Use layout folder for the output folder, to support in-process tests which expect to be running
          on a valid layout. -->
-    <OutputPath>$(ArtifactsBinDir)redist\$(Configuration)</OutputPath>
+    <OutputPath>$(TestHostFolder)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
@@ -99,7 +99,7 @@
 
   <Target Name="CompareCliSnapshots">
     <ItemGroup>
-      <SnapshotFiles Include="$(ArtifactsBinDir)redist\$(Configuration)\snapshots\**\*.received.*" />
+      <SnapshotFiles Include="$(TestHostFolder)snapshots\**\*.received.*" />
     </ItemGroup>
     <Copy SourceFiles="@(SnapshotFiles)" DestinationFolder="$(MSBuildThisFileDirectory)CompletionTests\snapshots\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(ToolsetTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <CanRunTestAsTool>false</CanRunTestAsTool>
-    <OutputPath>$(ArtifactsBinDir)redist\$(Configuration)</OutputPath>
+    <OutputPath>$(TestHostFolder)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replacement of https://github.com/dotnet/sdk/pull/48793

Push the dotnet-watch artifacts into the sdk redist testhost folder so that redist.csproj doesn't need to be rebuilt every time.
Also centrally define properties for the testhost folder.