### PR TITLE
Fix Framework-Dependent, RuntimeIdentifier-specific tool execution

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -189,8 +189,8 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ToolCommandRunner)' == ''">
-    <ToolCommandRunner>dotnet</ToolCommandRunner>
-    <ToolCommandRunner Condition="'$(SelfContained)' == 'true'">executable</ToolCommandRunner>
+    <ToolCommandRunner Condition="!$(UseAppHost)">dotnet</ToolCommandRunner>
+    <ToolCommandRunner Condition="$(UseAppHost)">executable</ToolCommandRunner>
   </PropertyGroup>
 
   <Target Name="_GenerateToolsSettingsFileInputCache">


### PR DESCRIPTION
Builds on top of https://github.com/dotnet/sdk/pull/49501, merge that one first.

Fixes #49494

The new multi-RID tool support relies on using the 'runner' set in the tool manifest to properly discover how to launch the app in the tool package. For this to work, the 'runner' type ('dotnet'/'executable') needs to align with the name of the binary inside the tool package we're running ('toolname.dll'/'toolname[.exe]'). These two were mismatched because we were pivoting the detection of which execution mode to use for tools off of the wrong property - if an apphost exists for the tool then we need to use the `executable` strategy.

A bit of test refactoring made this much easier to verify.