### PR TITLE
Fix deps.json  trimming with xUnit v2 and allow opt-out

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -371,9 +371,10 @@ namespace Microsoft.NET.Build.Tasks
                     var lib = unprocessedLibraries.First();
                     unprocessedLibraries.Remove(lib);
 
-                    if (lib.Library.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
+                    if (lib.Library.Name.Equals("xunit", StringComparison.OrdinalIgnoreCase) ||
+                        lib.Library.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
                     {
-                        // Special case xunit.core, it should not be removed because the xUnit v2 runner looks for this library in the deps.json to
+                        // Special case xunit and xunit.core, they should not be removed because the xUnit v2 runner looks for these libraries in the deps.json to
                         // identify test projects.
                         // See https://github.com/dotnet/sdk/issues/49248
                         continue;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -362,6 +362,14 @@ namespace Microsoft.NET.Build.Tasks
                 var lib = unprocessedLibraries.First();
                 unprocessedLibraries.Remove(lib);
 
+                if (lib.Library.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Special case xunit.core, it should not be removed because the xUnit v2 runner looks for this library in the deps.json to
+                    // identify test projects.
+                    // See https://github.com/dotnet/sdk/issues/49248
+                    continue;
+                }
+
                 if (lib.Library.RuntimeAssemblyGroups.Count == 0 && lib.Library.NativeLibraryGroups.Count == 0 && lib.Library.ResourceAssemblies.Count == 0)
                 {
                     if (lib.Library.Dependencies.All(d => !libraries.TryGetValue(d.Name, out var dependency) || dependency.Dependents.Count > 1))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -29,6 +29,7 @@ namespace Microsoft.NET.Build.Tasks
         private string _referenceAssembliesPath;
         private Dictionary<PackageIdentity, string> _filteredPackages;
         private bool _includeMainProjectInDepsFile = true;
+        private bool _trimLibrariesWithoutAssets = true;
         private readonly Dictionary<string, DependencyLibrary> _dependencyLibraries;
         private readonly Dictionary<string, List<LibraryDependency>> _libraryDependencies;
         private readonly List<string> _mainProjectDependencies;
@@ -212,6 +213,12 @@ namespace Microsoft.NET.Build.Tasks
             return this;
         }
 
+        public DependencyContextBuilder WithTrimLibrariesWithoutAssets(bool trimLibrariesWithoutAssets)
+        {
+            _trimLibrariesWithoutAssets = trimLibrariesWithoutAssets;
+            return this;
+        }
+
         public DependencyContextBuilder WithRuntimePackAssets(IEnumerable<RuntimePackAssetInfo> runtimePackAssets)
         {
             _runtimePackAssets = new Dictionary<string, List<RuntimePackAssetInfo>>();
@@ -356,39 +363,42 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            var unprocessedLibraries = runtimeLibraries.ToHashSet();
-            while (unprocessedLibraries.Any())
+            if (_trimLibrariesWithoutAssets)
             {
-                var lib = unprocessedLibraries.First();
-                unprocessedLibraries.Remove(lib);
-
-                if (lib.Library.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
+                var unprocessedLibraries = runtimeLibraries.ToHashSet();
+                while (unprocessedLibraries.Any())
                 {
-                    // Special case xunit.core, it should not be removed because the xUnit v2 runner looks for this library in the deps.json to
-                    // identify test projects.
-                    // See https://github.com/dotnet/sdk/issues/49248
-                    continue;
-                }
+                    var lib = unprocessedLibraries.First();
+                    unprocessedLibraries.Remove(lib);
 
-                if (lib.Library.RuntimeAssemblyGroups.Count == 0 && lib.Library.NativeLibraryGroups.Count == 0 && lib.Library.ResourceAssemblies.Count == 0)
-                {
-                    if (lib.Library.Dependencies.All(d => !libraries.TryGetValue(d.Name, out var dependency) || dependency.Dependents.Count > 1))
+                    if (lib.Library.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
                     {
-                        runtimeLibraries.Remove(lib);
-                        libraries.Remove(lib.Library.Name);
-                        foreach (var dependency in lib.Library.Dependencies)
-                        {
-                            if (libraries.TryGetValue(dependency.Name, out ModifiableRuntimeLibrary value))
-                            {
-                                value.Dependents.Remove(lib.Library.Name);
-                            }
-                        }
+                        // Special case xunit.core, it should not be removed because the xUnit v2 runner looks for this library in the deps.json to
+                        // identify test projects.
+                        // See https://github.com/dotnet/sdk/issues/49248
+                        continue;
+                    }
 
-                        foreach (var dependent in lib.Dependents)
+                    if (lib.Library.RuntimeAssemblyGroups.Count == 0 && lib.Library.NativeLibraryGroups.Count == 0 && lib.Library.ResourceAssemblies.Count == 0)
+                    {
+                        if (lib.Library.Dependencies.All(d => !libraries.TryGetValue(d.Name, out var dependency) || dependency.Dependents.Count > 1))
                         {
-                            if (libraries.TryGetValue(dependent, out var dep))
+                            runtimeLibraries.Remove(lib);
+                            libraries.Remove(lib.Library.Name);
+                            foreach (var dependency in lib.Library.Dependencies)
                             {
-                                unprocessedLibraries.Add(dep);
+                                if (libraries.TryGetValue(dependency.Name, out ModifiableRuntimeLibrary value))
+                                {
+                                    value.Dependents.Remove(lib.Library.Name);
+                                }
+                            }
+
+                            foreach (var dependent in lib.Dependents)
+                            {
+                                if (libraries.TryGetValue(dependent, out var dep))
+                                {
+                                    unprocessedLibraries.Add(dep);
+                                }
                             }
                         }
                     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -49,6 +49,8 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeMainProject { get; set; }
 
+        public bool TrimDepsJsonLibrariesWithoutAssets { get; set; }
+
         // @(ReferencePath) that will be passed to
         public ITaskItem[] ReferencePaths { get; set; } = Array.Empty<ITaskItem>();
 
@@ -230,6 +232,7 @@ namespace Microsoft.NET.Build.Tasks
 
             builder = builder
                 .WithMainProjectInDepsFile(IncludeMainProject)
+                .WithTrimLibrariesWithoutAssets(TrimDepsJsonLibrariesWithoutAssets)
                 .WithReferenceAssemblies(referenceAssemblyInfos)
                 .WithDirectReferences(directReferences)
                 .WithDependencyReferences(dependencyReferences)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -59,6 +59,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       AssetsFilePath="$(ProjectAssetsFile)"
       DepsFilePath="$(_DesignerDepsFilePath)"
       IncludeMainProject="false"
+      TrimDepsJsonLibrariesWithoutAssets="$(TrimDepsJsonLibrariesWithoutAssets)"
       IncludeRuntimeFileVersions="$(IncludeFileVersionsInDependencyFile)"
       IsSelfContained="false"
       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1248,6 +1248,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       ReferenceAssemblies="@(_ReferenceAssemblies)"
                       RuntimePackAssets="@(RuntimePackAsset)"
                       IncludeMainProject="$(IncludeMainProjectInDepsFile)"
+                      TrimDepsJsonLibrariesWithoutAssets="$(TrimDepsJsonLibrariesWithoutAssets)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       RuntimeFrameworks="@(RuntimeFramework)"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -88,6 +88,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ProjectRuntimeConfigFilePath Condition="'$(ProjectRuntimeConfigFilePath)' == ''">$(TargetDir)$(ProjectRuntimeConfigFileName)</ProjectRuntimeConfigFilePath>
     <ProjectRuntimeConfigDevFilePath Condition="'$(ProjectRuntimeConfigDevFilePath)' == '' and $(GenerateRuntimeConfigDevFile) == 'true'">$(TargetDir)$(AssemblyName).runtimeconfig.dev.json</ProjectRuntimeConfigDevFilePath>
     <IncludeMainProjectInDepsFile Condition=" '$(IncludeMainProjectInDepsFile)' == '' ">true</IncludeMainProjectInDepsFile>
+    <TrimDepsJsonLibrariesWithoutAssets Condition=" '$(TrimDepsJsonLibrariesWithoutAssets)' == '' ">true</TrimDepsJsonLibrariesWithoutAssets>
   </PropertyGroup>
 
   <Import Project="Microsoft.NET.Sdk.Shared.targets" />
@@ -316,6 +317,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       ReferenceAssemblies="@(_ReferenceAssemblies)"
                       RuntimePackAssets="@(RuntimePackAsset)"
                       IncludeMainProject="$(IncludeMainProjectInDepsFile)"
+                      TrimDepsJsonLibrariesWithoutAssets="$(TrimDepsJsonLibrariesWithoutAssets)"
                       RuntimeIdentifier="$(RuntimeIdentifier)"
                       PlatformLibraryName="$(MicrosoftNETPlatformLibrary)"
                       RuntimeFrameworks="@(RuntimeFramework)"


### PR DESCRIPTION
Fixes #49248

- Special-cases `xunit.core` library so it will never be trimmed from deps.json file
- Adds new property, `TrimDepsJsonLibrariesWithoutAssets`, which can be set to false to disable deps.json library trimming