### PR TITLE
Add CG2 to source-build bundle

### DIFF
--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -53,7 +53,10 @@
     <GenerateSdkBundleOnly Condition="'$(DotNetBuildPass)' == '3' and '$(OS)' == 'Windows_NT'">true</GenerateSdkBundleOnly>
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
     <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
-    <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleCrossgen2>
+
+    <_IsCommunityPlatform Condition="'$(OSName)' != 'win' and '$(OSName)' != 'osx' 
+      and !('$(OSName)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'))">true</_IsCommunityPlatform>
+    <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$( _IsCommunityPlatform )' == 'true'">true</BundleCrossgen2>
 
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
     <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' and '$(IsLinux)' == 'true' and !$(TargetRid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -53,6 +53,7 @@
     <GenerateSdkBundleOnly Condition="'$(DotNetBuildPass)' == '3' and '$(OS)' == 'Windows_NT'">true</GenerateSdkBundleOnly>
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
     <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
+    <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleCrossgen2>
 
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
     <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' and '$(IsLinux)' == 'true' and !$(TargetRid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -54,6 +54,8 @@
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
     <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
 
+    <!-- Crossgen2 is not bundled by default on platforms where Microsoft provides a package on nuget.org, 
+         because it is large (100MB+). -->
     <_IsCommunityPlatform Condition="'$(OSName)' != 'win' and '$(OSName)' != 'osx' 
       and !('$(OSName)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'))">true</_IsCommunityPlatform>
     <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$( _IsCommunityPlatform )' == 'true'">true</BundleCrossgen2>

--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -277,6 +277,10 @@
         Condition="'$(BundleNativeAotCompiler)' == 'true'"
         Include="$(ProductMonikerRid)" />
 
+      <Crossgen2SupportedRids
+        Condition="'$(BundleCrossgen2)' == 'true'"
+        Include="$(ProductMonikerRid)" />
+
       <Net60MonoRuntimePackRids Include="
         @(Net60RuntimePackRids);
         browser-wasm;

--- a/src/Layout/redist/targets/RestoreLayout.targets
+++ b/src/Layout/redist/targets/RestoreLayout.targets
@@ -116,6 +116,12 @@
       PackageVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
       RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
 
+    <BundledLayoutPackage Include="Microsoft.NETCore.App.Crossgen2.$(SharedFrameworkRid)"
+      Condition="'$(BundleCrossgen2)' == 'true'"
+      PackageName="Microsoft.NETCore.App.Crossgen2.$(SharedFrameworkRid)"
+      PackageVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+      RelativeLayoutPath="packs/%(PackageName)/%(PackageVersion)" />
+
     <BundledLayoutPackage Include="runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler"
       Condition="'$(BundleNativeAotCompiler)' == 'true'"
       PackageName="runtime.$(SharedFrameworkRid).Microsoft.DotNet.ILCompiler"


### PR DESCRIPTION
so that this last line https://github.com/filipnavara/dotnet-riscv/blob/ee6f66cef9df27c4783561219f6589112533ab43/.github/workflows/build.yml#L52 is not needed in SB scenarios (followed by manually copying it to `<SDK install prefix>/library-packs/` after extraction on target machine to enable PublishReadyToRun=true).

cc @jkoritzinsky, @filipnavara 