### PR TITLE
enable binlog in dotnet test for projects eval

### DIFF
--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -245,7 +245,7 @@ internal static class SolutionAndProjectUtility
             // NOTE: BuildManager is singleton.
             lock (s_buildLock)
             {
-                if (!project.Build(s_computeRunArgumentsTarget, loggers: loggers))
+                if (!project.Build(s_computeRunArgumentsTarget, loggers: null))
                 {
                     Logger.LogTrace(() => $"The target {s_computeRunArgumentsTarget} failed to build. Falling back to TargetPath.");
                     return new RunProperties(project.GetPropertyValue(ProjectProperties.TargetPath), null, null);


### PR DESCRIPTION
This pull request introduces improvements to logging and project collection handling in the `dotnet test` command implementation. The key changes include adding a logger utility to manage binloggers and ensuring proper shutdown of loggers after use. Additionally, a minor adjustment removes loggers from a specific build operation to simplify the code.

### Logging Enhancements:
* [`src/Cli/dotnet/Commands/Test/MSBuildUtility.cs`](diffhunk://#diff-05ea5ed00051f6828498b8723feeff80803a2488831aebc1e6c6863355923e73R18-R19): Introduced a constant `dotnetTestVerb` for logger identification and added a `FacadeLogger` to manage binloggers during project collection creation. Ensured the logger shuts down properly after use. [[1]](diffhunk://#diff-05ea5ed00051f6828498b8723feeff80803a2488831aebc1e6c6863355923e73R18-R19) [[2]](diffhunk://#diff-05ea5ed00051f6828498b8723feeff80803a2488831aebc1e6c6863355923e73L33-R39) [[3]](diffhunk://#diff-05ea5ed00051f6828498b8723feeff80803a2488831aebc1e6c6863355923e73L49-R57)

### Code Simplification:
* [`src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs`](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L248-R248): Removed loggers from the `Build` method call in `GetRunProperties` to streamline the operation.