### PR TITLE
quick, low-effort binlog upload when created by commands deriving from DotnetCommand

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ExponentialRetry.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ExponentialRetry.cs
@@ -55,7 +55,7 @@ public static class ExponentialRetry
                 return result;
             }
         }
-        throw new Exception("Timer should not be exhausted");
+        throw new Exception($"Timer for task {taskDescription} should not be exhausted.");
     }
 
     public static async Task<T> ExecuteWithRetry<T>(Func<T> action,

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -166,7 +166,7 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 command.StandardOutputEncoding(StandardOutputEncoding);
             }
-            
+
             string fileToShow = Path.GetFileNameWithoutExtension(spec.FileName!).Equals("dotnet", StringComparison.OrdinalIgnoreCase) ?
                 "dotnet" :
                 spec.FileName!;
@@ -175,6 +175,15 @@ namespace Microsoft.NET.TestFramework.Commands
             Log.WriteLine($"Executing '{display}':");
             var result = ((Command)command).Execute(ProcessStartedHandler);
             Log.WriteLine($"Command '{display}' exited with exit code {result.ExitCode}.");
+
+            if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT") is string uploadRoot)
+            {
+                var binlogFiles = Directory.GetFiles(spec.WorkingDirectory ?? Environment.CurrentDirectory, "*.binlog");
+                foreach (string binlogFile in binlogFiles)
+                {
+                    File.Copy(binlogFile, Path.Combine(uploadRoot, Path.GetFileName(binlogFile)), true);
+                }
+            }
 
             return result;
         }


### PR DESCRIPTION
We always forget how to get helix to upload binlogs, so what if we just did a check after each command we execute in the test framework to upload it?