### PR TITLE
Re-order command-line options for MTP dotnet test

### DIFF
--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -241,10 +241,10 @@ internal static class TestCommandParser
         command.Options.Add(CommonOptions.NoRestoreOption);
         command.Options.Add(TestingPlatformOptions.NoBuildOption);
         command.Options.Add(TestingPlatformOptions.NoAnsiOption);
-        command.Options.Add(TestingPlatformOptions.NoLaunchProfileOption);
-        command.Options.Add(TestingPlatformOptions.NoLaunchProfileArgumentsOption);
         command.Options.Add(TestingPlatformOptions.NoProgressOption);
         command.Options.Add(TestingPlatformOptions.OutputOption);
+        command.Options.Add(TestingPlatformOptions.NoLaunchProfileOption);
+        command.Options.Add(TestingPlatformOptions.NoLaunchProfileArgumentsOption);
 
         return command;
     }


### PR DESCRIPTION
This keeps output-related options grouped together.