### PR TITLE
Add Returns clauses to two key tool-packaging Targets to enable advanced users to build new kids of tool-based packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -157,7 +157,9 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <Target Name="PackToPublishDependencyIndirection"
           DependsOnTargets="$(_PackToolPublishDependency)"/>
 
-  <Target Name="PackTool" DependsOnTargets="SetPackToolProperties;GenerateToolsSettingsFileFromBuildProperty;PackToPublishDependencyIndirection;_PackToolValidation;PackToolImplementation" Condition=" '$(PackAsTool)' == 'true' ">
+  <Target Name="PackTool" DependsOnTargets="SetPackToolProperties;GenerateToolsSettingsFileFromBuildProperty;PackToPublishDependencyIndirection;_PackToolValidation;PackToolImplementation" 
+    Condition=" '$(PackAsTool)' == 'true' "
+    Returns="@(TfmSpecificPackageFile)">
     <ItemGroup>
       <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
       <!-- Note here that we're _not_ computing relative directories inside the package anymore. In our packages, we essentially want to
@@ -358,7 +360,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     </ItemGroup>
   </Target>
 
-  <Target Name="SetDotnetToolPackageType">
+  <Target Name="SetDotnetToolPackageType" Returns="$(_ToolPackageType)">
 
     <PropertyGroup>
       <_ToolPackageType Condition="'$(RuntimeIdentifier)' != '' And '$(_HasRIDSpecificTools)' != ''">DotnetToolRidPackage</_ToolPackageType>


### PR DESCRIPTION
Adding these Returns enables experimentation on new kinds of hybrid/combined packages - for example making a package that is both a normal library that can be PackageReferenced as well as installed and used as a .NET Tool.  You can see this in action [here](https://github.com/baronfel/multi-rid-tool/pull/1). To Frankenstein your own packages together, however, you need access to the outputs of the logic that cause the tool settings files and framework-agnostic package content to be created and tracked.

This PR does just that.