### PR TITLE
Target DotNetDeltaApplier to net6.0

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
+++ b/src/BuiltInTools/DotNetDeltaApplier/Microsoft.Extensions.DotNetDeltaApplier.csproj
@@ -4,12 +4,12 @@
   <Import Project="..\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
   <PropertyGroup>
     <!--
-      dotnet-watch may inject this assembly to .NET 6.0+ app, so we can't target a newer version.
-      At the same time source build requires us to not target 6.0, so we fall back to netstandard.
+      dotnet-watch may inject this assembly to .NET 6.0+ app.
 
-      When updating these also update ProjectReferences in dotnet-watch.csproj.
-     -->
-    <TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
+      When updating these also update ProjectReferences in dotnet-watch.csproj
+      and HotReloadAppModel.TryGetStartupHookPath.
+    -->
+    <TargetFrameworks>net6.0;net10.0</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 
     <!-- NuGet -->

--- a/src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj
+++ b/src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <!--
       Intentionally pinned. This feature is supported in projects targeting 6.0 or newer.
-      At the same time source build requires us to not target 6.0, so we fall back to netstandard.
     -->
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <DebugType>none</DebugType>
     <GenerateDependencyFile>false</GenerateDependencyFile>

--- a/src/BuiltInTools/dotnet-watch/HotReload/AppModels/HotReloadAppModel.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/AppModels/HotReloadAppModel.cs
@@ -26,7 +26,7 @@ internal abstract partial class HotReloadAppModel(ProjectGraphNode? agentInjecti
         var hookTargetFramework = agentInjectionProject.GetTargetFramework() switch
         {
             // Note: Hot Reload is only supported on net6.0+
-            "net6.0" or "net7.0" or "net8.0" or "net9.0" => "netstandard2.1",
+            "net6.0" or "net7.0" or "net8.0" or "net9.0" => "net6.0",
             _ => "net10.0",
         };
 

--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -67,8 +67,8 @@
       <OutputItemType>Content</OutputItemType>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
-      <TargetPath>hotreload\netstandard2.1\Microsoft.Extensions.DotNetDeltaApplier.dll</TargetPath>
+      <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
+      <TargetPath>hotreload\net6.0\Microsoft.Extensions.DotNetDeltaApplier.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Targeting net6.0 allows us to use more APIs that are not available in netstandard2.1.
Source build actually has 6.0 ref pack, so we can target 6.0 instead of netstandard2.1.