### PR TITLE
Fix overriding HelpName in Parser.cs, set it explicitly instead

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SharedOptions.cs
@@ -10,13 +10,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         public static Option<FileInfo> OutputOption { get; } = new("--output", "-o")
         {
             Description = SymbolStrings.Option_Output,
+            HelpName = SymbolStrings.Option_Output_HelpName,
             Required = false,
             Arity = new ArgumentArity(1, 1)
         };
 
         public static Option<FileInfo> ProjectPathOption { get; } = new Option<FileInfo>("--project")
         {
-            Description = SymbolStrings.Option_ProjectPath
+            Description = SymbolStrings.Option_ProjectPath,
+            HelpName = SymbolStrings.Option_ProjectPath_HelpName
         }.AcceptExistingOnly();
 
         public static Option<bool> InteractiveOption { get; } = SharedOptionsFactory.CreateInteractiveOption();
@@ -26,6 +28,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal static Option<string> NameOption { get; } = new("--name", "-n")
         {
             Description = SymbolStrings.TemplateCommand_Option_Name,
+            HelpName = SymbolStrings.TemplateCommand_Option_Name_HelpName,
             Arity = new ArgumentArity(1, 1)
         };
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
@@ -381,6 +381,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to OUTPUT
+        /// </summary>
+        internal static string Option_Output_HelpName {
+            get {
+                return ResourceManager.GetString("Option_Output_HelpName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on NuGet package ID..
         /// </summary>
         internal static string Option_PackageFilter {
@@ -395,6 +404,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         internal static string Option_ProjectPath {
             get {
                 return ResourceManager.GetString("Option_ProjectPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PROJECT
+        /// </summary>
+        internal static string Option_ProjectPath_HelpName {
+            get {
+                return ResourceManager.GetString("Option_ProjectPath_HelpName", resourceCulture);
             }
         }
         
@@ -467,6 +485,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         internal static string TemplateCommand_Option_Name {
             get {
                 return ResourceManager.GetString("TemplateCommand_Option_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NAME
+        /// </summary>
+        internal static string TemplateCommand_Option_Name_HelpName {
+            get {
+                return ResourceManager.GetString("TemplateCommand_Option_Name_HelpName", resourceCulture);
             }
         }
         

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
@@ -228,11 +228,17 @@ If command is specified without the argument, it lists all the template packages
   <data name="Option_Output" xml:space="preserve">
     <value>Location to place the generated output.</value>
   </data>
+  <data name="Option_Output_HelpName" xml:space="preserve">
+    <value>OUTPUT</value>
+  </data>
   <data name="Option_PackageFilter" xml:space="preserve">
     <value>Filters the templates based on NuGet package ID.</value>
   </data>
   <data name="Option_ProjectPath" xml:space="preserve">
     <value>The project that should be used for context evaluation.</value>
+  </data>
+  <data name="Option_ProjectPath_HelpName" xml:space="preserve">
+    <value>PROJECT</value>
   </data>
   <data name="Option_TagFilter" xml:space="preserve">
     <value>Filters the templates based on the tag.</value>
@@ -258,6 +264,9 @@ If command is specified without the argument, it lists all the template packages
   </data>
   <data name="TemplateCommand_Option_Name" xml:space="preserve">
     <value>The name for the output being created. If no name is specified, the name of the output directory is used.</value>
+  </data>
+  <data name="TemplateCommand_Option_Name_HelpName" xml:space="preserve">
+    <value>NAME</value>
   </data>
   <data name="TemplateCommand_Option_NoUpdateCheck" xml:space="preserve">
     <value>Disables checking for the template package updates when instantiating a template.</value>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
@@ -320,11 +320,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 }
             }
 
-            foreach (Option cliOption in optionsToShow)
-            {
-                cliOption.EnsureHelpName();
-            }
-
             context.Output.WriteLine(LocalizationResources.HelpOptionsTitle());
             IEnumerable<TwoColumnHelpRow> optionsToWrite = optionsToShow.Select(o => context.HelpBuilder.GetTwoColumnRow(o, context));
             context.HelpBuilder.WriteColumns(optionsToWrite.ToArray(), context);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
@@ -187,6 +187,11 @@ Pokud je příkaz zadán bez argumentu, zobrazí seznam všech nainstalovaných 
         <target state="translated">Umístění, do kterého se uloží vygenerovaný výstup</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtruje šablony podle ID balíčku NuGet.</target>
@@ -195,6 +200,11 @@ Pokud je příkaz zadán bez argumentu, zobrazí seznam všech nainstalovaných 
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Projekt, který by se měl použít pro vyhodnocení kontextu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Pokud je příkaz zadán bez argumentu, zobrazí seznam všech nainstalovaných 
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Název vytvářeného výstupu. Pokud se žádný název nezadá, použije se název výstupního adresáře.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
@@ -187,6 +187,11 @@ Wenn der Befehl ohne Argument angegeben wird, werden alle installierten Vorlagen
         <target state="translated">Speicherort für die generierte Ausgabe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtert die Vorlagen basierend auf der NuGet-Paket-ID.</target>
@@ -195,6 +200,11 @@ Wenn der Befehl ohne Argument angegeben wird, werden alle installierten Vorlagen
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Das Projekt, das für die Kontextauswertung verwendet werden soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Wenn der Befehl ohne Argument angegeben wird, werden alle installierten Vorlagen
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Der Name für die erstellte Ausgabe. Wenn kein Name angegeben wird, wird der Name des Ausgabeverzeichnisses verwendet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
@@ -187,6 +187,11 @@ Si el comando se especifica sin el argumento, muestra todos los paquetes de plan
         <target state="translated">Ubicación en la que se colocará el resultado generado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtra las plantillas en función del id. del paquete NuGet.</target>
@@ -195,6 +200,11 @@ Si el comando se especifica sin el argumento, muestra todos los paquetes de plan
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Proyecto que se debe usar para la evaluación de contexto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Si el comando se especifica sin el argumento, muestra todos los paquetes de plan
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Nombre de la salida que se va a crear. Si no se especifica ningún nombre, se usa el nombre del directorio de salida.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
@@ -187,6 +187,11 @@ Si la commande est spécifiée sans l’argument, elle répertorie tous les pack
         <target state="translated">Emplacement pour la sortie générée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtre les modèles en fonction de l’ID de package NuGet.</target>
@@ -195,6 +200,11 @@ Si la commande est spécifiée sans l’argument, elle répertorie tous les pack
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Projet à utiliser pour l’évaluation du contexte</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Si la commande est spécifiée sans l’argument, elle répertorie tous les pack
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Le nom de la sortie est en cours de création. Si aucun nom n’est spécifié, le nom du répertoire de sortie est utilisé.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
@@ -187,6 +187,11 @@ Se il comando è specificato senza l'argomento, vengono elencati tutti i pacchet
         <target state="translated">Percorso in cui inserire l'output generato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtra i modelli basati sull'ID pacchetto NuGet. Si applica a--search.</target>
@@ -195,6 +200,11 @@ Se il comando è specificato senza l'argomento, vengono elencati tutti i pacchet
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Progetto da usare per la valutazione del contesto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Se il comando è specificato senza l'argomento, vengono elencati tutti i pacchet
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Nome dell'output da creare. Se non viene specificato alcun nome, verrà usato il nome della directory di output.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
@@ -187,6 +187,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">生成された出力を配置する場所。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">NuGet パッケージ ID に基づいてテンプレートをフィルターします。</target>
@@ -195,6 +200,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">コンテキストの評価に使用する必要があるプロジェクトです。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">作成される出力の名前です。名前を指定しない場合は、出力ディレクトリの名前が使用されます。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
@@ -187,6 +187,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">생성된 출력을 배치할 위치입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">NuGet 패키지 ID를 기준으로 템플릿을 필터링합니다.</target>
@@ -195,6 +200,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">컨텍스트 평가에 사용해야 하는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">생성 중인 출력의 이름입니다. 이름을 지정하지 않으면 출력 디렉터리의 이름이 사용됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
@@ -187,6 +187,11 @@ Jeśli polecenie zostanie określone bez argumentu, zostanie wyświetlona lista 
         <target state="translated">Lokalizacja, w której mają zostać umieszczone wygenerowane dane wyjściowe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtruje szablony na podstawie identyfikatora pakietu NuGet..</target>
@@ -195,6 +200,11 @@ Jeśli polecenie zostanie określone bez argumentu, zostanie wyświetlona lista 
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Projekt, który powinien być używany do oceny kontekstu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Jeśli polecenie zostanie określone bez argumentu, zostanie wyświetlona lista 
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Nazwa tworzonych danych wyjściowych. Jeśli nie podano nazwy, zostanie użyta nazwa katalogu wyjściowego.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
@@ -187,6 +187,11 @@ Se o comando for especificado sem o argumento, ele listará todos os pacotes de 
         <target state="translated">Local para colocar a saída gerada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Filtra os modelos com base na ID do pacote NuGet.</target>
@@ -195,6 +200,11 @@ Se o comando for especificado sem o argumento, ele listará todos os pacotes de 
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">O projeto que deve ser usado para avaliação de contexto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Se o comando for especificado sem o argumento, ele listará todos os pacotes de 
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">O nome da saída que está sendo criada. Se nenhum nome for especificado, o nome do diretório de saída será usado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
@@ -187,6 +187,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">Расположение для размещения созданных выходных данных.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Фильтрация шаблонов по идентификатору пакета NuGet.</target>
@@ -195,6 +200,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Проект, который следует использовать для оценки контекста.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Имя создаваемых выходных данных. Если имя не указано, используется имя выходного каталога.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
@@ -187,6 +187,11 @@ Eğer komut bağımsız değişken olmadan belirtilirse yüklü tüm şablon pak
         <target state="translated">Oluşturulan çıkışın yerleştirileceği konum.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">Şablonları NuGet paketi kimliğine göre filtreler.</target>
@@ -195,6 +200,11 @@ Eğer komut bağımsız değişken olmadan belirtilirse yüklü tüm şablon pak
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">Bağlam değerlendirmesi için kullanılacak proje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ Eğer komut bağımsız değişken olmadan belirtilirse yüklü tüm şablon pak
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">Oluşturulan çıkışın adı. Ad belirtilmezse, çıkış dizininin adı kullanılır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
@@ -187,6 +187,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">要放置生成的输出的位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">根据 NuGet 包 ID 筛选模板。</target>
@@ -195,6 +200,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">应用于上下文评估的项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">正在创建的输出名称。如未指定名称，则使用输出目录的名称。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
@@ -187,6 +187,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="translated">放置產生輸出的位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Output_HelpName">
+        <source>OUTPUT</source>
+        <target state="new">OUTPUT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_PackageFilter">
         <source>Filters the templates based on NuGet package ID.</source>
         <target state="translated">根據 NuGet 套件識別碼篩選範本。</target>
@@ -195,6 +200,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="Option_ProjectPath">
         <source>The project that should be used for context evaluation.</source>
         <target state="translated">應該用於內容評估的專案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Option_ProjectPath_HelpName">
+        <source>PROJECT</source>
+        <target state="new">PROJECT</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_TagFilter">
@@ -235,6 +245,11 @@ If command is specified without the argument, it lists all the template packages
       <trans-unit id="TemplateCommand_Option_Name">
         <source>The name for the output being created. If no name is specified, the name of the output directory is used.</source>
         <target state="translated">要建立的輸出名稱。如果未指定名稱，則使用輸出目錄的名稱。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCommand_Option_Name_HelpName">
+        <source>NAME</source>
+        <target state="new">NAME</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateCommand_Option_NoUpdateCheck">

--- a/src/Cli/Microsoft.TemplateEngine.Cli/SymbolExtensions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/SymbolExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public static class SymbolExtensions
     {
-        public static void EnsureHelpName(this Option cliOption)
+        public static bool EnsureHelpName(this Option cliOption)
         {
             // System.CommandLine used to include the option's name without the prefix in the help output:
             // --name, --alias, -a <name> description
@@ -18,7 +18,10 @@ namespace Microsoft.TemplateEngine.Cli
                 && cliOption.CompletionSources.Count == 0) // and options that have completions
             {
                 cliOption.HelpName = cliOption.Name.RemovePrefix();
+                return true;
             }
+
+            return false;
         }
     }
 }

--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
@@ -34,7 +34,11 @@ internal static class NuGetCommandParser
         {
             Arity = ArgumentArity.Zero
         });
-        command.Options.Add(new Option<string>("--verbosity", "-v"));
+        command.Options.Add(new Option<string>("--verbosity", "-v")
+        {
+            Description = CliStrings.VerbosityOptionDescription,
+            HelpName = CliStrings.LevelArgumentName
+        });
 
         command.Subcommands.Add(GetDeleteCommand());
         command.Subcommands.Add(GetLocalsCommand());

--- a/src/Cli/dotnet/Commands/Reference/ReferenceCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Reference/ReferenceCommandParser.cs
@@ -18,6 +18,7 @@ internal static class ReferenceCommandParser
     public static readonly Option<string> ProjectOption = new Option<string>("--project")
     {
         Description = CliStrings.ProjectArgumentDescription,
+        HelpName = CliStrings.ProjectArgumentName,
         Recursive = true
     };
 

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -248,11 +248,11 @@ internal static class CommonOptions
         return result;
     }
 
-    public static readonly Option<string> TestPlatformOption = new("--Platform");
+    public static readonly Option<string> TestPlatformOption = new("--Platform") { HelpName = "PLATFORM" };
 
-    public static readonly Option<string> TestFrameworkOption = new("--Framework");
+    public static readonly Option<string> TestFrameworkOption = new("--Framework") { HelpName = "FRAMEWORK" };
 
-    public static readonly Option<string[]> TestLoggerOption = new("--logger");
+    public static readonly Option<string[]> TestLoggerOption = new("--logger") { HelpName = "LOGGER" };
 
     public static void ValidateSelfContainedOptions(bool hasSelfContainedOption, bool hasNoSelfContainedOption)
     {

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -319,11 +319,6 @@ public static class Parser
                 return;
             }
 
-            foreach (var option in command.Options)
-            {
-                option.EnsureHelpName();
-            }
-
             if (command.Equals(NuGetCommandParser.GetCommand()) || command.Parents.Any(parent => parent == NuGetCommandParser.GetCommand()))
             {
                 NuGetCommand.Run(context.ParseResult);

--- a/test/dotnet.Tests/CompletionTests/DotnetCliSnapshotTests.cs
+++ b/test/dotnet.Tests/CompletionTests/DotnetCliSnapshotTests.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using System.CommandLine.StaticCompletions;
 using System.CommandLine.StaticCompletions.Shells;
+using Microsoft.TemplateEngine.Cli;
 
 namespace Microsoft.DotNet.Cli.Completions.Tests;
 
@@ -32,4 +34,27 @@ public class DotnetCliSnapshotTests : SdkTest
     }
 
     public static IEnumerable<object[]> ShellNames = CompletionsCommand.DefaultShells.Select<IShellProvider, object[]>(x => [x.ArgumentName]);
+
+    [Fact]
+    public void AllOptionsHaveHelpNameSet()
+    {
+        List<string> optionsWithoutHelpName = new();
+
+        foreach (var command in Parser.Instance.RootCommand.Subcommands)
+        {
+            foreach (var option in command.HierarchicalOptions())
+            {
+                // make sure we have HelpName set explicitly for all options by checking whether EnsureHelpName adds a default
+                if (option.EnsureHelpName())
+                {
+                    optionsWithoutHelpName.Add($"{command.Name} {option.Name}");
+                }
+            }
+        }
+
+        if (optionsWithoutHelpName.Count > 0)
+        {
+            Assert.Fail($"The following options do not have HelpName set: {Environment.NewLine + string.Join(Environment.NewLine, optionsWithoutHelpName)}");
+        }
+    }
 }

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -314,8 +314,8 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
         'testhost;nuget' {
             $staticCompletions = @(
                 [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, "--version")
-                [CompletionResult]::new('--verbosity', '--verbosity', [CompletionResultType]::ParameterName, "--verbosity")
-                [CompletionResult]::new('--verbosity', '-v', [CompletionResultType]::ParameterName, "--verbosity")
+                [CompletionResult]::new('--verbosity', '--verbosity', [CompletionResultType]::ParameterName, "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].")
+                [CompletionResult]::new('--verbosity', '-v', [CompletionResultType]::ParameterName, "Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('delete', 'delete', [CompletionResultType]::ParameterValue, "delete")

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -158,14 +158,14 @@ _testhost() {
                     ;;
                 (new)
                     _arguments "${_arguments_options[@]}" : \
-                        '--output=[Location to place the generated output.]: :_files' \
-                        '-o=[Location to place the generated output.]: :_files' \
-                        '--name=[The name for the output being created. If no name is specified, the name of the output directory is used.]: : ' \
-                        '-n=[The name for the output being created. If no name is specified, the name of the output directory is used.]: : ' \
+                        '--output=[Location to place the generated output.]:OUTPUT:_files' \
+                        '-o=[Location to place the generated output.]:OUTPUT:_files' \
+                        '--name=[The name for the output being created. If no name is specified, the name of the output directory is used.]:NAME: ' \
+                        '-n=[The name for the output being created. If no name is specified, the name of the output directory is used.]:NAME: ' \
                         '--dry-run=[Displays a summary of what would happen if the given command line were run if it would result in a template creation.]: :((False\:"False" True\:"True" ))' \
                         '--force=[Forces content to be generated even if it would change existing files.]: :((False\:"False" True\:"True" ))' \
                         '--no-update-check=[Disables checking for the template package updates when instantiating a template.]: :((False\:"False" True\:"True" ))' \
-                        '--project=[The project that should be used for context evaluation.]: :_files' \
+                        '--project=[The project that should be used for context evaluation.]:PROJECT:_files' \
                         '--verbosity=[Sets the verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], and diag\[nostic\].]:LEVEL:((d\:"d" detailed\:"detailed" diag\:"diag" diagnostic\:"diagnostic" m\:"m" minimal\:"minimal" n\:"n" normal\:"normal" q\:"q" quiet\:"quiet" ))' \
                         '-v=[Sets the verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], and diag\[nostic\].]:LEVEL:((d\:"d" detailed\:"detailed" diag\:"diag" diagnostic\:"diagnostic" m\:"m" minimal\:"minimal" n\:"n" normal\:"normal" q\:"q" quiet\:"quiet" ))' \
                         '--diagnostics[Enables diagnostic output.]' \
@@ -183,14 +183,14 @@ _testhost() {
                                 case $line[1] in
                                     (create)
                                         _arguments "${_arguments_options[@]}" : \
-                                            '--output=[Location to place the generated output.]: :_files' \
-                                            '-o=[Location to place the generated output.]: :_files' \
-                                            '--name=[The name for the output being created. If no name is specified, the name of the output directory is used.]: : ' \
-                                            '-n=[The name for the output being created. If no name is specified, the name of the output directory is used.]: : ' \
+                                            '--output=[Location to place the generated output.]:OUTPUT:_files' \
+                                            '-o=[Location to place the generated output.]:OUTPUT:_files' \
+                                            '--name=[The name for the output being created. If no name is specified, the name of the output directory is used.]:NAME: ' \
+                                            '-n=[The name for the output being created. If no name is specified, the name of the output directory is used.]:NAME: ' \
                                             '--dry-run=[Displays a summary of what would happen if the given command line were run if it would result in a template creation.]: :((False\:"False" True\:"True" ))' \
                                             '--force=[Forces content to be generated even if it would change existing files.]: :((False\:"False" True\:"True" ))' \
                                             '--no-update-check=[Disables checking for the template package updates when instantiating a template.]: :((False\:"False" True\:"True" ))' \
-                                            '--project=[The project that should be used for context evaluation.]: :_files' \
+                                            '--project=[The project that should be used for context evaluation.]:PROJECT:_files' \
                                             '--verbosity=[Sets the verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], and diag\[nostic\].]:LEVEL:((d\:"d" detailed\:"detailed" diag\:"diag" diagnostic\:"diagnostic" m\:"m" minimal\:"minimal" n\:"n" normal\:"normal" q\:"q" quiet\:"quiet" ))' \
                                             '-v=[Sets the verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], and diag\[nostic\].]:LEVEL:((d\:"d" detailed\:"detailed" diag\:"diag" diagnostic\:"diagnostic" m\:"m" minimal\:"minimal" n\:"n" normal\:"normal" q\:"q" quiet\:"quiet" ))' \
                                             '--diagnostics[Enables diagnostic output.]' \
@@ -269,9 +269,9 @@ _testhost() {
                                             '--type=[Filters templates based on available types. Predefined values are \"project\" and \"item\".]: : ' \
                                             '--tag=[Filters the templates based on the tag.]: : ' \
                                             '--ignore-constraints[Disables checking if the template meets the constraints to be run.]' \
-                                            '--output=[Location to place the generated output.]: :_files' \
-                                            '-o=[Location to place the generated output.]: :_files' \
-                                            '--project=[The project that should be used for context evaluation.]: :_files' \
+                                            '--output=[Location to place the generated output.]:OUTPUT:_files' \
+                                            '-o=[Location to place the generated output.]:OUTPUT:_files' \
+                                            '--project=[The project that should be used for context evaluation.]:PROJECT:_files' \
                                             '--columns-all[Displays all columns in the output.]' \
                                             '*--columns=[Specifies the columns to display in the output. ]: :((author\:"author" language\:"language" tags\:"tags" type\:"type" ))' \
                                             '--verbosity=[Sets the verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], and diag\[nostic\].]:LEVEL:((d\:"d" detailed\:"detailed" diag\:"diag" diagnostic\:"diagnostic" m\:"m" minimal\:"minimal" n\:"n" normal\:"normal" q\:"q" quiet\:"quiet" ))' \
@@ -304,8 +304,8 @@ _testhost() {
                 (nuget)
                     _arguments "${_arguments_options[@]}" : \
                         '--version[]' \
-                        '--verbosity=[]: : ' \
-                        '-v=[]: : ' \
+                        '--verbosity=[Set the MSBuild verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], d\[etailed\], and diag\[nostic\].]:LEVEL: ' \
+                        '-v=[Set the MSBuild verbosity level. Allowed values are q\[uiet\], m\[inimal\], n\[ormal\], d\[etailed\], and diag\[nostic\].]:LEVEL: ' \
                         '--help[Show command line help.]' \
                         '-h[Show command line help.]' \
                         ":: :_testhost__nuget_commands" \
@@ -673,8 +673,8 @@ _testhost() {
                                 case $line[1] in
                                     (convert)
                                         _arguments "${_arguments_options[@]}" : \
-                                            '--output=[Location to place the generated output.]: :_files' \
-                                            '-o=[Location to place the generated output.]: :_files' \
+                                            '--output=[Location to place the generated output.]:OUTPUT:_files' \
+                                            '-o=[Location to place the generated output.]:OUTPUT:_files' \
                                             '--force[Force conversion even if there are malformed directives.]' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
@@ -730,7 +730,7 @@ _testhost() {
                     ;;
                 (reference)
                     _arguments "${_arguments_options[@]}" : \
-                        '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
+                        '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]:PROJECT: ' \
                         '--help[Show command line help.]' \
                         '-h[Show command line help.]' \
                         ":: :_testhost__reference_commands" \
@@ -747,7 +747,7 @@ _testhost() {
                                             '--framework=[Add the reference only when targeting a specific framework.]:FRAMEWORK:->dotnet_dynamic_complete' \
                                             '-f=[Add the reference only when targeting a specific framework.]:FRAMEWORK:->dotnet_dynamic_complete' \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
-                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]:PROJECT: ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             '*::PROJECT_PATH -- The paths to the projects to add as references.: ' \
@@ -765,7 +765,7 @@ _testhost() {
                                         ;;
                                     (list)
                                         _arguments "${_arguments_options[@]}" : \
-                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]:PROJECT: ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             && ret=0
@@ -774,7 +774,7 @@ _testhost() {
                                         _arguments "${_arguments_options[@]}" : \
                                             '--framework=[Remove the reference only when targeting a specific framework.]:FRAMEWORK: ' \
                                             '-f=[Remove the reference only when targeting a specific framework.]:FRAMEWORK: ' \
-                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]: : ' \
+                                            '--project=[The project file to operate on. If a file is not specified, the command will search the current directory for one.]:PROJECT: ' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             '*::PROJECT_PATH -- The paths to the referenced projects to remove.:->dotnet_dynamic_complete' \
@@ -1205,9 +1205,9 @@ _testhost() {
                     ;;
                 (vstest)
                     _arguments "${_arguments_options[@]}" : \
-                        '--Platform=[]: : ' \
-                        '--Framework=[]: : ' \
-                        '*--logger=[]: : ' \
+                        '--Platform=[]:PLATFORM: ' \
+                        '--Framework=[]:FRAMEWORK: ' \
+                        '*--logger=[]:LOGGER: ' \
                         '--help[Show command line help.]' \
                         '-h[Show command line help.]' \
                         && ret=0


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/sdk/issues/48817 and https://github.com/dotnet/sdk/pull/49418.

There were only a couple commands where the option HelpName was overridden by EnsureHelpName, make those explicit instead and add a test that verifies all options comply.

Only one place remains that is still using EnsureHelpName, but it's not feasible to change this as we'd need to change every template:

https://github.com/dotnet/sdk/blob/44798fa99855083679fdb8525f1cf586958e3286/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs#L274-L279