### PR TITLE
Revert "Explicitly enable BF for WinForms and WPF in Microsoft.NET.Sdk.targets"

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
@@ -194,7 +194,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- controls warn as error -->
     <_BinaryFormatterObsoleteAsError>true</_BinaryFormatterObsoleteAsError>
     <!-- controls runtime behavior (AppContext & trimming) -->
-    <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == '' AND '$(_ProjectTypeRequiresBinaryFormatter)' == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
     <EnableUnsafeBinaryFormatterSerialization Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) AND '$(_ProjectTypeRequiresBinaryFormatter)' != 'true'">false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 


### PR DESCRIPTION
Reverts dotnet/sdk#33004

This was a workaround for https://github.com/dotnet/sdk/issues/32969 which was fixed in 8.0 (at least the BinaryFormatter portion). The workaround was intended to be removed once that underlying issue was fixed.

Downloaded 8.0.0, checked the framework runtimeconfigs, and verified that running WinForms app without BinaryFormatter explicitly enabled in its runtime config works with 8.0.

cc @GrabYourPitchforks 