### PR TITLE
Add the property controlling publishing the symbols of reference projects

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -703,7 +703,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ResolvedCopyLocalPublishAssets Include="@(ReferenceCopyLocalPaths)"
                                        Exclude="@(_ResolvedCopyLocalBuildAssets);@(RuntimePackAsset)"
-                                       Condition="('$(PublishReferencesDocumentationFiles)' == 'true' or '%(ReferenceCopyLocalPaths.Extension)' != '.xml') and '%(ReferenceCopyLocalPaths.Private)' != 'false'">
+                                       Condition="(('$(PublishReferencesDocumentationFiles)' == 'true' and '%(ReferenceCopyLocalPaths.Extension)' == '.xml')
+                                                  or ('$(PublishReferencesSymbols)' == 'true' and '%(ReferenceCopyLocalPaths.Extension)' == '.pdb')
+                                                  or ('%(ReferenceCopyLocalPaths.Extension)' != '.xml' and '%(ReferenceCopyLocalPaths.Extension)' != '.pdb'))
+                                                  and '%(ReferenceCopyLocalPaths.Private)' != 'false'">
         <DestinationSubPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</DestinationSubPath>
       </_ResolvedCopyLocalPublishAssets>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -291,6 +291,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishDocumentationFiles Condition="'$(PublishDocumentationFiles)' == ''">true</PublishDocumentationFiles>
     <PublishDocumentationFile Condition="'$(PublishDocumentationFile)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishDocumentationFile>
     <PublishReferencesDocumentationFiles Condition="'$(PublishReferencesDocumentationFiles)' == '' and '$(PublishDocumentationFiles)' == 'true'">true</PublishReferencesDocumentationFiles>
+    <PublishReferencesSymbols Condition="'$(PublishReferencesSymbols)' == ''">true</PublishReferencesSymbols>
   </PropertyGroup>
 
   <!-- Add a project capability so that the project properties in the IDE can show the option to generate an XML documentation file without specifying the filename -->

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAProjectWithDependencies.cs
@@ -277,6 +277,33 @@ namespace Microsoft.NET.Publish.Tests
             }
         }
 
+        [Theory]
+        [InlineData("PublishReferencesSymbols=false", false)]
+        [InlineData("PublishReferencesSymbols=true", true)]
+        public void It_publishes_referenced_project_symbol(string property, bool expectReferenceSymbol)
+        {
+            var kitchenSinkAsset = _testAssetsManager
+                .CopyTestAsset("KitchenSink", identifier: $"{property.Replace("=", "")}")
+                .WithSource();
+
+            var publishCommand = new PublishCommand(kitchenSinkAsset, "TestApp");
+            var publishArgs = new string[] { $"/p:{property}" };
+            var publishResult = publishCommand.Execute(publishArgs);
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: ToolsetInfo.CurrentTargetFramework);
+
+            if (expectReferenceSymbol)
+            {
+                publishDirectory.Should().HaveFile("TestLibrary.pdb");
+            }
+            else
+            {
+                publishDirectory.Should().NotHaveFile("TestLibrary.pdb");
+            }
+        }
+
         private static JObject ReadJson(string path)
         {
             using (JsonTextReader jsonReader = new(File.OpenText(path)))


### PR DESCRIPTION
Fix https://github.com/dotnet/msbuild/issues/12044

Add the property `PublishReferenceSymbols` to control whether the .pdb file of the referenced project is published to the publish folder.