### PR TITLE
Fix variables in restore-toolset.sh/.ps1

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -9,8 +9,8 @@ function InitializeCustomSDKToolset {
   }
 
   # The following frameworks and tools are used only for testing.
-  # Do not attempt to install them in product build.
-  if ($productBuild) {
+  # Do not attempt to install them when building in the VMR.
+  if ($fromVmr) {
     return
   }
 

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -6,8 +6,8 @@ function InitializeCustomSDKToolset {
   fi
 
   # The following frameworks and tools are used only for testing.
-  # Do not attempt to install them in product build.
-  if [[ $product_build == true ]]; then
+  # Do not attempt to install them when building in the VMR.
+  if [[ $from_vmr == true ]]; then
     return
   fi
 


### PR DESCRIPTION
The productBuild variable (which was set in eng/common/tools.sh and tools.ps1) got renamed in https://github.com/dotnet/sdk/pull/49080 and this caused errors in the script.

```
The variable '$productBuild' cannot be retrieved because it has not been set.
System.Management.Automation.RuntimeException: The variable '$productBuild' cannot be retrieved because it has not been set.
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
at InitializeCustomSDKToolset, D:\a\_work\1\s\eng\restore-toolset.ps1: line 13
at <ScriptBlock>, D:\a\_work\1\s\eng\restore-toolset.ps1: line 166
at <ScriptBlock>, D:\a\_work\1\s\eng\dogfood.ps1: line 38
at Run-TestTemplateTests, D:\a\_work\1\s\build\RunTestTemplateTests.ps1: line 32
at <ScriptBlock>, D:\a\_work\1\s\build\RunTestTemplateTests.ps1: line 45
at <ScriptBlock>, D:\a\_work\_temp\0a4cc5cd-26ff-4d7d-9515-009330e688ca.ps1: line 4
at <ScriptBlock>, <No file>: line 1
D:\a\_work\1\s\build\RunTestTemplateTests.ps1 : Tests failed with exit code: 1
At D:\a\_work\_temp\0a4cc5cd-26ff-4d7d-9515-009330e688ca.ps1:4 char:1
+ build/RunTestTemplateTests.ps1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,RunTestTemplateTests.ps1
```