### PR TITLE
Use dark colors

### DIFF
--- a/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
@@ -553,9 +553,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         TerminalColor color = outcome switch
         {
-            TestOutcome.Error or TestOutcome.Fail or TestOutcome.Canceled or TestOutcome.Timeout => TerminalColor.Red,
-            TestOutcome.Skipped => TerminalColor.Yellow,
-            TestOutcome.Passed => TerminalColor.Green,
+            TestOutcome.Error or TestOutcome.Fail or TestOutcome.Canceled or TestOutcome.Timeout => TerminalColor.DarkRed,
+            TestOutcome.Skipped => TerminalColor.DarkYellow,
+            TestOutcome.Passed => TerminalColor.DarkGreen,
             _ => throw new NotSupportedException(),
         };
         string outcomeText = outcome switch


### PR DESCRIPTION
Unifying the colors to all use darker colors so we see the same colors for progress, error messages and for results.

![image](https://github.com/user-attachments/assets/03ec45b8-37f2-48d7-9272-7be5669dac00)


![image](https://github.com/user-attachments/assets/69d8d2c7-0fed-4e13-b892-d1371b581436)


Related to https://github.com/dotnet/sdk/issues/45927