### PR TITLE
Handle versioned `#:sdk` being first

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -578,12 +578,19 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         var packageDirectives = directives.OfType<CSharpDirective.Package>();
         var projectDirectives = directives.OfType<CSharpDirective.Project>();
 
-        string sdkValue = "Microsoft.NET.Sdk";
+        string firstSdkName;
+        string? firstSdkVersion;
 
         if (sdkDirectives.FirstOrDefault() is { } firstSdk)
         {
-            sdkValue = firstSdk.ToSlashDelimitedString();
+            firstSdkName = firstSdk.Name;
+            firstSdkVersion = firstSdk.Version;
             processedDirectives++;
+        }
+        else
+        {
+            firstSdkName = "Microsoft.NET.Sdk";
+            firstSdkVersion = null;
         }
 
         if (isVirtualProject)
@@ -607,13 +614,28 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                   </ItemGroup>
 
                   <!-- We need to explicitly import Sdk props/targets so we can override the targets below. -->
-                  <Import Project="Sdk.props" Sdk="{EscapeValue(sdkValue)}" />
                 """);
+
+            if (firstSdkVersion is null)
+            {
+                writer.WriteLine($"""
+                      <Import Project="Sdk.props" Sdk="{EscapeValue(firstSdkName)}" />
+                    """);
+            }
+            else
+            {
+                writer.WriteLine($"""
+                      <Import Project="Sdk.props" Sdk="{EscapeValue(firstSdkName)}" Version="{EscapeValue(firstSdkVersion)}" />
+                    """);
+            }
         }
         else
         {
+            string slashDelimited = firstSdkVersion is null
+                ? firstSdkName
+                : $"{firstSdkName}/{firstSdkVersion}";
             writer.WriteLine($"""
-                <Project Sdk="{EscapeValue(sdkValue)}">
+                <Project Sdk="{EscapeValue(slashDelimited)}">
 
                 """);
         }
@@ -776,7 +798,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
             if (!sdkDirectives.Any())
             {
-                Debug.Assert(sdkValue == "Microsoft.NET.Sdk");
+                Debug.Assert(firstSdkName == "Microsoft.NET.Sdk" && firstSdkVersion == null);
                 writer.WriteLine("""
                       <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
                     """);
@@ -1135,11 +1157,6 @@ internal abstract class CSharpDirective
                 Name = sdkName,
                 Version = sdkVersion,
             };
-        }
-
-        public string ToSlashDelimitedString()
-        {
-            return Version is null ? Name : $"{Name}/{Version}";
         }
     }
 

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1156,6 +1156,33 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             ]);
     }
 
+    [Fact] // https://github.com/dotnet/sdk/issues/49797
+    public void Directives_VersionedSdkFirst()
+    {
+        VerifyConversion(
+            inputCSharp: """
+                #:sdk Microsoft.NET.Sdk@9.0.0
+                Console.WriteLine();
+                """,
+            expectedProject: $"""
+                <Project Sdk="Microsoft.NET.Sdk/9.0.0">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                  </PropertyGroup>
+
+                </Project>
+
+                """,
+            expectedCSharp: """
+                Console.WriteLine();
+                """);
+    }
+
     private static void Convert(string inputCSharp, out string actualProject, out string? actualCSharp, bool force, string? filePath)
     {
         var sourceFile = new SourceFile(filePath ?? "/app/Program.cs", SourceText.From(inputCSharp, Encoding.UTF8));

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1555,6 +1555,21 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().Pass();
     }
 
+    [Fact] // https://github.com/dotnet/sdk/issues/49797
+    public void SdkReference_VersionedSdkFirst()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #:sdk Microsoft.NET.Sdk@9.0.0
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log, "build", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+    }
+
     [Theory]
     [InlineData("../Lib/Lib.csproj")]
     [InlineData("../Lib")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49797.