### PR TITLE
Remove extra newline from APIDiff TOC

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
@@ -155,8 +155,6 @@ internal sealed class FileOutputDiffGenerator : IDiffGenerator
             _log.LogMessage($"Wrote '{filePath}'.");
         }
 
-        tableOfContents.AppendLine();
-
         string tableOfContentsFilePath = Path.Combine(_outputFolderPath, $"{_tableOfContentsTitle}.md");
 
         if (_writeToDisk)

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
@@ -25,7 +25,6 @@ public class DiffDiskTests
 
         * [{DefaultAssemblyName}]({DefaultTableOfContentsTitle}_{DefaultAssemblyName}.md)
 
-
         """;
 
     private const string ExpectedEmptyTableOfContents = $"""
@@ -33,7 +32,6 @@ public class DiffDiskTests
 
         API listing follows standard diff formatting.
         Lines preceded by a '+' are additions and a '-' indicates removal.
-
 
 
         """;

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Disk.Tests.cs
@@ -237,7 +237,6 @@ Lines preceded by a '+' are additions and a '-' indicates removal.
 
 * [Assembly1]({DefaultTableOfContentsTitle}_Assembly1.md)
 * [Assembly2]({DefaultTableOfContentsTitle}_Assembly2.md)
-
 ";
 
         using TempDirectory inputFolderPath = new();


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49793

Each link is already added with a trailing newline:
```
tableOfContents.AppendLine($"* [{assemblyName}]({fileName})");
```

Adding another new-line makes an empty line at the end of the file that's triggering the linter.  Remove this.