### PR TITLE
Ignore date-only changes during manpage update

### DIFF
--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -22,17 +22,21 @@ jobs:
           rm ./documentation/manpages/sdk/*
 
           ./documentation/manpages/tool/run_docker.sh
-
-          if [[ -n $(git status -s) ]]; then
+      
+          # Only add files with more than 2 changed lines
+          for line in $(git diff --numstat | awk '$1+$2 > 2 {print $3}'); do
+            git add "$line"
+          done
+      
+          if ! git diff --cached --quiet; then
             git config user.name 'github-actions'
             git config user.email 'github-actions@github.com'
             date=$(date +%F)
-            git add .
             title="[automated] Update man pages"
             body="This action is executed twice a month to automatically update the manpages based on the latest changes to the dotnet/docs repo"
             branch=update-man-page-$date
             git checkout -b $branch
-            git commit -a -m "$title"
+            git commit -m "$title"
             git push -u origin $branch --force
             gh pr create --base main --head $branch --title "$title" --body "$body"
           fi


### PR DESCRIPTION
Use a simple heuristic to  reduce diff sizes. e.g. this type of PR https://github.com/dotnet/sdk/pull/49410/files would touch three files instead of 69.