### PR TITLE
Consume shared components from external URI in non-1xx feature band

### DIFF
--- a/src/Layout/redist/targets/RestoreLayout.targets
+++ b/src/Layout/redist/targets/RestoreLayout.targets
@@ -304,12 +304,13 @@
       </UrisToDownload>
     </ItemGroup>
 
-    <!-- If building in product source build mode, there is no need to attempt the external URIs. These are not desired,
-            and won't work anyway because the source build file URI doesn't use the same structure as the storage accounts.
-            For example, the dotnetbuilds uri for 'file:///vmr/dotnet2/artifacts/obj/x64/Release/blob-feed/assets//aspnetcore_base_runtime.version'
-            would end up 'https://ci.dot.net/public//dotnet-runtime-8.0.0-rc.1.23381.3-centos.8-x64.tar.gz'. This is
-            missing the runtime version number directory. -->
-    <ItemGroup Condition="'$(DotNetBuildFromVMR)' != 'true'">
+    <!--
+      Only access external URIs if building the repo outside the context of the VMR or if building a non-1xx feature band.
+      For VMR builds in the 1xx feature band, we want to use the locally built artifacts produced by repos built earlier in the build.
+      But in later feature bands, we need to download the artifacts since the current build did not produce them. They were only produced
+      by builds of the 1xx feature band and are being shared with other feature bands through this download workflow.
+    -->
+    <ItemGroup Condition="'$(DotNetBuildFromVMR)' != 'true' or '$(VersionSDKMinor)' != '1'">
       <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.BaseUrl)').Replace($(PublicBaseURL), 'https://ci.dot.net/public/'))/%(ComponentToDownload.DownloadFileName)"
                       Condition="'%(ComponentToDownload.ShouldDownload)' == 'true'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>


### PR DESCRIPTION
Fixes dotnet/dotnet#1109

For non-1xx feature bands, shared components like runtime and aspnetcore are not produced directly by the build. Only the 1xx feature band produces them. So in the non-1xx feature bands of the VMR, the sdk needs to be able to download those shared component artifacts from external URIs rather than expecting them to exist in a local directory feed.

This applies to Microsoft builds only since those are allowed to download external artifacts like this. The work to support this for source-only builds is tracked with https://github.com/dotnet/dotnet/issues/1111.