### PR TITLE
Adjusted CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,8 +30,8 @@
 /src/WasmSdk @lewing @akoeplinger @pavelsavara @maraf
 
 # Area-Format
-/src/Cli/dotnet/commands/dotnet-format @sharwell @arunchndr
-/test/dotnet-format.UnitTests @sharwell @arunchndr
+/src/Cli/dotnet/commands/dotnet-format @arunchndr
+/test/dotnet-format.UnitTests @arunchndr
 
 # Area-NuGet
 /src/Cli/dotnet/commands/dotnet-add/dotnet-add-package @dotnet/nuget-team


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/49237

There were 3 errors in the CODEOWNERS file. This PR fixes one of those. The other two were caused by these two policy violations:
- https://github.com/dotnet/org-policy-violations/issues/4844
- https://github.com/dotnet/org-policy-violations/issues/5617

One has been addressed. Once the other is addressed, the file will contain no more errors.