### PR TITLE
Remove @dotnet/area-type-system-and-startup from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,12 +65,9 @@
 # ILLink and ReadyToRun targets and tasks owned by runtime team
 # Area-ILLink Area-ReadyToRun
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets @dotnet/illink
-/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs @dotnet/area-type-system-and-startup 
-/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs @dotnet/area-type-system-and-startup 
 /test/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs @dotnet/illink
-/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishReadyToRun.cs @dotnet/area-type-system-and-startup
 # Publish.targets related to ILLink and ReadyToRun is own by both runtime and SDK team
-/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink @dotnet/area-type-system-and-startup @dotnet/dotnet-cli
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink @dotnet/dotnet-cli
 # Area-ClickOnce
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
 


### PR DESCRIPTION
## Summary

As a follow-up to [this PR](https://github.com/dotnet/sdk/pull/49269), I messaged the owner of this team. They have not responded so I'm removing their ownership of the files. If they address [their violation](https://github.com/dotnet/org-policy-violations/issues/5617), I can add the team to the repo with write access and add them back to these files again.