### PR TITLE
Strip all package types from inner multi-rid tool packages so they don't appear on search-based experiences

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -380,12 +380,18 @@ NOTE: This file is imported from the following contexts, so be aware when writin
        PackageType = 'MyDotnetTool'         -> 'DotnetTool;MyDotnetTool'
 
     _PaddedPackageType is used to ensure that the PackageType is semicolon delimited and can be easily checked for an existing DotnetTool package type.
+
+    All of this should only apply for the 'outer' tool package - the 'inner' RID-specific tool packages are always of type DotnetToolRidPackage.
+    This is so that the inner packages do not appear on any tool search results.
     -->
 
-    <AddPackageType CurrentPackageType="$(PackageType)" PackageTypeToAdd="$(_ToolPackageType)">
+    <AddPackageType Condition="$(_ToolPackageType) = 'DotnetTool'" CurrentPackageType="$(PackageType)" PackageTypeToAdd="$(_ToolPackageType)">
       <Output TaskParameter="UpdatedPackageType" PropertyName="PackageType" />
     </AddPackageType>
 
+    <PropertyGroup Condition="$(_ToolPackageType) = 'DotnetToolRidPackage'">
+      <PackageType>DotnetToolRidPackage</PackageType>
+    </PropertyGroup>
   </Target>
 
   <!-- Orchestrator for making the N RID-specific tool packages if this Tool supports that mode.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -385,11 +385,11 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     This is so that the inner packages do not appear on any tool search results.
     -->
 
-    <AddPackageType Condition="$(_ToolPackageType) = 'DotnetTool'" CurrentPackageType="$(PackageType)" PackageTypeToAdd="$(_ToolPackageType)">
+    <AddPackageType Condition="$(_ToolPackageType) == 'DotnetTool'" CurrentPackageType="$(PackageType)" PackageTypeToAdd="$(_ToolPackageType)">
       <Output TaskParameter="UpdatedPackageType" PropertyName="PackageType" />
     </AddPackageType>
 
-    <PropertyGroup Condition="$(_ToolPackageType) = 'DotnetToolRidPackage'">
+    <PropertyGroup Condition="$(_ToolPackageType) == 'DotnetToolRidPackage'">
       <PackageType>DotnetToolRidPackage</PackageType>
     </PropertyGroup>
   </Target>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 RidSpecific = true,
                 AdditionalPackageTypes = ["TestPackageType"]
             };
-            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings);
+            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings, collectBinlogs: true);
 
             var packages = Directory.GetFiles(toolPackagesPath, "*.nupkg");
             var packageIdentifier = toolSettings.ToolPackageId;

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -71,10 +71,10 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 {
                     builder.Append("-no-current-rid");
                 }
-                if (AdditionalPackageTypes is [] packages && packages.Length > 0)
+                if (AdditionalPackageTypes is not null && AdditionalPackageTypes.Length > 0)
                 {
                     builder.Append('-');
-                    builder.Append(string.Join("-", packages.Select(p => p.ToLowerInvariant())));
+                    builder.Append(string.Join("-", AdditionalPackageTypes.Select(p => p.ToLowerInvariant())));
                 }
 
                 return builder.ToString();
@@ -124,9 +124,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 testProject.AdditionalProperties["PublishTrimmed"] = "true";
             }
 
-            if (toolSettings.AdditionalPackageTypes is [] additionalPackageTypes && additionalPackageTypes.Length > 0)
+            if (toolSettings.AdditionalPackageTypes is not null && toolSettings.AdditionalPackageTypes.Length > 0)
             {
-                testProject.AdditionalProperties["PackageType"] = string.Join(";", additionalPackageTypes);
+                testProject.AdditionalProperties["PackageType"] = string.Join(";", toolSettings.AdditionalPackageTypes);
             }
 
             testProject.SourceFiles.Add("Program.cs", "Console.WriteLine(\"Hello Tool!\");");

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             public string ToolPackageId { get; set; } = "TestTool";
             public string ToolPackageVersion { get; set; } = "1.0.0";
             public string ToolCommandName { get; set; } = "TestTool";
+            public string[]? AdditionalPackageTypes { get; set; } = null;
 
             public bool NativeAOT { get; set { field = value; this.RidSpecific = value; } } = false;
             public bool SelfContained { get; set { field = value; this.RidSpecific = value; } } = false;
@@ -35,14 +36,55 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             public bool RidSpecific { get; set; } = false;
             public bool IncludeCurrentRid { get; set; } = true;
 
-            public string GetIdentifier() => $"{ToolPackageId}-{ToolPackageVersion}-{ToolCommandName}-{(NativeAOT ? "nativeaot" : SelfContained ? "selfcontained" : Trimmed ? "trimmed" : "managed")}{(RidSpecific ? "-specific" : "")}{(IncludeAnyRid ? "-anyrid" : "")}{(IncludeCurrentRid ? "" : "-no-current-rid")}";
+            public string GetIdentifier() {
+                var builder = new StringBuilder();
+                builder.Append(ToolPackageId.ToLowerInvariant());
+                builder.Append('-');
+                builder.Append(ToolPackageVersion.ToLowerInvariant());
+                builder.Append('-');
+                builder.Append(ToolCommandName.ToLowerInvariant());
+                if (NativeAOT)
+                {
+                    builder.Append("-nativeaot");
+                }
+                else if (SelfContained)
+                {
+                    builder.Append("-selfcontained");
+                }
+                else if (Trimmed)
+                {
+                    builder.Append("-trimmed");
+                }
+                else
+                {
+                    builder.Append("-managed");
+                }
+                if (RidSpecific)
+                {
+                    builder.Append("-specific");
+                }
+                if (IncludeAnyRid)
+                {
+                    builder.Append("-anyrid");
+                }
+                if (!IncludeCurrentRid)
+                {
+                    builder.Append("-no-current-rid");
+                }
+                if (AdditionalPackageTypes is [] packages && packages.Length > 0)
+                {
+                    builder.Append('-');
+                    builder.Append(string.Join("-", packages.Select(p => p.ToLowerInvariant())));
+                }
+
+                return builder.ToString();
+            }
         }
 
 
         public string CreateTestTool(ITestOutputHelper log, TestToolSettings toolSettings, bool collectBinlogs = false)
         {
             var targetDirectory = Path.Combine(TestContext.Current.TestExecutionDirectory, "TestTools", toolSettings.GetIdentifier());
-
 
             var testProject = new TestProject(toolSettings.ToolPackageId)
             {
@@ -80,6 +122,11 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             if (toolSettings.Trimmed)
             {
                 testProject.AdditionalProperties["PublishTrimmed"] = "true";
+            }
+
+            if (toolSettings.AdditionalPackageTypes is [] additionalPackageTypes && additionalPackageTypes.Length > 0)
+            {
+                testProject.AdditionalProperties["PackageType"] = string.Join(";", additionalPackageTypes);
             }
 
             testProject.SourceFiles.Add("Program.cs", "Console.WriteLine(\"Hello Tool!\");");


### PR DESCRIPTION
Fixes #49615

The outer tool package will have all package types (McpServer, DotnetTool), but the inner packages will just have DotnetToolRidPackage. This prevents experiences like the MCP registry, which search based on "has PackageType of McpServer", from reporting the inner packages.