### PR TITLE
make containers net472 target resilient to incorrectly-determined DOTNET_HOST_PATH values

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -22,17 +22,37 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
     {
         get
         {
+            // DOTNET_HOST_PATH, if set, is the full path to the dotnet host executable.
+            // However, not all environments/scenarios set it correctly - some set it to just the directory.
+
+            // this is the expected correct case - DOTNET_HOST_PATH is set to the full path of the dotnet host executable
             string path = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "";
+            if (Path.IsPathRooted(path) && File.Exists(path))
+            {
+                return path;
+            }
+            // some environments set it to just the directory, so we need to check that too
+            if (Path.IsPathRooted(path) && Directory.Exists(path))
+            {
+                path = Path.Combine(path, ToolExe);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+            }
+            // last-chance fallback - use the ToolPath and ToolExe properties to try to synthesize the path
             if (string.IsNullOrEmpty(path))
             {
+                // no
                 path = string.IsNullOrEmpty(ToolPath) ? "" : ToolPath;
+                path = Path.Combine(path, ToolExe);
             }
 
             return path;
         }
     }
 
-    protected override string GenerateFullPathToTool() => Path.Combine(DotNetPath, ToolExe);
+    protected override string GenerateFullPathToTool() => DotNetPath;
 
     /// <summary>
     /// Workaround to avoid storing user/pass into the EnvironmentVariables property, which gets logged by the task.


### PR DESCRIPTION
Related to #49735 

The SDK Containers targets are blowing up when used in VS instances that have the SDK Resolver changes we shipped in .NET 10 preview 6ish. This is because they assumed incorrect values that would be set in DOTNET_HOST_PATH. This change updates the logic to:

* support correct DOTNET_HOST_PATH values
* handle older, incorrect DOTNET_HOST_PATH values
* before falling back to the same last-chance fallback

This should help the container targets be resilient/correct in all hosting scenarios, regardless of other SDK 10 features.