### PR TITLE
Fix API Diff args + async

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tool/Program.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tool/Program.cs
@@ -152,10 +152,7 @@ public static class Program
 
     private static Task HandleCommandAsync(DiffConfiguration diffConfig, CancellationToken cancellationToken = default)
     {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return Task.FromCanceled(cancellationToken);
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         var log = new ConsoleLog(MessageImportance.Normal);
 

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tool/Program.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tool/Program.cs
@@ -18,66 +18,66 @@ public static class Program
 
     public static async Task Main(string[] args)
     {
-        RootCommand rootCommand = new("genapidiff");
+        RootCommand rootCommand = new("ApiDiff - Tool for generating a markdown diff of two different versions of the same assembly.");
 
-        Option<string> optionBeforeAssembliesFolderPath = new(name: "", aliases: ["--before", "-b"])
+        Option<string> optionBeforeAssembliesFolderPath = new("--before", "-b")
         {
             Description = "The path to the folder containing the old (before) assemblies to be included in the diff.",
             Arity = ArgumentArity.ExactlyOne,
             Required = true
         };
 
-        Option<string> optionBeforeRefAssembliesFolderPath = new(name: "", aliases: ["--refbefore", "-rb"])
+        Option<string> optionBeforeRefAssembliesFolderPath = new("--refbefore", "-rb")
         {
             Description = "The path to the folder containing the references required by old (before) assemblies, not to be included in the diff.",
             Arity = ArgumentArity.ExactlyOne,
             Required = false
         };
 
-        Option<string> optionAfterAssembliesFolderPath = new(name: "", aliases: ["--after", "-a"])
+        Option<string> optionAfterAssembliesFolderPath = new("--after", "-a")
         {
             Description = "The path to the folder containing the new (after) assemblies to be included in the diff.",
             Arity = ArgumentArity.ExactlyOne,
             Required = true
         };
 
-        Option<string> optionAfterRefAssembliesFolderPath = new(name: "", aliases: ["--refafter", "-ra"])
+        Option<string> optionAfterRefAssembliesFolderPath = new("--refafter", "-ra")
         {
             Description = "The path to the folder containing references required by the new (after) reference assemblies, not to be included in the diff.",
             Arity = ArgumentArity.ExactlyOne,
             Required = false
         };
 
-        Option<string> optionOutputFolderPath = new(name: "", aliases: ["--output", "-o"])
+        Option<string> optionOutputFolderPath = new("--output", "-o")
         {
             Description = "The path to the output folder.",
             Arity = ArgumentArity.ExactlyOne,
             Required = true
         };
 
-        Option<string> optionBeforeFriendlyName = new(name: "", aliases: ["--beforeFriendlyName", "-bfn"])
+        Option<string> optionBeforeFriendlyName = new("--beforeFriendlyName", "-bfn")
         {
             Description = "The friendly name to describe the 'before' assembly.",
             Arity = ArgumentArity.ExactlyOne,
             Required = true
         };
 
-        Option<string> optionAfterFriendlyName = new(name: "", aliases: ["--afterFriendlyName", "-afn"])
+        Option<string> optionAfterFriendlyName = new("--afterFriendlyName", "-afn")
         {
             Description = "The friendly name to describe the 'after' assembly.",
             Arity = ArgumentArity.ExactlyOne,
             Required = true
         };
 
-        Option<string> optionTableOfContentsTitle = new(name: "", aliases: ["--tableOfContentsTitle", "-tc"])
+        Option<string> optionTableOfContentsTitle = new("--tableOfContentsTitle", "-tc")
         {
             Description = $"The optional title of the markdown table of contents file that is placed in the output folder.",
-            Arity = ArgumentArity.ZeroOrMore,
+            Arity = ArgumentArity.ExactlyOne,
             Required = false,
             DefaultValueFactory = _ => "api_diff"
         };
 
-        Option<FileInfo[]?> optionFilesWithAssembliesToExclude = new(name: "", aliases: ["--assembliesToExclude", "-eas"])
+        Option<FileInfo[]?> optionFilesWithAssembliesToExclude = new("--assembliesToExclude", "-eas")
         {
             Description = "An optional array of filepaths, each containing a list of assemblies that should be excluded from the diff. Each file should contain one assembly name per line, with no extensions.",
             Arity = ArgumentArity.ZeroOrMore,
@@ -85,7 +85,7 @@ public static class Program
             DefaultValueFactory = _ => null
         };
 
-        Option<FileInfo[]?> optionFilesWithAttributesToExclude = new(name: "", aliases: ["--attributesToExclude", "-eattrs"])
+        Option<FileInfo[]?> optionFilesWithAttributesToExclude = new("--attributesToExclude", "-eattrs")
         {
             Description = $"An optional array of filepaths, each containing a list of attributes to exclude from the diff. Each file should contain one API full name per line. You can either modify the default file '{AttributesToExcludeDefaultFileName}' to add your own attributes, or include additional files using this command line option.",
             Arity = ArgumentArity.ZeroOrMore,
@@ -93,7 +93,7 @@ public static class Program
             DefaultValueFactory = _ => [new FileInfo(AttributesToExcludeDefaultFileName)]
         };
 
-        Option<FileInfo[]?> optionFilesWithApisToExclude = new(name: "", aliases: ["--apisToExclude", "-eapis"])
+        Option<FileInfo[]?> optionFilesWithApisToExclude = new("--apisToExclude", "-eapis")
         {
             Description = "An optional array of filepaths, each containing a list of APIs to exclude from the diff. Each file should contain one API full name per line.",
             Arity = ArgumentArity.ZeroOrMore,
@@ -101,13 +101,13 @@ public static class Program
             DefaultValueFactory = _ => null
         };
 
-        Option<bool> optionAddPartialModifier = new(name: "", aliases: ["--addPartialModifier", "-apm"])
+        Option<bool> optionAddPartialModifier = new("--addPartialModifier", "-apm")
         {
             Description = "Add the 'partial' modifier to types.",
             DefaultValueFactory = _ => false
         };
 
-        Option<bool> optionAttachDebugger = new(name: "", aliases: ["--attachDebugger", "-d"])
+        Option<bool> optionAttachDebugger = new("--attachDebugger", "-d")
         {
             Description = "Stops the tool at startup, prints the process ID and waits for a debugger to attach.",
             DefaultValueFactory = _ => false
@@ -128,9 +128,9 @@ public static class Program
         rootCommand.Options.Add(optionAddPartialModifier);
         rootCommand.Options.Add(optionAttachDebugger);
 
-        rootCommand.SetAction(async (ParseResult result) =>
+        rootCommand.SetAction(async (ParseResult result, CancellationToken cancellationToken) =>
         {
-            DiffConfiguration c = new(
+            DiffConfiguration diffConfig = new(
                 BeforeAssembliesFolderPath: result.GetValue(optionBeforeAssembliesFolderPath) ?? throw new NullReferenceException("Null before assemblies directory"),
                 BeforeAssemblyReferencesFolderPath: result.GetValue(optionBeforeRefAssembliesFolderPath),
                 AfterAssembliesFolderPath: result.GetValue(optionAfterAssembliesFolderPath) ?? throw new NullReferenceException("Null after assemblies directory"),
@@ -145,13 +145,18 @@ public static class Program
                 AddPartialModifier: result.GetValue(optionAddPartialModifier),
                 AttachDebugger: result.GetValue(optionAttachDebugger)
             );
-            await HandleCommandAsync(c).ConfigureAwait(false);
+            await HandleCommandAsync(diffConfig, cancellationToken).ConfigureAwait(false);
         });
         await rootCommand.Parse(args).InvokeAsync();
     }
 
-    private static Task HandleCommandAsync(DiffConfiguration diffConfig)
+    private static Task HandleCommandAsync(DiffConfiguration diffConfig, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
         var log = new ConsoleLog(MessageImportance.Normal);
 
         string assembliesToExclude = string.Join(", ", diffConfig.FilesWithAssembliesToExclude?.Select(a => a.FullName) ?? []);
@@ -197,7 +202,7 @@ public static class Program
                                                                    diagnosticOptions: null // TODO: If needed, add CLI option to pass specific diagnostic options
                                                                    );
 
-        return diffGenerator.RunAsync();
+        return diffGenerator.RunAsync(cancellationToken);
     }
 
     private static void WaitForDebugger()

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
@@ -92,10 +92,7 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
         Debug.Assert(_beforeAssembliesFolderPaths.Length == 1);
         Debug.Assert(_afterAssembliesFolderPaths.Length == 1);
 
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         (IAssemblySymbolLoader beforeLoader, Dictionary<string, IAssemblySymbol> beforeAssemblySymbols) =
             AssemblySymbolLoader.CreateFromFiles(
@@ -140,10 +137,7 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
 
         foreach ((string assemblyName, string text) in generator.Results.OrderBy(r => r.Key))
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             string fileName = $"{_tableOfContentsTitle}_{assemblyName}.md";
             tableOfContents.AppendLine($"* [{assemblyName}]({fileName})");

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
@@ -87,10 +87,15 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
     public IReadOnlyDictionary<string, string> Results => _results.AsReadOnly();
 
     /// <inheritdoc/>
-    public async Task RunAsync()
+    public async Task RunAsync(CancellationToken cancellationToken)
     {
         Debug.Assert(_beforeAssembliesFolderPaths.Length == 1);
         Debug.Assert(_afterAssembliesFolderPaths.Length == 1);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         (IAssemblySymbolLoader beforeLoader, Dictionary<string, IAssemblySymbol> beforeAssemblySymbols) =
             AssemblySymbolLoader.CreateFromFiles(
@@ -118,7 +123,7 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
                                                   _addPartialModifier,
                                                   _diagnosticOptions);
 
-        await generator.RunAsync().ConfigureAwait(false);
+        await generator.RunAsync(cancellationToken).ConfigureAwait(false);
 
         // If true, output is disk. Otherwise, it's the Results dictionary.
         if (_writeToDisk)
@@ -135,6 +140,11 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
 
         foreach ((string assemblyName, string text) in generator.Results.OrderBy(r => r.Key))
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             string fileName = $"{_tableOfContentsTitle}_{assemblyName}.md";
             tableOfContents.AppendLine($"* [{assemblyName}]({fileName})");
 

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/IDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/IDiffGenerator.cs
@@ -13,5 +13,5 @@ public interface IDiffGenerator
     /// <summary>
     /// Asynchronously runs the diff generator and may populate the <see cref="Results"/> dictionary depending on the use case.
     /// </summary>
-    Task RunAsync();
+    Task RunAsync(CancellationToken cancellationToken);
 }

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -91,10 +91,7 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
 
         foreach ((string beforeAssemblyName, IAssemblySymbol beforeAssemblySymbol) in _beforeAssemblySymbols)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Needs to block so the _afterAssemblySymbols dictionary gets updated.
             await ProcessBeforeAndAfterAssemblyAsync(beforeAssemblyName, beforeAssemblySymbol).ConfigureAwait(false);
@@ -103,10 +100,7 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
         // Needs to happen after processing the before and after assemblies and filtering out the existing ones.
         foreach ((string afterAssemblyName, IAssemblySymbol afterAssemblySymbol) in _afterAssemblySymbols)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await ProcessNewAssemblyAsync(afterAssemblyName, afterAssemblySymbol).ConfigureAwait(false);
         }

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -85,12 +85,17 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
     public IReadOnlyDictionary<string, string> Results => _results.AsReadOnly();
 
     /// <inheritdoc/>
-    public async Task RunAsync()
+    public async Task RunAsync(CancellationToken cancellationToken)
     {
         Stopwatch swRun = Stopwatch.StartNew();
 
         foreach ((string beforeAssemblyName, IAssemblySymbol beforeAssemblySymbol) in _beforeAssemblySymbols)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             // Needs to block so the _afterAssemblySymbols dictionary gets updated.
             await ProcessBeforeAndAfterAssemblyAsync(beforeAssemblyName, beforeAssemblySymbol).ConfigureAwait(false);
         }
@@ -98,6 +103,11 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
         // Needs to happen after processing the before and after assemblies and filtering out the existing ones.
         foreach ((string afterAssemblyName, IAssemblySymbol afterAssemblySymbol) in _afterAssemblySymbols)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             await ProcessNewAssemblyAsync(afterAssemblyName, afterAssemblySymbol).ConfigureAwait(false);
         }
 

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Base.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Base.Tests.cs
@@ -61,7 +61,7 @@ public abstract class DiffBaseTests
             addPartialModifier,
             DiffGeneratorFactory.DefaultDiagnosticOptions);
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         foreach ((string expectedAssemblyName, string expectedCode) in expected)
         {

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
@@ -96,7 +96,7 @@ public class DiffDiskTests
             outputFolderPath.DirPath,
             writeToDisk: true);
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         VerifyDiskWrite(outputFolderPath.DirPath, DefaultTableOfContentsTitle, ExpectedTableOfContents, DefaultExpectedAssemblyMarkdowns);
     }
@@ -255,7 +255,7 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
             outputFolderPath.DirPath,
             writeToDisk: true);
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         VerifyDiskWrite(outputFolderPath.DirPath, DefaultTableOfContentsTitle, expectedTableOfContents, expectedAssemblyMarkdowns);
     }
@@ -286,7 +286,7 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
             writeToDisk: true,
             filesWithAssembliesToExclude: await GetFileWithListsAsync(root, [DefaultAssemblyName]));
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         VerifyDiskWrite(outputFolderPath.FullName, DefaultTableOfContentsTitle, ExpectedEmptyTableOfContents, []);
     }
@@ -376,7 +376,7 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
             outputFolderPath.DirPath,
             writeToDisk: true);
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         VerifyDiskWrite(outputFolderPath.DirPath, DefaultTableOfContentsTitle, ExpectedTableOfContents, expectedAssemblyMarkdowns);
     }
@@ -401,7 +401,7 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
             outputFolderPath.DirPath,
             writeToDisk: false);
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         string tableOfContentsMarkdownFilePath = Path.Join(outputFolderPath.DirPath, $"{DefaultTableOfContentsTitle}.md");
         Assert.Contains(tableOfContentsMarkdownFilePath, generator.Results.Keys);
@@ -440,7 +440,7 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
             writeToDisk: false,
             filesWithAssembliesToExclude: await GetFileWithListsAsync(root, [DefaultAssemblyName]));
 
-        await generator.RunAsync();
+        await generator.RunAsync(CancellationToken.None);
 
         string tableOfContentsMarkdownFilePath = Path.Join(outputFolderPath.FullName, $"{DefaultTableOfContentsTitle}.md");
         Assert.Contains(tableOfContentsMarkdownFilePath, generator.Results.Keys);


### PR DESCRIPTION
APICompat was exiting at the first time it needed to go async.

This was because Commandline was treating the SetAction call as synchronous since it didn't accept a CancellationToken.  Fix this and plumb basic cancellation.

I also noticed that the usage of Option<T> was incorrect and corrected it to be consistent with the way we use in other tools.