### PR TITLE
Support `any` RID in multi-RID tools

### DIFF
--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -84,11 +84,9 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
         (var bestVersion, var packageSource) = _toolPackageDownloader.GetNuGetVersion(packageLocation, packageId, _verbosity, versionRange, _restoreActionConfig);
 
-        IToolPackage toolPackage;
-
         //  TargetFramework is null, which means to use the current framework.  Global tools can override the target framework to use (or select assets for),
         //  but we don't support this for local or one-shot tools.
-        if (!_toolPackageDownloader.TryGetDownloadedTool(packageId, bestVersion, targetFramework: null, out toolPackage))
+        if (!_toolPackageDownloader.TryGetDownloadedTool(packageId, bestVersion, targetFramework: null, verbosity: _verbosity, out var toolPackage))
         {
             if (!UserAgreedToRunFromSource(packageId, bestVersion, packageSource))
             {

--- a/src/Cli/dotnet/ToolPackage/IToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/IToolPackageDownloader.cs
@@ -1,8 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using NuGet.Configuration;
 using NuGet.Versioning;
@@ -14,25 +13,27 @@ internal interface IToolPackageDownloader
     IToolPackage InstallPackage(PackageLocation packageLocation,
         PackageId packageId,
         VerbosityOptions verbosity,
-        VersionRange versionRange = null,
-        string targetFramework = null,
+        VersionRange? versionRange = null,
+        string? targetFramework = null,
         bool isGlobalTool = false,
         bool isGlobalToolRollForward = false,
         bool verifySignatures = true,
-        RestoreActionConfig restoreActionConfig = null
+        RestoreActionConfig? restoreActionConfig = null
     );
 
     (NuGetVersion version, PackageSource source) GetNuGetVersion(
         PackageLocation packageLocation,
         PackageId packageId,
         VerbosityOptions verbosity,
-        VersionRange versionRange = null,
-        RestoreActionConfig restoreActionConfig = null
+        VersionRange? versionRange = null,
+        RestoreActionConfig? restoreActionConfig = null
     );
 
     bool TryGetDownloadedTool(
         PackageId packageId,
         NuGetVersion packageVersion,
-        string targetFramework,
-        out IToolPackage toolPackage);
+        string? targetFramework,
+        VerbosityOptions verbosity,
+        [NotNullWhen(true)]
+        out IToolPackage? toolPackage);
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -1,19 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
-using System.Reflection;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.TemplateEngine.Utils;
-using Newtonsoft.Json.Linq;
 using NuGet.Client;
-using NuGet.Commands;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.ContentModel;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -30,8 +24,8 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
 {
     public ToolPackageDownloader(
         IToolPackageStore store,
-        string runtimeJsonPathForTests = null,
-        string currentWorkingDirectory = null
+        string? runtimeJsonPathForTests = null,
+        string? currentWorkingDirectory = null
     ) : base(store, runtimeJsonPathForTests, currentWorkingDirectory, FileSystemWrapper.Default)
     {
     }
@@ -39,14 +33,14 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
     protected override INuGetPackageDownloader CreateNuGetPackageDownloader(
         bool verifySignatures,
         VerbosityOptions verbosity,
-        RestoreActionConfig restoreActionConfig)
+        RestoreActionConfig? restoreActionConfig)
     {
         ILogger verboseLogger = new NullLogger();
         if (verbosity.IsDetailedOrDiagnostic())
         {
             verboseLogger = new NuGetConsoleLogger();
         }
-        
+
         return new NuGetPackageDownloader.NuGetPackageDownloader(
             new DirectoryPath(),
             verboseLogger: verboseLogger,
@@ -63,13 +57,14 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         string packagesRootPath,
         NuGetVersion packageVersion,
         PackageSourceLocation packageSourceLocation,
+        VerbosityOptions verbosity,
         bool includeUnlisted = false
         )
     {
         var versionFolderPathResolver = new VersionFolderPathResolver(packagesRootPath);
 
-        string folderToDeleteOnFailure = null;
-        return TransactionalAction.Run<NuGetVersion>(() =>
+        string? folderToDeleteOnFailure = null;
+        return TransactionalAction.Run(() =>
         {
             var packagePath = nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation,
                         includeUnlisted: includeUnlisted, downloadFolder: new DirectoryPath(packagesRootPath)).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -86,11 +81,14 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
 
                 var packageHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(reader.GetNuspec()));
                 var hashPath = versionFolderPathResolver.GetHashPath(packageId.ToString(), version);
-
-                Directory.CreateDirectory(Path.GetDirectoryName(hashPath));
+                Directory.CreateDirectory(Path.GetDirectoryName(hashPath)!);
                 File.WriteAllText(hashPath, packageHash);
             }
 
+            if (verbosity.IsDetailedOrDiagnostic())
+            {
+                Reporter.Output.WriteLine($"Extracting package {packageId}@{packageVersion} to {packagePath}");
+            }
             // Extract the package
             var nupkgDir = versionFolderPathResolver.GetInstallPath(packageId.ToString(), version);
             nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(nupkgDir)).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -111,7 +109,6 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         NuGetv3LocalRepository nugetLocalRepository = new(packagesRootPath);
 
         var package = nugetLocalRepository.FindPackage(packageId.ToString(), packageVersion);
-
         return package != null;
     }
 
@@ -126,7 +123,8 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         DirectoryPath packagesRootPath,
         string assetFilePath,
         string runtimeJsonGraph,
-        string targetFramework = null
+        VerbosityOptions verbosity,
+        string? targetFramework = null
         )
     {
         // To get runtimeGraph:
@@ -222,7 +220,7 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
     protected static IEnumerable<LockFileItem> GetLockFileItems(
        IReadOnlyList<SelectionCriteria> criteria,
        ContentItemCollection items,
-       Action<LockFileItem> additionalAction,
+       Action<LockFileItem>? additionalAction,
        params PatternSet[] patterns)
     {
         // Loop through each criteria taking the first one that matches one or more items.

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -137,6 +137,11 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         NuGetv3LocalRepository localRepository = new(packagesRootPath.Value);
         var package = localRepository.FindPackage(packageId.ToString(), version);
 
+        if (verbosity.IsDetailedOrDiagnostic())
+        {
+            Reporter.Output.WriteLine($"Locating package {packageId}@{version} in package store {packagesRootPath.Value}");
+            Reporter.Output.WriteLine($"The package has {string.Join(',', package.Nuspec.GetPackageTypes().Select(p => $"{p.Name},{p.Version}"))} package types");
+        }
         if (!package.Nuspec.GetPackageTypes().Any(pt => pt.Name.Equals(PackageType.DotnetTool.Name, StringComparison.OrdinalIgnoreCase) ||
                                                         pt.Name.Equals("DotnetToolRidPackage", StringComparison.OrdinalIgnoreCase)))
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -41,27 +41,30 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- tools are specially-formatted packages, so we tell nuget Pack to not even try to include build output -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
+    <_IsRidSpecific>false</_IsRidSpecific>
+    <_IsRidSpecific Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">true</_IsRidSpecific>
+
     <!-- the publish* properties _can_ be set, but only for the 'inner' RID-specific builds. We need to make sure that for the outer, agnostic build they are unset  -->
     <!-- RID information is also stripped during Restore, so we need to make sure user
          decisions are preserved when Restoring, so that publishing-related packages are implicitly included.  -->
-    <PublishSelfContained Condition="'$(RuntimeIdentifier)' == '' and '$(MSBuildIsRestoring)' != 'true'">false</PublishSelfContained>
+    <PublishSelfContained Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishSelfContained>
     <!-- Have to set SelfContained similarly because PackTool targets are imported _after_ RuntimeIdentifierInference targets, where the Publish* properties are
          forwarded to the 'base' properties. -->
-    <SelfContained Condition="'$(RuntimeIdentifier)' == '' and '$(MSBuildIsRestoring)' != 'true'">false</SelfContained>
-    <PublishTrimmed Condition="'$(RuntimeIdentifier)' == '' and '$(MSBuildIsRestoring)' != 'true'">false</PublishTrimmed>
-    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == '' and '$(MSBuildIsRestoring)' != 'true'">false</PublishReadyToRun>
-    <PublishSingleFile Condition="'$(RuntimeIdentifier)' == '' and '$(MSBuildIsRestoring)' != 'true'">false</PublishSingleFile>
+    <SelfContained Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</SelfContained>
+    <PublishTrimmed Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishTrimmed>
+    <PublishReadyToRun Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishReadyToRun>
+    <PublishSingleFile Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishSingleFile>
 
     <!-- We need to know if the inner builds are _intended_ to be AOT even if we then explicitly disable AOT for the outer builds.
          Knowing this lets us correctly decide to create the RID-specific inner tools or not when packaging the outer tool. -->
     <_InnerToolsPublishAot>false</_InnerToolsPublishAot>
-    <_InnerToolsPublishAot Condition="'$(RuntimeIdentifier)' == '' and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
-    <PublishAot Condition="'$(RuntimeIdentifier)' == ''">false</PublishAot>
+    <_InnerToolsPublishAot Condition="$(_IsRidSpecific) and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
+    <PublishAot Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishAot>
 
     <!-- we want to ensure that we don't publish any AppHosts for the 'outer', RID-agnostic builds -->
-    <UseAppHost Condition="'$(RuntimeIdentifier)' == ''">false</UseAppHost>
+    <UseAppHost Condition="!$(_IsRidSpecific)">false</UseAppHost>
     <!-- we want to ensure that we _do_ publish any AppHosts for the 'inner', RID-specific builds -->
-    <UseAppHost Condition="'$(RuntimeIdentifier)' != ''">true</UseAppHost>
+    <UseAppHost Condition="$(_IsRidSpecific)">true</UseAppHost>
 
     <!-- If shims are included, we need to make sure we restore for those RIDs so the apphost shims are available during restore/publish.
          This means that we need to set RuntimeIdentifiers. However we need to track certain information about the _users_ decisions around RIDs
@@ -77,7 +80,8 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- Tool implementation files are not included in the primary package when the tool has RID-specific packages.  So only pack the tool implementation
        (and only depend on publish) if there are no RID-specific packages, or if the RuntimeIdentifier is set. -->
     <_ToolPackageShouldIncludeImplementation Condition=" '$(PackAsTool)' == 'true' And
-                                                  ('$(_UserSpecifiedToolPackageRids)' == '' Or '$(RuntimeIdentifier)' != '')">true</_ToolPackageShouldIncludeImplementation>
+                                                  ( '$(_UserSpecifiedToolPackageRids)' == ''
+                                                     or '$(RuntimeIdentifier)' != '')">true</_ToolPackageShouldIncludeImplementation>
     <_ToolPackageShouldIncludeImplementation Condition="'$(_ToolPackageShouldIncludeImplementation)' == ''">false</_ToolPackageShouldIncludeImplementation>
 
     <!-- inner builds and non-RID-specific outer builds need publish content-->
@@ -129,14 +133,13 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- Needs to be in a target so we don't need to worry about evaluation order with NativeBinary property -->
     <PropertyGroup Condition="'$(ToolEntryPoint)' == ''">
       <ToolEntryPoint>$(TargetFileName)</ToolEntryPoint>
-      <ToolEntryPoint Condition="'$(RuntimeIdentifier)' != '' and '$(UseAppHost)' == 'true' ">$(AssemblyName)$(_NativeExecutableExtension)</ToolEntryPoint>
+      <ToolEntryPoint Condition="$(_IsRidSpecific) and '$(UseAppHost)' == 'true' ">$(AssemblyName)$(_NativeExecutableExtension)</ToolEntryPoint>
     </PropertyGroup>
 
     <!-- inner-build tool packages get a RID suffix -->
-    <PropertyGroup Condition="'$(_HasRIDSpecificTools)' != '' And '$(RuntimeIdentifier)' != ''">
+    <PropertyGroup Condition="'$(_HasRIDSpecificTools)' != '' And $(RuntimeIdentifier) != ''">
       <PackageId>$(PackageId).$(RuntimeIdentifier)</PackageId>
     </PropertyGroup>
-
   </Target>
 
   <Target Name="PackToolImplementation">
@@ -385,14 +388,17 @@ NOTE: This file is imported from the following contexts, so be aware when writin
 
   <!-- Orchestrator for making the N RID-specific tool packages if this Tool supports that mode.
        We can't call this for AOT'd tools because we can't AOT cross-architecture and cross-platform in .NET today. -->
-  <Target Name="_CreateRIDSpecificToolPackages" Condition="'$(RuntimeIdentifier)' == '' and $(_HasRIDSpecificTools) and !$(_InnerToolsPublishAot) and !$(_ToolPackageShouldIncludeImplementation)">
+  <Target Name="_CreateRIDSpecificToolPackages"
+    Condition="'$(RuntimeIdentifier)' == ''
+      and $(_HasRIDSpecificTools)
+      and !$(_InnerToolsPublishAot)
+      and !$(_ToolPackageShouldIncludeImplementation)">
     <PropertyGroup>
         <_PackageRids>$(ToolPackageRuntimeIdentifiers)</_PackageRids>
         <_PackageRids Condition="'$(_PackageRids)' == ''">$(RuntimeIdentifiers)</_PackageRids>
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- Build the RID-specific packages.-->
         <_rids Include="$(_PackageRids)" />
         <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -82,7 +82,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- Tool implementation files are not included in the primary package when the tool has RID-specific packages.  So only pack the tool implementation
        (and only depend on publish) if there are no RID-specific packages, or if the RuntimeIdentifier is set. -->
     <_ToolPackageShouldIncludeImplementation Condition=" '$(PackAsTool)' == 'true' And
-                                                  ( '$(_UserSpecifiedToolPackageRids)' == ''
+                                                  ('$(_UserSpecifiedToolPackageRids)' == ''
                                                      or '$(RuntimeIdentifier)' != '')">true</_ToolPackageShouldIncludeImplementation>
     <_ToolPackageShouldIncludeImplementation Condition="'$(_ToolPackageShouldIncludeImplementation)' == ''">false</_ToolPackageShouldIncludeImplementation>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -41,9 +41,22 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- tools are specially-formatted packages, so we tell nuget Pack to not even try to include build output -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
+    <!-- Determine information about all of the potential tool packages to build -->
+    <!-- If shims are included, we need to make sure we restore for those RIDs so the apphost shims are available during restore/publish.
+      This means that we need to set RuntimeIdentifiers. However we need to track certain information about the _users_ decisions around RIDs
+      so that we can correctly decide if we need to package RID-specific tools or not. -->
+    <_ToolRidsAreOnlyShims>false</_ToolRidsAreOnlyShims>
+    <_ToolRidsAreOnlyShims Condition="'$(RuntimeIdentifiers)' == '' and $(PackAsToolShimRuntimeIdentifiers) != '' ">true</_ToolRidsAreOnlyShims>
+    <_UserSpecifiedToolPackageRids Condition="'$(ToolPackageRuntimeIdentifiers)' != ''">$(ToolPackageRuntimeIdentifiers)</_UserSpecifiedToolPackageRids>
+    <_UserSpecifiedToolPackageRids Condition="'$(_UserSpecifiedToolPackageRids)' == ''">$(RuntimeIdentifiers)</_UserSpecifiedToolPackageRids>
+    <_HasRIDSpecificTools Condition=" '$(_UserSpecifiedToolPackageRids)' != '' ">true</_HasRIDSpecificTools>
+    <_HasRIDSpecificTools Condition="'$(_HasRIDSpecificTools)' == ''">false</_HasRIDSpecificTools>
+    <RuntimeIdentifiers Condition="'$(PackAsToolShimRuntimeIdentifiers)' != ''">$(_UserSpecifiedToolPackageRids);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
+
     <_IsRidSpecific>false</_IsRidSpecific>
     <_IsRidSpecific Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">true</_IsRidSpecific>
 
+    <!-- Not determine information about this specific build of a single (or more!) tool packages -->
     <!-- the publish* properties _can_ be set, but only for the 'inner' RID-specific builds. We need to make sure that for the outer, agnostic build they are unset  -->
     <!-- RID information is also stripped during Restore, so we need to make sure user
          decisions are preserved when Restoring, so that publishing-related packages are implicitly included.  -->
@@ -58,24 +71,13 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <!-- We need to know if the inner builds are _intended_ to be AOT even if we then explicitly disable AOT for the outer builds.
          Knowing this lets us correctly decide to create the RID-specific inner tools or not when packaging the outer tool. -->
     <_InnerToolsPublishAot>false</_InnerToolsPublishAot>
-    <_InnerToolsPublishAot Condition="$(_IsRidSpecific) and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
+    <_InnerToolsPublishAot Condition="$(_HasRIDSpecificTools) and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
     <PublishAot Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishAot>
 
     <!-- we want to ensure that we don't publish any AppHosts for the 'outer', RID-agnostic builds -->
     <UseAppHost Condition="!$(_IsRidSpecific)">false</UseAppHost>
     <!-- we want to ensure that we _do_ publish any AppHosts for the 'inner', RID-specific builds -->
     <UseAppHost Condition="$(_IsRidSpecific)">true</UseAppHost>
-
-    <!-- If shims are included, we need to make sure we restore for those RIDs so the apphost shims are available during restore/publish.
-         This means that we need to set RuntimeIdentifiers. However we need to track certain information about the _users_ decisions around RIDs
-         so that we can correctly decide if we need to package RID-specific tools or not. -->
-    <_ToolRidsAreOnlyShims>false</_ToolRidsAreOnlyShims>
-    <_ToolRidsAreOnlyShims Condition="'$(RuntimeIdentifiers)' == '' and $(PackAsToolShimRuntimeIdentifiers) != '' ">true</_ToolRidsAreOnlyShims>
-    <_UserSpecifiedToolPackageRids Condition="'$(ToolPackageRuntimeIdentifiers)' != ''">$(ToolPackageRuntimeIdentifiers)</_UserSpecifiedToolPackageRids>
-    <_UserSpecifiedToolPackageRids Condition="'$(_UserSpecifiedToolPackageRids)' == ''">$(RuntimeIdentifiers)</_UserSpecifiedToolPackageRids>
-    <_HasRIDSpecificTools Condition=" '$(_UserSpecifiedToolPackageRids)' != '' ">true</_HasRIDSpecificTools>
-    <_HasRIDSpecificTools Condition="'$(_HasRIDSpecificTools)' == ''">false</_HasRIDSpecificTools>
-    <RuntimeIdentifiers Condition="'$(PackAsToolShimRuntimeIdentifiers)' != ''">$(_UserSpecifiedToolPackageRids);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
 
     <!-- Tool implementation files are not included in the primary package when the tool has RID-specific packages.  So only pack the tool implementation
        (and only depend on publish) if there are no RID-specific packages, or if the RuntimeIdentifier is set. -->

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 RidSpecific = true, // will make one package for each RID except the current RID
                 IncludeAnyRid = true // will make one package with the "any" RID
             };
-            List<string> expectedRids = [ .. ToolsetInfo.LatestRuntimeIdentifiers.Split(';').Where(rid => rid != RuntimeInformation.RuntimeIdentifier), "any"];
+            List<string> expectedRids = [.. ToolsetInfo.LatestRuntimeIdentifiers.Split(';').Where(rid => rid != RuntimeInformation.RuntimeIdentifier), "any"];
 
             string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings, collectBinlogs: true);
             var packages = Directory.GetFiles(toolPackagesPath, "*.nupkg").Select(p => Path.GetFileName(p)).ToArray();

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var testDirectory = _testAssetsManager.CreateTestDirectory();
             var homeFolder = Path.Combine(testDirectory.Path, "home");
 
-            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--yes", "--add-source", toolPackagesPath)
+            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--add-source", toolPackagesPath)
                 .WithEnvironmentVariables(homeFolder)
                 .WithWorkingDirectory(testDirectory.Path)
                 .Execute()
@@ -304,7 +304,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var testDirectory = _testAssetsManager.CreateTestDirectory();
             var homeFolder = Path.Combine(testDirectory.Path, "home");
 
-            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--yes", "--add-source", toolPackagesPath)
+            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--add-source", toolPackagesPath)
                 .WithEnvironmentVariables(homeFolder)
                 .WithWorkingDirectory(testDirectory.Path)
                 .Execute()

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var testDirectory = _testAssetsManager.CreateTestDirectory();
             var homeFolder = Path.Combine(testDirectory.Path, "home");
 
-            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--add-source", toolPackagesPath)
+            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--source", toolPackagesPath)
                 .WithEnvironmentVariables(homeFolder)
                 .WithWorkingDirectory(testDirectory.Path)
                 .Execute()
@@ -304,7 +304,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             var testDirectory = _testAssetsManager.CreateTestDirectory();
             var homeFolder = Path.Combine(testDirectory.Path, "home");
 
-            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--add-source", toolPackagesPath)
+            new DotnetToolCommand(Log, "exec", toolSettings.ToolPackageId, "--verbosity", "diagnostic", "--yes", "--source", toolPackagesPath)
                 .WithEnvironmentVariables(homeFolder)
                 .WithWorkingDirectory(testDirectory.Path)
                 .Execute()

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             {
                 IncludeAnyRid = true // will make one package with the "any" RID
             };
-            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings);
+            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings, collectBinlogs: true);
             var packages = Directory.GetFiles(toolPackagesPath, "*.nupkg").Select(p => Path.GetFileName(p)).ToArray();
             packages.Should().BeEquivalentTo([
                 $"{toolSettings.ToolPackageId}.{toolSettings.ToolPackageVersion}.nupkg",
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             };
             List<string> expectedRids = [ .. ToolsetInfo.LatestRuntimeIdentifiers.Split(';').Where(rid => rid != RuntimeInformation.RuntimeIdentifier), "any"];
 
-            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings);
+            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings, collectBinlogs: true);
             var packages = Directory.GetFiles(toolPackagesPath, "*.nupkg").Select(p => Path.GetFileName(p)).ToArray();
             packages.Should().BeEquivalentTo([
                 $"{toolSettings.ToolPackageId}.{toolSettings.ToolPackageVersion}.nupkg",

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
@@ -1,8 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands;
@@ -40,23 +39,23 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
         private const string ProjectFileName = "TempProject.csproj";
         private readonly IFileSystem _fileSystem;
-        private readonly IReporter _reporter;
+        private readonly IReporter? _reporter;
         private readonly List<MockFeed> _feeds;
 
         private readonly Dictionary<PackageId, IEnumerable<string>> _warningsMap;
         private readonly Dictionary<PackageId, IReadOnlyList<FilePath>> _packagedShimsMap;
         private readonly Dictionary<PackageId, IEnumerable<NuGetFramework>> _frameworksMap;
-        private readonly Action _downloadCallback;
+        private readonly Action? _downloadCallback;
 
         public ToolPackageDownloaderMock(
             IToolPackageStore store,
             IFileSystem fileSystem,
-            IReporter reporter = null,
-            List<MockFeed> feeds = null,
-            Action downloadCallback = null,
-            Dictionary<PackageId, IEnumerable<string>> warningsMap = null,
-            Dictionary<PackageId, IReadOnlyList<FilePath>> packagedShimsMap = null,
-            Dictionary<PackageId, IEnumerable<NuGetFramework>> frameworksMap = null
+            IReporter? reporter = null,
+            List<MockFeed>? feeds = null,
+            Action? downloadCallback = null,
+            Dictionary<PackageId, IEnumerable<string>>? warningsMap = null,
+            Dictionary<PackageId, IReadOnlyList<FilePath>>? packagedShimsMap = null,
+            Dictionary<PackageId, IEnumerable<NuGetFramework>>? frameworksMap = null
         )
         {
             _toolPackageStore = store ?? throw new ArgumentNullException(nameof(store)); ;
@@ -97,15 +96,15 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
         public IToolPackage InstallPackage(PackageLocation packageLocation, PackageId packageId,
             VerbosityOptions verbosity,
-            VersionRange versionRange = null,
-            string targetFramework = null,
+            VersionRange? versionRange = null,
+            string? targetFramework = null,
             bool isGlobalTool = false,
             bool isGlobalToolRollForward = false,
             bool verifySignatures = false,
-            RestoreActionConfig restoreActionConfig = null
+            RestoreActionConfig? restoreActionConfig = null
             )
         {
-            string rollbackDirectory = null;
+            string? rollbackDirectory = null;
             var packageRootDirectory = _toolPackageStore.GetRootPackageDirectory(packageId);
 
             return TransactionalAction.Run<IToolPackage>(
@@ -193,13 +192,13 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                         _fileSystem.Directory.Move(_toolDownloadDir.Value, packageDirectory.Value);
                         rollbackDirectory = packageDirectory.Value;
 
-                        IEnumerable<string> warnings = null;
+                        IEnumerable<string>? warnings = null;
                         _warningsMap.TryGetValue(packageId, out warnings);
 
-                        IReadOnlyList<FilePath> packedShims = null;
+                        IReadOnlyList<FilePath>? packedShims = null;
                         _packagedShimsMap.TryGetValue(packageId, out packedShims);
 
-                        IEnumerable<NuGetFramework> frameworks = null;
+                        IEnumerable<NuGetFramework>? frameworks = null;
                         _frameworksMap.TryGetValue(packageId, out frameworks);
 
                         return new ToolPackageMock(_fileSystem, id: packageId,
@@ -228,7 +227,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             VersionRange versionRange,
             FilePath? nugetConfig = null,
             DirectoryPath? rootConfigDirectory = null,
-            string[] sourceFeedOverrides = null)
+            string[]? sourceFeedOverrides = null)
         {
             var allPackages = _feeds
                 .Where(feed =>
@@ -314,8 +313,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             PackageLocation packageLocation,
             PackageId packageId,
             VerbosityOptions verbosity,
-            VersionRange versionRange = null,
-            RestoreActionConfig restoreActionConfig = null)
+            VersionRange? versionRange = null,
+            RestoreActionConfig? restoreActionConfig = null)
         {
             versionRange = VersionRange.Parse(versionRange?.OriginalString ?? "*");
 
@@ -334,26 +333,26 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             return (NuGetVersion.Parse(feedPackage.Version), new PackageSource("http://mock-feed", "MockFeed"));
         }
 
-        public bool TryGetDownloadedTool(PackageId packageId, NuGetVersion packageVersion, string targetFramework, out IToolPackage toolPackage) => throw new NotImplementedException();
+        public bool TryGetDownloadedTool(PackageId packageId, NuGetVersion packageVersion, string? targetFramework, VerbosityOptions verbosity, [NotNullWhen(true)] out IToolPackage? toolPackage) => throw new NotImplementedException();
 
         private class TestToolPackage : IToolPackage
         {
             public PackageId Id { get; set; }
 
-            public NuGetVersion Version { get; set; }
+            public NuGetVersion? Version { get; set; }
             public DirectoryPath PackageDirectory { get; set; }
 
-            public ToolCommand Command { get; set; }
+            public ToolCommand? Command { get; set; }
 
-            public IEnumerable<string> Warnings { get; set; }
+            public IEnumerable<string>? Warnings { get; set; }
 
-            public IReadOnlyList<FilePath> PackagedShims { get; set; }
+            public IReadOnlyList<FilePath>? PackagedShims { get; set; }
 
             public IEnumerable<NuGetFramework> Frameworks => throw new NotImplementedException();
 
             public PackageId ResolvedPackageId { get; set; }
 
-            public NuGetVersion ResolvedPackageVersion { get; set; }
+            public NuGetVersion? ResolvedPackageVersion { get; set; }
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock2.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock2.cs
@@ -1,14 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.Extensions.EnvironmentAbstractions;
-using NuGet.Commands.Restore;
 using NuGet.Packaging;
 using NuGet.Versioning;
 
@@ -26,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         public string? MockFeedWithNoPackages { get; set; }
 
         List<MockFeedPackage>? _packages = null;
-        
+
         public ToolPackageDownloaderMock2(IToolPackageStore store, string runtimeJsonPathForTests, string currentWorkingDirectory, IFileSystem fileSystem) : base(store, runtimeJsonPathForTests, currentWorkingDirectory, fileSystem)
         {
         }
@@ -60,7 +56,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             return matchingPackages.MaxBy(p => new NuGetVersion(p.Version));
         }
 
-        protected override void CreateAssetFile(PackageId packageId, NuGetVersion version, DirectoryPath packagesRootPath, string assetFilePath, string runtimeJsonGraph, string? targetFramework = null)
+        protected override void CreateAssetFile(PackageId packageId, NuGetVersion version, DirectoryPath packagesRootPath, string assetFilePath, string runtimeJsonGraph, VerbosityOptions verbosity, string? targetFramework = null)
         {
             var mockPackage = GetPackage(packageId, version);
             if (mockPackage == null)
@@ -116,7 +112,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         }
 
         protected override NuGetVersion DownloadAndExtractPackage(PackageId packageId, INuGetPackageDownloader nugetPackageDownloader, string packagesRootPath,
-            NuGetVersion packageVersion, PackageSourceLocation packageSourceLocation, bool includeUnlisted = false)
+            NuGetVersion packageVersion, PackageSourceLocation packageSourceLocation, VerbosityOptions verbosity, bool includeUnlisted = false)
         {
 
             var package = GetPackage(packageId, packageVersion);
@@ -179,7 +175,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         protected override ToolConfiguration GetToolConfiguration(PackageId id, DirectoryPath packageDirectory, DirectoryPath assetsJsonParentDirectory)
         {
             return new ToolConfiguration(DefaultToolCommandName, FakeEntrypointName, "dotnet");
-            
+
         }
         protected override bool IsPackageInstalled(PackageId packageId, NuGetVersion packageVersion, string packagesRootPath)
         {


### PR DESCRIPTION
This builds on top of https://github.com/dotnet/sdk/pull/49501 and https://github.com/dotnet/sdk/pull/49521, so it's in draft still.

Fixes #49499 by adding support for the `any` RID.  This RID can be specified, but if it is it _must never_ trigger any of the apphost, linking, etc related Publish* properties. So I've added clauses to always force the Publish* properties to false for the `any` RID, and then everything else more or less falls into place!

I've been able to test this end to end by removing the win-x64 RID from my set of supported RIDs and then running the generated tool. Because we do RID negotiation, and because the `any` RID is explicitly packed as a FDD tool, everything just works!

All of the actual changes are in the .targets file, the rest is just
* supporting tests/infrastructure
* adding more diag logging to tool execution in case we need to debug things