### PR TITLE
Make sure the repo-local install of dotnet is what copilot uses during iteration

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,3 +27,10 @@ jobs:
       - name: Do an initial build to ensure all dependencies are restored
         run: |
           ./build.sh
+      - name: Put repo-local dotnet install on PATH
+        run: |
+          echo "PATH=$PWD/.dotnet:$PATH" >> $GITHUB_ENV
+
+      - name: Check dotnet version
+        run: |
+          dotnet --version


### PR DESCRIPTION
The build.sh step downloads the correct dotnet to `.dotnet`, but we need to make sure we modify `PATH` so that Copilot can actually use it for subsequent invocations.