### PR TITLE
Ensure all evaluation data are in binlogs from file-based apps

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -180,7 +180,6 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         }
 
         Dictionary<string, string?> savedEnvironmentVariables = [];
-        ProjectCollection? projectCollection = null;
         try
         {
             // Set environment variables.
@@ -192,7 +191,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
             // Set up MSBuild.
             ReadOnlySpan<ILogger> binaryLoggers = binaryLogger is null ? [] : [binaryLogger];
-            projectCollection = new ProjectCollection(
+            var projectCollection = new ProjectCollection(
                 MSBuildArgs.GlobalProperties,
                 [.. binaryLoggers, consoleLogger],
                 ToolsetDefinitionLocations.Default);
@@ -202,18 +201,22 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 LogTaskInputs = binaryLoggers.Length != 0,
             };
 
+            // Projects need to be created before BeginBuild is called, otherwise binlog doesn't contain evaluation data.
+            var restoreProject = NoRestore ? null : CreateProjectInstance(projectCollection, addGlobalProperties: AddRestoreGlobalProperties(MSBuildArgs.RestoreGlobalProperties));
+            var buildProject = NoBuild ? null : CreateProjectInstance(projectCollection);
+
+            BuildManager.DefaultBuildManager.BeginBuild(parameters);
+
             // Do a restore first (equivalent to MSBuild's "implicit restore", i.e., `/restore`).
             // See https://github.com/dotnet/msbuild/blob/a1c2e7402ef0abe36bf493e395b04dd2cb1b3540/src/MSBuild/XMake.cs#L1838
             // and https://github.com/dotnet/msbuild/issues/11519.
-            if (!NoRestore)
+            if (restoreProject != null)
             {
                 var restoreRequest = new BuildRequestData(
-                    CreateProjectInstance(projectCollection, addGlobalProperties: AddRestoreGlobalProperties(MSBuildArgs.RestoreGlobalProperties)),
+                    restoreProject,
                     targetsToBuild: ["Restore"],
                     hostServices: null,
                     BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentTargets | BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports | BuildRequestDataFlags.FailOnUnresolvedSdk);
-
-                BuildManager.DefaultBuildManager.BeginBuild(parameters);
 
                 var restoreResult = BuildManager.DefaultBuildManager.BuildRequest(restoreRequest);
                 if (restoreResult.OverallResult != BuildResultCode.Success)
@@ -223,17 +226,11 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             // Then do a build.
-            if (!NoBuild)
+            if (buildProject != null)
             {
                 var buildRequest = new BuildRequestData(
-                    CreateProjectInstance(projectCollection),
+                    buildProject,
                     targetsToBuild: MSBuildArgs.RequestedTargets ?? ["Build"]);
-
-                // For some reason we need to BeginBuild after creating BuildRequestData otherwise the binlog doesn't contain Evaluation.
-                if (NoRestore)
-                {
-                    BuildManager.DefaultBuildManager.BeginBuild(parameters);
-                }
 
                 var buildResult = BuildManager.DefaultBuildManager.BuildRequest(buildRequest);
                 if (buildResult.OverallResult != BuildResultCode.Success)

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -190,7 +190,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             // Set up MSBuild.
-            ReadOnlySpan<ILogger> binaryLoggers = binaryLogger is null ? [] : [binaryLogger];
+            ReadOnlySpan<ILogger> binaryLoggers = binaryLogger is null ? [] : [binaryLogger.Value];
             IEnumerable<ILogger> loggers = [.. binaryLoggers, consoleLogger];
             var projectCollection = new ProjectCollection(
                 MSBuildArgs.GlobalProperties,
@@ -255,7 +255,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 Environment.SetEnvironmentVariable(key, value);
             }
 
-            binaryLogger?.ReallyShutdown();
+            binaryLogger?.Value.ReallyShutdown();
             consoleLogger.Shutdown();
         }
 
@@ -283,7 +283,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             };
         }
 
-        static FacadeLogger? GetBinaryLogger(IReadOnlyList<string>? args)
+        static Lazy<FacadeLogger>? GetBinaryLogger(IReadOnlyList<string>? args)
         {
             if (args is null) return null;
             // Like in MSBuild, only the last binary logger is used.
@@ -292,13 +292,17 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 var arg = args[i];
                 if (LoggerUtility.IsBinLogArgument(arg))
                 {
-                    var logger = new BinaryLogger
+                    // We don't want to create the binlog file until actually needed, hence we wrap this in a Lazy.
+                    return new(() =>
                     {
-                        Parameters = arg.IndexOf(':') is >= 0 and var index
-                            ? arg[(index + 1)..]
-                            : "msbuild.binlog",
-                    };
-                    return LoggerUtility.CreateFacadeLogger([logger]);
+                        var logger = new BinaryLogger
+                        {
+                            Parameters = arg.IndexOf(':') is >= 0 and var index
+                                ? arg[(index + 1)..]
+                                : "msbuild.binlog",
+                        };
+                        return LoggerUtility.CreateFacadeLogger([logger]);
+                    });
                 }
             }
 

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -48,14 +48,14 @@ internal static class LoggerUtility
         // We need a custom logger to handle this, because the MSBuild API for evaluation and execution calls logger Initialize and Shutdown methods, so will not allow us to do this.
         if (binaryLoggers.Count > 0)
         {
-            var fakeLogger = ConfigureDispatcher(binaryLoggers);
+            var fakeLogger = CreateFacadeLogger(binaryLoggers);
 
             return fakeLogger;
         }
         return null;
     }
 
-    private static FacadeLogger ConfigureDispatcher(List<BinaryLogger> binaryLoggers)
+    public static FacadeLogger CreateFacadeLogger(List<BinaryLogger> binaryLoggers)
     {
         var dispatcher = new PersistentDispatcher(binaryLoggers);
         return new FacadeLogger(dispatcher);

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -939,8 +939,8 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         new FileInfo(binaryLogPath).Should().Exist();
 
         var records = BinaryLog.ReadRecords(binaryLogPath).ToList();
-        records.Any(static r => r.Args is ProjectEvaluationStartedEventArgs).Should().BeTrue();
-        records.Any(static r => r.Args is ProjectEvaluationFinishedEventArgs).Should().BeTrue();
+        records.Count(static r => r.Args is ProjectEvaluationStartedEventArgs).Should().Be(2);
+        records.Count(static r => r.Args is ProjectEvaluationFinishedEventArgs).Should().Be(2);
     }
 
     /// <summary>


### PR DESCRIPTION
Better fix than https://github.com/dotnet/sdk/pull/49588.
Currently only restore evaluation data are in the binlogs, not build evaluation data - this PR fixes that.