### PR TITLE
Ensure binlogs from file-based apps have evaluation data

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -248,7 +248,8 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 Environment.SetEnvironmentVariable(key, value);
             }
 
-            projectCollection?.Dispose();
+            binaryLogger?.Shutdown();
+            consoleLogger.Shutdown();
         }
 
         static ILogger? GetBinaryLogger(IReadOnlyList<string> args)

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Basic.CompilerLog.Util" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.TemplateEngine.Mocks" />


### PR DESCRIPTION
Binlogs from file-based apps didn't have the evaluation data (or at least not visible in the binlog viewer), which is pretty important for build investigations, so I shuffled stuff around until it started working.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/cc58ce8c-e074-4e3f-8fe5-e045a49e3a15) | ![image](https://github.com/user-attachments/assets/bc5b3d21-ccd8-45ac-93ba-a82bdd0b8b56) |