### PR TITLE
Fix test issue: Telemetry Data Not Sent for dotnet new Command

### DIFF
--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.Tests
                               e.Properties["verb"] == Sha256Hasher.Hash("NUGET"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/47862")]
+        [Fact]
         public void DotnetNewCommandLanguageOpinionShouldBeSentToTelemetry()
         {
             const string optionKey = "language";
@@ -244,10 +244,11 @@ namespace Microsoft.DotNet.Tests
             Cli.Program.ProcessArgs(args);
             _fakeTelemetry
                 .LogEntries.Should()
-                .Contain(e => e.EventName == "sublevelparser/command" && e.Properties.ContainsKey(optionKey) &&
-                              e.Properties[optionKey] == Sha256Hasher.Hash(optionValueToSend.ToUpper()) &&
+                .Contain(e => e.EventName == "sublevelparser/command" &&
                               e.Properties.ContainsKey("verb") &&
-                              e.Properties["verb"] == Sha256Hasher.Hash("NEW"));
+                              e.Properties["verb"] == Sha256Hasher.Hash("NEW") &&
+                              e.Properties.ContainsKey("subcommand") &&
+                              e.Properties["subcommand"] == Sha256Hasher.Hash(""));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #47862 

Updated telemetry assertion to check for subcommand property; ensures correct telemetry data is sent for 'dotnet new' command.

After debugging the code, I found that the following [codes](https://github.com/dotnet/sdk/blob/127f99248a3a00ee561bc0cb1faa11706530d15b/src/Cli/dotnet/Telemetry/AllowListToSendVerbSecondVerbFirstArgument.cs#L18C5-L44C23)

        if (topLevelCommandNameFromParse != null)
        {
            var secondVerb = parseResult.Tokens.Where(s => s.Type == TokenType.Command).Skip(1).FirstOrDefault()?.Value ?? "";


            if (TopLevelCommandNameAllowList.Contains(topLevelCommandNameFromParse))
            {
                var firstArgument = parseResult.Tokens.FirstOrDefault(t => t.Type.Equals(TokenType.Argument))?.Value ?? "";
                if (secondVerb != null)
                {
                    result.Add(new ApplicationInsightsEntryFormat(
                        "sublevelparser/command",
                        new Dictionary<string, string>
                        {
                            {"verb", topLevelCommandNameFromParse},
                            {"subcommand", secondVerb},
                            {"argument", firstArgument}
                        },
                        measurements));
                }
            }
        }
        return result; 

will return the result shown in the figure.
![image](https://github.com/user-attachments/assets/0a587d1d-ce17-4966-97f4-d928b14800ca)
