### PR TITLE
Update package registration logic

### DIFF
--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -281,15 +281,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                         version = match.Groups[3].Value;
                     }
 
-                    // Find existing registration for this package or null if not found
+                    // Find existing registration for this package with the SAME VERSION
                     var existingRegistration = manifest.Registrations?.FirstOrDefault(r =>
                         r.Component != null &&
                         r.Component.Nuget != null &&
-                        string.Equals(r.Component.Nuget.Name, packageId, StringComparison.OrdinalIgnoreCase));
+                        string.Equals(r.Component.Nuget.Name, packageId, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(r.Component.Nuget.Version, version, StringComparison.OrdinalIgnoreCase));
 
                     if (existingRegistration == null)
                     {
-                        // Add new package if it doesn't exist
+                        // Add new package if it doesn't exist with this version
                         manifest.Registrations?.Add(new Registration
                         {
                             Component = new Component
@@ -302,12 +303,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                                 }
                             }
                         });
-                        updatedManifest = true;
-                    }
-                    else if (existingRegistration.Component?.Nuget?.Version != version)
-                    {
-                        // Update version if it's different from the existing one
-                        existingRegistration.Component?.Nuget?.Version = version;
                         updatedManifest = true;
                     }
                 }


### PR DESCRIPTION
This pull request refines the logic for recording package registrations in the `RecordPackages` method of `DotnetNewTestTemplatesTests.cs`. The changes ensure that package registrations are uniquely identified by both name and version, and remove code for updating versions of existing registrations.

Enhancements to package registration logic:

* [`test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs`](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL284-R293): Updated the logic to find existing package registrations by matching both `Name` and `Version` properties, ensuring that registrations are version-specific.
* [`test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs`](diffhunk://#diff-186c574a5e9e4f3f1c7f3d0a4456670c788b21f22232bf8767b4bf76c419b44bL307-L312): Removed the code that updated the version of an existing registration, simplifying the method and enforcing immutability of package versions once registered.

Closes https://github.com/dotnet/sdk/issues/48607