### PR TITLE
Make it so the artifacts folders register files for cleanup

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -51,6 +51,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ArtifactsBinOutputName Condition="'$(ArtifactsBinOutputName)' == ''">bin</ArtifactsBinOutputName>
     <ArtifactsPublishOutputName Condition="'$(ArtifactsPublishOutputName)' == ''">publish</ArtifactsPublishOutputName>
     <ArtifactsPackageOutputName Condition="'$(ArtifactsPackageOutputName)' == ''">package</ArtifactsPackageOutputName>
+    <!-- When using artifacts output, we need to track file writes  with a bit more knowledge than the MSBuild Common targets have-->
+    <IncrementalCleanDependsOn>$(IncrementalCleanDependsOn);_TrackFileWritesShareableUnderArtifactsPath</IncrementalCleanDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(ArtifactsPivots)' == ''">
@@ -90,9 +92,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- The package output path does not include the project name, and only includes the Configuration as a pivot -->
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(ArtifactsPath)\$(ArtifactsPackageOutputName)\$(Configuration.ToLowerInvariant())\</PackageOutputPath>
-    
+
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(UseArtifactsOutput)' != 'true'">
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
     <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
@@ -155,10 +157,31 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <NetSdkError Condition="'$(UseArtifactsOutput)' == 'true' and '$(_ArtifactsPathSetEarly)' != 'true'"
                  ResourceName="ArtifactsPathCannotBeSetInProject" />
-    
+
     <NetSdkError Condition="'$(_ArtifactsPathLocationType)' == 'ProjectFolder'"
                  ResourceName="UseArtifactsOutputRequiresDirectoryBuildProps" />
 
+  </Target>
+
+
+  <!-- Addresses a gap in the _CleanGetCurrentAndPriorFileWrites:
+       https://github.com/dotnet/msbuild/blob/25d1e4c409f9efd81c345fb41fbee6d2af83bed6/src/Tasks/Microsoft.Common.CurrentVersion.targets#L5765-L5777
+
+       This Target won't remove FileWritesShareable if they aren't under the Project's own directory,
+       but in Artifacts layout that will never be the case. So we allow finding the FileWritesShareable under our output
+       paths as well -->
+  <Target Name="_TrackFileWritesShareableUnderArtifactsPath">
+    <FindUnderPath Path="$(OutputPath)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
+      <Output TaskParameter="InPath" ItemName="_LocatedFileWritesShareable"/>
+    </FindUnderPath>
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
+      <Output TaskParameter="InPath" ItemName="_LocatedFileWritesShareable"/>
+    </FindUnderPath>
+
+    <!-- Remove duplicates from files produced in this build. -->
+    <RemoveDuplicates Inputs="@(_LocatedFileWritesShareable)" >
+      <Output TaskParameter="Filtered" ItemName="_CleanCurrentFileWrites"/>
+    </RemoveDuplicates>
   </Target>
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultOutputPaths.targets
@@ -51,8 +51,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ArtifactsBinOutputName Condition="'$(ArtifactsBinOutputName)' == ''">bin</ArtifactsBinOutputName>
     <ArtifactsPublishOutputName Condition="'$(ArtifactsPublishOutputName)' == ''">publish</ArtifactsPublishOutputName>
     <ArtifactsPackageOutputName Condition="'$(ArtifactsPackageOutputName)' == ''">package</ArtifactsPackageOutputName>
-    <!-- When using artifacts output, we need to track file writes  with a bit more knowledge than the MSBuild Common targets have-->
-    <IncrementalCleanDependsOn>$(IncrementalCleanDependsOn);_TrackFileWritesShareableUnderArtifactsPath</IncrementalCleanDependsOn>
+    <!-- By default MSBuild won't allow tracking/automatic clean-up of files that are outside of a Project's child directory structure.
+         This flag opts us into a mode where the Common targets will track and clean such files, which is good because
+         in Artifacts layout virtually all transitive and package references are such files. 
+         See https://github.com/dotnet/msbuild/pull/12096 for full details. -->
+    <TrackFileWritesShareableOutsideOfProjectDirectory>true</TrackFileWritesShareableOutsideOfProjectDirectory>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true' And '$(ArtifactsPivots)' == ''">
@@ -161,27 +164,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NetSdkError Condition="'$(_ArtifactsPathLocationType)' == 'ProjectFolder'"
                  ResourceName="UseArtifactsOutputRequiresDirectoryBuildProps" />
 
-  </Target>
-
-
-  <!-- Addresses a gap in the _CleanGetCurrentAndPriorFileWrites:
-       https://github.com/dotnet/msbuild/blob/25d1e4c409f9efd81c345fb41fbee6d2af83bed6/src/Tasks/Microsoft.Common.CurrentVersion.targets#L5765-L5777
-
-       This Target won't remove FileWritesShareable if they aren't under the Project's own directory,
-       but in Artifacts layout that will never be the case. So we allow finding the FileWritesShareable under our output
-       paths as well -->
-  <Target Name="_TrackFileWritesShareableUnderArtifactsPath">
-    <FindUnderPath Path="$(OutputPath)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
-      <Output TaskParameter="InPath" ItemName="_LocatedFileWritesShareable"/>
-    </FindUnderPath>
-    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
-      <Output TaskParameter="InPath" ItemName="_LocatedFileWritesShareable"/>
-    </FindUnderPath>
-
-    <!-- Remove duplicates from files produced in this build. -->
-    <RemoveDuplicates Inputs="@(_LocatedFileWritesShareable)" >
-      <Output TaskParameter="Filtered" ItemName="_CleanCurrentFileWrites"/>
-    </RemoveDuplicates>
   </Target>
 
 </Project>

--- a/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -541,6 +541,11 @@ namespace Microsoft.NET.Build.Tests
                 UseArtifactsOutput = true,
             };
 
+            var hostfxrName =
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "hostfxr.dll" :
+                RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "libhostfxr.so" :
+                "libhostfxr.dylib";
+
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             //  Now add a Directory.Build.props file setting UseArtifactsOutput to true
@@ -567,11 +572,11 @@ namespace Microsoft.NET.Build.Tests
                 .Pass();
 
             var outputDir = new DirectoryInfo(OutputPathCalculator.FromProject(testAsset.Path, testProject).GetOutputDirectory(configuration: "release"));
-            outputDir.Should().Exist().And.HaveFile("hostfxr.dll");
+            outputDir.Should().Exist().And.HaveFile(hostfxrName);
             LocateAndRunApp(outputDir);
 
             var publishDir = new DirectoryInfo(OutputPathCalculator.FromProject(testAsset.Path, testProject).GetPublishDirectory(configuration: "release"));
-            publishDir.Should().Exist().And.HaveFile("hostfxr.dll");
+            publishDir.Should().Exist().And.HaveFile(hostfxrName);
             LocateAndRunApp(publishDir);
 
             // now build the app in Release configuration.
@@ -583,7 +588,7 @@ namespace Microsoft.NET.Build.Tests
                 .Should()
                 .Pass();
             outputDir.Should().Exist();
-            outputDir.Should().NotHaveFiles(["hostfxr.dll"]);
+            outputDir.Should().NotHaveFiles([hostfxrName]);
             LocateAndRunApp(outputDir);
 
             void LocateAndRunApp(DirectoryInfo root)


### PR DESCRIPTION
Fixes #49582

The SDK knows that it's opting into Artifacts Path, and so the SDK can coordinate correcting the cleanup behavior for ArtifactsPath.

