### PR TITLE
ensure that Content items are available during restore to un-break Razor

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -19,7 +19,9 @@ public static class Constants
 
     public static readonly string MSBUILD_EXE_PATH = nameof(MSBUILD_EXE_PATH);
     public static readonly string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
+
     public static readonly string EnableDefaultItems = nameof(EnableDefaultItems);
+    public static readonly string EnableDefaultContentItems = nameof(EnableDefaultContentItems);
     public static readonly string EnableDefaultCompileItems = nameof(EnableDefaultCompileItems);
     public static readonly string EnableDefaultEmbeddedResourceItems = nameof(EnableDefaultEmbeddedResourceItems);
     public static readonly string EnableDefaultNoneItems = nameof(EnableDefaultNoneItems);

--- a/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Collections.ObjectModel;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
@@ -12,7 +11,6 @@ namespace Microsoft.DotNet.Cli.Commands.Restore;
 
 public class RestoringCommand : MSBuildForwardingApp
 {
-
     /// <summary>
     /// This dictionary contains properties that are set to disable the default items
     /// that are added to the project by default. These Item types are not needed
@@ -22,7 +20,9 @@ public class RestoringCommand : MSBuildForwardingApp
     public static ReadOnlyDictionary<string, string> RestoreOptimizationProperties =>
         new(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            { Constants.EnableDefaultItems, "false" },
+            // note that we do not disable all default items - Razor at least needs Content
+            // in order to do implicit PackageReferences if js files are present
+            { Constants.EnableDefaultCompileItems, "false" },
             { Constants.EnableDefaultEmbeddedResourceItems, "false" },
             { Constants.EnableDefaultNoneItems, "false" },
         });

--- a/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
@@ -21,7 +21,7 @@ public class RestoringCommand : MSBuildForwardingApp
         new(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             // note that we do not disable all default items - Razor at least needs Content
-            // in order to do implicit PackageReferences if js files are present
+            // in order to do implicit PackageReferences if Razor files are present
             { Constants.EnableDefaultCompileItems, "false" },
             { Constants.EnableDefaultEmbeddedResourceItems, "false" },
             { Constants.EnableDefaultNoneItems, "false" },


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3701

We accidentally disabled _all_ default items for review - I intended to only disable Content, Compile, EmbeddedResource, and None.

However, disabling Content items breaks Razor, who include an additional implicit PackageReference when `.razor` Content items are found.