### PR TITLE
Prefer CLI commands to loose files

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -129,7 +129,7 @@ public class Program
         using (new PerformanceMeasurement(performanceData, "Parse Time"))
         {
             parseResult = Parser.Instance.Parse(args);
-            // If we get didn't match any built-in commands, and a C# file path is the first argument,
+            // If we didn't match any built-in commands, and a C# file path is the first argument,
             // parse as `dotnet run file.cs ..rest_of_args` instead.
             if (parseResult.CommandResult.Command is RootCommand
                 && parseResult.GetValue(Parser.DotnetSubCommand) is { } unmatchedCommandOrFile


### PR DESCRIPTION
When testing https://github.com/dotnet/sdk/pull/49461#issuecomment-2986354515 I discovered that https://github.com/dotnet/sdk/pull/48387 introduced a subtle failure mode - if you have a file that we think is a C# runnable file in the current directory that matches the name of a CLI command, we'll prefer your file over the CLI command.

This is backwards to me - we should be preferring our commands. This PR does that!

Some proof is in order: Here I have a directory with a file called `dnx` in it. I explicitly run it, and we see a build failure because I'm missing NuGet feeds. Point is, we're running the single-file app.

Then, I call `dotnet dnx`. Before, this would also try to run the app. Now it correctly runs the actual `dnx` command.

```shell

(dogfood) PS E:\Code\Scratch\foo> dotnet run dnx
    E:\Code\Scratch\foo\dnx.csproj : error NU1102:
      Unable to find package Microsoft.NET.ILLink.Tasks with version (>= 10.0.0-preview.6.25316.103)
        - Found 54 version(s) in nuget [ Nearest version: 10.0.0-preview.5.25277.114 ]

The build failed. Fix the build errors and run again.
(dogfood) PS E:\Code\Scratch\foo> dotnet dnx
Required argument missing for command: 'dnx'.

Description:
  Executes a tool from source without permanently installing it.

Usage:
  dotnet dnx <packageId> [<commandArguments>...] [options]

Arguments:
  <PACKAGE_ID>        Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and version separated by '@' like 'Newtonsoft.Json@13.0.3'.
  <commandArguments>  Arguments forwarded to the tool

Options:
  --version <VERSION>       The version of the tool package to install.
  -y, --yes                 Accept all confirmation prompts using "yes."
  --interactive             Allows the command to stop and wait for user input or action (for example to complete authentication). [default: True]
  --allow-roll-forward      Allow a .NET tool to roll forward to newer versions of the .NET runtime if the runtime it targets isn't installed.
  --prerelease              Include pre-release packages.
  --configfile <FILE>       The NuGet configuration file to use.
  --source <SOURCE>         Replace all NuGet package sources to use during installation with these.
  --add-source <ADDSOURCE>  Add an additional NuGet package source to use during installation.
  --disable-parallel        Prevent restoring multiple projects in parallel.
  --ignore-failed-sources   Treat package source failures as warnings.
  --no-http-cache           Do not cache packages and http requests.
  -v, --verbosity <LEVEL>   Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
  -?, -h, --help            Show command line help.
```