### PR TITLE
Add dotnet package update command

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -119,7 +119,7 @@ public static class Parser
     // Argument
     public static readonly Argument<string> DotnetSubCommand = new("subcommand") { Arity = ArgumentArity.ZeroOrOne, Hidden = true };
 
-    private static Command ConfigureCommandLine(Command rootCommand)
+    private static Command ConfigureCommandLine(RootCommand rootCommand)
     {
         for (int i = rootCommand.Options.Count - 1; i >= 0; i--)
         {
@@ -155,6 +155,9 @@ public static class Parser
 
         // Add argument
         rootCommand.Arguments.Add(DotnetSubCommand);
+
+        // NuGet implements several commands in its own repo. Add them to the .NET SDK via the provided API.
+        NuGet.CommandLine.XPlat.NuGetCommands.Add(rootCommand);
 
         rootCommand.SetAction(parseResult =>
         {

--- a/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
+++ b/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
@@ -171,7 +171,6 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .Pass()
                 .And.NotHaveStdErr();
 
-            _ = listPackageCommandResult.StdOut;
             var updatedPackageVersionString = JObject.Parse(listPackageCommandResult.StdOut)
                 .SelectToken("$.projects[0].frameworks[0].topLevelPackages[?(@.id == 'dotnet-hello')].requestedVersion")
                 .ToString();

--- a/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
+++ b/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
@@ -6,6 +6,8 @@
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.NuGet;
 using Moq;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Tools.Run.Tests
 {
@@ -132,6 +134,52 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .Pass()
                 .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("has the following dependency");
+        }
+
+        [Fact]
+        public void ItCanUpdatePackages()
+        {
+            // Arrange
+            var testAssetName = "TestAppSimple";
+            var testAsset = _testAssetsManager
+                .CopyTestAsset(testAssetName)
+                .WithSource();
+            var projectDirectory = testAsset.Path;
+
+            NuGetConfigWriter.Write(projectDirectory, TestContext.Current.TestPackages);
+
+            new DotnetCommand(Log, "package", "add", "dotnet-hello@1.0.0")
+                .WithWorkingDirectory(projectDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr();
+
+            // Act
+            var commandResult = new DotnetCommand(Log, "package", "update", "dotnet-hello")
+                .WithWorkingDirectory(projectDirectory)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.NotHaveStdErr();
+
+            // Assert
+            var listPackageCommandResult = new DotnetCommand(Log, "package", "list", "--format", "json")
+                .WithWorkingDirectory(projectDirectory)
+                .Execute();
+            listPackageCommandResult.Should()
+                .Pass()
+                .And.NotHaveStdErr();
+
+            _ = listPackageCommandResult.StdOut;
+            var updatedPackageVersionString = JObject.Parse(listPackageCommandResult.StdOut)
+                .SelectToken("$.projects[0].frameworks[0].topLevelPackages[?(@.id == 'dotnet-hello')].requestedVersion")
+                .ToString();
+
+            var v1 = NuGetVersion.Parse("1.0.0");
+            var updatedVersion = NuGetVersion.Parse(updatedPackageVersionString);
+
+            updatedVersion.Should().BeGreaterThan(v1);
         }
     }
 }

--- a/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1006,7 +1006,7 @@ _testhost_package() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="search add list remove --help" 
+    opts="search add list remove update --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -1031,6 +1031,11 @@ _testhost_package() {
             
         (remove)
             _testhost_package_remove $(($1+1))
+            return
+            ;;
+            
+        (update)
+            _testhost_package_update $(($1+1))
             return
             ;;
             
@@ -1116,6 +1121,23 @@ _testhost_package_remove() {
     COMPREPLY=()
     
     opts="--interactive --project --help" 
+    
+    if [[ $COMP_CWORD == "$1" ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return
+    fi
+    
+    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+}
+
+
+_testhost_package_update() {
+
+    cur="${COMP_WORDS[COMP_CWORD]}" 
+    prev="${COMP_WORDS[COMP_CWORD-1]}" 
+    COMPREPLY=()
+    
+    opts="--project --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -573,6 +573,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
                 [CompletionResult]::new('add', 'add', [CompletionResultType]::ParameterValue, "Add a NuGet package reference to the project.")
                 [CompletionResult]::new('list', 'list', [CompletionResultType]::ParameterValue, "List all package references of the project or solution.")
                 [CompletionResult]::new('remove', 'remove', [CompletionResultType]::ParameterValue, "Remove a NuGet package reference from the project.")
+                [CompletionResult]::new('update', 'update', [CompletionResultType]::ParameterValue, "Update referenced packages in a project or solution.")
             )
             $completions += $staticCompletions
             break
@@ -650,6 +651,15 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
             $staticCompletions = @(
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "The project file to operate on. If a file is not specified, the command will search the current directory for one.")
+                [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
+                [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
+            )
+            $completions += $staticCompletions
+            break
+        }
+        'testhost;package;update' {
+            $staticCompletions = @(
+                [CompletionResult]::new('--project', '--project', [CompletionResultType]::ParameterName, "Path to a project or solution file, or a directory.")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -646,6 +646,14 @@ _testhost() {
                                             '*::PACKAGE_NAME -- The package reference to remove.: ' \
                                             && ret=0
                                         ;;
+                                    (update)
+                                        _arguments "${_arguments_options[@]}" : \
+                                            '--project=[Path to a project or solution file, or a directory.]: : ' \
+                                            '--help[Show command line help.]' \
+                                            '-h[Show command line help.]' \
+                                            '*::packages: ' \
+                                            && ret=0
+                                        ;;
                                 esac
                             ;;
                         esac
@@ -1640,6 +1648,7 @@ _testhost__package_commands() {
         'add:Add a NuGet package reference to the project.' \
         'list:List all package references of the project or solution.' \
         'remove:Remove a NuGet package reference from the project.' \
+        'update:Update referenced packages in a project or solution.' \
     )
     _describe -t commands 'testhost package commands' commands "$@"
 }
@@ -1666,6 +1675,12 @@ _testhost__package__list_commands() {
 _testhost__package__remove_commands() {
     local commands; commands=()
     _describe -t commands 'testhost package remove commands' commands "$@"
+}
+
+(( $+functions[_testhost__package__update_commands] )) ||
+_testhost__package__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'testhost package update commands' commands "$@"
 }
 
 (( $+functions[_testhost__project_commands] )) ||


### PR DESCRIPTION
NuGet.Client added a (VERY!!!) MVP version of `dotnet package update`.

Rather than adding a new API to NuGet.Client every time we add a new command (and therefore are unable to add integration tests until after the dotnet/sdk repo is updated), I added a generic `NuGetCommands.Add(RootCommand)` API, so in the future NuGet can add its own integration tests in the same PR that adds new commands.

Added a single, fairly simple test here, to make sure that the command works, but the NuGet.Client repo has all the exhaustive tests for the command.