### PR TITLE
Implement support for changing project and package references

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Build/BuildNames.cs
+++ b/src/BuiltInTools/dotnet-watch/Build/BuildNames.cs
@@ -37,6 +37,7 @@ internal static class ItemNames
 internal static class MetadataNames
 {
     public const string Watch = nameof(Watch);
+    public const string TargetPath = nameof(TargetPath);
 }
 
 internal static class TargetNames
@@ -44,4 +45,5 @@ internal static class TargetNames
     public const string Compile = nameof(Compile);
     public const string Restore = nameof(Restore);
     public const string GenerateComputedBuildStaticWebAssets = nameof(GenerateComputedBuildStaticWebAssets);
+    public const string ReferenceCopyLocalPathsOutputGroup = nameof(ReferenceCopyLocalPathsOutputGroup);
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -97,8 +97,9 @@ internal class IncrementalMSBuildWorkspace : Workspace
         UpdateReferencesAfterAdd();
 
         ProjectReference MapProjectReference(ProjectReference pr)
-            // Only C# and VB projects are loaded by the MSBuildProjectLoader, so some references might be missing:
-            => new(projectIdMap.TryGetValue(pr.ProjectId, out var mappedId) ? mappedId : pr.ProjectId, pr.Aliases, pr.EmbedInteropTypes);
+            // Only C# and VB projects are loaded by the MSBuildProjectLoader, so some references might be missing.
+            // When a new project is added along with a new project reference the old project id is also null.
+            => new(projectIdMap.TryGetValue(pr.ProjectId, out var oldProjectId) && oldProjectId != null ? oldProjectId : pr.ProjectId, pr.Aliases, pr.EmbedInteropTypes);
 
         ImmutableArray<DocumentInfo> MapDocuments(ProjectId mappedProjectId, IReadOnlyList<DocumentInfo> documents)
             => documents.Select(docInfo =>

--- a/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
@@ -65,6 +65,7 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor HotReloadSessionStarted = new("Hot reload session started.", HotReloadEmoji, MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor ProjectsRebuilt = new("Projects rebuilt ({0})", HotReloadEmoji, MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor ProjectsRestarted = new("Projects restarted ({0})", HotReloadEmoji, MessageSeverity.Verbose, s_id++);
+        public static readonly MessageDescriptor ProjectDependenciesDeployed = new("Project dependencies deployed ({0})", HotReloadEmoji, MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor FixBuildError = new("Fix the error to continue or press Ctrl+C to exit.", WatchEmoji, MessageSeverity.Warning, s_id++);
         public static readonly MessageDescriptor WaitingForChanges = new("Waiting for changes", WatchEmoji, MessageSeverity.Verbose, s_id++);
         public static readonly MessageDescriptor LaunchedProcess = new("Launched '{0}' with arguments '{1}': process id {2}", LaunchEmoji, MessageSeverity.Verbose, s_id++);

--- a/test/TestAssets/TestProjects/WatchAppWithProjectDeps/AppWithDeps/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAppWithProjectDeps/AppWithDeps/Program.cs
@@ -19,9 +19,14 @@ namespace ConsoleApplication
 
             while (true)
             {
-                Lib.Print();
+                CallLib();
                 Thread.Sleep(1000);
             }
+        }
+
+        public static void CallLib()
+        {
+            Lib.Print();
         }
     }
 }

--- a/test/TestAssets/TestProjects/WatchAppWithProjectDeps/Dependency/Foo.cs
+++ b/test/TestAssets/TestProjects/WatchAppWithProjectDeps/Dependency/Foo.cs
@@ -4,5 +4,6 @@ public class Lib
 {
     public static void Print()
     {
+        System.Console.WriteLine("<Lib>");
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
@@ -90,15 +91,15 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         return await startOp(cancellationToken);
     }
 
-    private RunningWatcher StartWatcher(TestAsset testAsset, string[] args, string workingDirectory, string projectPath, SemaphoreSlim? fileChangesCompleted = null)
+    private RunningWatcher StartWatcher(TestAsset testAsset, string[] args, string? workingDirectory = null)
     {
         var console = new TestConsole(Logger);
         var reporter = new TestReporter(Logger);
-        var environmentOptions = TestOptions.GetEnvironmentOptions(workingDirectory, TestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset);
+        var environmentOptions = TestOptions.GetEnvironmentOptions(workingDirectory ?? testAsset.Path, TestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset);
         var processRunner = new ProcessRunner(environmentOptions.ProcessCleanupTimeout);
 
         var program = Program.TryCreate(
-           TestOptions.GetCommandLineOptions(["--verbose", ..args, "--project", projectPath]),
+           TestOptions.GetCommandLineOptions(["--verbose", ..args]),
            console,
            environmentOptions,
            reporter,
@@ -154,7 +155,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var libProject = Path.Combine(libDir, "Lib.csproj");
         var libSource = Path.Combine(libDir, "Lib.cs");
 
-        await using var w = StartWatcher(testAsset, ["--non-interactive"], workingDirectory, hostProject);
+        await using var w = StartWatcher(testAsset, ["--non-interactive", "--project", hostProject], workingDirectory);
 
         var launchCompletionA = w.CreateCompletionSource();
         var launchCompletionB = w.CreateCompletionSource();
@@ -317,7 +318,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var libProject = Path.Combine(libDir, "Lib.csproj");
         var libSource = Path.Combine(libDir, "Lib.cs");
 
-        await using var w = StartWatcher(testAsset, ["--non-interactive"], workingDirectory, hostProject);
+        await using var w = StartWatcher(testAsset, ["--non-interactive", "--project", hostProject], workingDirectory);
 
         var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
         var changeHandled = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadChangeHandled);
@@ -407,7 +408,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var libProject = Path.Combine(testAsset.Path, "Lib2", "Lib2.csproj");
         var lib = Path.Combine(testAsset.Path, "Lib2", "Lib2.cs");
 
-        await using var w = StartWatcher(testAsset, args: [], workingDirectory, hostProject);
+        await using var w = StartWatcher(testAsset, args: ["--project", hostProject], workingDirectory);
 
         var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
         var changeHandled = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadChangeHandled);
@@ -496,7 +497,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var serviceSourceA2 = Path.Combine(serviceDirA, "A2.cs");
         var serviceProjectA = Path.Combine(serviceDirA, "A.csproj");
 
-        await using var w = StartWatcher(testAsset, ["--non-interactive"], workingDirectory, hostProject);
+        await using var w = StartWatcher(testAsset, ["--non-interactive", "--project", hostProject], workingDirectory);
 
         var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
 
@@ -588,7 +589,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             }
         }
 
-        await using var w = StartWatcher(testAsset, ["--no-exit"], workingDirectory, workingDirectory);
+        await using var w = StartWatcher(testAsset, ["--no-exit"], workingDirectory);
 
         var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
         var changeHandled = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadChangeHandled);
@@ -646,7 +647,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var projectPath = Path.Combine(testAsset.Path, "WatchHotReloadApp.csproj");
         var programPath = Path.Combine(testAsset.Path, "Program.cs");
 
-        await using var w = StartWatcher(testAsset, [], workingDirectory, projectPath);
+        await using var w = StartWatcher(testAsset, [], workingDirectory);
 
         var fileChangesCompleted = w.CreateCompletionSource();
         w.Watcher.Test_FileChangesCompletedTask = fileChangesCompleted.Task;
@@ -664,7 +665,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             }
         };
 
-        // let the host process start:
+        // start process:
         Log("Waiting for changes...");
         await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
 
@@ -681,5 +682,131 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
         Log("Waiting for output 'System.Xml.Linq.XDocument'...");
         await hasUpdatedOutput.Task;
+    }
+
+    [Fact]
+    public async Task ProjectAndSourceFileChange_AddProjectReference()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
+            .WithSource()
+            .WithProjectChanges(project =>
+            {
+                foreach (var r in project.Root!.Descendants().Where(e => e.Name.LocalName == "ProjectReference").ToArray())
+                {
+                    r.Remove();
+                }
+            });
+
+        var appProjDir = Path.Combine(testAsset.Path, "AppWithDeps");
+        var appProjFile = Path.Combine(appProjDir, "App.WithDeps.csproj");
+        var appFile = Path.Combine(appProjDir, "Program.cs");
+
+        UpdateSourceFile(appFile, code => code.Replace("Lib.Print();", "// Lib.Print();"));
+
+        await using var w = StartWatcher(testAsset, [], appProjDir);
+
+        var fileChangesCompleted = w.CreateCompletionSource();
+        w.Watcher.Test_FileChangesCompletedTask = fileChangesCompleted.Task;
+
+        var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
+        var projectChangeTriggeredReEvaluation = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectChangeTriggeredReEvaluation);
+        var projectsRebuilt = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectsRebuilt);
+        var projectDependenciesDeployed = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectDependenciesDeployed);
+        var hotReloadSucceeded = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadSucceeded);
+
+        var hasUpdatedOutput = w.CreateCompletionSource();
+        w.Reporter.OnProcessOutput += line =>
+        {
+            if (line.Content.Contains("<Lib>"))
+            {
+                hasUpdatedOutput.TrySetResult();
+            }
+        };
+
+        // start process:
+        Log("Waiting for changes...");
+        await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
+
+        // change the project and source files at the same time:
+
+        UpdateSourceFile(appProjFile, src => src.Replace("""
+            <ItemGroup />
+            """, """
+            <ItemGroup>
+                <ProjectReference Include="..\Dependency\Dependency.csproj" />
+            </ItemGroup>
+            """));
+
+        UpdateSourceFile(appFile, code => code.Replace("// Lib.Print();", "Lib.Print();"));
+
+        // done updating files:
+        fileChangesCompleted.TrySetResult();
+
+        Log("Waiting for output '<Lib>'...");
+        await hasUpdatedOutput.Task;
+
+        AssertEx.ContainsSubstring("Resolving 'Dependency, Version=1.0.0.0'", w.Reporter.ProcessOutput);
+
+        Assert.Equal(1, projectChangeTriggeredReEvaluation.CurrentCount);
+        Assert.Equal(1, projectsRebuilt.CurrentCount);
+        Assert.Equal(1, projectDependenciesDeployed.CurrentCount);
+        Assert.Equal(1, hotReloadSucceeded.CurrentCount);
+    }
+
+    [Fact]
+    public async Task ProjectAndSourceFileChange_AddPackageReference()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
+            .WithSource();
+
+        var projFilePath = Path.Combine(testAsset.Path, "WatchHotReloadApp.csproj");
+        var programFilePath = Path.Combine(testAsset.Path, "Program.cs");
+
+        await using var w = StartWatcher(testAsset, []);
+
+        var fileChangesCompleted = w.CreateCompletionSource();
+        w.Watcher.Test_FileChangesCompletedTask = fileChangesCompleted.Task;
+
+        var waitingForChanges = w.Reporter.RegisterSemaphore(MessageDescriptor.WaitingForChanges);
+        var projectChangeTriggeredReEvaluation = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectChangeTriggeredReEvaluation);
+        var projectsRebuilt = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectsRebuilt);
+        var projectDependenciesDeployed = w.Reporter.RegisterSemaphore(MessageDescriptor.ProjectDependenciesDeployed);
+        var hotReloadSucceeded = w.Reporter.RegisterSemaphore(MessageDescriptor.HotReloadSucceeded);
+
+        var hasUpdatedOutput = w.CreateCompletionSource();
+        w.Reporter.OnProcessOutput += line =>
+        {
+            if (line.Content.Contains("Newtonsoft.Json.Linq.JToken"))
+            {
+                hasUpdatedOutput.TrySetResult();
+            }
+        };
+
+        // start process:
+        Log("Waiting for changes...");
+        await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
+
+        // change the project and source files at the same time:
+
+        UpdateSourceFile(projFilePath, source => source.Replace("""
+            <!-- items placeholder -->
+            """, """
+            <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+            """));
+
+        UpdateSourceFile(programFilePath, source => source.Replace("Console.WriteLine(\".\");", "Console.WriteLine(typeof(Newtonsoft.Json.Linq.JToken));"));
+
+        // done updating files:
+        fileChangesCompleted.TrySetResult();
+
+        Log("Waiting for output 'Newtonsoft.Json.Linq.JToken'...");
+        await hasUpdatedOutput.Task;
+
+        AssertEx.ContainsSubstring("Resolving 'Newtonsoft.Json, Version=13.0.0.0'", w.Reporter.ProcessOutput);
+
+        Assert.Equal(1, projectChangeTriggeredReEvaluation.CurrentCount);
+        Assert.Equal(0, projectsRebuilt.CurrentCount);
+        Assert.Equal(1, projectDependenciesDeployed.CurrentCount);
+        Assert.Equal(1, hotReloadSucceeded.CurrentCount);
     }
 }


### PR DESCRIPTION
Adding a package or project reference requires the following steps:
1) Roslyn validating that the change is allowed (e.g. changing version of preexisting dependency is not allowed since we replace assembly that's already loaded with a new one).
2) Roslyn determines which projects need redeployment and returns the set in ModuleUpdates (along with projects to rebuild/restart).
Redeploying means copying dependencies that were added via package/project reference. These dlls are not present in output directory and need to be copied there.
dotnet-watch executes `ReferenceCopyLocalPathsOutputGroup` target on these projects.
3) At runtime the DotNetDeltaApplier needs to implement AssemblyResolving event that loads the new dependencies. These are not automatically loaded by the runtime since they were not present in the .deps.json file when the app launched.

We also need to move managed code update application after dependencies have been built and deployed, otherwise the updated code might start calling to the dependency that's not deployed yet.