### PR TITLE
fix ordering so that getting Container config establishes RIDness

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -71,7 +71,7 @@
 
   <!-- This Target is called early on in the chain for both single-RID and multi-RID containers - but for single-RID it's important
        that we ensure all of the data necessary to create a single-RID container is computed after we exit this target. -->
-  <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage;_ComputeContainerExecutionArgs">
+  <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage;_ContainerEstablishRIDNess;_ComputeContainerExecutionArgs">
     <PropertyGroup Label="VS defaults">
       <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
       <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>
@@ -181,21 +181,20 @@
   <PropertyGroup>
     <PublishContainerDependsOn>
       _ContainerVerifySDKVersion;
-      _ContainerEstablishRIDNess;
       ComputeContainerConfig;
-      _CheckContainersPackage
+      _CheckContainersPackage;
     </PublishContainerDependsOn>
   </PropertyGroup>
 
   <!-- These args are relevant to container execution and are per-RID by nature. Therefore they're a direct dependency of the _PublishSingleContainer
        target and not computed at the outer, multi-RID build layer. -->
-  <Target Name="_ComputeContainerExecutionArgs" Condition="'$(_IsSingleRIDBuild)' == 'true'">
+  <Target Name="_ComputeContainerExecutionArgs" DependsOnTargets="_ContainerEstablishRIDNess" Condition="'$(_IsSingleRIDBuild)' == 'true'">
     <PropertyGroup>
       <!-- The Container RID should default to the RID used for the entire build (to ensure things run on the platform they are built for), but the user knows best and so should be able to set it explicitly.
            For builds that have a RID, we default to that RID. Otherwise, we default to the Linux RID matching the architecture of the currently-executing SDK. -->
       <_ContainerIsTargetingWindows>false</_ContainerIsTargetingWindows>
       <_ContainerIsTargetingWindows Condition="$(ContainerRuntimeIdentifier.StartsWith('win'))">true</_ContainerIsTargetingWindows>
-      
+
       <!-- Set the WorkingDirectory depending on the RID -->
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and !$(_ContainerIsTargetingWindows)">/app/</ContainerWorkingDirectory>
       <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and $(_ContainerIsTargetingWindows)">C:\app\</ContainerWorkingDirectory>

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -22,7 +22,6 @@ public class TargetsTests
         {
             [prop] = value.ToString(),
             [ContainerRuntimeIdentifier] = $"{os}-x64",
-            ["_IsSingleRIDBuild"] = "true",
 
         }, projectName: $"{nameof(CanDeferContainerAppCommand)}_{prop}_{value}_{string.Join("_", expectedAppCommandArgs)}");
         using var _ = d;
@@ -312,7 +311,6 @@ public class TargetsTests
             ["TargetFrameworkVersion"] = tfm,
             ["TargetFramework"] = "net" + tfm.TrimStart('v'),
             ["ContainerRuntimeIdentifier"] = rid,
-            ["_IsSingleRIDBuild"] = "true",
         }, projectName: $"{nameof(CanComputeContainerUser)}_{tfm}_{rid}_{expectedUser}");
         using var _ = d;
         var instance = project.CreateProjectInstance(ProjectInstanceSettings.None);


### PR DESCRIPTION
Fixes #49586 by making sure that the Target that sets the conditions for the execution args to be computed is called in every case where ComputeContainerConfig might be called standalone.