### PR TITLE
Limit the expected search location for the dotnet muxer from the sdk resolver result

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -299,7 +299,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         {
             var expectedFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Constants.DotNetExe : Constants.DotNet;
             var currentDir = resolverResult.ResolvedSdkDirectory;
-            var expectedDotnetRoot = Path.GetFullPath(Path.Combine(currentDir, "..", ".."));
+            var expectedDotnetRoot = Path.GetDirectoryName(Path.GetDirectoryName(currentDir));
             var expectedMuxerPath = Path.Combine(expectedDotnetRoot, expectedFileName);
             if (File.Exists(expectedMuxerPath))
             {


### PR DESCRIPTION
We limit the probing to the expected layouts instead of allowing unrestricted probing up the file system.

Also part of https://github.com/dotnet/sdk/issues/49363