### PR TITLE
Remove env var workaround that causes dotnet to use MSBuild out-of-proc

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -121,17 +121,6 @@ internal class MSBuildForwardingAppWithoutLogging
         {
             _msbuildRequiredEnvironmentVariables.Add(name, value);
         }
-
-        if (value == string.Empty || value == "\0")
-        {
-            // Unlike ProcessStartInfo.EnvironmentVariables, Environment.SetEnvironmentVariable can't set a variable
-            // to an empty value, so we just fall back to calling MSBuild out-of-proc if we encounter this case.
-            // https://github.com/dotnet/runtime/issues/50554
-            InitializeForOutOfProcForwarding();
-
-            // Disable MSBUILDUSESERVER if any env vars are null as those are not properly transferred to build nodes
-            _msbuildRequiredEnvironmentVariables["MSBUILDUSESERVER"] = "0";
-        }
     }
 
     public int Execute()


### PR DESCRIPTION
Per the comment, to work around https://github.com/dotnet/runtime/issues/50554 the CLI would silently shift to out-of-proc mode.

However, this issue was addressed in .NET 8, so we can remove the workaround in the dotnet CLI since main always runs on 10+ runtimes.