### PR TITLE
Cleanup PipeNameDescription

### DIFF
--- a/src/Cli/dotnet/Commands/Test/IPC/PipeNameDescription.cs
+++ b/src/Cli/dotnet/Commands/Test/IPC/PipeNameDescription.cs
@@ -12,18 +12,11 @@ internal sealed class PipeNameDescription(string name, bool isDirectory) : IDisp
 
     public string Name { get; } = name;
 
-    public void Dispose() => Dispose(true);
-
-    public void Dispose(bool disposing)
+    public void Dispose()
     {
         if (_disposed)
         {
             return;
-        }
-
-        if (disposing)
-        {
-            // TODO: dispose managed state (managed objects).
         }
 
         if (_isDirectory)


### PR DESCRIPTION
This class is sealed and the current dispose implementation is unnecessarily complicated. The `Dispose(bool)` method is only relevant in non-sealed classes.

Corresponding testfx PR was merged as well: https://github.com/microsoft/testfx/pull/6000