### PR TITLE
Fix path

### DIFF
--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This breaks incremental build because Readme.md is considered an input, but is not found, so the dotnet-format project rebuilds every time