### PR TITLE
Clean up containers packaging, leaning into NuGet's expected patterns

### DIFF
--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -21,11 +21,12 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>containers;docker;Microsoft.NET.Build.Containers</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PreparePackageReleaseNotesFromFile;AddItemsForPackaging;$(GenerateNuspecDependsOn);</TargetsForTfmSpecificContentInPackage>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
-                          SetTargetFramework="TargetFramework=$(TargetFramework)"
+                          SetTargetFramework="TargetFramework=$(SdkTargetFramework)"
                           OutputItemType="ContainerLibraryOutput"/>
 
         <ProjectReference Include="../../Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj"
@@ -34,76 +35,86 @@
 
         <ProjectReference Include="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj"
                           SetTargetFramework="TargetFramework=$(VSCompatTargetFramework)"
-                          OutputItemType="ContainerLibraryOutputNet472" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+                          OutputItemType="ContainerLibraryOutputNet472"
+                          Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
 
-        <ProjectReference Include="../containerize/containerize.csproj" PrivateAssets="all" IncludeAssets="runtime" ReferenceOutputAssembly="true" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+        <ProjectReference Include="../containerize/containerize.csproj"
+                          PrivateAssets="all"
+                          IncludeAssets="runtime"
+                          ReferenceOutputAssembly="true"
+                          OutputItemType="ContainerizeBinaryOutput"
+                          Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     </ItemGroup>
 
-    <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
-        <PropertyGroup>
-            <PackageReleaseNotesFile>../docs/ReleaseNotes/v8.0.300.md</PackageReleaseNotesFile>
-            <PackageReleaseNotes>$([System.IO.File]::ReadAllText($(PackageReleaseNotesFile)))</PackageReleaseNotes>
-        </PropertyGroup>
+    <ItemGroup>
+      <!-- These things are static, just always include them-->
+      <Content Include="README.md" Pack="true" PackagePath="" />
+      <Content Include="build/**" Pack="true" PackagePath="build/" />
+    </ItemGroup>
+
+    <Target Name="PreparePackageReleaseNotesFromFile">
+      <PropertyGroup>
+        <PackageReleaseNotesFile>../docs/ReleaseNotes/v8.0.300.md</PackageReleaseNotesFile>
+        <PackageReleaseNotes>$([System.IO.File]::ReadAllText($(PackageReleaseNotesFile)))</PackageReleaseNotes>
+      </PropertyGroup>
     </Target>
 
-    <Target Name="AddItemsForPackaging" AfterTargets="Build">
-        <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(VSCompatTargetFramework)" Targets="ResolveAssemblyReferences" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <!-- We need to depend on ResolveProjectReferences so that the 'OutputItemTypes' from the ProjectReferences above are populated.
+         `dotnet build` + GeneratePackageOnBuild does that automatically, but
+         `dotnet pack` + GeneratePackageOnBuild does not (because that would be an inifite loop) -->
+    <Target Name="AddItemsForPackaging" DependsOnTargets="ResolveProjectReferences">
+      <!-- build the containerize folder with the containerize binary and its dependencies -->
+      <MSBuild Projects="../containerize/containerize.csproj" Targets="ResolveAssemblyReferences" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+            <Output TaskParameter="TargetOutputs" ItemName="_AllContainerExeDependencies" />
+      </MSBuild>
+      <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+        <NecessaryContainerizeBinaryDependencies Include="@(_AllContainerExeDependencies)" Condition="(
+                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('NuGet')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
+                          ) and
+                          %(_AllContainerExeDependencies.NuGetIsFrameworkReference) != true" />
+        <_ContainerizeBinaryDependency Include="@(NecessaryContainerizeBinaryDependencies)" />
+        <_ContainerizeBinaryDependency Include="@(ContainerLibraryOutput)" />
+        <_ContainerizeBinaryDependency Include="@(ContainerizeBinaryOutput)" />
+        <TfmSpecificPackageFile Include="@(_ContainerizeBinaryDependency)" PackagePath="containerize/" />
+      </ItemGroup>
+
+      <!-- build the VS Task directory from the Tasks project built for net472 -->
+      <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(VSCompatTargetFramework)" Targets="ResolveAssemblyReferences" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
             <Output TaskParameter="TargetOutputs" ItemName="_AllNet472ContainerTaskDependencies" />
-        </MSBuild>
-        <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-            <NecessaryNet472ContainerTaskDependencies Include="@(_AllNet472ContainerTaskDependencies)" Condition="(
-                                $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
-                                $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
-                                $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
-                            ) and
-                            %(_AllNet472ContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
-            
-            <!-- containerize folder -->
-            <Content Include="$(OutDir)containerize.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)containerize.runtimeconfig.json" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)Newtonsoft.Json.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)NuGet.*.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)Microsoft.DotNet.Cli.Utils.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)System.CommandLine.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)Valleysoft.DockerCredsProvider.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="$(OutDir)Microsoft.Extensions.*.dll" Pack="true" PackagePath="containerize/" />
-            <Content Include="@(ContainerLibraryOutput)" Pack="true" PackagePath="containerize/" />
+      </MSBuild>
+      <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+          <NecessaryNet472ContainerTaskDependencies Include="@(_AllNet472ContainerTaskDependencies)" Condition="(
+                              $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllNet472ContainerTaskDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
+                          ) and
+                          %(_AllNet472ContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
+          <_ContainerTaskFrameworkDependency Include="@(NecessaryNet472ContainerTaskDependencies)" PackagePath="tasks/$(VSCompatTargetFramework)/" />
+          <_ContainerTaskFrameworkDependency Include="@(ContainerLibraryOutputNet472)" PackagePath="tasks/$(VSCompatTargetFramework)/" />
+          <TfmSpecificPackageFile Include="@(_ContainerTaskFrameworkDependency)" PackagePath="tasks/$(VSCompatTargetFramework)/" />
+      </ItemGroup>
 
-            <!-- net472 tasks -->
-            <!-- dependencies -->
-            <Content Include="@(NecessaryNet472ContainerTaskDependencies)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" />
-            <!-- actual DLL  -->
-            <Content Include="@(ContainerLibraryOutputNet472)" Pack="true" PackagePath="tasks/$(VSCompatTargetFramework)/" />
-        </ItemGroup>
-        <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(TargetFramework)" Targets="ResolveAssemblyReferences">
-            <Output TaskParameter="TargetOutputs" ItemName="_AllNetContainerTaskDependencies" />
-        </MSBuild>
-        <ItemGroup>
-             <NecessaryNetContainerTaskDependencies Include="@(_AllNetContainerTaskDependencies)" Condition="(
-                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
-                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
-                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Valleysoft')) or
-                                $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
-                            ) and
-                            %(_AllNetContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
+      <!-- build the CLI Task directory from the Tasks project build for the netcore TFM -->
+      <MSBuild Projects="../Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj" Properties="TargetFramework=$(SdkTargetFramework)" Targets="ResolveAssemblyReferences">
+          <Output TaskParameter="TargetOutputs" ItemName="_AllNetContainerTaskDependencies" />
+      </MSBuild>
+      <ItemGroup>
+            <NecessaryNetContainerTaskDependencies Include="@(_AllNetContainerTaskDependencies)" Condition="(
+                              $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('NuGet')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Valleysoft')) or
+                              $([MSBuild]::ValueOrDefault('%(_AllNetContainerTaskDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
+                          ) and
+                          %(_AllNetContainerTaskDependencies.NuGetIsFrameworkReference) != true" />
 
-            <!-- root folder -->
-            <Content Include="README.md" Pack="true" PackagePath="" />
-
-            <!-- tasks folder -->
-            <!-- net7.0 tasks -->
-            <!-- dependencies -->
-            <Content Include="@(NecessaryNetContainerTaskDependencies)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
-            <Content Include="@(DotNetCliUtilsLibraryOutput)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
-
-            <!-- runtime deps json -->
-            <Content Include="$(ArtifactsDir)bin/Microsoft.NET.Build.Containers/$(Configuration)/$(TargetFramework)/Microsoft.NET.Build.Containers.deps.json" Pack="true" PackagePath="tasks/$(TargetFramework)" />
-            <!-- actual DLL  -->
-            <Content Include="@(ContainerLibraryOutput)" Pack="true" PackagePath="tasks/$(TargetFramework)/" />
-
-            <!-- build folder -->
-            <Content Include="build/**" Pack="true" PackagePath="build/" />
-        </ItemGroup>
+          <_ContainerTaskCoreDependency Include="@(NecessaryNetContainerTaskDependencies)" />
+          <_ContainerTaskCoreDependency Include="@(DotNetCliUtilsLibraryOutput)" />
+          <_ContainerTaskCoreDependency Include="$(ArtifactsDir)bin/Microsoft.NET.Build.Containers/$(Configuration)/$(SdkTargetFramework)/Microsoft.NET.Build.Containers.deps.json" />
+          <_ContainerTaskCoreDependency Include="@(ContainerLibraryOutput)" />
+          <TfmSpecificPackageFile Include="@(_ContainerTaskCoreDependency)" PackagePath="tasks/$(SdkTargetFramework)/" />
+      </ItemGroup>
     </Target>
 
     <!-- Hacky workaround for the fact that we don't publish the package yet. -->

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -67,15 +67,13 @@
       <MSBuild Projects="../containerize/containerize.csproj" Targets="ResolveAssemblyReferences" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
             <Output TaskParameter="TargetOutputs" ItemName="_AllContainerExeDependencies" />
       </MSBuild>
+      <MSBuild Projects="../containerize/containerize.csproj" Targets="GetCopyToOutputDirectoryItems" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+            <Output TaskParameter="TargetOutputs" ItemName="ContainerizeBinaryOutput" />
+      </MSBuild>
       <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-        <NecessaryContainerizeBinaryDependencies Include="@(_AllContainerExeDependencies)" Condition="(
-                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('NuGet')) or
-                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('Newtonsoft')) or
-                              $([MSBuild]::ValueOrDefault('%(_AllContainerExeDependencies.NuGetPackageId)', '').Contains('Microsoft.Extensions'))
-                          ) and
-                          %(_AllContainerExeDependencies.NuGetIsFrameworkReference) != true" />
+        <NecessaryContainerizeBinaryDependencies Include="@(_AllContainerExeDependencies)"
+                                                 Condition="'%(_AllContainerExeDependencies.FrameworkReferenceName)' == ''" />
         <_ContainerizeBinaryDependency Include="@(NecessaryContainerizeBinaryDependencies)" />
-        <_ContainerizeBinaryDependency Include="@(ContainerLibraryOutput)" />
         <_ContainerizeBinaryDependency Include="@(ContainerizeBinaryOutput)" />
         <TfmSpecificPackageFile Include="@(_ContainerizeBinaryDependency)" PackagePath="containerize/" />
       </ItemGroup>


### PR DESCRIPTION
NuGet expects folks that want to customize output paths (i.e. non-library packages) to use the TargetsForTfmSpecificContentInPackage extensibility point to create TfmSpecificPackageFile Items with PackagePath metadata.

Instead of our old custom orchestration, we lean into this. I also cleaned up how we determine the dependencies to package for the containerize.dll binary.

This can be tested very easily by running `dotnet pack -bl` on the `packaging.csproj` project itself (or `dotnet build`, because we have GeneratePackageOnBuild set for this project).