### PR TITLE
Replicate change from dotnet/command-line-api#2586

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Help/HelpBuilder.Default.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Help/HelpBuilder.Default.cs
@@ -50,19 +50,22 @@ public partial class HelpBuilder
             // By default Option.Name == Argument.Name, don't repeat it
             return parameter switch
             {
-                Argument argument => GetUsageLabel(argument.HelpName, argument.ValueType, argument.CompletionSources, argument) ?? $"<{argument.Name}>",
-                Option option => GetUsageLabel(option.HelpName, option.ValueType, option.CompletionSources, option) ?? "",
+                Argument argument => GetUsageLabel(argument.HelpName, argument.ValueType, argument.CompletionSources, argument, argument.Arity) ?? $"<{argument.Name}>",
+                Option option => GetUsageLabel(option.HelpName, option.ValueType, option.CompletionSources, option, option.Arity) ?? "",
                 _ => throw new InvalidOperationException()
             };
 
-            static string? GetUsageLabel(string? helpName, Type valueType, List<Func<CompletionContext, IEnumerable<CompletionItem>>> completionSources, Symbol symbol)
+            static string? GetUsageLabel(string? helpName, Type valueType, List<Func<CompletionContext, IEnumerable<CompletionItem>>> completionSources, Symbol symbol, ArgumentArity arity)
             {
                 // Argument.HelpName is always first choice
                 if (!string.IsNullOrWhiteSpace(helpName))
                 {
                     return $"<{helpName}>";
                 }
-                else if (!(valueType == typeof(bool) || valueType == typeof(bool?)) && completionSources.Count > 0)
+                else if (
+                    !(valueType == typeof(bool) || valueType == typeof(bool?))
+                    && arity.MaximumNumberOfValues > 0 // allowing zero arguments means we don't need to show usage
+                    && completionSources.Count > 0)
                 {
                     IEnumerable<string> completions = symbol
                         .GetCompletions(CompletionContext.Empty)


### PR DESCRIPTION
Ensures that any zero-arity options or arguments never show an argument in help output.

This is a no-op right now (because we have no non-bool-typed zero-arity Options), but as soon as we do have one we'd hit this case.