### PR TITLE
Update copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Do an initial build to ensure all dependencies are restored
+        continue-on-error: true
         run: |
           ./build.sh
       - name: Put repo-local dotnet install on PATH


### PR DESCRIPTION
This prevents Copilot from floundering when working on an already-broken workspace state