### PR TITLE
Fix tool projects so they don't remove apphosts when publishing (not packing)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -147,7 +147,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     </PropertyGroup>
 
     <!-- inner-build tool packages get a RID suffix -->
-    <PropertyGroup Condition="'$(_HasRIDSpecificTools)' != '' And $(RuntimeIdentifier) != ''">
+    <PropertyGroup Condition="'$(_HasRIDSpecificTools)' != '' And '$(RuntimeIdentifier)' != ''">
       <PackageId>$(PackageId).$(RuntimeIdentifier)</PackageId>
     </PropertyGroup>
   </Target>
@@ -413,7 +413,10 @@ NOTE: This file is imported from the following contexts, so be aware when writin
 
     <ItemGroup>
         <_rids Include="$(_PackageRids)" />
-        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
+        <_ridsWithoutAny Include="@(_rids)" Condition="%(Identity) != 'any'" />
+        <_ridsWithAny Include="@(_rids)" Condition="%(Identity) == 'any'" />
+        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_ridsWithoutAny.Identity);" />
+        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="UseAppHost=false;RuntimeIdentifier=any;" Condition="@(_ridsWithAny->Count()) &gt; 0" />
     </ItemGroup>
 
     <MSBuild BuildInParallel="true" Projects="@(_RidSpecificToolPackageProject)" Targets="Pack">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -74,11 +74,6 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <_InnerToolsPublishAot Condition="$(_HasRIDSpecificTools) and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
     <PublishAot Condition="!$(_IsRidSpecific) and '$(MSBuildIsRestoring)' != 'true'">false</PublishAot>
 
-    <!-- we want to ensure that we don't publish any AppHosts for the 'outer', RID-agnostic builds -->
-    <UseAppHost Condition="!$(_IsRidSpecific)">false</UseAppHost>
-    <!-- we want to ensure that we _do_ publish any AppHosts for the 'inner', RID-specific builds -->
-    <UseAppHost Condition="$(_IsRidSpecific)">true</UseAppHost>
-
     <!-- Tool implementation files are not included in the primary package when the tool has RID-specific packages.  So only pack the tool implementation
        (and only depend on publish) if there are no RID-specific packages, or if the RuntimeIdentifier is set. -->
     <_ToolPackageShouldIncludeImplementation Condition=" '$(PackAsTool)' == 'true' And
@@ -132,6 +127,19 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <Target Name="SetPackToolProperties"
           BeforeTargets="_GenerateRestoreProjectSpec;_GenerateToolsSettingsFileInputCache;_GenerateShimInputCache;_GetOutputItemsFromPack">
 
+    <!-- We set UseAppHost here instead of as a 'raw' property because we don't want to impact 'normal' Publish operations on these apps.  -->
+    <PropertyGroup>
+      <!-- we want to ensure that we don't publish any AppHosts for the 'outer', RID-agnostic builds -->
+      <UseAppHost Condition="!$(_IsRidSpecific)">false</UseAppHost>
+      <!-- we want to ensure that we _do_ publish any AppHosts for the 'inner', RID-specific builds -->
+      <UseAppHost Condition="$(_IsRidSpecific)">true</UseAppHost>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(ToolCommandRunner)' == ''">
+      <ToolCommandRunner Condition="!$(UseAppHost)">dotnet</ToolCommandRunner>
+      <ToolCommandRunner Condition="$(UseAppHost)">executable</ToolCommandRunner>
+    </PropertyGroup>
+
     <!-- Needs to be in a target so we don't need to worry about evaluation order with NativeBinary property -->
     <PropertyGroup Condition="'$(ToolEntryPoint)' == ''">
       <ToolEntryPoint>$(TargetFileName)</ToolEntryPoint>
@@ -157,7 +165,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <Target Name="PackToPublishDependencyIndirection"
           DependsOnTargets="$(_PackToolPublishDependency)"/>
 
-  <Target Name="PackTool" DependsOnTargets="SetPackToolProperties;GenerateToolsSettingsFileFromBuildProperty;PackToPublishDependencyIndirection;_PackToolValidation;PackToolImplementation" 
+  <Target Name="PackTool" DependsOnTargets="SetPackToolProperties;GenerateToolsSettingsFileFromBuildProperty;PackToPublishDependencyIndirection;_PackToolValidation;PackToolImplementation"
     Condition=" '$(PackAsTool)' == 'true' "
     Returns="@(TfmSpecificPackageFile)">
     <ItemGroup>
@@ -193,11 +201,6 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <ToolRuntimeIdentifier Condition=" '$(ToolRuntimeIdentifier)' == ''">$(RuntimeIdentifier)</ToolRuntimeIdentifier>
     <_GenerateToolsSettingsFileCacheFile Condition="'$(_GenerateToolsSettingsFileCacheFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).toolssettingsinput.cache</_GenerateToolsSettingsFileCacheFile>
     <_GenerateToolsSettingsFileCacheFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_GenerateToolsSettingsFileCacheFile)))</_GenerateToolsSettingsFileCacheFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(ToolCommandRunner)' == ''">
-    <ToolCommandRunner Condition="!$(UseAppHost)">dotnet</ToolCommandRunner>
-    <ToolCommandRunner Condition="$(UseAppHost)">executable</ToolCommandRunner>
   </PropertyGroup>
 
   <Target Name="_GenerateToolsSettingsFileInputCache">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -127,23 +127,23 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <Target Name="SetPackToolProperties"
           BeforeTargets="_GenerateRestoreProjectSpec;_GenerateToolsSettingsFileInputCache;_GenerateShimInputCache;_GetOutputItemsFromPack">
 
-    <!-- We set UseAppHost here instead of as a 'raw' property because we don't want to impact 'normal' Publish operations on these apps.  -->
     <PropertyGroup>
-      <!-- we want to ensure that we don't publish any AppHosts for the 'outer', RID-agnostic builds -->
-      <UseAppHost Condition="!$(_IsRidSpecific)">false</UseAppHost>
-      <!-- we want to ensure that we _do_ publish any AppHosts for the 'inner', RID-specific builds -->
-      <UseAppHost Condition="$(_IsRidSpecific)">true</UseAppHost>
+      <!-- Fun fact - UseAppHost is false for NativeAot because _RuntimeIdentifierUsesAppHost gets set to false.
+           So we need to check if PublishAot is set as part of this too. As far as I can tell there is no 'common'
+           property for 'you should expect a native binary here' -->
+      <_ToolUsesPlatformSpecificExecutable Condition="$(_IsRidSpecific) and ('$(UseAppHost)' == 'true' or '$(PublishAot)' == 'true')">true</_ToolUsesPlatformSpecificExecutable>
+      <_ToolUsesPlatformSpecificExecutable Condition="'$(_ToolUsesPlatformSpecificExecutable)' == ''">false</_ToolUsesPlatformSpecificExecutable>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(ToolCommandRunner)' == ''">
-      <ToolCommandRunner Condition="!$(UseAppHost)">dotnet</ToolCommandRunner>
-      <ToolCommandRunner Condition="$(UseAppHost)">executable</ToolCommandRunner>
+      <ToolCommandRunner Condition="!$(_ToolUsesPlatformSpecificExecutable)">dotnet</ToolCommandRunner>
+      <ToolCommandRunner Condition="$(_ToolUsesPlatformSpecificExecutable)">executable</ToolCommandRunner>
     </PropertyGroup>
 
     <!-- Needs to be in a target so we don't need to worry about evaluation order with NativeBinary property -->
     <PropertyGroup Condition="'$(ToolEntryPoint)' == ''">
-      <ToolEntryPoint>$(TargetFileName)</ToolEntryPoint>
-      <ToolEntryPoint Condition="$(_IsRidSpecific) and '$(UseAppHost)' == 'true' ">$(AssemblyName)$(_NativeExecutableExtension)</ToolEntryPoint>
+      <ToolEntryPoint Condition="!$(_ToolUsesPlatformSpecificExecutable)">$(TargetFileName)</ToolEntryPoint>
+      <ToolEntryPoint Condition="$(_ToolUsesPlatformSpecificExecutable)">$(AssemblyName)$(_NativeExecutableExtension)</ToolEntryPoint>
     </PropertyGroup>
 
     <!-- inner-build tool packages get a RID suffix -->
@@ -174,8 +174,15 @@ NOTE: This file is imported from the following contexts, so be aware when writin
           recreate the publish layout, but under a TFM- or RID-specific root path. Because we're globbing from the PublishDir,
           the MSBuild Items will have the RecursiveDir metadata - this is used by the PackLogic to combine with the PackagePath
           we set below to ensure we have the correct layout in the end. If the PackLogic didn't try to use RecursiveDir, then
-          we could just explicitly set everything ourselves.   -->
+          we could just explicitly set everything ourselves.
+
+          We _also_ have to filter out apphosts here from platform-agnostic builds, because we don't want to include them in the tool package.
+          This is because we try not to influence the selection of UseAppHost (so that we do not impact 'normal' publishing and end up
+          influencing the contents of the 'normal' publish directory), so it's possible that the 'publish' of an otherwise RID-agnostic
+          tool may include an apphost.
+      -->
       <_PublishFiles Condition="'$(_ToolPackageShouldIncludeImplementation)' == 'true'" Include="$(PublishDir)/**/*" />
+      <_PublishFiles Condition="'$(UseAppHost)' == 'true' and '$(RuntimeIdentifier)' == ''" Remove="$(PublishDir)$(AssemblyName)$(_NativeExecutableExtension)"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -413,10 +420,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
 
     <ItemGroup>
         <_rids Include="$(_PackageRids)" />
-        <_ridsWithoutAny Include="@(_rids)" Condition="%(Identity) != 'any'" />
-        <_ridsWithAny Include="@(_rids)" Condition="%(Identity) == 'any'" />
-        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_ridsWithoutAny.Identity);" Condition="@(_ridsWithoutAny->Count()) &gt; 0" />
-        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="UseAppHost=false;RuntimeIdentifier=any;" Condition="@(_ridsWithAny->Count()) &gt; 0" />
+        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
     </ItemGroup>
 
     <MSBuild BuildInParallel="true" Projects="@(_RidSpecificToolPackageProject)" Targets="Pack">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -415,7 +415,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
         <_rids Include="$(_PackageRids)" />
         <_ridsWithoutAny Include="@(_rids)" Condition="%(Identity) != 'any'" />
         <_ridsWithAny Include="@(_rids)" Condition="%(Identity) == 'any'" />
-        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_ridsWithoutAny.Identity);" />
+        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_ridsWithoutAny.Identity);" Condition="@(_ridsWithoutAny->Count()) &gt; 0" />
         <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="UseAppHost=false;RuntimeIdentifier=any;" Condition="@(_ridsWithAny->Count()) &gt; 0" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -184,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               $([MSBuild]::VersionLessThan($(_TargetFrameworkVersionWithoutV), '8.0'))">true</SelfContained>
 
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
-    <_RuntimeIdentifierUsesAppHost Condition="$(RuntimeIdentifier.StartsWith('ios')) or $(RuntimeIdentifier.StartsWith('tvos')) or $(RuntimeIdentifier.StartsWith('maccatalyst')) or $(RuntimeIdentifier.StartsWith('android')) or $(RuntimeIdentifier.StartsWith('browser')) or $(RuntimeIdentifier.StartsWith('wasi'))">false</_RuntimeIdentifierUsesAppHost>
+    <_RuntimeIdentifierUsesAppHost Condition="$(RuntimeIdentifier.StartsWith('ios')) or $(RuntimeIdentifier.StartsWith('tvos')) or $(RuntimeIdentifier.StartsWith('maccatalyst')) or $(RuntimeIdentifier.StartsWith('android')) or $(RuntimeIdentifier.StartsWith('browser')) or $(RuntimeIdentifier.StartsWith('wasi')) or $(RuntimeIdentifier) == 'any'">false</_RuntimeIdentifierUsesAppHost>
     <_RuntimeIdentifierUsesAppHost Condition="'$(_IsPublishing)' == 'true' and '$(PublishAot)' == 'true'">false</_RuntimeIdentifierUsesAppHost>
     <_RuntimeIdentifierUsesAppHost Condition="'$(_RuntimeIdentifierUsesAppHost)' == ''">true</_RuntimeIdentifierUsesAppHost>
     <UseAppHost Condition="'$(UseAppHost)' == '' and

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void InstallAndRunToolGlobal()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings();
-            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings);
+            string toolPackagesPath = ToolBuilder.CreateTestTool(Log, toolSettings, collectBinlogs: true);
 
             var testDirectory = _testAssetsManager.CreateTestDirectory();
             var homeFolder = Path.Combine(testDirectory.Path, "home");

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         }
 
 
-        public string CreateTestTool(ITestOutputHelper log, TestToolSettings toolSettings, bool collectBinlogs = false)
+        public string CreateTestTool(ITestOutputHelper log, TestToolSettings toolSettings, bool collectBinlogs = true)
         {
             var targetDirectory = Path.Combine(TestContext.Current.TestExecutionDirectory, "TestTools", toolSettings.GetIdentifier());
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProject.cs
@@ -35,7 +35,7 @@ namespace Microsoft.NET.Publish.Tests
             publishCommand.Execute();
 
             publishCommand.GetOutputDirectory(targetFramework: ToolsetInfo.CurrentTargetFramework)
-                .EnumerateFiles().Should().Contain(f => f.Name == "consoledemo" + Constants.ExeSuffix);
+                .Should().HaveFile("consoledemo" + Constants.ExeSuffix);
         }
     }
 }

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAToolProject.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System.Runtime.CompilerServices;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishAToolProject : SdkTest
+    {
+        public GivenThatWeWantToPublishAToolProject(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        private TestAsset SetupTestAsset([CallerMemberName] string callingMethod = "")
+        {
+            TestAsset helloWorldAsset = _testAssetsManager
+                .CopyTestAsset("PortableTool", callingMethod)
+                .WithSource();
+
+
+            return helloWorldAsset;
+        }
+
+        [Fact]
+        // this test verifies that we don't regress the 'normal' publish experience accidentally in the
+        // PackTool.targets
+        public void It_can_publish_and_has_apphost()
+        {
+            var testAsset = SetupTestAsset();
+            var publishCommand = new PublishCommand(testAsset);
+
+            publishCommand.Execute();
+
+            publishCommand.GetOutputDirectory(targetFramework: ToolsetInfo.CurrentTargetFramework)
+                .EnumerateFiles().Should().Contain(f => f.Name == "consoledemo" + Constants.ExeSuffix);
+        }
+    }
+}

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -20,9 +20,9 @@ namespace Microsoft.NET.ToolPack.Tests
 
         private string SetupNuGetPackage(bool multiTarget, string packageType = null, [CallerMemberName] string callingMethod = "")
         {
-
+            string id = $"{callingMethod}-{_targetFrameworkOrFrameworks}";
             TestAsset helloWorldAsset = _testAssetsManager
-                .CopyTestAsset("PortableTool", callingMethod + multiTarget + (packageType ?? ""))
+                .CopyTestAsset("PortableTool", id)
                 .WithSource()
                 .WithProjectChanges(project =>
                 {
@@ -39,7 +39,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
             var packCommand = new PackCommand(helloWorldAsset);
 
-            var result = packCommand.Execute();
+            var result = packCommand.Execute($"/bl:{id}-{{}}.binlog");
             result.Should().Pass();
 
             return packCommand.GetNuGetPackage();
@@ -192,9 +192,9 @@ namespace Microsoft.NET.ToolPack.Tests
                 string[] args = multiTarget ? new[] { $"/p:TargetFramework={_targetFrameworkOrFrameworks}" } : Array.Empty<string>();
                 getValuesCommand.Execute(args)
                     .Should().Pass();
-                string runCommandPath = getValuesCommand.GetValues().Single();
-                runCommandPath
-                    .Should().Be("dotnet", because: "The RunCommand should recognize that this is a non-AppHost tool and should use the muxer to launch it");
+                var runCommand = new FileInfo(getValuesCommand.GetValues().Single());
+                runCommand.Name
+                    .Should().StartWith("consoledemo", because: "The RunCommand should recognize that this is an AppHost project and should use the muxer to launch it for non-tool use cases.");
             }
         }
 

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Runtime.CompilerServices;
+using Microsoft.DotNet.Cli.Utils;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 
@@ -194,7 +195,7 @@ namespace Microsoft.NET.ToolPack.Tests
                     .Should().Pass();
                 var runCommand = new FileInfo(getValuesCommand.GetValues().Single());
                 runCommand.Name
-                    .Should().StartWith("consoledemo", because: "The RunCommand should recognize that this is an AppHost project and should use the muxer to launch it for non-tool use cases.");
+                    .Should().Be("consoledemo" + Constants.ExeSuffix, because: "The RunCommand should recognize that this is an AppHost-using project and should use the AppHost for non-tool use cases.");
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49799

The PackTool targets were unconditionally overwriting the UseAppHost and related properties at evaluation-time. This results in publishes of the projects not having AppHosts when they were expected to.

Instead of modifying the way that the projects are Published, we now use knowledge of the _intent_ of the Publish to determine if the apphost/binary should be included in the generated tool package.