### PR TITLE
use the sdk.paths mechanism from .NET 10p3

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -104,10 +104,10 @@ jobs:
         env:
           BuildConfig: $(buildConfiguration)
           TestFullMSBuild: ${{ parameters.testFullMSBuild }}
-          
+
       - powershell: build/RunTestTemplateTests.ps1
         displayName: 🟣 Run Test Templates Tests
-        
+
     - ${{ else }}:
       - script: |
           source $(Build.SourcesDirectory)/eng/common/native/init-os-and-arch.sh
@@ -137,6 +137,7 @@ jobs:
       - ${{ if eq(parameters.runAoTTests, true) }}:
         # For the reason this is here, see: https://github.com/dotnet/sdk/issues/22655
         - script: $(Build.SourcesDirectory)/artifacts/bin/redist/$(buildConfiguration)/dotnet/dotnet workload install wasm-tools --skip-manifest-update
+          workingDirectory: $(Build.SourcesDirectory)/artifacts
           displayName: 🟣 Install wasm-tools Workload
       # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
       - ${{ if eq(parameters.pool.os, 'windows') }}:

--- a/global.json
+++ b/global.json
@@ -1,4 +1,11 @@
 {
+  "sdk": {
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The .NET SDK is not installed or is not configured correctly. Please run ./build to install the correct SDK version locally."
+  },
   "tools": {
     "dotnet": "10.0.100-preview.6.25315.102",
     "runtimes": {

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -117,5 +117,4 @@
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(FullNugetVersion)" />
-
 </Project>

--- a/src/Layout/redist/targets/Directory.Build.targets
+++ b/src/Layout/redist/targets/Directory.Build.targets
@@ -21,6 +21,7 @@
     <Import Project="GenerateArchives.targets" />
 
     <Import Project="OverlaySdkOnLKG.targets" />
+    <Import Project="GenerateTestingGlobalJson.targets" />
   </ImportGroup>
 
   <!-- Installers -->

--- a/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
+++ b/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <_TestingGlobalJsonPath>$(ArtifactsTmpDir)global.json</_TestingGlobalJsonPath>
+    <!-- We put this in the root of the artifacts dir so that any usage (not just from ./tmp, but also from ./bin) gets redirected. -->
+    <_TestingGlobalJsonPath>$(ArtifactsDir)global.json</_TestingGlobalJsonPath>
   </PropertyGroup>
 
   <!-- Since the dotnet binary respects sdk.paths in global.json now, and we use this in the repo root to make sure that we consistently use the repo-local

--- a/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
+++ b/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
@@ -1,0 +1,32 @@
+<Project>
+  <PropertyGroup>
+    <_TestingGlobalJsonPath>$(ArtifactsTmpDir)global.json</_TestingGlobalJsonPath>
+  </PropertyGroup>
+
+  <!-- Since the dotnet binary respects sdk.paths in global.json now, and we use this in the repo root to make sure that we consistently use the repo-local
+       SDK for building/etc, we need to put something in place so that tests don't use the repo-local SDK and instead use the redist SDK. -->
+  <Target Name="CreateRedistGlobalJsonForTesting"
+    BeforeTargets="AfterBuild"
+    Outputs="$(_TestingGlobalJsonPath)">
+    <PropertyGroup>
+      <_TestingRedistDotnetPath>$(TestHostDotNetRoot.Replace('\', '\\'))</_TestingRedistDotnetPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_RedistGlobalJsonLines Include="{" />
+      <_RedistGlobalJsonLines Include="  &quot;sdk&quot;: {" />
+      <_RedistGlobalJsonLines Include="    &quot;paths&quot;: [" />
+      <_RedistGlobalJsonLines Include="      &quot;$(_TestingRedistDotnetPath)&quot;" />
+      <_RedistGlobalJsonLines Include="    ]" />
+      <_RedistGlobalJsonLines Include="  }" />
+      <_RedistGlobalJsonLines Include="}" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_TestingGlobalJsonPath)"
+                       Lines="@(_RedistGlobalJsonLines)"
+                       Overwrite="true"
+                       Encoding="utf-8"
+                       WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_TestingGlobalJsonPath)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
This makes it easier for editors and other tools to use the correct dotnet in more circumstances when working with this repo.

This mostly removes the need for the artifacts/sdk-build-env scripts.