### PR TITLE
Place file-based app artifacts into repo's artifacts dir if used

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -178,7 +178,9 @@ have the shared `.cs` files source-included via `<Compile Include="../Shared/**/
 
 ## Build outputs
 
-Build outputs are placed under a subdirectory whose name is hashed file path of the entry point
+If [artifacts output layout][artifacts-output] is enabled, build outputs of the file-based app are placed there
+(except caching markers which are placed in the global temp directory described next).
+Otherwise, build outputs are placed under a subdirectory whose name is hashed file path of the entry point
 inside a temp or app data directory which should be owned by and unique to the current user per [runtime guidelines][temp-guidelines].
 The subdirectory is created by the SDK CLI with permissions restricting access to it to the current user (`0700`) and the run fails if that is not possible.
 Note that it is possible for multiple users to run the same file-based program, however each user's run uses different build artifacts since the base directory is unique per user.

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -650,8 +650,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 <Project>
 
                   <PropertyGroup>
-                    <IncludeProjectNameInArtifactsPaths>false</IncludeProjectNameInArtifactsPaths>
-                    <ArtifactsPath>{EscapeValue(artifactsPath)}</ArtifactsPath>
+                    <FileBasedAppArtifactsPath>{EscapeValue(artifactsPath)}</FileBasedAppArtifactsPath>
                     <PublishDir>artifacts/$(MSBuildProjectName)</PublishDir>
                   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/UseArtifactsOutputPath.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/UseArtifactsOutputPath.props
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        If the .props file is not imported here, it will be imported from Microsoft.NET.DefaultOutputPaths.targets, so that artifacts output
        properties can be set directly in the project file too (only in that case they won't affect the intermediate output). -->
   <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.DefaultArtifactsPath.props"
-          Condition="'$(UseArtifactsOutput)' == 'true' Or '$(ArtifactsPath)' != ''"/>
+          Condition="'$(UseArtifactsOutput)' == 'true' Or '$(ArtifactsPath)' != '' Or '$(FileBasedAppArtifactsPath)' != ''"/>
 
   <PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
     <UseArtifactsIntermediateOutput Condition="'$(UseArtifactsIntermediateOutput)' == ''">true</UseArtifactsIntermediateOutput>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
@@ -40,4 +40,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ArtifactsPath>$(MSBuildProjectDirectory)\artifacts</ArtifactsPath>
     <_ArtifactsPathLocationType>ProjectFolder</_ArtifactsPathLocationType>
   </PropertyGroup>
+
+  <!-- Use FileBasedAppArtifactsPath if set -->
+  <PropertyGroup Condition="'$(ArtifactsPath)' == '' And '$(FileBasedAppArtifactsPath)' != ''">
+    <UseArtifactsOutput Condition="'$(UseArtifactsOutput)' == '' And '$(UsingMicrosoftArtifactsSdk)' != 'true'">true</UseArtifactsOutput>
+    <ArtifactsPath>$(FileBasedAppArtifactsPath)</ArtifactsPath>
+    <IncludeProjectNameInArtifactsPaths Condition="'$(IncludeProjectNameInArtifactsPaths)' == ''">false</IncludeProjectNameInArtifactsPaths>
+    <_ArtifactsPathLocationType>FileBasedApp</_ArtifactsPathLocationType>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Contributes to fixing the issue described in https://github.com/dotnet/sdk/issues/49826.