### PR TITLE
Simplify our container usage

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -190,24 +190,8 @@ extends:
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
               runTests: false
-            - categoryName: glibc
-              container: azureLinux30Net10BuildAmd64
-              # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:IsRPMBasedDistro=true
-              runTests: false
-            - categoryName: glibc
-              container: azureLinux30Net10BuildAmd64
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:IsRPMBasedDistro=true
-              runTests: false
-            ### MUSL ###
-            - categoryName: Musl
+            ### musl ###
+            - categoryName: musl
               container: azureLinux30Net10BuildAmd64
               runtimeIdentifier: linux-musl-x64
               publishArgument: $(_publishArgument)
@@ -217,7 +201,7 @@ extends:
               # SBOM generation is not supported for alpine.
               enableSbom: false
               runTests: false
-            - categoryName: Musl
+            - categoryName: musl
               container: azureLinux30Net10BuildAmd64
               targetArchitecture: arm
               runtimeIdentifier: linux-musl-arm
@@ -225,7 +209,7 @@ extends:
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: /p:OSName=linux-musl
               runTests: false
-            - categoryName: Musl
+            - categoryName: musl
               targetArchitecture: arm64
               runtimeIdentifier: linux-musl-arm64
               publishArgument: $(_publishArgument)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -155,56 +155,56 @@ extends:
             timeoutInMinutes: 90
             linuxJobParameterSets:
             ### OFFICIAL ###
-            # Note: These builds are also portable like the Portable category, but that category uses containers, and doesn't publish zips and tarballs.
+            # Note: These builds are also glibc like the glibc category, but that category uses containers, and doesn't publish zips and tarballs.
             - categoryName: Official
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties)
+              osProperties: $(linuxOsglibcProperties)
               runTests: false
             - categoryName: Official
               targetArchitecture: arm
               runtimeIdentifier: linux-arm
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties)
+              osProperties: $(linuxOsglibcProperties)
               runTests: false
             - categoryName: Official
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties)
+              osProperties: $(linuxOsglibcProperties)
               runTests: false
-            ### PORTABLE ###
-            - categoryName: Portable
+            ### glibc ###
+            - categoryName: glibc
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:BuildSdkDeb=true
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
               runTests: false
-            - categoryName: Portable
+            - categoryName: glibc
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:BuildSdkDeb=true
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
               runTests: false
-            - categoryName: Portable
+            - categoryName: glibc
               container: azureLinux30Net10BuildAmd64
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
+              osProperties: $(linuxOsglibcProperties) /p:IsRPMBasedDistro=true
               runTests: false
-            - categoryName: Portable
+            - categoryName: glibc
               container: azureLinux30Net10BuildAmd64
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
+              osProperties: $(linuxOsglibcProperties) /p:IsRPMBasedDistro=true
               runTests: false
             ### MUSL ###
             - categoryName: Musl

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -64,16 +64,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      alpine322Amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.22-amd64
-      centosStream9:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-      debian12Amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc15-amd64
-      fedora39:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-      mariner20CrossArm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm
+      azureLinux30Net10BuildAmd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
@@ -198,14 +191,14 @@ extends:
               osProperties: $(linuxOsPortableProperties) /p:BuildSdkDeb=true
               runTests: false
             - categoryName: Portable
-              container: centosStream9
+              container: azureLinux30Net10BuildAmd64
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
               runTests: false
             - categoryName: Portable
-              container: centosStream9
+              container: azureLinux30Net10BuildAmd64
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
@@ -215,7 +208,7 @@ extends:
               runTests: false
             ### MUSL ###
             - categoryName: Musl
-              container: alpine322Amd64
+              container: azureLinux30Net10BuildAmd64
               runtimeIdentifier: linux-musl-x64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
@@ -225,7 +218,7 @@ extends:
               enableSbom: false
               runTests: false
             - categoryName: Musl
-              container: mariner20CrossArm
+              container: azureLinux30Net10BuildAmd64
               targetArchitecture: arm
               runtimeIdentifier: linux-musl-arm
               publishArgument: $(_publishArgument)

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -27,16 +27,8 @@ variables:
 
 resources:
   containers:
-  - container: alpine322Amd64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.22-amd64
-  - container: centosStream9
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-  - container: debian12Amd64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc15-amd64
-  - container: fedora39
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-  - container: ubuntu2204DebPkg
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+  - container: azureLinux30Net10BuildAmd64
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
 
 stages:
 ############### BUILD STAGE ###############

--- a/eng/Badge.proj
+++ b/eng/Badge.proj
@@ -9,7 +9,7 @@
     <PropertyGroup>
       <!-- Replace '-' with '_' for os names like 'linux-musl' -->
       <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(TargetArchitecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(IsLinuxPortable)' == 'true'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(IsLinuxglibc)' == 'true'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
 
       <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <VersionSvgTemplate>$(MSBuildThisFileDirectory)version_badge.svg</VersionSvgTemplate>

--- a/eng/Badge.proj
+++ b/eng/Badge.proj
@@ -9,7 +9,6 @@
     <PropertyGroup>
       <!-- Replace '-' with '_' for os names like 'linux-musl' -->
       <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(TargetArchitecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(OSNAME)' == 'linux'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
 
       <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <VersionSvgTemplate>$(MSBuildThisFileDirectory)version_badge.svg</VersionSvgTemplate>

--- a/eng/Badge.proj
+++ b/eng/Badge.proj
@@ -9,7 +9,7 @@
     <PropertyGroup>
       <!-- Replace '-' with '_' for os names like 'linux-musl' -->
       <VersionBadgeMoniker>$(OSName.Replace('-', '_'))_$(TargetArchitecture)</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition="'$(IsLinuxglibc)' == 'true'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition="'$(OSNAME)' == 'linux'">linux_$(TargetArchitecture)</VersionBadgeMoniker>
 
       <VersionBadge>$(ArtifactsShippingPackagesDir)$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <VersionSvgTemplate>$(MSBuildThisFileDirectory)version_badge.svg</VersionSvgTemplate>

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -31,11 +31,6 @@ parameters:
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
     helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
-    osProperties: $(linuxOsglibcProperties)
-    runTests: true
-  - categoryName: ContainerBased
-    container: azureLinux30Net10BuildAmd64
-    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -29,39 +29,20 @@ parameters:
     # Don't run the tests on arm64. Only perform the build itself.
     runTests: false
   - categoryName: ContainerBased
-    container: ubuntu2204DebPkg
-    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
+    container: azureLinux30Net10BuildAmd64
+    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
     osProperties: $(linuxOsPortableProperties)
     runTests: true
   - categoryName: ContainerBased
-    container: fedora39
-    # No fedora Helix container is available, so use the ubuntu one instead.
-    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
-    osProperties: $(linuxOsPortableProperties)
-    # Skipping all container-based testing for now.
-    # See: https://github.com/dotnet/sdk/issues/40935
-    runTests: false
-  - categoryName: ContainerBased
-    container: centosStream9
-    helixTargetContainer: $(helixTargetContainerPrefix)centos-stream9-helix
+    container: azureLinux30Net10BuildAmd64
+    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
     osProperties: /p:OSName=linux
     runTests: true
   - categoryName: ContainerBased
-    container: debian12Amd64
-    helixTargetContainer: $(helixTargetContainerPrefix)debian-11-helix-amd64
+    container: azureLinux30Net10BuildAmd64
+    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
-  - categoryName: ContainerBased
-    container: alpine322Amd64
-    helixTargetContainer: $(helixTargetContainerPrefix)alpine-3.22-helix-amd64
-    runtimeIdentifier: linux-musl-x64
-    # Use HostOSName when running on alpine.
-    osProperties: /p:HostOSName=linux-musl
-    # SBOM generation is not supported for alpine.
-    enableSbom: false
-    # Skipping all container-based testing for now.
-    # See: https://github.com/dotnet/sdk/issues/40935
-    runTests: false
   - categoryName: TemplateEngine
     osProperties: $(linuxOsPortableProperties)
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -30,7 +30,7 @@ parameters:
     runTests: false
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
-    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux-3.0-net10.0-build-amd64
+    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -30,7 +30,7 @@ parameters:
     runTests: false
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
-    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-22.04-helix-amd64
+    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -30,7 +30,7 @@ parameters:
     runTests: false
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
-    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
+    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux-3.0-net10.0-build-amd64
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -36,11 +36,6 @@ parameters:
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
     helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
-    osProperties: /p:OSName=linux
-    runTests: true
-  - categoryName: ContainerBased
-    container: azureLinux30Net10BuildAmd64
-    helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -21,17 +21,17 @@ parameters:
   ### LINUX ###
   linuxJobParameterSets:
   - categoryName: TestBuild
-    osProperties: $(linuxOsPortableProperties)
+    osProperties: $(linuxOsglibcProperties)
   - categoryName: TestBuild
     targetArchitecture: arm64
     runtimeIdentifier: linux-arm64
-    osProperties: $(linuxOsPortableProperties)
+    osProperties: $(linuxOsglibcProperties)
     # Don't run the tests on arm64. Only perform the build itself.
     runTests: false
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
     helixTargetContainer: $(helixTargetContainerPrefix)azurelinux.3.amd64.open
-    osProperties: $(linuxOsPortableProperties)
+    osProperties: $(linuxOsglibcProperties)
     runTests: true
   - categoryName: ContainerBased
     container: azureLinux30Net10BuildAmd64
@@ -44,7 +44,7 @@ parameters:
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
   - categoryName: TemplateEngine
-    osProperties: $(linuxOsPortableProperties)
+    osProperties: $(linuxOsglibcProperties)
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
   ### MACOS ###

--- a/eng/pipelines/templates/variables/sdk-defaults.yml
+++ b/eng/pipelines/templates/variables/sdk-defaults.yml
@@ -1,7 +1,7 @@
 variables:
   ############### BUILD ###############
   buildConfiguration: Release
-  linuxOsPortableProperties: /p:OSName=linux /p:IsLinuxPortable=true
+  linuxOsglibcProperties: /p:OSName=linux /p:IsLinuxglibc=true
   helixTargetContainerPrefix: '@mcr.microsoft.com/dotnet-buildtools/prereqs:'
 
   ############### ARCADE ###############

--- a/eng/pipelines/templates/variables/sdk-defaults.yml
+++ b/eng/pipelines/templates/variables/sdk-defaults.yml
@@ -1,7 +1,7 @@
 variables:
   ############### BUILD ###############
   buildConfiguration: Release
-  linuxOsglibcProperties: /p:OSName=linux /p:IsLinuxglibc=true
+  linuxOsglibcProperties: /p:OSName=linux
   helixTargetContainerPrefix: '@mcr.microsoft.com/dotnet-buildtools/prereqs:'
 
   ############### ARCADE ###############

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -15,19 +15,14 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
+        // Some netcoreapp2.0 Linux tests are no longer working on ubuntu 2404
+        [PlatformSpecificTheory(TestPlatforms.Windows | TestPlatforms.OSX)]
         [InlineData("netcoreapp1.1", false)]
         [InlineData("netcoreapp2.0", false)]
         [InlineData("netcoreapp3.0", true)]
         public void It_builds_a_runnable_output(string targetFramework, bool dependenciesIncluded)
         {
             if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
-            {
-                return;
-            }
-
-            // Some netcoreapp2.0 Linux tests are no longer working on ubuntu 2404
-            if (targetFramework == "netcoreapp2.0" && OperatingSystem.IsLinux())
             {
                 return;
             }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -26,6 +26,12 @@ namespace Microsoft.NET.Build.Tests
                 return;
             }
 
+            // Some netcoreapp2.0 Linux tests are no longer working on ubuntu 2404
+            if (targetFramework == "netcoreapp2.0" && OperatingSystem.IsLinux())
+            {
+                return;
+            }
+
             var runtimeIdentifier = EnvironmentInfo.GetCompatibleRid(targetFramework);
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", identifier: targetFramework)

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -71,6 +71,12 @@ namespace Microsoft.NET.Publish.Tests
                 return;
             }
 
+            // Some netcoreapp2.0 Linux tests are no longer working on ubuntu 2404
+            if (targetFramework == "netcoreapp2.0" && OperatingSystem.IsLinux())
+            {
+                return;
+            }
+
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var helloWorldAsset = _testAssetsManager
@@ -228,7 +234,8 @@ public static class Program
             Conflicts_are_resolved_when_publishing(selfContained: false, ridSpecific: false);
         }
 
-        [Fact]
+        // This test is for netcoreapp2 and no longer working on ubuntu 2404
+        [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void Conflicts_are_resolved_when_publishing_a_self_contained_app()
         {
             Conflicts_are_resolved_when_publishing(selfContained: true, ridSpecific: true);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -49,7 +49,8 @@ namespace Microsoft.NET.Publish.Tests
             });
         }
 
-        [Fact]
+        // This test is for netcoreapp2 and no longer working on ubuntu 2404
+        [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void It_should_publish_self_contained_for_2x()
         {
             var tfm = "netcoreapp2.2";
@@ -109,6 +110,8 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("Microsoft.AspNetCore.All")]
         public void It_should_publish_framework_dependent_for_2x(string platformLibrary)
         {
+
+
             var tfm = "netcoreapp2.2";
 
             var testProject = new TestProject()


### PR DESCRIPTION
Based on offline guidance, simplify our container usage in main to use the azure linux images for all linux builds.  ASP.NET followed this guidance and there change was here: 
https://github.com/dotnet/aspnetcore/pull/60260/files

Open questions:

1. I kept some of the sdk job legs that had different parameters passing in for osProperties but we should review and determine if they really are different
2. The VMR now handles the production of the packages so we probably don't need most of these in the CI build either. I just changed the container they built on but perhaps we can remove some/most of those as well as they are just for validation in the SDK repo at this point.