### PR TITLE
Minimal work to make System.Diagnostics.Activity usable by the dotnet CLI application and codebase

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,7 @@
     <PackageVersion Include="System.Composition.Runtime" Version="$(SystemCompositionRuntimePackageVersion)" />
     <PackageVersion Include="System.Composition.TypedParts" Version="$(SystemCompositionTypedPartsPackageVersion)" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePackageVersion)" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
     <PackageVersion Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />
     <!-- System.Reflection.Metadata and System.Collections.Immutable cannot be pinned here because of hard dependencies within Roslyn on specific versions that have to work both here and in VS -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,6 +119,7 @@
     <SystemCompositionHostingPackageVersion>10.0.0-preview.7.25359.101</SystemCompositionHostingPackageVersion>
     <SystemCompositionRuntimePackageVersion>10.0.0-preview.7.25359.101</SystemCompositionRuntimePackageVersion>
     <SystemCompositionTypedPartsPackageVersion>10.0.0-preview.7.25359.101</SystemCompositionTypedPartsPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.0-preview.7.25359.101</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>10.0.0-preview.7.25359.101</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemReflectionMetadataLoadContextVersion>10.0.0-preview.7.25359.101</SystemReflectionMetadataLoadContextVersion>
     <SystemResourcesExtensionsPackageVersion>10.0.0-preview.7.25359.101</SystemResourcesExtensionsPackageVersion>

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Cli.Utils;
+
+/// <summary>
+/// Contains helpers for working with <see cref="System.Diagnostics.Activity">Activities</see> in the .NET CLI.
+/// </summary>
+public static class Activities
+{
+
+    /// <summary>
+    /// The main entrypoint for creating <see cref="Activity">Activities</see> in the .NET CLI.
+    /// All activities created in the CLI should use this <see cref="ActivitySource"/>, to allow
+    /// consumers to easily filter and trace CLI activities.
+    /// </summary>
+    public static ActivitySource Source { get; } = new("dotnet-cli", Product.Version);
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ForwardingAppImplementation.cs
@@ -19,7 +19,7 @@ internal class ForwardingAppImplementation
     private readonly string? _depsFile;
     private readonly string? _runtimeConfig;
     private readonly string? _additionalProbingPath;
-    private Dictionary<string, string> _environmentVariables;
+    private Dictionary<string, string?> _environmentVariables;
 
     private readonly string[] _allArgs;
 
@@ -29,7 +29,7 @@ internal class ForwardingAppImplementation
         string? depsFile = null,
         string? runtimeConfig = null,
         string? additionalProbingPath = null,
-        Dictionary<string, string>? environmentVariables = null)
+        Dictionary<string, string?>? environmentVariables = null)
     {
         _forwardApplicationPath = forwardApplicationPath;
         _argsToForward = argsToForward;
@@ -86,7 +86,7 @@ internal class ForwardingAppImplementation
         return processInfo;
     }
 
-    public ForwardingAppImplementation WithEnvironmentVariable(string name, string value)
+    public ForwardingAppImplementation WithEnvironmentVariable(string name, string? value)
     {
         _environmentVariables.Add(name, value);
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -39,7 +39,7 @@ internal class MSBuildForwardingAppWithoutLogging
     // True if, given current state of the class, MSBuild would be executed in its own process.
     public bool ExecuteMSBuildOutOfProc => _forwardingApp != null;
 
-    private readonly Dictionary<string, string> _msbuildRequiredEnvironmentVariables = GetMSBuildRequiredEnvironmentVariables();
+    private readonly Dictionary<string, string?> _msbuildRequiredEnvironmentVariables = GetMSBuildRequiredEnvironmentVariables();
 
     private readonly List<string> _msbuildRequiredParameters = [ "-maxcpucount", "--verbosity:m" ];
 
@@ -112,7 +112,7 @@ internal class MSBuildForwardingAppWithoutLogging
             : $"--{label}:{property.Key}={property.Value}";
     }
 
-    public void EnvironmentVariable(string name, string value)
+    public void EnvironmentVariable(string name, string? value)
     {
         if (_forwardingApp != null)
         {
@@ -153,7 +153,7 @@ internal class MSBuildForwardingAppWithoutLogging
         Dictionary<string, string?> savedEnvironmentVariables = [];
         try
         {
-            foreach (KeyValuePair<string, string> kvp in _msbuildRequiredEnvironmentVariables)
+            foreach (KeyValuePair<string, string?> kvp in _msbuildRequiredEnvironmentVariables)
             {
                 savedEnvironmentVariables[kvp.Key] = Environment.GetEnvironmentVariable(kvp.Key);
                 Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
@@ -218,7 +218,7 @@ internal class MSBuildForwardingAppWithoutLogging
         return new Muxer().MuxerPath;
     }
 
-    internal static Dictionary<string, string> GetMSBuildRequiredEnvironmentVariables()
+    internal static Dictionary<string, string?> GetMSBuildRequiredEnvironmentVariables()
     {
         return new()
         {

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -59,7 +59,7 @@ public class MSBuildForwardingApp : CommandBase
 
     public IEnumerable<string> MSBuildArguments { get { return _forwardingAppWithoutLogging.GetAllArguments(); } }
 
-    public void EnvironmentVariable(string name, string value)
+    public void EnvironmentVariable(string name, string? value)
     {
         _forwardingAppWithoutLogging.EnvironmentVariable(name, value);
     }

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Frozen;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using RuntimeEnvironment = Microsoft.DotNet.Cli.Utils.RuntimeEnvironment;
@@ -52,7 +53,7 @@ internal class TelemetryCommonProperties(
     private const string MachineIdCacheKey = "MachineId";
     private const string IsDockerContainerCacheKey = "IsDockerContainer";
 
-    public Dictionary<string, string> GetTelemetryCommonProperties()
+    public FrozenDictionary<string, string> GetTelemetryCommonProperties()
     {
         return new Dictionary<string, string>
         {
@@ -82,7 +83,7 @@ internal class TelemetryCommonProperties(
             {ProductType, ExternalTelemetryProperties.GetProductType()},
             {LibcRelease, ExternalTelemetryProperties.GetLibcRelease()},
             {LibcVersion, ExternalTelemetryProperties.GetLibcVersion()}
-        };
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     private string GetMachineId()


### PR DESCRIPTION
I'm breaking out the monolithic set of changes from https://github.com/dotnet/sdk/pull/49409 into a more digestible series of changesets.

This first one adds the ability to _use_ System.Diagnostic.Activity at all in our codebase - creating an ActivitySource for us to use, and hooking the existing telemetry publishing up to it in a zero-cost way if no Activity Listeners are configured (which is the case today).

This is part of https://github.com/dotnet/sdk/issues/49668.