### PR TITLE
set env var to rollback revocation check change in .NET 10 previews

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -7,5 +7,6 @@ if %errorlevel%==0 (
     REM skip crossgen for inner-loop builds to save a ton of time
     set skipFlags="/p:SkipUsingCrossgen=true /p:SkipBuildingInstallers=true"
 )
+set DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true
 powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -msbuildEngine dotnet %skipFlags% %*"
 exit /b %ErrorLevel%

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,5 @@ if [[ "$@" != *"-pack"* ]]; then
   skipFlags="/p:SkipUsingCrossgen=true /p:SkipBuildingInstallers=true"
 fi
 
-DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT="true" . "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags "$@"
+export DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT="true"
+. "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags "$@"

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ if [[ "$@" != *"-pack"* ]]; then
   skipFlags="/p:SkipUsingCrossgen=true /p:SkipBuildingInstallers=true"
 fi
 
-. "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags "$@"
+DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT="true" . "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags "$@"

--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -52,6 +52,7 @@ try {
   # Avoid downloading Microsoft.Net.Sdk.Compilers.Toolset from feed
   # Locally built SDK package version is Major.Minor.0-dev, which won't be available.
   $env:BuildWithNetFrameworkHostedCompiler = $false
+  $env:DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=$true
 
   if ($command -eq $null -and $env:DOTNET_SDK_DOGFOOD_SHELL -ne $null) {
     $command = , $env:DOTNET_SDK_DOGFOOD_SHELL

--- a/eng/dogfood.sh
+++ b/eng/dogfood.sh
@@ -27,3 +27,4 @@ export PATH=$testDotnetRoot:$PATH
 export DOTNET_ROOT=$testDotnetRoot
 export DOTNET_ADD_GLOBAL_TOOLS_TO_PATH=0
 export PS1="(dogfood) $PS1"
+export DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT="true"


### PR DESCRIPTION
Workaround https://github.com/dotnet/runtime/issues/117681, which can break MSBuild SDK restore and other restore operations.