### PR TITLE
Update namespace for interceptors used by ValidationsGenerator

### DIFF
--- a/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
+++ b/src/WebSdk/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
@@ -70,7 +70,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Set the namespaces emitted by the ConfigurationBindingGenerator for interception when applicable. -->
     <InterceptorsPreviewNamespaces Condition="'$(EnableConfigurationBindingGenerator)' == 'true'">$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
     <!-- Set the namespaces emitted by the ValidationsGenerator for interception when applicable (.NET 10 and above). -->
-    <InterceptorsPreviewNamespaces Condition="'$(_TargetFrameworkVersionWithoutV)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Validation.Generated</InterceptorsPreviewNamespaces>
+    <InterceptorsPreviewNamespaces Condition="'$(_TargetFrameworkVersionWithoutV)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Validation.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <!--

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Build.Tests
                 .WithTargetFramework(targetFramework);
 
             VerifyValidationsGeneratorIsUsed(asset, expectEnabled);
-            VerifyInterceptorsFeatureProperties(asset, expectEnabled, "Microsoft.AspNetCore.Http.Validation.Generated");
+            VerifyInterceptorsFeatureProperties(asset, expectEnabled, "Microsoft.Extensions.Validation.Generated");
         }
 
         [Fact]


### PR DESCRIPTION
We moved the validations generator to a new namespace/assembly and need to update the SDK accordingly.