### PR TITLE
Don't put testing global.json in artifacts dir directly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@
     <TestHostFolder>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'redist', '$(Configuration)'))</TestHostFolder>
     <TestHostDotNetRoot>$([MSBuild]::NormalizeDirectory('$(TestHostFolder)', 'dotnet'))</TestHostDotNetRoot>
     <TestHostDotNetTool>$(TestHostDotNetRoot)$([System.IO.Path]::GetFileName('$(DotNetTool)'))</TestHostDotNetTool>
+    <TestLayoutDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTmpDir)', 'testing'))</TestLayoutDir>
 
     <PackageProjectUrl>https://github.com/dotnet/sdk</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -137,7 +137,7 @@ jobs:
       - ${{ if eq(parameters.runAoTTests, true) }}:
         # For the reason this is here, see: https://github.com/dotnet/sdk/issues/22655
         - script: $(Build.SourcesDirectory)/artifacts/bin/redist/$(buildConfiguration)/dotnet/dotnet workload install wasm-tools --skip-manifest-update
-          workingDirectory: $(Build.SourcesDirectory)/artifacts
+          workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
           displayName: 🟣 Install wasm-tools Workload
       # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
       - ${{ if eq(parameters.pool.os, 'windows') }}:

--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -122,7 +122,7 @@
 
   <!-- Copy to *.csproj for using in sanity checks integration tests. -->
   <Target Name="CopyCsprojToTestExecutionDirectory" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(ArtifactsTmpDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(TestLayoutDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/src/Containers/containerize/containerize.csproj
+++ b/src/Containers/containerize/containerize.csproj
@@ -26,11 +26,11 @@
     <ItemGroup>
       <ContainerizeFiles Include="$(ArtifactsBinDir)containerize\$(Configuration)\$(SdkTargetFramework)\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(ContainerizeFiles)" DestinationFiles="@(ContainerizeFiles->'$(ArtifactsTmpDir)Container\containerize\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(ContainerizeFiles)" DestinationFiles="@(ContainerizeFiles->'$(TestLayoutDir)Container\containerize\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Copy to *.csproj for using in sanity checks integration tests. -->
   <Target Name="CopyCsprojToTestExecutionDirectory" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(ArtifactsTmpDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileFullPath)" DestinationFiles="$(TestLayoutDir)Container\ProjectFiles\$(MSBuildThisFileName).csproj" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/Containers/packaging/package.csproj
+++ b/src/Containers/packaging/package.csproj
@@ -112,14 +112,14 @@
     <!-- Hacky workaround for the fact that we don't publish the package yet. -->
     <Target Name="CopyNupkgToCustomFolder" AfterTargets="Pack">
         <Copy SourceFiles="$(ArtifactsDir)packages/$(Configuration)/Shipping/Microsoft.NET.Build.Containers.$(Version).nupkg"
-            DestinationFiles="$(ArtifactsTmpDir)Container/package/Microsoft.NET.Build.Containers.$(Version).nupkg" />
+            DestinationFiles="$(TestLayoutDir)Container/package/Microsoft.NET.Build.Containers.$(Version).nupkg" />
     </Target>
 
     <!-- Copy files that are needed by Integration tests. -->
     <Target Name="CopyPropsAndTargets" AfterTargets="Pack">
       <Copy SourceFiles="./build/Microsoft.NET.Build.Containers.props"
-          DestinationFiles="$(ArtifactsTmpDir)Container/packaging/Microsoft.NET.Build.Containers.props" />
+          DestinationFiles="$(TestLayoutDir)Container/packaging/Microsoft.NET.Build.Containers.props" />
       <Copy SourceFiles="./build/Microsoft.NET.Build.Containers.targets"
-          DestinationFiles="$(ArtifactsTmpDir)Container/packaging/Microsoft.NET.Build.Containers.targets" />
+          DestinationFiles="$(TestLayoutDir)Container/packaging/Microsoft.NET.Build.Containers.targets" />
     </Target>
 </Project>

--- a/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
+++ b/src/Layout/redist/targets/GenerateTestingGlobalJson.targets
@@ -1,14 +1,14 @@
 <Project>
-  <PropertyGroup>
-    <!-- We put this in the root of the artifacts dir so that any usage (not just from ./tmp, but also from ./bin) gets redirected. -->
-    <_TestingGlobalJsonPath>$(ArtifactsDir)global.json</_TestingGlobalJsonPath>
-  </PropertyGroup>
+  <ItemGroup>
+    <_TestingGlobalJsonPath Include="$(ArtifactsBinDir)global.json" />
+    <_TestingGlobalJsonPath Include="$(TestLayoutDir)global.json" />
+  </ItemGroup>
 
   <!-- Since the dotnet binary respects sdk.paths in global.json now, and we use this in the repo root to make sure that we consistently use the repo-local
        SDK for building/etc, we need to put something in place so that tests don't use the repo-local SDK and instead use the redist SDK. -->
   <Target Name="CreateRedistGlobalJsonForTesting"
     BeforeTargets="AfterBuild"
-    Outputs="$(_TestingGlobalJsonPath)">
+    Outputs="@(_TestingGlobalJsonPath)">
     <PropertyGroup>
       <_TestingRedistDotnetPath>$(TestHostDotNetRoot.Replace('\', '\\'))</_TestingRedistDotnetPath>
     </PropertyGroup>
@@ -21,13 +21,13 @@
       <_RedistGlobalJsonLines Include="  }" />
       <_RedistGlobalJsonLines Include="}" />
     </ItemGroup>
-    <WriteLinesToFile File="$(_TestingGlobalJsonPath)"
+    <WriteLinesToFile File="%(_TestingGlobalJsonPath.Identity)"
                        Lines="@(_RedistGlobalJsonLines)"
                        Overwrite="true"
                        Encoding="utf-8"
                        WriteOnlyWhenDifferent="true" />
     <ItemGroup>
-      <FileWrites Include="$(_TestingGlobalJsonPath)" />
+      <FileWrites Include="@(_TestingGlobalJsonPath)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
@@ -4,7 +4,7 @@
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-        <OutputPath>$(ArtifactsTmpDir)</OutputPath>
+        <OutputPath>$(TestLayoutDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
         <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
         <IsPackable>true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/Microsoft.DotNet.Common.ProjectTemplates.10.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/Microsoft.DotNet.Common.ProjectTemplates.10.0.csproj
@@ -4,7 +4,7 @@
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-        <OutputPath>$(ArtifactsTmpDir)</OutputPath>
+        <OutputPath>$(TestLayoutDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
         <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
         <IsPackable>true</IsPackable>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -19,16 +19,16 @@
     <!-- Set this to true for test project only because test assets contains .editorconfig file -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="$(MSBuildThisFileDirectory)Common\Program.cs" />
   </ItemGroup>
 
   <Target Name="TestAsTool" DependsOnTargets="Pack;_InnerGetTestsToRun">
     <PropertyGroup>
-      <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
-      <TestLocalToolExecutionFolder>$(ArtifactsTmpDir)$(ToolCommandName)\w</TestLocalToolExecutionFolder>
-      <DOTNET_CLI_HOME>$(ArtifactsTmpDir)DOTNET_CLI_HOME\</DOTNET_CLI_HOME>
+      <TestLocalToolFolder>$(TestLayoutDir)$(ToolCommandName)\</TestLocalToolFolder>
+      <TestLocalToolExecutionFolder>$(TestLayoutDir)$(ToolCommandName)\w</TestLocalToolExecutionFolder>
+      <DOTNET_CLI_HOME>$(TestLayoutDir)DOTNET_CLI_HOME\</DOTNET_CLI_HOME>
     </PropertyGroup>
 
     <RemoveDir Directories="$(TestLocalToolExecutionFolder)" />
@@ -46,11 +46,11 @@
       IgnoreStandardErrorWarningFormat="true"
       WorkingDirectory="$(TestLocalToolFolder)"
       EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
-    
+
     <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(PackageVersion) --add-source $(ArtifactsNonShippingPackagesDir)"
       WorkingDirectory="$(TestLocalToolFolder)"
       EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
-    
+
     <Exec Command="dotnet tool restore"
       WorkingDirectory="$(TestLocalToolFolder)"
       EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
     //  global packages folder to ensure that the newly built package is used the next time a test tries to install it.
     //
     //  The main thing this class can't handle is if the way the .NET SDK builds packages changes.  In CI runs, we should use a clean test execution folder each time (I think!), so this shouldn't be an issue.
-    //  For local testing, you may need to delete the artifacts\tmp\Debug\TestTools folder if the SDK changes in a way that affects the built package.
+    //  For local testing, you may need to delete the artifacts\tmp\Debug\testing\TestTools folder if the SDK changes in a way that affects the built package.
     public class TestToolBuilder
     {
         public class TestToolSettings

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
@@ -438,7 +438,7 @@ public class DefineStaticWebAssetEndpointsTest
                     ["AssetRole"] = "Alternative",
                     ["AssetTraitValue"] = "gzip",
                     ["AssetTraitName"] = "Content-Encoding",
-                    ["OriginalItemSpec"] = Path.Combine("D:", "work", "dotnet-sdk", "artifacts", "tmp", "Release", "Publish60Host---0200F604", "Client", "bin", "Debug", "net6.0", "wwwroot", "_framework", "dotnet.timezones.blat"),
+                    ["OriginalItemSpec"] = Path.Combine("D:", "work", "dotnet-sdk", "artifacts", "tmp", "Release", "testing", "Publish60Host---0200F604", "Client", "bin", "Debug", "net6.0", "wwwroot", "_framework", "dotnet.timezones.blat"),
                     ["CopyToPublishDirectory"] = "Never",
                     ["FileLength"] = "10",
                     ["LastWriteTime"] = lastWrite.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)

--- a/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -1,7 +1,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Test">
 
   <PropertyGroup>
-    <TestPackagesDir>$(ArtifactsTmpDir)testpackages/</TestPackagesDir>
+    <TestPackagesDir>$(TestLayoutDir)testpackages/</TestPackagesDir>
   </PropertyGroup>
 
   <Target Name="PrepareTests"

--- a/test/Microsoft.NET.TestFramework/SetupTestRoot.targets
+++ b/test/Microsoft.NET.TestFramework/SetupTestRoot.targets
@@ -8,9 +8,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.props" />
-    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir)Directory.Build.targets" />
-    <_CopyDirectoryBuildTestDependenciesOutput Include="$(ArtifactsTmpDir).editorconfig" />
+    <_CopyDirectoryBuildTestDependenciesOutput Include="$(TestLayoutDir)Directory.Build.props" />
+    <_CopyDirectoryBuildTestDependenciesOutput Include="$(TestLayoutDir)Directory.Build.targets" />
+    <_CopyDirectoryBuildTestDependenciesOutput Include="$(TestLayoutDir).editorconfig" />
   </ItemGroup>
 
   <!-- Since TestFramework is multi-targeted, only copy these files for one of the inner builds -->
@@ -18,14 +18,14 @@
           Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">
     <Copy SourceFiles="@(_CopyDirectoryBuildTestDependenciesInput)" DestinationFiles="@(_CopyDirectoryBuildTestDependenciesOutput)" />
   </Target>
-  
-  <Target Name="WriteNugetConfigFile" 
+
+  <Target Name="WriteNugetConfigFile"
           AfterTargets="Build"
           Inputs="$(RepoRoot)NuGet.config"
-          Outputs="$(ArtifactsTmpDir)NuGet.config"
+          Outputs="$(TestLayoutDir)NuGet.config"
           Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
           >
-    <Copy SourceFiles="$(RepoRoot)NuGet.config" DestinationFiles="$(ArtifactsTmpDir)NuGet.config" />
+    <Copy SourceFiles="$(RepoRoot)NuGet.config" DestinationFiles="$(TestLayoutDir)NuGet.config" />
   </Target>
 
 </Project>

--- a/test/Microsoft.NET.TestFramework/TestContext.cs
+++ b/test/Microsoft.NET.TestFramework/TestContext.cs
@@ -206,7 +206,7 @@ namespace Microsoft.NET.TestFramework
                 string? FindFolder2 = FindFolderInTree(Path.Combine("test", "TestAssets"), AppContext.BaseDirectory);
                 if (FindFolder1 is not null)
                 {
-                    testContext.TestExecutionDirectory = Path.Combine(FindFolder1, "tmp", repoConfiguration);
+                    testContext.TestExecutionDirectory = Path.Combine(FindFolder1, "tmp", repoConfiguration, "testing");
                 }
                 if (FindFolder2 is not null)
                 {
@@ -237,7 +237,7 @@ namespace Microsoft.NET.TestFramework
                 testContext.NuGetExePath = Path.Combine(artifactsDir, ".nuget", $"nuget{Constants.ExeSuffix}");
                 testContext.NuGetCachePath = Path.Combine(artifactsDir, ".nuget", "packages");
 
-                testContext.TestPackages = Path.Combine(artifactsDir, "tmp", repoConfiguration, "testpackages");
+                testContext.TestPackages = Path.Combine(artifactsDir, "tmp", repoConfiguration, "testing", "testpackages");
             }
             else if (runAsTool)
             {

--- a/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -346,7 +346,7 @@ namespace Microsoft.NET.TestFramework
 
             if (repoRoot != null && repoArtifactsDir is not null)
             {
-                ret.CliHomePath = Path.Combine(repoArtifactsDir, "tmp", configuration);
+                ret.CliHomePath = Path.Combine(repoArtifactsDir, "tmp", configuration, "testing");
             }
 
             return ret;

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -105,7 +105,7 @@
         <DestinationFolder>eng/</DestinationFolder>
       </TestExecutionDirectoryFiles>
 
-      <FilesInHelixRoot Include="$(RepoRoot)artifacts\tmp\$(Configuration)\NuGet.config" />
+      <FilesInHelixRoot Include="$(TestLayoutDir)\NuGet.config" />
       <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(RepoRoot)build\RunTestsOnHelix.cmd" />
       <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)build\RunTestsOnHelix.sh" />
     </ItemGroup>

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -82,21 +82,21 @@
       <!-- Get full framework msbuild end -->
 
       <!-- include .dotnet folder. So there is no extra first run experience run during the test -->
-      <DotnetCliHome Include="$(ArtifactsTmpDir).dotnet\**\*.*" />
+      <DotnetCliHome Include="$(TestLayoutDir).dotnet\**\*.*" />
 
-      <Testpackages Include="$(ArtifactsTmpDir)testpackages\**\*.*" />
+      <Testpackages Include="$(TestLayoutDir)testpackages\**\*.*" />
 
       <!-- include Container artifacts for running test in Helix -->
-      <ContainerFiles Include="$(ArtifactsTmpDir)Container\**\*.*" />
+      <ContainerFiles Include="$(TestLayoutDir)Container\**\*.*" />
 
       <LockFiles Include="..\src\Tasks\Microsoft.NET.Build.Tasks.UnitTests\LockFiles\**\*.*" />
 
       <AssetFiles Include="TestAssets\**\*.*" />
 
       <!-- Files in testExecutionDirectory to prevent environment interference -->
-      <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)NuGet.config" />
-      <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)Directory.Build.props" />
-      <TestExecutionDirectoryFiles Include="$(ArtifactsTmpDir)Directory.Build.targets" />
+      <TestExecutionDirectoryFiles Include="$(TestLayoutDir)NuGet.config" />
+      <TestExecutionDirectoryFiles Include="$(TestLayoutDir)Directory.Build.props" />
+      <TestExecutionDirectoryFiles Include="$(TestLayoutDir)Directory.Build.targets" />
       <TestExecutionDirectoryFiles Include="$(RepoRoot)testAsset.props" />
       <TestExecutionDirectoryFiles Include="$(RepoRoot)eng\Versions.props">
         <DestinationFolder>eng/</DestinationFolder>

--- a/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
+++ b/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         /// <summary>
         /// Creates a temp test directory under test execution folder.
-        /// Format: artifacts\tmp\Debug\dotnet-new.IntegrationTests\<paramref name="testName"/>\<paramref name="folderName"/>\date-time-utc-now[optional counter].
+        /// Format: artifacts\tmp\Debug\testing\dotnet-new.IntegrationTests\<paramref name="testName"/>\<paramref name="folderName"/>\date-time-utc-now[optional counter].
         /// </summary>
         /// <remarks>
         /// Use this method when temp folder should be under location that is aware of repo nuget.config.

--- a/test/dotnet-new.IntegrationTests/Utilities.cs
+++ b/test/dotnet-new.IntegrationTests/Utilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         /// <summary>
         /// Creates a temp folder in location dedicated for dotnet-new.IntegrationTests.
-        /// Format: artifacts\tmp\Debug\dotnet-new.IntegrationTests\<paramref name="caller"/>\<paramref name="customName"/>\date-time-utc-now[optional counter].
+        /// Format: artifacts\tmp\Debug\testing\dotnet-new.IntegrationTests\<paramref name="caller"/>\<paramref name="customName"/>\date-time-utc-now[optional counter].
         /// </summary>
         internal static string CreateTemporaryFolder([CallerMemberName] string caller = "Unnamed", string customName = "")
         {

--- a/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+++ b/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -68,9 +68,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
     <WriteLinesToFile Lines="$(GeneratedText)" File="$(GeneratedFilePath)" WriteOnlyWhenDifferent="true" Overwrite="true" />
   </Target>
 
-  <Target Name="CopyDBFilesToArtifactsTmpDir" AfterTargets="Build">
-    <Copy SourceFiles="TestDirectoryBuildFiles/Directory.Build.props" DestinationFolder="$(ArtifactsTmpDir)" />
-    <Copy SourceFiles="TestDirectoryBuildFiles/Directory.Build.targets" DestinationFolder="$(ArtifactsTmpDir)" />
+  <Target Name="CopyDBFilesToTestLayoutDir" AfterTargets="Build">
+    <Copy SourceFiles="TestDirectoryBuildFiles/Directory.Build.props" DestinationFolder="$(TestLayoutDir)" />
+    <Copy SourceFiles="TestDirectoryBuildFiles/Directory.Build.targets" DestinationFolder="$(TestLayoutDir)" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Move testing into a subfolder under artifacts/tmp

Prevents interference between the testing global.json with Arcade's signing logic

Fixes https://github.com/dotnet/dotnet/issues/1486