### PR TITLE
Accept version ranges via `package@version` syntax

### DIFF
--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Commands.NuGet;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
-using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli.Commands.Package.Add;
 
@@ -19,7 +18,7 @@ namespace Microsoft.DotNet.Cli.Commands.Package.Add;
 /// </param>
 internal class PackageAddCommand(ParseResult parseResult, string fileOrDirectory) : CommandBase(parseResult)
 {
-    private readonly PackageIdentity _packageId = parseResult.GetValue(PackageAddCommandParser.CmdPackageArgument);
+    private readonly PackageIdentityWithRange _packageId = parseResult.GetValue(PackageAddCommandParser.CmdPackageArgument);
 
     public override int Execute()
     {
@@ -101,7 +100,7 @@ internal class PackageAddCommand(ParseResult parseResult, string fileOrDirectory
         }
     }
 
-    private string[] TransformArgs(PackageIdentity packageId, string tempDgFilePath, string projectFilePath)
+    private string[] TransformArgs(PackageIdentityWithRange packageId, string tempDgFilePath, string projectFilePath)
     {
         List<string> args = [
             "package",
@@ -111,11 +110,11 @@ internal class PackageAddCommand(ParseResult parseResult, string fileOrDirectory
             "--project",
             projectFilePath
         ];
-        
+
         if (packageId.HasVersion)
         {
             args.Add("--version");
-            args.Add(packageId.Version.ToString());
+            args.Add(packageId.VersionRange.OriginalString);
         }
 
         args.AddRange(_parseResult

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommandParser.cs
@@ -5,17 +5,16 @@
 
 using System.CommandLine;
 using System.CommandLine.Completions;
+using System.CommandLine.Parsing;
+using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Versioning;
-using Microsoft.DotNet.Cli.Extensions;
-using System.CommandLine.Parsing;
-using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli.Commands.Package.Add;
 
 internal static class PackageAddCommandParser
 {
-    public static readonly Argument<PackageIdentity> CmdPackageArgument = CommonArguments.RequiredPackageIdentityArgument()
+    public static readonly Argument<PackageIdentityWithRange> CmdPackageArgument = CommonArguments.RequiredPackageIdentityArgument()
     .AddCompletions((context) =>
     {
         // we should take --prerelease flags into account for version completion
@@ -31,7 +30,7 @@ internal static class PackageAddCommandParser
         .AddCompletions((context) =>
         {
             // we can only do version completion if we have a package id
-            if (context.ParseResult.GetValue(CmdPackageArgument) is PackageIdentity packageId && !packageId.HasVersion)
+            if (context.ParseResult.GetValue(CmdPackageArgument) is { HasVersion: false } packageId)
             {
                 // we should take --prerelease flags into account for version completion
                 var allowPrerelease = context.ParseResult.GetValue(PrereleaseOption);
@@ -106,7 +105,7 @@ internal static class PackageAddCommandParser
 
     private static void DisallowVersionIfPackageIdentityHasVersionValidator(OptionResult result)
     {
-        if (result.Parent.GetValue(CmdPackageArgument) is PackageIdentity identity && identity.HasVersion)
+        if (result.Parent.GetValue(CmdPackageArgument).HasVersion)
         {
             result.AddError(CliCommandStrings.ValidationFailedDuplicateVersion);
         }

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -7,19 +7,14 @@ using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
 using Microsoft.DotNet.Cli.Commands.Tool.Restore;
 using Microsoft.DotNet.Cli.Commands.Tool.Run;
-using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolManifest;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
-
 using Microsoft.Extensions.EnvironmentAbstractions;
-using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
-
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Execute;
 
@@ -27,7 +22,7 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 {
     const int ERROR_CANCELLED = 1223; //  Windows error code for "Operation canceled by user"
 
-    private readonly PackageIdentity _packageToolIdentityArgument = result.GetRequiredValue(ToolExecuteCommandParser.PackageIdentityArgument);
+    private readonly PackageIdentityWithRange _packageToolIdentityArgument = result.GetRequiredValue(ToolExecuteCommandParser.PackageIdentityArgument);
     private readonly IEnumerable<string> _forwardArguments = result.GetValue(ToolExecuteCommandParser.CommandArgument) ?? Enumerable.Empty<string>();
     private readonly bool _allowRollForward = result.GetValue(ToolExecuteCommandParser.RollForwardOption);
     private readonly string? _configFile = result.GetValue(ToolExecuteCommandParser.ConfigOption);

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommandParser.cs
@@ -3,14 +3,13 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Execute;
 
 internal static class ToolExecuteCommandParser
 
 {
-    public static readonly Argument<PackageIdentity> PackageIdentityArgument = ToolInstallCommandParser.PackageIdentityArgument;
+    public static readonly Argument<PackageIdentityWithRange> PackageIdentityArgument = ToolInstallCommandParser.PackageIdentityArgument;
 
     public static readonly Argument<IEnumerable<string>> CommandArgument = new("commandArguments")
     {

--- a/src/Cli/dotnet/Commands/Tool/Install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ParseResultExtension.cs
@@ -13,7 +13,7 @@ internal static class ParseResultExtension
 {
     public static VersionRange GetVersionRange(this ParseResult parseResult)
     {
-        var packageVersionFromIdentityArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument)?.Version?.ToString();
+        var packageVersionFromIdentityArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument).VersionRange?.OriginalString;
         var packageVersionFromVersionOption = parseResult.GetValue(ToolInstallCommandParser.VersionOption);
 
         // Check that only one of these has a value

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallCommandParser.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli.Commands.Tool.Common;
 using Microsoft.DotNet.Cli.Commands.Tool.Search;
 using Microsoft.DotNet.Cli.Extensions;
-using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Install;
 
 internal static class ToolInstallCommandParser
 {
-    public static readonly Argument<PackageIdentity> PackageIdentityArgument = CommonArguments.RequiredPackageIdentityArgument();
+    public static readonly Argument<PackageIdentityWithRange> PackageIdentityArgument = CommonArguments.RequiredPackageIdentityArgument();
 
     public static readonly Option<string> VersionOption = new("--version")
     {

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
@@ -71,7 +71,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         _verifySignatures = verifySignatures;
         _currentWorkingDirectory = currentWorkingDirectory;
 
-        var packageIdArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument)?.Id;
+        var packageIdArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument).Id;
 
         _packageId = packageId ?? (packageIdArgument is not null ? new PackageId(packageIdArgument) : null);
         _configFilePath = parseResult.GetValue(ToolInstallCommandParser.ConfigOption);

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallLocalCommand.cs
@@ -46,7 +46,7 @@ internal class ToolInstallLocalCommand : CommandBase
         : base(parseResult)
     {
         _updateAll = parseResult.GetValue(ToolUpdateCommandParser.UpdateAllOption);
-        var packageIdArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument)?.Id;
+        var packageIdArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument).Id;
         _packageId = packageId ?? (packageIdArgument is not null ? new PackageId(packageIdArgument) : null);
         _explicitManifestFile = parseResult.GetValue(ToolInstallCommandParser.ToolManifestOption);
 

--- a/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommand.cs
@@ -82,7 +82,7 @@ internal class ToolUpdateCommand : CommandBase
 
     internal static void EnsureNoConflictPackageIdentityVersionOption(ParseResult parseResult)
     {
-        if (!string.IsNullOrEmpty(parseResult.GetValue(ToolUpdateCommandParser.PackageIdentityArgument)?.Version?.ToString()) &&
+        if (!string.IsNullOrEmpty(parseResult.GetValue(ToolUpdateCommandParser.PackageIdentityArgument)?.VersionRange?.OriginalString) &&
             !string.IsNullOrEmpty(parseResult.GetValue(ToolAppliedOption.VersionOption)))
         {
             throw new GracefulException(CliStrings.PackageIdentityArgumentVersionOptionConflict);

--- a/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Tool/Update/ToolUpdateCommandParser.cs
@@ -4,13 +4,12 @@
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Tool.Common;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Update;
 
 internal static class ToolUpdateCommandParser
 {
-    public static readonly Argument<PackageIdentity?> PackageIdentityArgument = CommonArguments.OptionalPackageIdentityArgument();
+    public static readonly Argument<PackageIdentityWithRange?> PackageIdentityArgument = CommonArguments.OptionalPackageIdentityArgument();
 
     public static readonly Option<bool> UpdateAllOption = ToolAppliedOption.UpdateAllOption;
 

--- a/src/Cli/dotnet/CommonArguments.cs
+++ b/src/Cli/dotnet/CommonArguments.cs
@@ -4,14 +4,13 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli.Utils;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli
 {
     internal class CommonArguments
     {
-        public static DynamicArgument<PackageIdentity?> OptionalPackageIdentityArgument() =>
+        public static DynamicArgument<PackageIdentityWithRange?> OptionalPackageIdentityArgument() =>
             new("packageId")
             {
                 HelpName = "PACKAGE_ID",
@@ -20,17 +19,17 @@ namespace Microsoft.DotNet.Cli
                 Arity = ArgumentArity.ZeroOrOne,
             };
 
-        public static DynamicArgument<PackageIdentity> RequiredPackageIdentityArgument() =>
+        public static DynamicArgument<PackageIdentityWithRange> RequiredPackageIdentityArgument() =>
             new("packageId")
             {
                 HelpName = "PACKAGE_ID",
                 Description = CliStrings.PackageIdentityArgumentDescription,
-                CustomParser = (ArgumentResult argumentResult) => ParsePackageIdentityWithVersionSeparator(argumentResult.Tokens[0]?.Value),
+                CustomParser = (ArgumentResult argumentResult) => ParsePackageIdentityWithVersionSeparator(argumentResult.Tokens[0]?.Value)!.Value,
                 Arity = ArgumentArity.ExactlyOne,
             };
 
 
-        private static PackageIdentity? ParsePackageIdentityWithVersionSeparator(string? packageIdentity, char versionSeparator = '@')
+        private static PackageIdentityWithRange? ParsePackageIdentityWithVersionSeparator(string? packageIdentity, char versionSeparator = '@')
         {
             if (string.IsNullOrEmpty(packageIdentity))
             {
@@ -47,15 +46,20 @@ namespace Microsoft.DotNet.Cli
 
             if (string.IsNullOrEmpty(versionString))
             {
-                return new PackageIdentity(packageId, null);
+                return new PackageIdentityWithRange(packageId, null);
             }
 
-            if (!NuGetVersion.TryParse(versionString, out var version))
+            if (!VersionRange.TryParse(versionString, out var versionRange))
             {
                 throw new GracefulException(string.Format(CliStrings.InvalidVersion, versionString));
             }
 
-            return new PackageIdentity(packageId, new NuGetVersion(version));
+            return new PackageIdentityWithRange(packageId, versionRange);
         }
+    }
+
+    internal readonly record struct PackageIdentityWithRange(string Id, VersionRange? VersionRange)
+    {
+        public bool HasVersion => VersionRange != null;
     }
 }

--- a/test/dotnet.Tests/CommandTests/Package/Add/GivenDotnetPackageAdd.cs
+++ b/test/dotnet.Tests/CommandTests/Package/Add/GivenDotnetPackageAdd.cs
@@ -229,6 +229,29 @@ namespace Microsoft.DotNet.Cli.Package.Add.Tests
                 .Fail();
         }
 
+        [Theory, CombinatorialData]
+        public void VersionRange(bool asArgument)
+        {
+            var testAsset = "TestAppSimple";
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset(testAsset)
+                .WithSource()
+                .Path;
+
+            var packageName = "Humanizer";
+            var packageVersion = "2.*";
+            string[] args = asArgument
+                ? ["add", "package", $"{packageName}@{packageVersion}"]
+                : ["add", "package", packageName, "--version", packageVersion];
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(args);
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Contain($"PackageReference for package '{packageName}' version '{packageVersion}' " +
+                $"added to file '{projectDirectory + Path.DirectorySeparatorChar + testAsset}.csproj'.");
+            cmd.StdErr.Should().BeEmpty();
+        }
+
 
         private static TestProject GetProject(string targetFramework, string referenceProjectName, string version)
         {

--- a/test/dotnet.Tests/CommandTests/Tool/Install/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/InstallToolParserTests.cs
@@ -6,9 +6,6 @@
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.Tool;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using Microsoft.DotNet.Cli.Commands.Tool.Update;
-using Microsoft.DotNet.Cli.Extensions;
-using NuGet.Packaging.Core;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests.ParserTests
@@ -23,16 +20,18 @@ namespace Microsoft.DotNet.Tests.ParserTests
         }
 
         [Theory]
-        [InlineData("console.test.app --version 1.0.0")]
-        [InlineData("console.test.app@1.0.0")]
-        public void InstallGlobalToolParserCanGetPackageIdentityWithVersion(string arguments)
+        [InlineData("console.test.app --version 1.0.0", "1.0.0")]
+        [InlineData("console.test.app --version 1.*", "1.*")]
+        [InlineData("console.test.app@1.0.0", "1.0.0")]
+        [InlineData("console.test.app@1.*", "1.*")]
+        public void InstallGlobalToolParserCanGetPackageIdentityWithVersion(string arguments, string expectedVersion)
         {
             var result = Parser.Instance.Parse($"dotnet tool install -g {arguments}");
-            var packageIdentity = result.GetValue<PackageIdentity>(ToolInstallCommandParser.PackageIdentityArgument);
-            var packageId = packageIdentity?.Id;
-            var packageVersion = packageIdentity?.Version?.ToString() ?? result.GetValue<string>(ToolInstallCommandParser.VersionOption);
+            var packageIdentity = result.GetValue(ToolInstallCommandParser.PackageIdentityArgument);
+            var packageId = packageIdentity.Id;
+            var packageVersion = packageIdentity.VersionRange?.OriginalString ?? result.GetValue(ToolInstallCommandParser.VersionOption);
             packageId.Should().Be("console.test.app");
-            packageVersion.Should().Be("1.0.0");
+            packageVersion.Should().Be(expectedVersion);
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Tool/Update/UpdateToolParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Update/UpdateToolParserTests.cs
@@ -7,7 +7,6 @@ using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.Tool;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
 using Microsoft.DotNet.Cli.Commands.Tool.Update;
-using NuGet.Packaging.Core;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests.ParserTests
@@ -22,16 +21,18 @@ namespace Microsoft.DotNet.Tests.ParserTests
         }
 
         [Theory]
-        [InlineData("console.test.app --version 1.0.0")]
-        [InlineData("console.test.app@1.0.0")]
-        public void UpdateGlobalToolParserCanGetPackageIdentityWithVersion(string arguments)
+        [InlineData("console.test.app --version 1.0.0", "1.0.0")]
+        [InlineData("console.test.app --version 1.*", "1.*")]
+        [InlineData("console.test.app@1.0.0", "1.0.0")]
+        [InlineData("console.test.app@1.*", "1.*")]
+        public void UpdateGlobalToolParserCanGetPackageIdentityWithVersion(string arguments, string expectedVersion)
         {
             var result = Parser.Instance.Parse($"dotnet tool update -g {arguments}");
-            var packageIdentity = result.GetValue<PackageIdentity>(ToolUpdateCommandParser.PackageIdentityArgument);
+            var packageIdentity = result.GetValue(ToolUpdateCommandParser.PackageIdentityArgument);
             var packageId = packageIdentity?.Id;
-            var packageVersion = packageIdentity?.Version?.ToString() ?? result.GetValue<string>(ToolInstallCommandParser.VersionOption);
+            var packageVersion = packageIdentity?.VersionRange?.OriginalString ?? result.GetValue(ToolInstallCommandParser.VersionOption);
             packageId.Should().Be("console.test.app");
-            packageVersion.Should().Be("1.0.0");
+            packageVersion.Should().Be(expectedVersion);
         }
 
 
@@ -40,7 +41,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
         {
             var result = Parser.Instance.Parse("dotnet tool update -g console.test.app");
 
-            var packageId = result.GetValue<PackageIdentity>(ToolUpdateCommandParser.PackageIdentityArgument)?.Id;
+            var packageId = result.GetValue(ToolUpdateCommandParser.PackageIdentityArgument)?.Id;
 
             packageId.Should().Be("console.test.app");
         }


### PR DESCRIPTION
Seemed inconsistent to not be able to do `dotnet package add Humanizer@2.*` when I can do `dotnet package add Humanizer --version 2.*` just fine.