### PR TITLE
Use x64 emscripten version for downloading workload packs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -67,7 +67,10 @@
     <Dependency Name="Microsoft.NET.Runtime.Emscripten.Sdk.Internal" Version="10.0.0-preview.6.25316.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>20343176cfd35b56036dc4ca9d9ddd2a201a4e92</Sha>
-      <SourceBuild RepoName="emsdk" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Cache.win-x64" Version="10.0.0-preview.6.25316.103">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>20343176cfd35b56036dc4ca9d9ddd2a201a4e92</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.15.0-preview-25316-103">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -274,6 +274,7 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/emsdk -->
     <MicrosoftNETRuntimeEmscriptenSdkInternalVersion>10.0.0-preview.6.25316.103</MicrosoftNETRuntimeEmscriptenSdkInternalVersion>
+    <MicrosoftNETRuntimeEmscripten3156Cachewinx64Version>10.0.0-preview.6.25316.103</MicrosoftNETRuntimeEmscripten3156Cachewinx64Version>
     <!-- emscripten versions, these are are included in package IDs and need to be kept in sync with emsdk -->
     <EmscriptenVersionCurrent>3.1.56</EmscriptenVersionCurrent>
     <EmscriptenVersionNet9>3.1.56</EmscriptenVersionNet9>

--- a/src/Workloads/VSInsertion/workloads.csproj
+++ b/src/Workloads/VSInsertion/workloads.csproj
@@ -96,13 +96,13 @@
 
   <ItemGroup Condition="'$(BuildWorkloads)' == 'true'">
     <PackageDownload Include="@(RuntimeWorkloadPacksToDownload)" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
-    <PackageDownload Include="@(EmsdkWorkloadPacksToDownload)" Version="[$(MicrosoftNETRuntimeEmscriptenSdkInternalVersion)]" />
+    <PackageDownload Include="@(EmsdkWorkloadPacksToDownload)" Version="[$(MicrosoftNETRuntimeEmscripten3156Cachewinx64Version)]" />
   </ItemGroup>
 
   <Target Name="_CollectDownloadedWorkloadPacks">
     <ItemGroup>
       <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(RuntimeWorkloadPacksToDownload.Identity)\$(MicrosoftNETCoreAppRuntimePackageVersion)\*.nupkg" />
-      <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(EmsdkWorkloadPacksToDownload.Identity)\$(MicrosoftNETRuntimeEmscriptenSdkInternalVersion)\*.nupkg" />
+      <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(EmsdkWorkloadPacksToDownload.Identity)\$(MicrosoftNETRuntimeEmscripten3156Cachewinx64Version)\*.nupkg" />
     </ItemGroup>
 
     <Copy SourceFiles="@(DownloadedWorkloadPacks)"


### PR DESCRIPTION
The internal version won't work for stable builds. Unfortunely, there's not a non-arch or emscripten version specific package to use. Nothing else from emsdk ships that is built in an earlier pass. Not ideal. If we create a non-shipping package that has stable versioning, publishing will reject it because won't go to an isolated feed. So far, repos have avoided having shipping sentinel packages.