### PR TITLE
Add "dotnet dnx" command as alias for "dotnet tool execute"

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Help/HelpBuilder.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Help/HelpBuilder.cs
@@ -43,11 +43,6 @@ public partial class HelpBuilder
             throw new ArgumentNullException(nameof(context));
         }
 
-        if (context.Command.Hidden)
-        {
-            return;
-        }
-
         foreach (var writeSection in GetLayout(context))
         {
             if (writeSection(context))

--- a/src/Cli/dotnet/Commands/Dnx/DnxCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Dnx/DnxCommandParser.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Tool;
+using Microsoft.DotNet.Cli.Commands.Tool.Execute;
+
+namespace Microsoft.DotNet.Cli.Commands.Dnx;
+
+internal static class DnxCommandParser
+{
+    public static readonly Command Command = ConstructCommand();
+    public static Command GetCommand()
+    {
+        return Command;
+    }
+
+    private static Command ConstructCommand()
+    {
+        Command command = new("dnx", CliCommandStrings.ToolExecuteCommandDescription);
+        command.Hidden = true;
+
+        foreach (var argument in ToolExecuteCommandParser.Command.Arguments)
+        {
+            command.Arguments.Add(argument);
+        }
+
+        foreach (var option in ToolExecuteCommandParser.Command.Options)
+        {
+            command.Options.Add(option);
+        }
+
+        command.SetAction((parseResult) => new ToolExecuteCommand(parseResult).Execute());
+
+        return command;
+    }
+}

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -354,38 +354,40 @@ public static class Parser
             {
                 new FsiForwardingApp(helpArgs).Execute();
             }
-
-            // argument/option cleanups specific to help
-            foreach (var option in command.Options)
+            else
             {
-                option.EnsureHelpName();
-            }
-
-            if (command.Name.Equals(ListReferenceCommandParser.GetCommand().Name))
-            {
-                Command listCommand = command.Parents.Single() as Command;
-
-                for (int i = 0; i < listCommand.Arguments.Count; i++)
+                // argument/option cleanups specific to help
+                foreach (var option in command.Options)
                 {
-                    if (listCommand.Arguments[i].Name == CliStrings.SolutionOrProjectArgumentName)
+                    option.EnsureHelpName();
+                }
+
+                if (command.Name.Equals(ListReferenceCommandParser.GetCommand().Name))
+                {
+                    Command listCommand = command.Parents.Single() as Command;
+
+                    for (int i = 0; i < listCommand.Arguments.Count; i++)
                     {
-                        // Name is immutable now, so we create a new Argument with the right name..
-                        listCommand.Arguments[i] = ListCommandParser.CreateSlnOrProjectArgument(CliStrings.ProjectArgumentName, CliStrings.ProjectArgumentDescription);
+                        if (listCommand.Arguments[i].Name == CliStrings.SolutionOrProjectArgumentName)
+                        {
+                            // Name is immutable now, so we create a new Argument with the right name..
+                            listCommand.Arguments[i] = ListCommandParser.CreateSlnOrProjectArgument(CliStrings.ProjectArgumentName, CliStrings.ProjectArgumentDescription);
+                        }
                     }
                 }
-            }
-            else if (command.Name.Equals(AddPackageCommandParser.GetCommand().Name) || command.Name.Equals(AddCommandParser.GetCommand().Name))
-            {
-                // Don't show package completions in help
-                PackageAddCommandParser.CmdPackageArgument.CompletionSources.Clear();
-            }
-            else if (command.Name.Equals(WorkloadSearchCommandParser.GetCommand().Name))
-            {
-                // Set shorter description for displaying parent command help.
-                WorkloadSearchVersionsCommandParser.GetCommand().Description = CliStrings.ShortWorkloadSearchVersionDescription;
-            }
+                else if (command.Name.Equals(AddPackageCommandParser.GetCommand().Name) || command.Name.Equals(AddCommandParser.GetCommand().Name))
+                {
+                    // Don't show package completions in help
+                    PackageAddCommandParser.CmdPackageArgument.CompletionSources.Clear();
+                }
+                else if (command.Name.Equals(WorkloadSearchCommandParser.GetCommand().Name))
+                {
+                    // Set shorter description for displaying parent command help.
+                    WorkloadSearchVersionsCommandParser.GetCommand().Description = CliStrings.ShortWorkloadSearchVersionDescription;
+                }
 
-            base.Write(context);
+                base.Write(context);
+            }
         }
     }
 }

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -315,6 +315,12 @@ public static class Parser
                 return;
             }
 
+            // argument/option cleanups specific to help
+            foreach (var option in command.Options)
+            {
+                option.EnsureHelpName();
+            }
+
             if (command.Equals(NuGetCommandParser.GetCommand()) || command.Parents.Any(parent => parent == NuGetCommandParser.GetCommand()))
             {
                 NuGetCommand.Run(context.ParseResult);
@@ -356,12 +362,6 @@ public static class Parser
             }
             else
             {
-                // argument/option cleanups specific to help
-                foreach (var option in command.Options)
-                {
-                    option.EnsureHelpName();
-                }
-
                 if (command.Name.Equals(ListReferenceCommandParser.GetCommand().Name))
                 {
                     Command listCommand = command.Parents.Single() as Command;

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Microsoft.DotNet.Cli.Commands.Build;
 using Microsoft.DotNet.Cli.Commands.BuildServer;
 using Microsoft.DotNet.Cli.Commands.Clean;
+using Microsoft.DotNet.Cli.Commands.Dnx;
 using Microsoft.DotNet.Cli.Commands.Format;
 using Microsoft.DotNet.Cli.Commands.Fsi;
 using Microsoft.DotNet.Cli.Commands.Help;
@@ -65,6 +66,7 @@ public static class Parser
         BuildCommandParser.GetCommand(),
         BuildServerCommandParser.GetCommand(),
         CleanCommandParser.GetCommand(),
+        DnxCommandParser.GetCommand(),
         FormatCommandParser.GetCommand(),
         CompleteCommandParser.GetCommand(),
         FsiCommandParser.GetCommand(),


### PR DESCRIPTION
This adds a root `dotnet dnx` command which forwards to `dotnet tool execute`.  This will enable us to add a `dnx` shell script which calls `dotnet dnx`.