### PR TITLE
Fix a couple of dotnet-watch test failures

### DIFF
--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 }
                 """);
 
+            await App.AssertOutputLineStartsWith(MessageDescriptor.ReEvaluationCompleted);
+
             // update existing file:
             UpdateSourceFile(Path.Combine(dependencyDir, "Foo.cs"), """
                 public class Lib

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Text.RegularExpressions;
+
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class ApplyDeltaTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
@@ -254,7 +256,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             App.Start(testAsset, []);
 
             await App.AssertWaitingForChanges();
-            App.AssertOutputContains(@"dotnet watch ⌚ Exclusion glob: 'AppData/**/*.*;bin\Debug\/**;obj\Debug\/**;bin\/**;obj\/**");
+            App.AssertOutputContains(new Regex(@"dotnet watch ⌚ Exclusion glob: 'AppData/[*][*]/[*][.][*];bin[/\\]+Debug[/\\]+[*][*];obj[/\\]+Debug[/\\]+[*][*];bin[/\\]+[*][*];obj[/\\]+[*][*]"));
             App.Process.ClearOutput();
 
             UpdateSourceFile(appDataFilePath, """

--- a/test/dotnet-watch.Tests/Utilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/Utilities/AssertEx.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Watch.UnitTests
@@ -243,6 +244,27 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var message = new StringBuilder();
             message.AppendLine($"Expected output not found:");
             message.AppendLine(expected);
+            message.AppendLine();
+            message.AppendLine("Actual output:");
+
+            foreach (var item in items)
+            {
+                message.AppendLine($"'{item}'");
+            }
+
+            Fail(message.ToString());
+        }
+
+        public static void ContainsPattern(Regex expected, IEnumerable<string> items)
+        {
+            if (items.Any(item => expected.IsMatch(item)))
+            {
+                return;
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine($"Expected pattern not found in the output:");
+            message.AppendLine(expected.ToString());
             message.AppendLine();
             message.AppendLine("Actual output:");
 

--- a/test/dotnet-watch.Tests/Watch/Utilities/DotNetWatchTestBase.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/DotNetWatchTestBase.cs
@@ -30,8 +30,9 @@ public abstract class DotNetWatchTestBase : IDisposable
 
     public void UpdateSourceFile(string path, string text, [CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)
     {
+        var existed = File.Exists(path);
         WriteAllText(path, text);
-        Log($"File '{path}' updated", testPath, testLine);
+        Log($"File '{path}' " + (existed ? "updated" : "added"), testPath, testLine);
     }
 
     public void UpdateSourceFile(string path, Func<string, string> contentTransform, [CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)

--- a/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/Watch/Utilities/WatchableApp.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests
 {
@@ -38,6 +39,9 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         public void AssertOutputDoesNotContain(string message)
             => Assert.DoesNotContain(Process.Output, line => line.Contains(message));
+
+        public void AssertOutputContains(Regex pattern)
+            => AssertEx.ContainsPattern(pattern, Process.Output);
 
         public void AssertOutputContains(MessageDescriptor descriptor, string projectDisplay = null)
             => AssertOutputContains(GetLinePrefix(descriptor, projectDisplay));


### PR DESCRIPTION
When validating DefaultItemExcludes account for Unix directory separators (not sure why the test passed CI).
AddSourceFile tested adding and then updating source files. Apparently, the file system may reorder these operations and dotnet-watch might observe the update before the addition and try apply change, which will fail. 

