### PR TITLE
Move localization to main

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -107,7 +107,7 @@ extends:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          locBranch: release/9.0.3xx
+          locBranch: main
           # WORKAROUND: BinSkim requires the folder exist prior to scanning.
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force


### PR DESCRIPTION
9.0.3xx is locked down. Let's enable localization in main so we get early net10 loc especially as we moved all our resx files around.