### PR TITLE
Update test method to fix test issue:47861

### DIFF
--- a/test/dotnet.Tests/GivenExponentialRetry.cs
+++ b/test/dotnet.Tests/GivenExponentialRetry.cs
@@ -25,17 +25,18 @@ namespace Microsoft.DotNet.Tests
             retryCount.Should().Be(1);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/47861")]
+        [Fact]
         public async Task ItRetriesOnError()
         {
             var retryCount = 0;
             Func<Task<string>> action = () =>
             {
                 retryCount++;
-                throw new Exception();
+                return Task.FromResult<string>(null);
             };
-            await Assert.ThrowsAsync<AggregateException>(async () => await ExponentialRetry.ExecuteWithRetryOnFailure<string>(action, 2, timer: () => ExponentialRetry.Timer(ExponentialRetry.TestingIntervals)));
+            var res = await ExponentialRetry.ExecuteWithRetryOnFailure<string>(action, 2, timer: () => ExponentialRetry.Timer(ExponentialRetry.TestingIntervals));
 
+            res.Should().BeNull();
             retryCount.Should().Be(2);
         }
     }

--- a/test/dotnet.Tests/GivenExponentialRetry.cs
+++ b/test/dotnet.Tests/GivenExponentialRetry.cs
@@ -29,12 +29,12 @@ namespace Microsoft.DotNet.Tests
         public async Task ItRetriesOnError()
         {
             var retryCount = 0;
-            Func<Task<string>> action = () =>
+            Func<Task<string?>> action = () => // Updated to use nullable reference type  
             {
                 retryCount++;
-                return Task.FromResult<string>(null);
+                return Task.FromResult<string?>(null); // Updated to match nullable reference type  
             };
-            var res = await ExponentialRetry.ExecuteWithRetryOnFailure<string>(action, 2, timer: () => ExponentialRetry.Timer(ExponentialRetry.TestingIntervals));
+            var res = await ExponentialRetry.ExecuteWithRetryOnFailure<string?>(action, 2, timer: () => ExponentialRetry.Timer(ExponentialRetry.TestingIntervals));
 
             res.Should().BeNull();
             retryCount.Should().Be(2);


### PR DESCRIPTION
Fix test issue: #47861 

## Root Cause
Throw an exception in the action delegate will stop the Retry method! 
Referring to the ExecuteAsyncWithRetry method
``` c#
public static async Task<T> ExecuteAsyncWithRetry<T>(Func<Task<T>> action,
    Func<T, bool> shouldStopRetry,
    int maxRetryCount,
    Func<IEnumerable<Task>> timer,
    string taskDescription = "")
{
    var count = 0;
    foreach (var t in timer())
    {
        await t;
        T result = default;
        count++;

        result = await action();

        if (shouldStopRetry(result))
        {
            return result;
        }

        if (count == maxRetryCount)
        {
            return result;
        }
    }
    throw new Exception("Timer should not be exhausted");
}
```
Whether or not to retry is only relevant to the expression in 
```
await ExecuteAsyncWithRetry(action, result => result != null && !result.Equals(default), maxRetryCount, timer);
```
so consider modifying the test case to simulate failure retries.



## Proposed changes

- 
- Update test case.
- 