### PR TITLE
Make `dotnet project convert` interactive

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1501,31 +1501,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   <data name="ProjectConvertAppFullName" xml:space="preserve">
     <value>Convert a file-based program to a project-based program.</value>
   </data>
-  <data name="CmdOptionKeepSourceDescription" xml:space="preserve">
-    <value>Whether to keep source files intact (copy) or delete them after conversion (move).</value>
-  </data>
   <data name="ProjectConvertAskForOutputDirectory" xml:space="preserve">
     <value>Specify the output directory ({0}):</value>
     <comment>{0} is the default value</comment>
-  </data>
-  <data name="ProjectConvertAskForSourceFilesAction" xml:space="preserve">
-    <value>Source files action [{0}/{1}] ({0}):</value>
-    <comment>{0} is the copy action (the default choice). {1} is the move action.</comment>
-  </data>
-  <data name="ProjectConvertCopyAction" xml:space="preserve">
-    <value>copy</value>
-    <comment>One of the choices for the source files action. The user needs to type this to the console to select the option.</comment>
-  </data>
-  <data name="ProjectConvertMoveAction" xml:space="preserve">
-    <value>move</value>
-    <comment>One of the choices for the source files action. The user needs to type this to the console to select the option.</comment>
-  </data>
-  <data name="ProjectConvertInvalidSourceAction" xml:space="preserve">
-    <value>Please type '{0}' or '{1}'.</value>
-  </data>
-  <data name="ProjectConvertNeedsConfirmation" xml:space="preserve">
-    <value>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</value>
-    <comment>{Locked="--source"}</comment>
   </data>
   <data name="ProjectConvertDryRun" xml:space="preserve">
     <value>Determines changes without actually modifying the file system</value>
@@ -1538,9 +1516,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>Dry run: would copy file '{0}' to '{1}'.</value>
     <comment>{0} and {1} are file full paths.</comment>
   </data>
-  <data name="ProjectConvertWouldConvertAndMoveFile" xml:space="preserve">
-    <value>Dry run: would remove directives from file '{0}' and move it to '{1}'.</value>
-    <comment>{0} and {1} are file full paths.</comment>
+  <data name="ProjectConvertWouldConvertFile" xml:space="preserve">
+    <value>Dry run: would remove file-level directives from file: {0}</value>
+    <comment>{0} is the file full path.</comment>
   </data>
   <data name="ProjectConvertWouldMoveFile" xml:space="preserve">
     <value>Dry run: would move file '{0}' to '{1}'.</value>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1502,18 +1502,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>Convert a file-based program to a project-based program.</value>
   </data>
   <data name="CmdOptionKeepSourceDescription" xml:space="preserve">
-    <value>Whether to keep source files intact (otherwise, they are deleted after conversion).</value>
+    <value>Whether to keep source files intact (copy) or delete them after conversion (move).</value>
   </data>
   <data name="ProjectConvertAskForOutputDirectory" xml:space="preserve">
     <value>Specify the output directory ({0}):</value>
     <comment>{0} is the default value</comment>
   </data>
-  <data name="ProjectConvertConfirmKeepSourceFiles" xml:space="preserve">
-    <value>Keep source files?</value>
+  <data name="ProjectConvertAskForSourceFilesAction" xml:space="preserve">
+    <value>Source files action [{0}/{1}] ({0}):</value>
+    <comment>{0} is the copy action (the default choice). {1} is the move action.</comment>
+  </data>
+  <data name="ProjectConvertCopyAction" xml:space="preserve">
+    <value>copy</value>
+    <comment>One of the choices for the source files action. The user needs to type this to the console to select the option.</comment>
+  </data>
+  <data name="ProjectConvertMoveAction" xml:space="preserve">
+    <value>move</value>
+    <comment>One of the choices for the source files action. The user needs to type this to the console to select the option.</comment>
+  </data>
+  <data name="ProjectConvertInvalidSourceAction" xml:space="preserve">
+    <value>Please type '{0}' or '{1}'.</value>
   </data>
   <data name="ProjectConvertNeedsConfirmation" xml:space="preserve">
-    <value>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</value>
-    <comment>{Locked="--keep-source"}</comment>
+    <value>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</value>
+    <comment>{Locked="--source"}</comment>
   </data>
   <data name="ProjectManifest" xml:space="preserve">
     <value>PROJECT_MANIFEST</value>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1527,6 +1527,33 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</value>
     <comment>{Locked="--source"}</comment>
   </data>
+  <data name="ProjectConvertDryRun" xml:space="preserve">
+    <value>Determines changes without actually modifying the file system</value>
+  </data>
+  <data name="ProjectConvertWouldCreateDirectory" xml:space="preserve">
+    <value>Dry run: would create directory: {0}</value>
+    <comment>{0} is the directory full path.</comment>
+  </data>
+  <data name="ProjectConvertWouldCopyFile" xml:space="preserve">
+    <value>Dry run: would copy file '{0}' to '{1}'.</value>
+    <comment>{0} and {1} are file full paths.</comment>
+  </data>
+  <data name="ProjectConvertWouldConvertAndMoveFile" xml:space="preserve">
+    <value>Dry run: would remove directives from file '{0}' and move it to '{1}'.</value>
+    <comment>{0} and {1} are file full paths.</comment>
+  </data>
+  <data name="ProjectConvertWouldMoveFile" xml:space="preserve">
+    <value>Dry run: would move file '{0}' to '{1}'.</value>
+    <comment>{0} and {1} are file full paths.</comment>
+  </data>
+  <data name="ProjectConvertWouldDeleteFile" xml:space="preserve">
+    <value>Dry run: would delete file: {0}</value>
+    <comment>{0} is the file full path.</comment>
+  </data>
+  <data name="ProjectConvertWouldCreateFile" xml:space="preserve">
+    <value>Dry run: would create file: {0}</value>
+    <comment>{0} is the file full path.</comment>
+  </data>
   <data name="ProjectManifest" xml:space="preserve">
     <value>PROJECT_MANIFEST</value>
   </data>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1504,6 +1504,10 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   <data name="CmdOptionKeepSourceDescription" xml:space="preserve">
     <value>Whether to keep source files intact (otherwise, they are deleted after conversion).</value>
   </data>
+  <data name="ProjectConvertAskForOutputDirectory" xml:space="preserve">
+    <value>Specify the output directory ({0}):</value>
+    <comment>{0} is the default value</comment>
+  </data>
   <data name="ProjectConvertConfirmKeepSourceFiles" xml:space="preserve">
     <value>Keep source files?</value>
   </data>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1501,6 +1501,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   <data name="ProjectConvertAppFullName" xml:space="preserve">
     <value>Convert a file-based program to a project-based program.</value>
   </data>
+  <data name="CmdOptionKeepSourceDescription" xml:space="preserve">
+    <value>Whether to keep source files intact (otherwise, they are deleted after conversion).</value>
+  </data>
+  <data name="ProjectConvertConfirmKeepSourceFiles" xml:space="preserve">
+    <value>Keep source files?</value>
+  </data>
+  <data name="ProjectConvertNeedsConfirmation" xml:space="preserve">
+    <value>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</value>
+    <comment>{Locked="--keep-source"}</comment>
+  </data>
   <data name="ProjectManifest" xml:space="preserve">
     <value>PROJECT_MANIFEST</value>
   </data>

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -141,7 +141,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         bool? keepSourceFiles =
             _parseResult.HasOption(ProjectConvertCommandParser.KeepSourceOption)
             ? _parseResult.GetValue(ProjectConvertCommandParser.KeepSourceOption)
-            : InteractiveConsole.Confirm(CliCommandStrings.ProjectConvertConfirmKeepSourceFiles, _parseResult);
+            : InteractiveConsole.Confirm(CliCommandStrings.ProjectConvertConfirmKeepSourceFiles, _parseResult, acceptEscapeForFalse: false);
         return keepSourceFiles is { } value
             ? value
             : throw new GracefulException(CliCommandStrings.ProjectConvertNeedsConfirmation);

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -142,8 +142,6 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
             _parseResult.HasOption(ProjectConvertCommandParser.KeepSourceOption)
             ? _parseResult.GetValue(ProjectConvertCommandParser.KeepSourceOption)
             : InteractiveConsole.Confirm(CliCommandStrings.ProjectConvertConfirmKeepSourceFiles, _parseResult, acceptEscapeForFalse: false);
-        return keepSourceFiles is { } value
-            ? value
-            : throw new GracefulException(CliCommandStrings.ProjectConvertNeedsConfirmation);
+        return keepSourceFiles ?? throw new GracefulException(CliCommandStrings.ProjectConvertNeedsConfirmation);
     }
 }

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -136,7 +136,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
             }
             else
             {
-                File.Copy(source, target);
+                File.Move(source, target);
             }
         }
 

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
@@ -20,18 +20,6 @@ internal sealed class ProjectConvertCommandParser
         Arity = ArgumentArity.Zero,
     };
 
-    public static readonly Option<SourceAction?> SourceOption = new("--source")
-    {
-        Description = CliCommandStrings.CmdOptionKeepSourceDescription,
-        Arity = ArgumentArity.ExactlyOne,
-    };
-
-    public enum SourceAction
-    {
-        copy,
-        move,
-    }
-
     public static readonly Option<bool> DryRunOption = new("--dry-run")
     {
         Description = CliCommandStrings.ProjectConvertDryRun,
@@ -44,7 +32,6 @@ internal sealed class ProjectConvertCommandParser
         {
             FileArgument,
             SharedOptions.OutputOption,
-            SourceOption,
             ForceOption,
             CommonOptions.InteractiveOption(),
             DryRunOption,

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
@@ -32,6 +32,12 @@ internal sealed class ProjectConvertCommandParser
         move,
     }
 
+    public static readonly Option<bool> DryRunOption = new("--dry-run")
+    {
+        Description = CliCommandStrings.ProjectConvertDryRun,
+        Arity = ArgumentArity.Zero,
+    };
+
     public static Command GetCommand()
     {
         Command command = new("convert", CliCommandStrings.ProjectConvertAppFullName)
@@ -41,6 +47,7 @@ internal sealed class ProjectConvertCommandParser
             SourceOption,
             ForceOption,
             CommonOptions.InteractiveOption(),
+            DryRunOption,
         };
 
         command.SetAction((parseResult) => new ProjectConvertCommand(parseResult).Execute());

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
@@ -20,13 +20,21 @@ internal sealed class ProjectConvertCommandParser
         Arity = ArgumentArity.Zero,
     };
 
+    public static readonly Option<bool> KeepSourceOption = new("--keep-source")
+    {
+        Description = CliCommandStrings.CmdOptionKeepSourceDescription,
+        Arity = ArgumentArity.ZeroOrOne,
+    };
+
     public static Command GetCommand()
     {
         Command command = new("convert", CliCommandStrings.ProjectConvertAppFullName)
         {
             FileArgument,
             SharedOptions.OutputOption,
+            KeepSourceOption,
             ForceOption,
+            CommonOptions.InteractiveOption(),
         };
 
         command.SetAction((parseResult) => new ProjectConvertCommand(parseResult).Execute());

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommandParser.cs
@@ -20,11 +20,17 @@ internal sealed class ProjectConvertCommandParser
         Arity = ArgumentArity.Zero,
     };
 
-    public static readonly Option<bool> KeepSourceOption = new("--keep-source")
+    public static readonly Option<SourceAction?> SourceOption = new("--source")
     {
         Description = CliCommandStrings.CmdOptionKeepSourceDescription,
-        Arity = ArgumentArity.ZeroOrOne,
+        Arity = ArgumentArity.ExactlyOne,
     };
+
+    public enum SourceAction
+    {
+        copy,
+        move,
+    }
 
     public static Command GetCommand()
     {
@@ -32,7 +38,7 @@ internal sealed class ProjectConvertCommandParser
         {
             FileArgument,
             SharedOptions.OutputOption,
-            KeepSourceOption,
+            SourceOption,
             ForceOption,
             CommonOptions.InteractiveOption(),
         };

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -128,6 +128,6 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
     private bool UserAgreedToRunFromSource(PackageId packageId, NuGetVersion version, PackageSource source)
     {
         string promptMessage = string.Format(CliCommandStrings.ToolDownloadConfirmationPrompt, packageId, version.ToString(), source.Source);
-        return InteractiveConsole.Confirm(promptMessage, _parseResult);
+        return InteractiveConsole.Confirm(promptMessage, _parseResult) == true;
     }
 }

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -128,6 +128,6 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
     private bool UserAgreedToRunFromSource(PackageId packageId, NuGetVersion version, PackageSource source)
     {
         string promptMessage = string.Format(CliCommandStrings.ToolDownloadConfirmationPrompt, packageId, version.ToString(), source.Source);
-        return InteractiveConsole.Confirm(promptMessage, _parseResult) == true;
+        return InteractiveConsole.Confirm(promptMessage, _parseResult, acceptEscapeForFalse: true) == true;
     }
 }

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -30,7 +30,6 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
     private readonly string[] _addSource = result.GetValue(ToolExecuteCommandParser.AddSourceOption) ?? [];
     private readonly bool _interactive = result.GetValue(ToolExecuteCommandParser.InteractiveOption);
     private readonly VerbosityOptions _verbosity = result.GetValue(ToolExecuteCommandParser.VerbosityOption);
-    private readonly bool _yes = result.GetValue(ToolExecuteCommandParser.YesOption);
     private readonly IToolPackageDownloader _toolPackageDownloader = ToolPackageFactory.CreateToolPackageStoresAndDownloader().downloader;
 
     private readonly RestoreActionConfig _restoreActionConfig = new RestoreActionConfig(DisableParallel: result.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
@@ -128,47 +127,7 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
     private bool UserAgreedToRunFromSource(PackageId packageId, NuGetVersion version, PackageSource source)
     {
-        if (_yes)
-        {
-            return true;
-        }
-
-        if (!_interactive)
-        {
-            return false;
-        }
-
         string promptMessage = string.Format(CliCommandStrings.ToolDownloadConfirmationPrompt, packageId, version.ToString(), source.Source);
-
-        static string AddPromptOptions(string message)
-        {
-            return $"{message} [{CliCommandStrings.ConfirmationPromptYesValue}/{CliCommandStrings.ConfirmationPromptNoValue}] ({CliCommandStrings.ConfirmationPromptYesValue}): ";
-        }
-
-        Console.Write(AddPromptOptions(promptMessage));
-
-        static bool KeyMatches(ConsoleKeyInfo pressedKey, string valueKey)
-        {
-            //  Apparently you can't do invariant case insensitive comparison on a char directly, so we have to convert it to a string.
-            //  The resource string should be a single character, but we take the first character just to be sure.
-            return pressedKey.KeyChar.ToString().ToLowerInvariant().Equals(
-                    valueKey.ToLowerInvariant().Substring(0, 1));
-        }
-
-        while (true)
-        {
-            var key = Console.ReadKey();
-            Console.WriteLine();
-            if (key.Key == ConsoleKey.Enter || KeyMatches(key, CliCommandStrings.ConfirmationPromptYesValue))
-            {
-                return true;
-            }
-            if (key.Key == ConsoleKey.Escape || KeyMatches(key, CliCommandStrings.ConfirmationPromptNoValue))
-            {
-                return false;
-            }
-
-            Console.Write(AddPromptOptions(string.Format(CliCommandStrings.ConfirmationPromptInvalidChoiceMessage, CliCommandStrings.ConfirmationPromptYesValue, CliCommandStrings.ConfirmationPromptNoValue)));
-        }
+        return InteractiveConsole.Confirm(promptMessage, _parseResult);
     }
 }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -611,11 +611,6 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">Vynuťte převod i v případě, že existují chybné direktivy.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Vypíše balíčky, které mají novější verze. Nedá se kombinovat s možností --deprecated ani --vulnerable.</target>
@@ -2300,40 +2295,15 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -611,6 +611,11 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">Vynuťte převod i v případě, že existují chybné direktivy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Vypíše balíčky, které mají novější verze. Nedá se kombinovat s možností --deprecated ani --vulnerable.</target>
@@ -2289,6 +2294,16 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Umožňuje převést program na bázi souboru na program na bázi projektu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2310,6 +2310,11 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2295,6 +2295,11 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="translated">Umožňuje převést program na bázi souboru na program na bázi projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -612,8 +612,8 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -611,11 +611,6 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">Erzwingen Sie die Konvertierung, auch wenn falsch formatierte Direktiven vorhanden sind.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Listet Pakete mit neueren Versionen auf. Kann nicht mit den Optionen "--deprecated" oder "--vulnerable" kombiniert werden.</target>
@@ -2300,40 +2295,15 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -612,8 +612,8 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2295,6 +2295,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="translated">Konvertieren Sie ein dateibasiertes Programm in ein projektbasiertes Programm.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -611,6 +611,11 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">Erzwingen Sie die Konvertierung, auch wenn falsch formatierte Direktiven vorhanden sind.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Listet Pakete mit neueren Versionen auf. Kann nicht mit den Optionen "--deprecated" oder "--vulnerable" kombiniert werden.</target>
@@ -2289,6 +2294,16 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Konvertieren Sie ein dateibasiertes Programm in ein projektbasiertes Programm.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2310,6 +2310,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -611,11 +611,6 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">Forzar la conversión incluso si hay directivas con formato incorrecto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Muestra los paquetes que tienen versiones más recientes. No se puede combinar con las opciones '--deprecated" o "--vulnerable".</target>
@@ -2300,40 +2295,15 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -611,6 +611,11 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">Forzar la conversión incluso si hay directivas con formato incorrecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Muestra los paquetes que tienen versiones más recientes. No se puede combinar con las opciones '--deprecated" o "--vulnerable".</target>
@@ -2289,6 +2294,16 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Convertir un programa basado en archivos en un programa basado en proyecto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2295,6 +2295,11 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="translated">Convertir un programa basado en archivos en un programa basado en proyecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -612,8 +612,8 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2310,6 +2310,11 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -611,11 +611,6 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">Forcer la conversion même s’il existe des directives incorrectes.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Liste les packages qui ont versions plus récentes. Impossible à combiner avec les options '--deprecated' ou '--vulnerable'.</target>
@@ -2300,40 +2295,15 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -612,8 +612,8 @@ Cela équivaut à supprimer project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -611,6 +611,11 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">Forcer la conversion même s’il existe des directives incorrectes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Liste les packages qui ont versions plus récentes. Impossible à combiner avec les options '--deprecated' ou '--vulnerable'.</target>
@@ -2289,6 +2294,16 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Convertissez un programme basé sur des fichiers en programme basé sur un projet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2295,6 +2295,11 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="translated">Convertissez un programme basé sur des fichiers en programme basé sur un projet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2310,6 +2310,11 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -611,11 +611,6 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">Forza la conversione anche in presenza di direttive non valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Elenca i pacchetti con versioni più recenti. Non può essere combinato con l'opzione '--deprecated' o '--vulnerable'.</target>
@@ -2300,40 +2295,15 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2310,6 +2310,11 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -611,6 +611,11 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">Forza la conversione anche in presenza di direttive non valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Elenca i pacchetti con versioni più recenti. Non può essere combinato con l'opzione '--deprecated' o '--vulnerable'.</target>
@@ -2289,6 +2294,16 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Converti un programma basato su file in un programma basato su progetto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2295,6 +2295,11 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="translated">Converti un programma basato su file in un programma basato su progetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -612,8 +612,8 @@ Equivale a eliminare project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -611,11 +611,6 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">形式に誤りがあるディレクティブがある場合でも、強制的に変換します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">新しいバージョンのパッケージを一覧表示します。'--deprecated' または '--vulnerable' オプションと組み合わせることはできません。</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -611,6 +611,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">形式に誤りがあるディレクティブがある場合でも、強制的に変換します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">新しいバージョンのパッケージを一覧表示します。'--deprecated' または '--vulnerable' オプションと組み合わせることはできません。</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">ファイルベースのプログラムをプロジェクトベースのプログラムに変換します。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -612,8 +612,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">ファイルベースのプログラムをプロジェクトベースのプログラムに変換します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -611,11 +611,6 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">잘못된 형식의 지시문이 있는 경우에도 강제로 변환합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">최신 버전이 포함된 패키지를 나열합니다. '--deprecated' 또는 '--vulnerable' 옵션과 함께 사용할 수 없습니다.</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">파일 기반 프로그램을 프로젝트 기반 프로그램으로 변환합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -611,6 +611,11 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">잘못된 형식의 지시문이 있는 경우에도 강제로 변환합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">최신 버전이 포함된 패키지를 나열합니다. '--deprecated' 또는 '--vulnerable' 옵션과 함께 사용할 수 없습니다.</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">파일 기반 프로그램을 프로젝트 기반 프로그램으로 변환합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -612,8 +612,8 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -611,11 +611,6 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">Wymuś konwersję, nawet jeśli istnieją źle sformułowane dyrektywy.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Wyświetla pakiety, które mają nowszą wersję. Nie można łączyć z opcją „--deprecated” ani „--vulnerable”.</target>
@@ -2300,40 +2295,15 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -612,8 +612,8 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2295,6 +2295,11 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="translated">Konwertuj program oparty na plikach na program oparty na projekcie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2310,6 +2310,11 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -611,6 +611,11 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">Wymuś konwersję, nawet jeśli istnieją źle sformułowane dyrektywy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Wyświetla pakiety, które mają nowszą wersję. Nie można łączyć z opcją „--deprecated” ani „--vulnerable”.</target>
@@ -2289,6 +2294,16 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Konwertuj program oparty na plikach na program oparty na projekcie.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -611,11 +611,6 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">Forçar conversão mesmo se houver diretivas malformadas.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Lista os pacotes que têm versões mais recentes. Não pode ser combinado com a opção '--deprecated' nem com a opção '--vulnerable'.</target>
@@ -2300,40 +2295,15 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -611,6 +611,11 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">Forçar conversão mesmo se houver diretivas malformadas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Lista os pacotes que têm versões mais recentes. Não pode ser combinado com a opção '--deprecated' nem com a opção '--vulnerable'.</target>
@@ -2289,6 +2294,16 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Converta um programa baseado em arquivo em um programa baseado em projeto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2295,6 +2295,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="translated">Converta um programa baseado em arquivo em um programa baseado em projeto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2310,6 +2310,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -612,8 +612,8 @@ Isso equivale a excluir o project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -611,11 +611,6 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">Принудительно выполнять преобразование, даже если имеются неправильно сформированные директивы.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Возвращает список пакетов, у которых есть более новые версии. Не может использоваться с параметрами "--deprecated" или "--vulnerable".</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">Преобразование программы на основе файла в программу на основе проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -612,8 +612,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -611,6 +611,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">Принудительно выполнять преобразование, даже если имеются неправильно сформированные директивы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Возвращает список пакетов, у которых есть более новые версии. Не может использоваться с параметрами "--deprecated" или "--vulnerable".</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Преобразование программы на основе файла в программу на основе проекта.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -611,11 +611,6 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">Hatalı biçimlendirilmiş yönergeler olsa bile dönüştürmeye zorlar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Daha yeni sürümlere sahip paketleri listeler. '--deprecated' veya '--vulnerable' seçenekleriyle birleştirilemez.</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -612,8 +612,8 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -611,6 +611,11 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">Hatalı biçimlendirilmiş yönergeler olsa bile dönüştürmeye zorlar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">Daha yeni sürümlere sahip paketleri listeler. '--deprecated' veya '--vulnerable' seçenekleriyle birleştirilemez.</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">Dosya tabanlı bir programı proje tabanlı bir programa dönüştür.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">Dosya tabanlı bir programı proje tabanlı bir programa dönüştür.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -611,11 +611,6 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">即使存在格式不正确的指令，也强制执行转换。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出具有较新版本的包。不能与 "--deprecated" 或 "--vulnerable" 选项结合使用。</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -611,6 +611,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">即使存在格式不正确的指令，也强制执行转换。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出具有较新版本的包。不能与 "--deprecated" 或 "--vulnerable" 选项结合使用。</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">将基于文件的程序转换为基于项目的程序。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">将基于文件的程序转换为基于项目的程序。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -612,8 +612,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -611,11 +611,6 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">即使提示詞格式錯誤，仍強制執行轉換。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
-        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出有更新版本的套件。無法與 '--deprecated' 或 '--vulnerable' 選項一併使用。</target>
@@ -2300,40 +2295,15 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertAskForSourceFilesAction">
-        <source>Source files action [{0}/{1}] ({0}):</source>
-        <target state="new">Source files action [{0}/{1}] ({0}):</target>
-        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertCopyAction">
-        <source>copy</source>
-        <target state="new">copy</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
       <trans-unit id="ProjectConvertDryRun">
         <source>Determines changes without actually modifying the file system</source>
         <target state="new">Determines changes without actually modifying the file system</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectConvertInvalidSourceAction">
-        <source>Please type '{0}' or '{1}'.</source>
-        <target state="new">Please type '{0}' or '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectConvertMoveAction">
-        <source>move</source>
-        <target state="new">move</target>
-        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
-        <note>{Locked="--source"}</note>
-      </trans-unit>
-      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
-        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
-        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
-        <note>{0} and {1} are file full paths.</note>
+      <trans-unit id="ProjectConvertWouldConvertFile">
+        <source>Dry run: would remove file-level directives from file: {0}</source>
+        <target state="new">Dry run: would remove file-level directives from file: {0}</target>
+        <note>{0} is the file full path.</note>
       </trans-unit>
       <trans-unit id="ProjectConvertWouldCopyFile">
         <source>Dry run: would copy file '{0}' to '{1}'.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2295,6 +2295,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">將檔案型程式轉換成專案型程式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertAskForOutputDirectory">
+        <source>Specify the output directory ({0}):</source>
+        <target state="new">Specify the output directory ({0}):</target>
+        <note>{0} is the default value</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
         <source>Keep source files?</source>
         <target state="new">Keep source files?</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -612,8 +612,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdOptionKeepSourceDescription">
-        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
-        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <source>Whether to keep source files intact (copy) or delete them after conversion (move).</source>
+        <target state="new">Whether to keep source files intact (copy) or delete them after conversion (move).</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
@@ -2300,15 +2300,30 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">Specify the output directory ({0}):</target>
         <note>{0} is the default value</note>
       </trans-unit>
-      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
-        <source>Keep source files?</source>
-        <target state="new">Keep source files?</target>
+      <trans-unit id="ProjectConvertAskForSourceFilesAction">
+        <source>Source files action [{0}/{1}] ({0}):</source>
+        <target state="new">Source files action [{0}/{1}] ({0}):</target>
+        <note>{0} is the copy action (the default choice). {1} is the move action.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertCopyAction">
+        <source>copy</source>
+        <target state="new">copy</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertInvalidSourceAction">
+        <source>Please type '{0}' or '{1}'.</source>
+        <target state="new">Please type '{0}' or '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectConvertMoveAction">
+        <source>move</source>
+        <target state="new">move</target>
+        <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
+      </trans-unit>
       <trans-unit id="ProjectConvertNeedsConfirmation">
-        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
-        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
-        <note>{Locked="--keep-source"}</note>
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
+        <note>{Locked="--source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2310,6 +2310,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">copy</target>
         <note>One of the choices for the source files action. The user needs to type this to the console to select the option.</note>
       </trans-unit>
+      <trans-unit id="ProjectConvertDryRun">
+        <source>Determines changes without actually modifying the file system</source>
+        <target state="new">Determines changes without actually modifying the file system</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectConvertInvalidSourceAction">
         <source>Please type '{0}' or '{1}'.</source>
         <target state="new">Please type '{0}' or '{1}'.</target>
@@ -2324,6 +2329,36 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</source>
         <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--source" command-line option to confirm.</target>
         <note>{Locked="--source"}</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldConvertAndMoveFile">
+        <source>Dry run: would remove directives from file '{0}' and move it to '{1}'.</source>
+        <target state="new">Dry run: would remove directives from file '{0}' and move it to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCopyFile">
+        <source>Dry run: would copy file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would copy file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateDirectory">
+        <source>Dry run: would create directory: {0}</source>
+        <target state="new">Dry run: would create directory: {0}</target>
+        <note>{0} is the directory full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldCreateFile">
+        <source>Dry run: would create file: {0}</source>
+        <target state="new">Dry run: would create file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldDeleteFile">
+        <source>Dry run: would delete file: {0}</source>
+        <target state="new">Dry run: would delete file: {0}</target>
+        <note>{0} is the file full path.</note>
+      </trans-unit>
+      <trans-unit id="ProjectConvertWouldMoveFile">
+        <source>Dry run: would move file '{0}' to '{1}'.</source>
+        <target state="new">Dry run: would move file '{0}' to '{1}'.</target>
+        <note>{0} and {1} are file full paths.</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -611,6 +611,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">即使提示詞格式錯誤，仍強制執行轉換。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdOptionKeepSourceDescription">
+        <source>Whether to keep source files intact (otherwise, they are deleted after conversion).</source>
+        <target state="new">Whether to keep source files intact (otherwise, they are deleted after conversion).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutdatedDescription">
         <source>Lists packages that have newer versions. Cannot be combined with '--deprecated' or '--vulnerable' options.</source>
         <target state="translated">列出有更新版本的套件。無法與 '--deprecated' 或 '--vulnerable' 選項一併使用。</target>
@@ -2289,6 +2294,16 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <source>Convert a file-based program to a project-based program.</source>
         <target state="translated">將檔案型程式轉換成專案型程式。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertConfirmKeepSourceFiles">
+        <source>Keep source files?</source>
+        <target state="new">Keep source files?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectConvertNeedsConfirmation">
+        <source>Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</source>
+        <target state="new">Conversion command needs to confirm whether to keep source files. Run in interactive mode or use the "--keep-source" command-line option to confirm.</target>
+        <note>{Locked="--keep-source"}</note>
       </trans-unit>
       <trans-unit id="ProjectManifest">
         <source>PROJECT_MANIFEST</source>

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -240,6 +240,8 @@ internal static class CommonOptions
     private static bool IsCIEnvironmentOrRedirected() =>
         new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment() || Console.IsOutputRedirected;
 
+    public const string InteractiveOptionName = "--interactive";
+
     /// <summary>
     /// A 'template' for interactive usage across the whole dotnet CLI. Use this as a base and then specialize it for your use cases.
     /// Despite being a 'forwarded option' there is no default forwarding configured, so if you want forwarding you can add it on a per-command basis.
@@ -250,7 +252,7 @@ internal static class CommonOptions
     /// If this is set to function as a flag, then there is no simple user-provided way to circumvent the behavior.
     /// </remarks>
     public static ForwardedOption<bool> InteractiveOption(bool acceptArgument = false) =>
-        new("--interactive")
+        new(InteractiveOptionName)
         {
             Description = CliStrings.CommandInteractiveOptionDescription,
             Arity = acceptArgument ? ArgumentArity.ZeroOrOne : ArgumentArity.Zero,

--- a/src/Cli/dotnet/CommonOptions.cs
+++ b/src/Cli/dotnet/CommonOptions.cs
@@ -241,11 +241,6 @@ internal static class CommonOptions
         new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment() || Console.IsOutputRedirected;
 
     /// <summary>
-    /// The interactive option is cached so utilities like <see cref="InteractiveConsole"/> can refer to the same instance.
-    /// </summary>
-    private static ForwardedOption<bool>? s_interactiveOptionWithoutArgument, s_interactiveOptionWithArgument;
-
-    /// <summary>
     /// A 'template' for interactive usage across the whole dotnet CLI. Use this as a base and then specialize it for your use cases.
     /// Despite being a 'forwarded option' there is no default forwarding configured, so if you want forwarding you can add it on a per-command basis.
     /// </summary>
@@ -254,17 +249,14 @@ internal static class CommonOptions
     /// If not set by a user, this will default to true if the user is not in a CI environment as detected by <see cref="Telemetry.CIEnvironmentDetectorForTelemetry.IsCIEnvironment"/>.
     /// If this is set to function as a flag, then there is no simple user-provided way to circumvent the behavior.
     /// </remarks>
-    public static ForwardedOption<bool> InteractiveOption(bool acceptArgument = false)
-    {
-        ref ForwardedOption<bool>? optionRef = ref acceptArgument ? ref s_interactiveOptionWithArgument : ref s_interactiveOptionWithoutArgument;
-        return optionRef ??= new("--interactive")
+    public static ForwardedOption<bool> InteractiveOption(bool acceptArgument = false) =>
+        new("--interactive")
         {
             Description = CliStrings.CommandInteractiveOptionDescription,
             Arity = acceptArgument ? ArgumentArity.ZeroOrOne : ArgumentArity.Zero,
             // this default is called when no tokens/options are passed on the CLI args
             DefaultValueFactory = (ar) => !IsCIEnvironmentOrRedirected()
         };
-    }
 
     public static Option<bool> InteractiveMsBuildForwardOption = InteractiveOption(acceptArgument: true).ForwardAsSingle(b => $"--property:NuGetInteractive={(b ? "true" : "false")}");
 

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -57,4 +57,29 @@ public static class InteractiveConsole
                 valueKey.ToLowerInvariant().Substring(0, 1));
         }
     }
+
+    public static string? Ask(string question, ParseResult parseResult, Func<string?, string?> validate)
+    {
+        if (!parseResult.GetValue(CommonOptions.InteractiveOption()))
+        {
+            return null;
+        }
+
+        while (true)
+        {
+            Console.Write(question);
+            Console.Write(' ');
+
+            string? answer = Console.ReadLine();
+            answer = string.IsNullOrWhiteSpace(answer) ? null : answer.Trim();
+            if (validate(answer) is { } error)
+            {
+                Console.WriteLine(error);
+            }
+            else
+            {
+                return answer;
+            }
+        }
+    }
 }

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli;
 
 public static class InteractiveConsole
 {
-    public static bool Confirm(string message, ParseResult parseResult)
+    public static bool? Confirm(string message, ParseResult parseResult)
     {
         if (parseResult.GetValue(CommonOptions.YesOption))
         {
@@ -17,7 +17,7 @@ public static class InteractiveConsole
 
         if (!parseResult.GetValue(CommonOptions.InteractiveOption()))
         {
-            return false;
+            return null;
         }
 
         Console.Write(AddPromptOptions(message));

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -25,7 +25,7 @@ public static class InteractiveConsole
             return true;
         }
 
-        if (!parseResult.GetValue(CommonOptions.InteractiveOption()))
+        if (!parseResult.GetValue<bool>(CommonOptions.InteractiveOptionName))
         {
             return null;
         }
@@ -75,7 +75,7 @@ public static class InteractiveConsole
         Validator<TResult> validate,
         out TResult? result)
     {
-        if (!parseResult.GetValue(CommonOptions.InteractiveOption()))
+        if (!parseResult.GetValue<bool>(CommonOptions.InteractiveOptionName))
         {
             result = default;
             return false;

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.Commands;
+
+namespace Microsoft.DotNet.Cli;
+
+public static class InteractiveConsole
+{
+    public static bool Confirm(string message, ParseResult parseResult)
+    {
+        if (parseResult.GetValue(CommonOptions.YesOption))
+        {
+            return true;
+        }
+
+        if (!parseResult.GetValue(CommonOptions.InteractiveOption()))
+        {
+            return false;
+        }
+
+        Console.Write(AddPromptOptions(message));
+
+        while (true)
+        {
+            var key = Console.ReadKey();
+            Console.WriteLine();
+
+            if (key.Key == ConsoleKey.Enter || KeyMatches(key, CliCommandStrings.ConfirmationPromptYesValue))
+            {
+                return true;
+            }
+
+            if (key.Key == ConsoleKey.Escape || KeyMatches(key, CliCommandStrings.ConfirmationPromptNoValue))
+            {
+                return false;
+            }
+
+            Console.Write(AddPromptOptions(string.Format(CliCommandStrings.ConfirmationPromptInvalidChoiceMessage, CliCommandStrings.ConfirmationPromptYesValue, CliCommandStrings.ConfirmationPromptNoValue)));
+        }
+
+        static string AddPromptOptions(string message)
+        {
+            return $"{message} [{CliCommandStrings.ConfirmationPromptYesValue}/{CliCommandStrings.ConfirmationPromptNoValue}] ({CliCommandStrings.ConfirmationPromptYesValue}): ";
+        }
+
+        static bool KeyMatches(ConsoleKeyInfo pressedKey, string valueKey)
+        {
+            //  Apparently you can't do invariant case insensitive comparison on a char directly, so we have to convert it to a string.
+            //  The resource string should be a single character, but we take the first character just to be sure.
+            return pressedKey.KeyChar.ToString().ToLowerInvariant().Equals(
+                valueKey.ToLowerInvariant().Substring(0, 1));
+        }
+    }
+}

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -13,6 +13,11 @@ public static class InteractiveConsole
     /// If you need to confirm an action, Escape means "cancel" and that is fine.
     /// If you need an answer where the "no" might mean something dangerous, Escape should not be used as implicit "no".
     /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the user confirmed the action,
+    /// <see langword="false"/> if the user declined it,
+    /// <see langword="null"/> if the user could not answer because <c>--no-interactive</c> was specified.
+    /// </returns>
     public static bool? Confirm(string message, ParseResult parseResult, bool acceptEscapeForFalse)
     {
         if (parseResult.GetValue(CommonOptions.YesOption))

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -8,7 +8,11 @@ namespace Microsoft.DotNet.Cli;
 
 public static class InteractiveConsole
 {
-    public static bool? Confirm(string message, ParseResult parseResult)
+    /// <param name="acceptEscapeForFalse">
+    /// If you need to confirm an action, Escape means "cancel" and that is fine.
+    /// If you need an answer where the "no" might mean something dangerous, Escape should not be used as implicit "no".
+    /// </param>
+    public static bool? Confirm(string message, ParseResult parseResult, bool acceptEscapeForFalse)
     {
         if (parseResult.GetValue(CommonOptions.YesOption))
         {
@@ -32,7 +36,7 @@ public static class InteractiveConsole
                 return true;
             }
 
-            if (key.Key == ConsoleKey.Escape || KeyMatches(key, CliCommandStrings.ConfirmationPromptNoValue))
+            if ((acceptEscapeForFalse && key.Key == ConsoleKey.Escape) || KeyMatches(key, CliCommandStrings.ConfirmationPromptNoValue))
             {
                 return false;
             }

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -26,14 +26,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var csFile = Path.Combine(dotnetProjectConvert, "Program.cs");
         File.WriteAllText(csFile, """Console.WriteLine("Test");""");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(dotnetProjectConvert)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(dotnetProjectConvert)
             .EnumerateFileSystemInfos().Select(d => d.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs"]);
 
         new DirectoryInfo(Path.Join(dotnetProjectConvert, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -90,7 +90,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "MyApp"));
         File.WriteAllText(Path.Join(testInstance.Path, "MyApp.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -133,14 +133,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Program1.cs"), "Console.WriteLine(1);");
         File.WriteAllText(Path.Join(testInstance.Path, "Program2.cs"), "Console.WriteLine(2);");
 
-        new DotnetCommand(Log, "project", "convert", "Program1.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program1.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(d => d.Name).Order()
-            .Should().BeEquivalentTo(["Program1", "Program2.cs"]);
+            .Should().BeEquivalentTo(["Program1", "Program1.cs", "Program2.cs"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program1"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -201,14 +201,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.CS"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "Program.CS", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.CS")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.CS"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -223,14 +223,17 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), content);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs"]);
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program.cs"))
+            .Should().Be(content);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -248,14 +251,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(appDirectory);
         File.WriteAllText(Path.Join(appDirectory, "Program.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "app/Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "app/Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(Path.Join(testInstance.Path, "app"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "app", "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -278,7 +281,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "subdir"));
         File.WriteAllText(Path.Join(testInstance.Path, "subdir", "second.json"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -308,7 +311,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -334,7 +337,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -371,7 +374,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             </Project>
             """);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -413,7 +416,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -464,7 +467,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
@@ -514,7 +517,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
@@ -535,23 +538,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
     }
 
-    [Fact]
-    public void KeepSourceNotSpecified()
-    {
-        var testInstance = _testAssetsManager.CreateTestDirectory();
-        var filePath = Path.Join(testInstance.Path, "Program.cs");
-        File.WriteAllText(filePath, "Console.WriteLine();");
-
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
-            .WithWorkingDirectory(testInstance.Path)
-            .Execute()
-            .Should().Fail()
-            .And.HaveStdErrContaining(CliCommandStrings.ProjectConvertNeedsConfirmation);
-
-        new DirectoryInfo(Path.Join(testInstance.Path))
-            .EnumerateDirectories().Should().BeEmpty();
-    }
-
     /// <summary>
     /// When processing fails due to invalid directives, no conversion should be performed
     /// (e.g., the target directory should not be created).
@@ -563,7 +549,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:invalid");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -584,7 +570,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:sdk Microsoft.ThisSdkDoesNotExist");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -602,19 +588,23 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     public void ProcessingSucceeds()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();
-        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+        var originalSource = """
             #:package Humanizer@2.14.1
             Console.WriteLine();
-            """);
+            """;
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), originalSource);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs"]);
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program.cs"))
+            .Should().Be(originalSource);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -26,7 +26,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var csFile = Path.Combine(dotnetProjectConvert, "Program.cs");
         File.WriteAllText(csFile, """Console.WriteLine("Test");""");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
             .WithWorkingDirectory(dotnetProjectConvert)
             .Execute()
             .Should().Pass();
@@ -90,7 +90,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "MyApp"));
         File.WriteAllText(Path.Join(testInstance.Path, "MyApp.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1")
+        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -133,7 +133,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Program1.cs"), "Console.WriteLine(1);");
         File.WriteAllText(Path.Join(testInstance.Path, "Program2.cs"), "Console.WriteLine(2);");
 
-        new DotnetCommand(Log, "project", "convert", "Program1.cs")
+        new DotnetCommand(Log, "project", "convert", "Program1.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -201,7 +201,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.CS"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "Program.CS")
+        new DotnetCommand(Log, "project", "convert", "Program.CS", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -223,7 +223,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), content);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -248,7 +248,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(appDirectory);
         File.WriteAllText(Path.Join(appDirectory, "Program.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "app/Program.cs")
+        new DotnetCommand(Log, "project", "convert", "app/Program.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -278,14 +278,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "subdir"));
         File.WriteAllText(Path.Join(testInstance.Path, "subdir", "second.json"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program", "Resources.resx", "Util.cs", "my.json", "subdir"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs", "Resources.resx", "Util.cs", "my.json", "subdir"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -308,14 +308,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program", "Resources.resx", "Util.cs", "my.json"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs", "Resources.resx", "Util.cs", "my.json"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -334,14 +334,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program", "Resources.resx", "Util.cs", "my.json"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs", "Resources.resx", "Util.cs", "my.json"]);
 
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -371,14 +371,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             </Project>
             """);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Directory.Build.targets", "Program", "Resources.resx", "Util.cs", "my.json", "second.json"]);
+            .Should().BeEquivalentTo(["Directory.Build.targets", "Program", "Program.cs", "Resources.resx", "Util.cs", "my.json", "second.json"]);
 
         // `second.json` is excluded from the conversion.
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
@@ -413,14 +413,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(testInstance.Path)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Directory.Build.props", "Program", "Util.cs"]);
+            .Should().BeEquivalentTo(["Directory.Build.props", "Program", "Program.cs", "Util.cs"]);
 
         // Directory.Build.props is included as it's a None item.
         new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
@@ -464,14 +464,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(subdir)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program", "Util.cs"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs", "Util.cs"]);
 
         new DirectoryInfo(Path.Join(subdir, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -514,14 +514,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
 
         new DirectoryInfo(subdir)
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
-            .Should().BeEquivalentTo(["Program"]);
+            .Should().BeEquivalentTo(["Program", "Program.cs"]);
 
         new DirectoryInfo(Path.Join(subdir, "Program"))
             .EnumerateFileSystemInfos().Select(f => f.Name).Order()
@@ -535,6 +535,23 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
     }
 
+    [Fact]
+    public void KeepSourceNotSpecified()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var filePath = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(filePath, "Console.WriteLine();");
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErrContaining(CliCommandStrings.ProjectConvertNeedsConfirmation);
+
+        new DirectoryInfo(Path.Join(testInstance.Path))
+            .EnumerateDirectories().Should().BeEmpty();
+    }
+
     /// <summary>
     /// When processing fails due to invalid directives, no conversion should be performed
     /// (e.g., the target directory should not be created).
@@ -546,7 +563,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:invalid");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -567,7 +584,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:sdk Microsoft.ThisSdkDoesNotExist");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -590,7 +607,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             Console.WriteLine();
             """);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -26,7 +26,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var csFile = Path.Combine(dotnetProjectConvert, "Program.cs");
         File.WriteAllText(csFile, """Console.WriteLine("Test");""");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
             .WithWorkingDirectory(dotnetProjectConvert)
             .Execute()
             .Should().Pass();
@@ -90,7 +90,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "MyApp"));
         File.WriteAllText(Path.Join(testInstance.Path, "MyApp.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "MyApp.cs", "-o", "MyApp1", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -133,7 +133,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Program1.cs"), "Console.WriteLine(1);");
         File.WriteAllText(Path.Join(testInstance.Path, "Program2.cs"), "Console.WriteLine(2);");
 
-        new DotnetCommand(Log, "project", "convert", "Program1.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program1.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -201,7 +201,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.CS"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "Program.CS", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.CS", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -223,7 +223,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var testInstance = _testAssetsManager.CreateTestDirectory();
         File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), content);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -248,7 +248,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(appDirectory);
         File.WriteAllText(Path.Join(appDirectory, "Program.cs"), "Console.WriteLine();");
 
-        new DotnetCommand(Log, "project", "convert", "app/Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "app/Program.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -278,7 +278,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         Directory.CreateDirectory(Path.Join(testInstance.Path, "subdir"));
         File.WriteAllText(Path.Join(testInstance.Path, "subdir", "second.json"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -308,7 +308,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -334,7 +334,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         File.WriteAllText(Path.Join(testInstance.Path, "Resources.resx"), "");
         File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), "");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -371,7 +371,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             </Project>
             """);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -413,7 +413,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();
@@ -464,7 +464,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
@@ -514,7 +514,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
 
         // Convert.
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=copy")
             .WithWorkingDirectory(subdir)
             .Execute()
             .Should().Pass();
@@ -563,7 +563,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:invalid");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -584,7 +584,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var filePath = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(filePath, "#:sdk Microsoft.ThisSdkDoesNotExist");
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Fail()
@@ -607,7 +607,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             Console.WriteLine();
             """);
 
-        new DotnetCommand(Log, "project", "convert", "Program.cs", "--keep-source=false")
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "--source=move")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass();

--- a/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1178,19 +1178,12 @@ _testhost_project_convert() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="--output --source --force --interactive --dry-run --help" 
+    opts="--output --force --interactive --dry-run --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     fi
-    
-    case $prev in
-        --source)
-            COMPREPLY=( $(compgen -W "copy move" -- "$cur") )
-            return
-        ;;
-    esac
     
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }

--- a/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1178,12 +1178,19 @@ _testhost_project_convert() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="--output --force --help" 
+    opts="--output --keep-source --force --interactive --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     fi
+    
+    case $prev in
+        --keep-source)
+            COMPREPLY=( $(compgen -W "False True" -- "$cur") )
+            return
+        ;;
+    esac
     
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }

--- a/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1178,7 +1178,7 @@ _testhost_project_convert() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="--output --keep-source --force --interactive --help" 
+    opts="--output --source --force --interactive --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -1186,8 +1186,8 @@ _testhost_project_convert() {
     fi
     
     case $prev in
-        --keep-source)
-            COMPREPLY=( $(compgen -W "False True" -- "$cur") )
+        --source)
+            COMPREPLY=( $(compgen -W "copy move" -- "$cur") )
             return
         ;;
     esac

--- a/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/bash/DotnetCliSnapshotTests.VerifyCompletions.verified.sh
@@ -1178,7 +1178,7 @@ _testhost_project_convert() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" 
     COMPREPLY=()
     
-    opts="--output --source --force --interactive --help" 
+    opts="--output --source --force --interactive --dry-run --help" 
     
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -679,7 +679,6 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
             $staticCompletions = @(
                 [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, "Location to place the generated output.")
                 [CompletionResult]::new('--output', '-o', [CompletionResultType]::ParameterName, "Location to place the generated output.")
-                [CompletionResult]::new('--source', '--source', [CompletionResultType]::ParameterName, "Whether to keep source files intact (copy) or delete them after conversion (move).")
                 [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, "Force conversion even if there are malformed directives.")
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--dry-run', '--dry-run', [CompletionResultType]::ParameterName, "Determines changes without actually modifying the file system")

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -679,7 +679,9 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
             $staticCompletions = @(
                 [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, "Location to place the generated output.")
                 [CompletionResult]::new('--output', '-o', [CompletionResultType]::ParameterName, "Location to place the generated output.")
+                [CompletionResult]::new('--keep-source', '--keep-source', [CompletionResultType]::ParameterName, "Whether to keep source files intact (otherwise, they are deleted after conversion).")
                 [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, "Force conversion even if there are malformed directives.")
+                [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -679,7 +679,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
             $staticCompletions = @(
                 [CompletionResult]::new('--output', '--output', [CompletionResultType]::ParameterName, "Location to place the generated output.")
                 [CompletionResult]::new('--output', '-o', [CompletionResultType]::ParameterName, "Location to place the generated output.")
-                [CompletionResult]::new('--keep-source', '--keep-source', [CompletionResultType]::ParameterName, "Whether to keep source files intact (otherwise, they are deleted after conversion).")
+                [CompletionResult]::new('--source', '--source', [CompletionResultType]::ParameterName, "Whether to keep source files intact (copy) or delete them after conversion (move).")
                 [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, "Force conversion even if there are malformed directives.")
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")

--- a/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
+++ b/test/dotnet.Tests/CompletionTests/snapshots/pwsh/DotnetCliSnapshotTests.VerifyCompletions.verified.ps1
@@ -682,6 +682,7 @@ Register-ArgumentCompleter -Native -CommandName 'testhost' -ScriptBlock {
                 [CompletionResult]::new('--source', '--source', [CompletionResultType]::ParameterName, "Whether to keep source files intact (copy) or delete them after conversion (move).")
                 [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, "Force conversion even if there are malformed directives.")
                 [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, "Allows the command to stop and wait for user input or action (for example to complete authentication).")
+                [CompletionResult]::new('--dry-run', '--dry-run', [CompletionResultType]::ParameterName, "Determines changes without actually modifying the file system")
                 [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, "Show command line help.")
                 [CompletionResult]::new('--help', '-h', [CompletionResultType]::ParameterName, "Show command line help.")
             )

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -675,7 +675,6 @@ _testhost() {
                                         _arguments "${_arguments_options[@]}" : \
                                             '--output=[Location to place the generated output.]: :_files' \
                                             '-o=[Location to place the generated output.]: :_files' \
-                                            '--source=[Whether to keep source files intact (copy) or delete them after conversion (move).]: :((copy\:"copy" move\:"move" ))' \
                                             '--force[Force conversion even if there are malformed directives.]' \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--dry-run[Determines changes without actually modifying the file system]' \

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -675,7 +675,7 @@ _testhost() {
                                         _arguments "${_arguments_options[@]}" : \
                                             '--output=[Location to place the generated output.]: :_files' \
                                             '-o=[Location to place the generated output.]: :_files' \
-                                            '--keep-source=[Whether to keep source files intact (otherwise, they are deleted after conversion).]: :((False\:"False" True\:"True" ))' \
+                                            '--source=[Whether to keep source files intact (copy) or delete them after conversion (move).]: :((copy\:"copy" move\:"move" ))' \
                                             '--force[Force conversion even if there are malformed directives.]' \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--help[Show command line help.]' \

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -678,6 +678,7 @@ _testhost() {
                                             '--source=[Whether to keep source files intact (copy) or delete them after conversion (move).]: :((copy\:"copy" move\:"move" ))' \
                                             '--force[Force conversion even if there are malformed directives.]' \
                                             '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
+                                            '--dry-run[Determines changes without actually modifying the file system]' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             ':file -- Path to the file-based program.: ' \

--- a/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
+++ b/test/dotnet.Tests/CompletionTests/snapshots/zsh/DotnetCliSnapshotTests.VerifyCompletions.verified.zsh
@@ -675,7 +675,9 @@ _testhost() {
                                         _arguments "${_arguments_options[@]}" : \
                                             '--output=[Location to place the generated output.]: :_files' \
                                             '-o=[Location to place the generated output.]: :_files' \
+                                            '--keep-source=[Whether to keep source files intact (otherwise, they are deleted after conversion).]: :((False\:"False" True\:"True" ))' \
                                             '--force[Force conversion even if there are malformed directives.]' \
+                                            '--interactive[Allows the command to stop and wait for user input or action (for example to complete authentication).]' \
                                             '--help[Show command line help.]' \
                                             '-h[Show command line help.]' \
                                             ':file -- Path to the file-based program.: ' \


### PR DESCRIPTION
And allow users to specify whether the files should be copied or moved.

Resolves https://github.com/dotnet/sdk/issues/49624.