### PR TITLE
allow reading uid from ContainerUser to set the Tar entry uid

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -160,8 +160,8 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
                 Log.LogErrorWithCodeFromResources(nameof(Strings.InvalidContainerImageFormat), ImageFormat, string.Join(",", Enum.GetValues<KnownImageFormats>()));
             }
         }
-
-        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType);
+        var userId = imageBuilder.IsWindows ? null : ContainerBuilder.TryParseUserId(ContainerUser);
+        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows, imageBuilder.ManifestMediaType, userId);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(WorkingDirectory);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk-container-builds/issues/639

We read ContainerUser and, if it is an int or the well-known user name `root`, apply that value as the `Uid` on the TarEntries that we create.

One thing that Docker does better here is allowing Groups, as well as user and group values that aren't integers (presumably there's some kind of lookup that happens?).