### PR TITLE
[release/8.0.1xx] Use new ACR for registry image

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
@@ -27,7 +27,7 @@ public class DockerRegistryManager
     private static string RegistryImageToUse => SDK_AzureContainerRegistryImage;
 
 
-    public static async Task StartAndPopulateDockerRegistry(ITestOutputHelper testOutput)
+    public static void StartAndPopulateDockerRegistry(ITestOutputHelper testOutput)
     {
         using TestLoggerFactory loggerFactory = new(testOutput);
 

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryManager.cs
@@ -26,18 +26,6 @@ public class DockerRegistryManager
     // TODO: some logic to pivot between this and Docker Hub
     private static string RegistryImageToUse => SDK_AzureContainerRegistryImage;
 
-    internal class SameArchManifestPicker : IManifestPicker
-    {
-        public PlatformSpecificManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificManifest> manifestList, string runtimeIdentifier)
-        {
-            return manifestList.Values.SingleOrDefault(m => m.platform.os == "linux" && m.platform.architecture == "amd64");
-        }
-
-        public PlatformSpecificOciManifest? PickBestManifestForRid(IReadOnlyDictionary<string, PlatformSpecificOciManifest> manifestList, string runtimeIdentifier)
-        {
-            return manifestList.Values.SingleOrDefault(m => m.platform.os == "linux" && m.platform.architecture == "amd64");
-        }
-    }
 
     public static async Task StartAndPopulateDockerRegistry(ITestOutputHelper testOutput)
     {


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/49677 to release/8.0.1xx