### PR TITLE
Normalize shim output directory in publish scenario

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1288,7 +1288,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <GetEmbeddedApphostPaths
-      PackagedShimOutputDirectory="$(PackagedShimOutputRootDirectory)/shims/$(TargetFramework)"
+      PackagedShimOutputDirectory="$([System.IO.Path]::Combine($(PackagedShimOutputRootDirectory), 'shims', $(TargetFramework)))"
       ShimRuntimeIdentifiers="@(_PackAsToolShimRuntimeIdentifiers)"
       ToolCommandName="$(ToolCommandName)"
       >


### PR DESCRIPTION
https://github.com/dotnet/sdk/commit/578eba8efd9faad6917946db5a5103082c920dfe normalized the output path for shims in the pack as tool scenario. However, the publish scenario is unnormalized and the two end up with colliding assets due to path separators. The easiest fix seems to be normalizing all paths.