### PR TITLE
Override default properties with custom file-level directives

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -61,6 +61,18 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         "MSBuild.rsp",
     ];
 
+    /// <remarks>
+    /// Kept in sync with the default <c>dotnet new console</c> project file (enforced by <c>DotnetProjectAddTests.SameAsTemplate</c>).
+    /// </remarks>
+    private static readonly FrozenDictionary<string, string> s_defaultProperties = FrozenDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase,
+    [
+        new("OutputType", "Exe"),
+        new("TargetFramework", "net10.0"),
+        new("ImplicitUsings", "enable"),
+        new("Nullable", "enable"),
+        new("PublishAot", "true"),
+    ]);
+
     internal static readonly string TargetOverrides = """
           <!--
             Override targets which don't work with project files that are not present on disk.
@@ -645,33 +657,37 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             writer.WriteLine();
         }
 
-        // Kept in sync with the default `dotnet new console` project file (enforced by `DotnetProjectAddTests.SameAsTemplate`).
-        writer.WriteLine($"""
-              <PropertyGroup>
-                <OutputType>Exe</OutputType>
-                <TargetFramework>net10.0</TargetFramework>
-                <ImplicitUsings>enable</ImplicitUsings>
-                <Nullable>enable</Nullable>
-                <PublishAot>true</PublishAot>
-              </PropertyGroup>
-            """);
+        // Write default properties unless they are overridden by custom directives.
+        var propertyDirectiveNames = propertyDirectives.Select(d => d.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!s_defaultProperties.Keys.All(propertyDirectiveNames.Contains))
+        {
+            writer.WriteLine("  <PropertyGroup>");
+            foreach (var (name, value) in s_defaultProperties)
+            {
+                if (!propertyDirectiveNames.Contains(name))
+                {
+                    writer.WriteLine($"""
+                            <{name}>{EscapeValue(value)}</{name}>
+                        """);
+                }
+            }
+            writer.WriteLine("  </PropertyGroup>");
+            writer.WriteLine();
+        }
 
         if (isVirtualProject)
         {
             writer.WriteLine("""
-
                   <PropertyGroup>
                     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                   </PropertyGroup>
+
                 """);
         }
 
         if (propertyDirectives.Any())
         {
-            writer.WriteLine("""
-
-                  <PropertyGroup>
-                """);
+            writer.WriteLine("  <PropertyGroup>");
 
             foreach (var property in propertyDirectives)
             {
@@ -683,25 +699,23 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             writer.WriteLine("  </PropertyGroup>");
+            writer.WriteLine();
         }
 
         if (isVirtualProject)
         {
             // After `#:property` directives so they don't override this.
             writer.WriteLine("""
-
                   <PropertyGroup>
                     <Features>$(Features);FileBasedProgram</Features>
                   </PropertyGroup>
+
                 """);
         }
 
         if (packageDirectives.Any())
         {
-            writer.WriteLine("""
-
-                  <ItemGroup>
-                """);
+            writer.WriteLine("  <ItemGroup>");
 
             foreach (var package in packageDirectives)
             {
@@ -722,14 +736,12 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             writer.WriteLine("  </ItemGroup>");
+            writer.WriteLine();
         }
 
         if (projectDirectives.Any())
         {
-            writer.WriteLine("""
-
-                  <ItemGroup>
-                """);
+            writer.WriteLine("  <ItemGroup>");
 
             foreach (var projectReference in projectDirectives)
             {
@@ -741,6 +753,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             writer.WriteLine("  </ItemGroup>");
+            writer.WriteLine();
         }
 
         Debug.Assert(processedDirectives + directives.OfType<CSharpDirective.Shebang>().Count() == directives.Length);
@@ -750,7 +763,6 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             Debug.Assert(targetFilePath is not null);
 
             writer.WriteLine($"""
-
                   <ItemGroup>
                     <Compile Include="{EscapeValue(targetFilePath)}" />
                   </ItemGroup>
@@ -784,12 +796,10 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
             writer.WriteLine();
             writer.WriteLine(TargetOverrides);
+            writer.WriteLine();
         }
 
-        writer.WriteLine("""
-
-            </Project>
-            """);
+        writer.WriteLine("</Project>");
 
         static string EscapeValue(string value) => SecurityElement.Escape(value);
 

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -659,7 +659,9 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
         // Write default and custom properties.
         {
-            writer.WriteLine("  <PropertyGroup>");
+            writer.WriteLine("""
+                  <PropertyGroup>
+                """);
 
             // First write the default properties except those specified by the user.
             var customPropertyNames = propertyDirectives.Select(d => d.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -699,13 +701,17 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                     """);
             }
 
-            writer.WriteLine("  </PropertyGroup>");
-            writer.WriteLine();
+            writer.WriteLine("""
+                  </PropertyGroup>
+
+                """);
         }
 
         if (packageDirectives.Any())
         {
-            writer.WriteLine("  <ItemGroup>");
+            writer.WriteLine("""
+                  <ItemGroup>
+                """);
 
             foreach (var package in packageDirectives)
             {
@@ -725,13 +731,17 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 processedDirectives++;
             }
 
-            writer.WriteLine("  </ItemGroup>");
-            writer.WriteLine();
+            writer.WriteLine("""
+                  </ItemGroup>
+
+                """);
         }
 
         if (projectDirectives.Any())
         {
-            writer.WriteLine("  <ItemGroup>");
+            writer.WriteLine("""
+                  <ItemGroup>
+                """);
 
             foreach (var projectReference in projectDirectives)
             {
@@ -742,8 +752,10 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 processedDirectives++;
             }
 
-            writer.WriteLine("  </ItemGroup>");
-            writer.WriteLine();
+            writer.WriteLine("""
+                  </ItemGroup>
+
+                """);
         }
 
         Debug.Assert(processedDirectives + directives.OfType<CSharpDirective.Shebang>().Count() == directives.Length);
@@ -763,12 +775,12 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             {
                 var targetDirectory = Path.GetDirectoryName(targetFilePath) ?? "";
                 writer.WriteLine($"""
-                  <ItemGroup>
-                    <RuntimeHostConfigurationOption Include="EntryPointFilePath" Value="{EscapeValue(targetFilePath)}" />
-                    <RuntimeHostConfigurationOption Include="EntryPointFileDirectoryPath" Value="{EscapeValue(targetDirectory)}" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <RuntimeHostConfigurationOption Include="EntryPointFilePath" Value="{EscapeValue(targetFilePath)}" />
+                        <RuntimeHostConfigurationOption Include="EntryPointFileDirectoryPath" Value="{EscapeValue(targetDirectory)}" />
+                      </ItemGroup>
 
-                """);
+                    """);
             }
 
             foreach (var sdk in sdkDirectives)
@@ -784,12 +796,16 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                     """);
             }
 
-            writer.WriteLine();
-            writer.WriteLine(TargetOverrides);
-            writer.WriteLine();
+            writer.WriteLine($"""
+
+                {TargetOverrides}
+
+                """);
         }
 
-        writer.WriteLine("</Project>");
+        writer.WriteLine("""
+            </Project>
+            """);
 
         static string EscapeValue(string value) => SecurityElement.Escape(value);
 

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -650,9 +650,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <TargetFramework>net472</TargetFramework>
                     <LangVersion>preview</LangVersion>
                   </PropertyGroup>
@@ -724,9 +721,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <MyProp>MyValue</MyProp>
                   </PropertyGroup>
 
@@ -802,9 +796,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Prop1>One=a/b</Prop1>
                     <Prop2>Two/a=b</Prop2>
                   </PropertyGroup>
@@ -914,9 +905,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Prop>&lt;test&quot;&gt;</Prop>
                   </PropertyGroup>
 
@@ -951,9 +939,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Name>Value</Name>
                     <NugetPackageDescription>&quot;My package with spaces&quot;</NugetPackageDescription>
                   </PropertyGroup>
@@ -998,9 +983,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Prop1>1</Prop1>
                     <Prop2>2</Prop2>
                   </PropertyGroup>
@@ -1047,9 +1029,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Prop1>1</Prop1>
                     <Prop2>2</Prop2>
                   </PropertyGroup>
@@ -1093,9 +1072,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
-                  </PropertyGroup>
-
-                  <PropertyGroup>
                     <Prop1>1</Prop1>
                     <Prop2>2</Prop2>
                   </PropertyGroup>

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -635,7 +635,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                 #!/program
                 #:sdk Microsoft.NET.Sdk
                 #:sdk Aspire.Hosting.Sdk@9.1.0
-                #:property TargetFramework=net11.0
+                #:property TargetFramework=net472
                 #:package System.CommandLine@2.0.0-beta4.22272.1
                 #:property LangVersion=preview
                 Console.WriteLine();
@@ -653,7 +653,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                   </PropertyGroup>
 
                   <PropertyGroup>
-                    <TargetFramework>net11.0</TargetFramework>
+                    <TargetFramework>net472</TargetFramework>
                     <LangVersion>preview</LangVersion>
                   </PropertyGroup>
 
@@ -680,7 +680,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                 #!/program
                 #:sdk Microsoft.NET.Web.Sdk
                 #:property OutputType=Exe
-                #:property TargetFramework=net11.0
+                #:property TargetFramework=net472
                 #:property Nullable=disable
                 #:property PublishAot=false
                 #:property Custom=1
@@ -692,7 +692,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
 
                   <PropertyGroup>
                     <OutputType>Exe</OutputType>
-                    <TargetFramework>net11.0</TargetFramework>
+                    <TargetFramework>net472</TargetFramework>
                     <Nullable>disable</Nullable>
                     <PublishAot>false</PublishAot>
                     <Custom>1</Custom>

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -640,14 +640,13 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                 #:property LangVersion=preview
                 Console.WriteLine();
                 """,
-            expectedProject: $"""
+            expectedProject: """
                 <Project Sdk="Microsoft.NET.Sdk">
 
                   <Sdk Name="Aspire.Hosting.Sdk" Version="9.1.0" />
 
                   <PropertyGroup>
                     <OutputType>Exe</OutputType>
-                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
                     <ImplicitUsings>enable</ImplicitUsings>
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
@@ -661,6 +660,44 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                   <ItemGroup>
                     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
                   </ItemGroup>
+
+                </Project>
+
+                """,
+            expectedCSharp: """
+                Console.WriteLine();
+                """);
+    }
+
+    /// <summary>
+    /// There should be only one <c>PropertyGroup</c> element when the default properties are overridden.
+    /// </summary>
+    [Fact]
+    public void Directives_AllDefaultOverridden()
+    {
+        VerifyConversion(
+            inputCSharp: """
+                #!/program
+                #:sdk Microsoft.NET.Web.Sdk
+                #:property OutputType=Exe
+                #:property TargetFramework=net11.0
+                #:property Nullable=disable
+                #:property PublishAot=false
+                #:property Custom=1
+                #:property ImplicitUsings=disable
+                Console.WriteLine();
+                """,
+            expectedProject: """
+                <Project Sdk="Microsoft.NET.Web.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net11.0</TargetFramework>
+                    <Nullable>disable</Nullable>
+                    <PublishAot>false</PublishAot>
+                    <Custom>1</Custom>
+                    <ImplicitUsings>disable</ImplicitUsings>
+                  </PropertyGroup>
 
                 </Project>
 

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1861,18 +1861,9 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                         <ImplicitUsings>enable</ImplicitUsings>
                         <Nullable>enable</Nullable>
                         <PublishAot>true</PublishAot>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <TargetFramework>net11.0</TargetFramework>
                         <LangVersion>preview</LangVersion>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <Features>$(Features);FileBasedProgram</Features>
                       </PropertyGroup>
 
@@ -1939,13 +1930,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                         <ImplicitUsings>enable</ImplicitUsings>
                         <Nullable>enable</Nullable>
                         <PublishAot>true</PublishAot>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <Features>$(Features);FileBasedProgram</Features>
                       </PropertyGroup>
 
@@ -2011,13 +1996,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                         <ImplicitUsings>enable</ImplicitUsings>
                         <Nullable>enable</Nullable>
                         <PublishAot>true</PublishAot>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                      </PropertyGroup>
-
-                      <PropertyGroup>
                         <Features>$(Features);FileBasedProgram</Features>
                       </PropertyGroup>
 

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1858,7 +1858,6 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
 
                       <PropertyGroup>
                         <OutputType>Exe</OutputType>
-                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
                         <ImplicitUsings>enable</ImplicitUsings>
                         <Nullable>enable</Nullable>
                         <PublishAot>true</PublishAot>


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/49177.

I've also consolidated the project writing logic so each "section" is responsible for its own trailing blank line.