### PR TITLE
The pull request label check wasn't getting run when a draft PR was published

### DIFF
--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -2,6 +2,8 @@ name: PR Analysis
 on:
   pull_request_target:
     types: [opened, synchronize, labeled, unlabeled]
+  pull_request:
+    types: [ready_for_review]
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -1,9 +1,7 @@
 name: PR Analysis
 on:
   pull_request_target:
-    types: [opened, synchronize, labeled, unlabeled]
-  pull_request:
-    types: [ready_for_review]
+    types: [opened, synchronize, labeled, unlabeled, ready_for_review]
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
copilot creates it's PRs in draft mode and then we publish after discussion. I noticed that the branch lockdown check wouldn't end up getting run and I'd have to force it to run. This should fix that I believe.