### PR TITLE
Ensure GetNuGetShortFolderName Task is ambiently available

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackProjectTool.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackProjectTool.props
@@ -10,6 +10,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This UsingTask is in the PackTool.props because there is usage of it in other areas of the product
+       and on public GitHub: https://github.com/search?q=path%3A*.props+OR+path%3A*.targets+AND+%28NOT+path%3A*%2FMicrosoft.NET.PackTool.targets%29+AND+%28NOT+path%3A*%2FMicrosoft.NET.Publish.targets%29+GetNuGetShortFolderName&amp;type=code -->
+  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetNuGetShortFolderName"
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackProjectToolValidation</TargetsForTfmSpecificContentInPackage>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -33,9 +33,9 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GenerateShims"
             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetEmbeddedApphostPaths"
-      AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.NET.Build.Tasks.GetNuGetShortFolderName"
-             AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask TaskName="AddPackageType"
+            AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <PropertyGroup>
     <!-- tools are specially-formatted packages, so we tell nuget Pack to not even try to include build output -->
@@ -350,8 +350,6 @@ NOTE: This file is imported from the following contexts, so be aware when writin
       <FileWrites Include="$(_ShimInputCacheFile)" />
     </ItemGroup>
   </Target>
-
-  <UsingTask TaskName="AddPackageType" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <Target Name="SetDotnetToolPackageType">
 


### PR DESCRIPTION
Fixes a reported issue in ios/android/maui builds where this [Target was implicitly assumed to be available](https://github.com/search?q=path%3A*.props+OR+path%3A*.targets+AND+%28NOT+path%3A*%2FMicrosoft.NET.PackTool.targets%29+AND+%28NOT+path%3A*%2FMicrosoft.NET.Publish.targets%29+GetNuGetShortFolderName&type=code).

This was introduced as part of the multi-RID tool refactorings.