### PR TITLE
Disable the container job and allow jobs to disable themselves

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -64,7 +64,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      azureLinux30Net10BuildAmd64:
+      azureLinux30Amd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
 
     sdl:
@@ -192,7 +192,7 @@ extends:
               runTests: false
             ### musl ###
             - categoryName: musl
-              container: azureLinux30Net10BuildAmd64
+              container: azureLinux30Amd64
               runtimeIdentifier: linux-musl-x64
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
@@ -201,14 +201,18 @@ extends:
               # SBOM generation is not supported for alpine.
               enableSbom: false
               runTests: false
+              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+              disableJob: true
             - categoryName: musl
-              container: azureLinux30Net10BuildAmd64
+              container: azureLinux30Amd64
               targetArchitecture: arm
               runtimeIdentifier: linux-musl-arm
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               osProperties: /p:OSName=linux-musl
               runTests: false
+              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+              disableJob: true
             - categoryName: musl
               targetArchitecture: arm64
               runtimeIdentifier: linux-musl-arm64

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -27,7 +27,7 @@ variables:
 
 resources:
   containers:
-  - container: azureLinux30Net10BuildAmd64
+  - container: azureLinux30Amd64
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
 
 stages:

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -12,10 +12,9 @@ parameters:
     runTestsAsTool: true
     # This job uses the build step for testing, so the extra test step is not necessary.
     runTests: false
-  # Turn off template engine runs on Windows temporarily until agent images are updated
-  #- categoryName: TemplateEngine
-  #  testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-  #  publishXunitResults: true
+  - categoryName: TemplateEngine
+    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+    publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true
   ### LINUX ###
@@ -29,10 +28,12 @@ parameters:
     # Don't run the tests on arm64. Only perform the build itself.
     runTests: false
   - categoryName: ContainerBased
-    container: azureLinux30Net10BuildAmd64
+    container: azureLinux30Amd64
     helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     runTests: true
+    # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+    disableJob: true
   - categoryName: TemplateEngine
     osProperties: $(linuxOsglibcProperties)
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -64,19 +65,22 @@ jobs:
 # The parameters sent to this template are also passed to the job, which does include the os-specific jobParameterSets array, but that array itself isn't used in the job.
 - ${{ if eq(parameters.pool.os, 'windows') }}:
   - ${{ each jobParameters in parameters.windowsJobParameterSets }}:
-    - template: /eng/pipelines/templates/jobs/sdk-build.yml
-      parameters:
-        ${{ insert }}: ${{ parameters }}
-        ${{ insert }}: ${{ jobParameters }}
+    - ${{ if not(jobParameters.disableJob) }}:
+      - template: /eng/pipelines/templates/jobs/sdk-build.yml
+        parameters:
+          ${{ insert }}: ${{ parameters }}
+          ${{ insert }}: ${{ jobParameters }}
 - ${{ if eq(parameters.pool.os, 'linux') }}:
   - ${{ each jobParameters in parameters.linuxJobParameterSets }}:
-    - template: /eng/pipelines/templates/jobs/sdk-build.yml
-      parameters:
-        ${{ insert }}: ${{ parameters }}
-        ${{ insert }}: ${{ jobParameters }}
+    - ${{ if not(jobParameters.disableJob) }}:
+      - template: /eng/pipelines/templates/jobs/sdk-build.yml
+        parameters:
+          ${{ insert }}: ${{ parameters }}
+          ${{ insert }}: ${{ jobParameters }}
 - ${{ if eq(parameters.pool.os, 'macOS') }}:
   - ${{ each jobParameters in parameters.macOSJobParameterSets }}:
-    - template: /eng/pipelines/templates/jobs/sdk-build.yml
-      parameters:
-        ${{ insert }}: ${{ parameters }}
-        ${{ insert }}: ${{ jobParameters }}
+    - ${{ if not(jobParameters.disableJob) }}:
+      - template: /eng/pipelines/templates/jobs/sdk-build.yml
+        parameters:
+          ${{ insert }}: ${{ parameters }}
+          ${{ insert }}: ${{ jobParameters }}


### PR DESCRIPTION
## Summary

Currently, there is a [Helix issue](https://github.com/dotnet/dnceng/issues/6000) causing our job that uses a container to hang/timeout. Instead of just commenting out the job, I added the ability for jobs to disable themselves via the `disableJob` parameter.

### Changes
- Added a `disableJob` parameter for problematic jobs
- Shortened the container name from `azureLinux30Net10BuildAmd64` to `azureLinux30Amd64`
- Re-enabled the TemplateEngine Windows job as it has been disabled for a long time
  - If it doesn't work, I'll use the new parameter to disable it again