### PR TITLE
Re-add Version.Details.xml props for win* repos.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -225,6 +225,39 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
     </Dependency>
+    <!-- Do not use properties based on:
+         - Microsoft.WindowsDesktop.App.Ref
+         - Microsoft.WindowsDesktop.App.Internal
+         - Microsoft.NET.Sdk.WindowsDesktop
+         - Microsoft.Dotnet.WinForms.ProjectTemplates
+         - Microsoft.DotNet.Wpf.ProjectTemplates
+         In VMR builds on non-Windows, they aren't built. Instead, use the following:
+         - Microsoft.WindowsDesktop.App.Ref - Microsoft.NETCore.App.Ref
+         - Microsoft.WindowsDesktop.App.Internal - Microsoft.NETCore.Platforms
+         - Microsoft.NET.Sdk.WindowsDesktop - Microsoft.NETCore.App.Ref
+         - Microsoft.Dotnet.WinForms.ProjectTemplates - Microsoft.NETCore.Platforms
+         - Microsoft.DotNet.Wpf.ProjectTemplates - Microsoft.NETCore.Platforms
+    -->
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-preview.7.25359.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App.Internal" Version="10.0.0-preview.7.25359.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="10.0.0-preview.7.25359.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.7.25359.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="10.0.0-preview.7.25359.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="10.0.0-preview.7.25359.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>f451e5d3036a4f140a989e0a7f3f1ae432420e71</Sha>


### PR DESCRIPTION
These were removed in a previous check-in to avoid them accidentally being used. However, this causes the VMR dependency flow infra to omit build feeds for windowsdesktop, wpf, and winforms. This is correct behavior according to the way the system was designed. Re add the deps, with a comment indicating they are only for flow.