### PR TITLE
Remove unneccessary crypto using

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ComputeDotnetBaseImageAndTag.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 using NuGet.Versioning;
 #if NETFRAMEWORK


### PR DESCRIPTION
I was hoping there'd be more as we're reviewing all usage of this namespace. Remove this one as it was flagged as unused.