### PR TITLE
Upgrade scancode to 32.4.0 and revert pinning of click

### DIFF
--- a/eng/install-scancode.sh
+++ b/eng/install-scancode.sh
@@ -5,13 +5,12 @@ set -euo pipefail
 # Install instructions: https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-a-library-via-pip
 
 # See latest release at https://github.com/nexB/scancode-toolkit/releases
-SCANCODE_VERSION="32.3.3"
+SCANCODE_VERSION="32.4.0"
 
 pyEnvPath="/tmp/scancode-env"
 python3 -m venv $pyEnvPath
 source $pyEnvPath/bin/activate
 pip install scancode-toolkit==$SCANCODE_VERSION
-pip install click==8.1.8
 deactivate
 
 # Setup a script which executes scancode in the virtual environment

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -67,6 +67,7 @@ public class LicenseScanTests : TestBase
         "cc-by-sa-4.0", // https://creativecommons.org/licenses/by-sa/4.0/legalcode
         "cc-pd", // https://creativecommons.org/publicdomain/mark/1.0/
         "cc-sa-1.0", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/cc-sa-1.0.LICENSE
+        "cpl-1.0", // https://opensource.org/license/cpl1-0-txt
         "epl-1.0", // https://opensource.org/license/epl-1-0/
         "generic-cla", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/generic-cla.LICENSE
         "gpl-1.0-plus", // https://opensource.org/license/gpl-1-0/

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -67,7 +67,6 @@ public class LicenseScanTests : TestBase
         "cc-by-sa-4.0", // https://creativecommons.org/licenses/by-sa/4.0/legalcode
         "cc-pd", // https://creativecommons.org/publicdomain/mark/1.0/
         "cc-sa-1.0", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/cc-sa-1.0.LICENSE
-        "cpl-1.0", // https://opensource.org/license/cpl1-0-txt
         "epl-1.0", // https://opensource.org/license/epl-1-0/
         "generic-cla", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/generic-cla.LICENSE
         "gpl-1.0-plus", // https://opensource.org/license/gpl-1-0/

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -13,8 +13,7 @@
 #
 
 # False positive
-src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown
-src/arcade/src/Microsoft.DotNet.XUnitAssert/src/README.md|free-unknown
+src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown,unknown-license-reference
 
 # Doesn't apply to code
 src/arcade/eng/xcopy-msbuild/msbuild.nuspec|ms-visual-2015-sdk
@@ -22,6 +21,8 @@ src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/*
 
 # Applies to installer, not source
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/eula.rtf
+src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/templates/debian/copyright|unknown-license-reference
+src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/rpm_templates/copyright|unknown-license-reference
 
 #
 # aspnetcore
@@ -34,10 +35,10 @@ src/aspnetcore/THIRD-PARTY-NOTICES.txt|unknown
 # Windows installer files that have a reference to a URL for license
 src/aspnetcore/src/Installers/Windows/**/*.wxl|unknown-license-reference
 src/aspnetcore/src/Installers/Windows/**/*.wxs|unknown-license-reference
+src/aspnetcore/src/Installers/Debian/tools/templates/debian/copyright|unknown-license-reference
 
 # License reference used in configuration, but not applying to code
 src/aspnetcore/src/Mvc/Settings.StyleCop|unknown-license-reference
-src/aspnetcore/src/submodules/MessagePack-CSharp/stylecop.json|unknown
 
 #
 # command-line-api
@@ -90,17 +91,20 @@ src/msbuild/src/Directory.Build.props|ms-net-library-2018-11
 # False positive
 src/msbuild/documentation/specs/BuildCheck/interactive-package-references.md|unknown-license-reference
 src/msbuild/src/Build/Instance/ProjectItemInstance.cs|generic-exception
+src/msbuild/src/Tasks/XamlRules/ProjectItemsSchema.xaml|unknown-license-reference
 
 #
 # nuget-client
 #
 
 # False positive
+src/nuget-client/.editorconfig|unknown-license-reference
 src/nuget-client/README.md|unknown-license-reference
 src/nuget-client/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs|unknown-license-reference
 src/nuget-client/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs|unknown-license-reference
 src/nuget-client/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/LicenseMetadataFormatter.cs|proprietary-license
 src/nuget-client/src/NuGet.Core/NuGet.Packaging/Rules/DefaultManifestValuesRule.cs|unknown-license-reference
+src/nuget-client/scripts/utils/UpdateNuGetLicenseSPDXList.ps1|json
 src/nuget-client/test/TestExtensions/GenerateLicenseList/Program.cs|json
 
 # Test data
@@ -111,6 +115,7 @@ src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/DefaultManifestValue
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/LicenseExpressionTokenizerTests.cs
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseExpressionParserTests.cs
 src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/LicensesTests/NuGetLicenseTests.cs
+src/nuget-client/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs|unknown-license-reference
 src/nuget-client/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs|389-exception
 src/nuget-client/test/TestUtilities/Test.Utility/JsonData.cs
 
@@ -126,7 +131,7 @@ src/roslyn-analyzers/assets/EULA.txt|ms-net-library
 #
 
 # Test data
-src/roslyn/src/Analyzers/VisualBasic/Tests/FileHeaders/FileHeaderTests.vb|unknown-license-reference
+src/roslyn/src/Analyzers/*/Tests/FileHeaders/FileHeaderTests.*|unknown-license-reference
 src/roslyn/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/Regex_RealWorldPatterns.json
 
 # Applicable to installer, not source
@@ -153,20 +158,19 @@ src/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs|ot
 src/runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs|other-permissive
 src/runtime/src/libraries/System.Reflection.Metadata/tests/Resources/README.md|unknown-license-reference
 src/runtime/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlLicenseTransform.cs|proprietary-license
-src/runtime/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs|unknown-license-reference
 src/runtime/src/mono/mono/mini/mini-posix.c|unknown-license-reference
 src/runtime/src/mono/mono/mini/mini-windows.c|unknown-license-reference
 src/runtime/src/native/external/libunwind/doc/libunwind-ia64.*|generic-exception
-src/runtime/src/native/external/zlib-ng/cmake/detect-arch.cmake|unknown-license-reference
-src/runtime/src/native/external/zlib-ng/cmake/detect-coverage.cmake|other-permissive,tsl-2020,unknown-license-reference
-src/runtime/src/native/external/zlib-ng/cmake/detect-sanitizer.cmake|unknown-license-reference
+src/runtime/src/native/external/zlib-ng/cmake/detect-*|unknown-license-reference
+src/runtime/src/native/external/zlib-ng/cmake/detect-install-dirs.cmake|proprietary-license
+src/runtime/src/native/external/zlib-ng/cmake/fallback-macros.cmake|unknown-license-reference
 src/runtime/src/tests/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs|unknown-license-reference
+src/runtime/src/tools/illink/.editorconfig|unknown-license-reference
 
 # Test data
 src/runtime/src/libraries/System.Private.Xml.Linq/tests/XDocument.Common/InputSpace.cs|other-permissive
 src/runtime/src/libraries/System.Private.Xml.Linq/tests/XDocument.Common/THIRD-PARTY-NOTICE|other-permissive
 src/runtime/src/libraries/System.Runtime/tests/System.Runtime.Tests/TestModule/README.md|unknown-license-reference
-src/runtime/src/libraries/System.ServiceModel.Syndication/tests/TestFeeds/AtomFeeds/*.xml
 
 # Reference to a license, not applicable to source
 src/runtime/src/libraries/System.Text.Json/roadmap/images/core-components.txt|unknown-license-reference
@@ -178,6 +182,9 @@ src/runtime/src/libraries/System.Text.Json/roadmap/images/higher-level-component
 
 # False positive
 src/sdk/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
+src/Installer/redist-installer/packaging/deb/dotnet-debian_config.json|commercial-license
+src/Installer/redist-installer/packaging/rpm/dotnet-config.json|commercial-license
+src/sdk/src/Installer/redist-installer/packaging/rpm/templates/copyright|unknown-license-reference
 
 # Configuration, doesn't apply to source directly
 src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
@@ -187,14 +194,10 @@ src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
 #
 
 # False positive
-src/source-build-externals/src/abstractions-xunit/README.md|free-unknown
-src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown
+src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown-license-reference
 src/source-build-externals/src/humanizer/NuSpecs/*.nuspec*
-src/source-build-externals/src/xunit/README.md|free-unknown
-src/source-build-externals/src/xunit/src/xunit.assert/Asserts/README.md|free-unknown
 
 # Configuration, doesn't apply to source directly
-src/source-build-externals/src/vs-solutionpersistence/stylecop.json
 
 # Scanner is identifying the https://github.com/SixLabors/ImageSharp/blob/master/LICENSE license as unknown. But this license is not applicable because we're
 # relying on the Spectre.Console distribution.
@@ -231,6 +234,7 @@ src/sourcelink/docs/GitSpec/GitSpec.md|unknown-license-reference
 
 # Not applicable to source
 src/test-templates/Templates/**/*.vstemplate
+src/test-templates/template_feed/Microsoft.DotNet.Test.ProjectTemplates.9.0/content/*/.template.config/localize/templatestrings.fr.json|proprietary-license
 
 #
 # vstest
@@ -238,9 +242,9 @@ src/test-templates/Templates/**/*.vstemplate
 
 # False positive
 src/vstest/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpArgsBuilder.cs|proprietary-license
+src/vstest/src/Microsoft.TestPlatform.ObjectModel/Nuget.Frameworks/.editorconfig|unknown-license-reference
 
 # Build asset, but not applying to code
-src/vstest/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/License.rtf
 
 #
 # wpf
@@ -260,3 +264,4 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|mpl-2.0
 src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/*.xaml|bsd-2-clause-views
 src/wpf/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs|proprietary-license
+src/wpf/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/UserUseLicenseDictionaryLoader.cs|proprietary-license

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -182,8 +182,8 @@ src/runtime/src/libraries/System.Text.Json/roadmap/images/higher-level-component
 
 # False positive
 src/sdk/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
-src/Installer/redist-installer/packaging/deb/dotnet-debian_config.json|commercial-license
-src/Installer/redist-installer/packaging/rpm/dotnet-config.json|commercial-license
+src/sdk/src/Installer/redist-installer/packaging/deb/dotnet-debian_config.json|commercial-license
+src/sdk/src/Installer/redist-installer/packaging/rpm/dotnet-config.json|commercial-license
 src/sdk/src/Installer/redist-installer/packaging/rpm/templates/copyright|unknown-license-reference
 
 # Configuration, doesn't apply to source directly
@@ -195,6 +195,7 @@ src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
 
 # False positive
 src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidatorConstants.cs|cpl-1.0
 src/source-build-externals/src/humanizer/NuSpecs/*.nuspec*
 
 # Configuration, doesn't apply to source directly

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -14,6 +14,8 @@
 
 # False positive
 src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown,unknown-license-reference
+src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/templates/debian/copyright|unknown-license-reference
+src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/rpm_templates/copyright|unknown-license-reference
 
 # Doesn't apply to code
 src/arcade/eng/xcopy-msbuild/msbuild.nuspec|ms-visual-2015-sdk
@@ -21,12 +23,13 @@ src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/*
 
 # Applies to installer, not source
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/eula.rtf
-src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/templates/debian/copyright|unknown-license-reference
-src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/rpm_templates/copyright|unknown-license-reference
 
 #
 # aspnetcore
 #
+
+# False positive
+src/aspnetcore/src/Installers/Debian/tools/templates/debian/copyright|unknown-license-reference
 
 # A generic statement about license applicability that is being detected as "unknown"
 src/aspnetcore/src/Components/THIRD-PARTY-NOTICES.txt|unknown
@@ -35,7 +38,6 @@ src/aspnetcore/THIRD-PARTY-NOTICES.txt|unknown
 # Windows installer files that have a reference to a URL for license
 src/aspnetcore/src/Installers/Windows/**/*.wxl|unknown-license-reference
 src/aspnetcore/src/Installers/Windows/**/*.wxs|unknown-license-reference
-src/aspnetcore/src/Installers/Debian/tools/templates/debian/copyright|unknown-license-reference
 
 # License reference used in configuration, but not applying to code
 src/aspnetcore/src/Mvc/Settings.StyleCop|unknown-license-reference
@@ -195,6 +197,7 @@ src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
 
 # False positive
 src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-externals/src/application-insights/WEB/ThirdPartyNotices.txt|unknown-license-reference
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidatorConstants.cs|cpl-1.0
 src/source-build-externals/src/humanizer/NuSpecs/*.nuspec*
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/Licenses.source-build-externals.json
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/Licenses.source-build-externals.json
@@ -2,7 +2,11 @@
   "files": [
     {
       "path": "src/application-insights/LOGGING/ThirdPartyNotices.txt",
-      "detected_license_expression": "unknown AND apache-2.0 AND mit AND bsd-new"
+      "detected_license_expression": "(unknown-license-reference AND apache-2.0) AND mit AND bsd-new"
+    },
+    {
+      "path": "src/application-insights/WEB/ThirdPartyNotices.txt",
+      "detected_license_expression": "(unknown-license-reference AND bsd-new) AND mit AND ms-pl AND apache-2.0 AND (cc-by-3.0-us AND cc-by-3.0 AND mit) AND ms-rl"
     }
   ]
 }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/Licenses.source-build-externals.json
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/Licenses.source-build-externals.json
@@ -3,10 +3,6 @@
     {
       "path": "src/application-insights/LOGGING/ThirdPartyNotices.txt",
       "detected_license_expression": "(unknown-license-reference AND apache-2.0) AND mit AND bsd-new"
-    },
-    {
-      "path": "src/application-insights/WEB/ThirdPartyNotices.txt",
-      "detected_license_expression": "(unknown-license-reference AND bsd-new) AND mit AND ms-pl AND apache-2.0 AND (cc-by-3.0-us AND cc-by-3.0 AND mit) AND ms-rl"
     }
   ]
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5208

New release of scancode is available, revert pinning of click package.