### PR TITLE
Use SdkResolver APIs for reporting environment variables

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,5 +8,5 @@ if %errorlevel%==0 (
     set skipFlags="/p:SkipUsingCrossgen=true /p:SkipBuildingInstallers=true"
 )
 set DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -msbuildEngine dotnet %skipFlags% %*"
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -command "& """%~dp0eng\common\build.ps1""" -restore -build -msbuildEngine dotnet %skipFlags% /tlp:summary %*"
 exit /b %ErrorLevel%

--- a/build.sh
+++ b/build.sh
@@ -14,4 +14,4 @@ if [[ "$@" != *"-pack"* ]]; then
 fi
 
 export DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT="true"
-. "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags "$@"
+. "$ScriptRoot/eng/common/build.sh" --build --restore $skipFlags /tlp:summary "$@"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -133,16 +133,16 @@
     <SystemFormatsAsn1Version>10.0.0-preview.7.25367.101</SystemFormatsAsn1Version>
     <!-- These are minimum versions used for netfx-targeted components that run in Visual Studio because in those cases,
          Visual Studio is providing those assemblies, and we should work with whichever version it ships. -->
-    <MicrosoftBclAsyncInterfacesToolsetPackageVersion>8.0.0</MicrosoftBclAsyncInterfacesToolsetPackageVersion>
+    <MicrosoftBclAsyncInterfacesToolsetPackageVersion>9.0.0</MicrosoftBclAsyncInterfacesToolsetPackageVersion>
     <MicrosoftDeploymentDotNetReleasesToolsetPackageVersion>2.0.0-preview.1.24427.4</MicrosoftDeploymentDotNetReleasesToolsetPackageVersion>
     <SystemBuffersToolsetPackageVersion>4.5.1</SystemBuffersToolsetPackageVersion>
-    <SystemCollectionsImmutableToolsetPackageVersion>8.0.0</SystemCollectionsImmutableToolsetPackageVersion>
+    <SystemCollectionsImmutableToolsetPackageVersion>9.0.0</SystemCollectionsImmutableToolsetPackageVersion>
     <SystemMemoryToolsetPackageVersion>4.5.5</SystemMemoryToolsetPackageVersion>
-    <SystemReflectionMetadataLoadContextToolsetPackageVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetPackageVersion>
-    <SystemReflectionMetadataToolsetPackageVersion>8.0.0</SystemReflectionMetadataToolsetPackageVersion>
-    <SystemTextJsonToolsetPackageVersion>8.0.5</SystemTextJsonToolsetPackageVersion>
+    <SystemReflectionMetadataLoadContextToolsetPackageVersion>9.0.0</SystemReflectionMetadataLoadContextToolsetPackageVersion>
+    <SystemReflectionMetadataToolsetPackageVersion>9.0.0</SystemReflectionMetadataToolsetPackageVersion>
+    <SystemTextJsonToolsetPackageVersion>9.0.0</SystemTextJsonToolsetPackageVersion>
     <SystemThreadingTasksExtensionsToolsetPackageVersion>4.5.4</SystemThreadingTasksExtensionsToolsetPackageVersion>
-    <SystemResourcesExtensionsToolsetPackageVersion>8.0.0</SystemResourcesExtensionsToolsetPackageVersion>
+    <SystemResourcesExtensionsToolsetPackageVersion>9.0.0</SystemResourcesExtensionsToolsetPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
@@ -190,7 +190,8 @@
          Additionally, set the MinimumVSVersion for the installer UI that's required for targeting NetCurrent -->
     <MicrosoftBuildVersion>17.15.0-preview-25367-101</MicrosoftBuildVersion>
     <MicrosoftBuildLocalizationVersion>17.15.0-preview-25367-101</MicrosoftBuildLocalizationVersion>
-    <MicrosoftBuildMinimumVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">17.11.4</MicrosoftBuildMinimumVersion>
+    <!-- TODO: ensure the right version actually gets inserted -->
+    <MicrosoftBuildMinimumVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(MicrosoftBuildVersion)</MicrosoftBuildMinimumVersion>
     <MinimumVSVersion>17.13</MinimumVSVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -105,18 +105,19 @@
     </ResolveAssemblyReference>
 
     <ItemGroup>
-      <ExpectedDependencies Include="Microsoft.Deployment.DotNet.Releases, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-      <ExpectedDependencies Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-      <ExpectedDependencies Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
       <ExpectedDependencies Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      <ExpectedDependencies Include="System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      <ExpectedDependencies Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-      <ExpectedDependencies Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-      <ExpectedDependencies Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      <ExpectedDependencies Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-      <ExpectedDependencies Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="Microsoft.Deployment.DotNet.Releases, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <ExpectedDependencies Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      <ExpectedDependencies Include="System.Diagnostics.DiagnosticSource, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="System.IO.Pipelines, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      <ExpectedDependencies Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      <ExpectedDependencies Include="System.Text.Encodings.Web, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <ExpectedDependencies Include="System.Text.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
       <ExpectedDependencies Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-      <ExpectedDependencies Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
     </ItemGroup>
 
     <!-- Check that the dependencies of the output assembly match our expectations -->
@@ -127,9 +128,11 @@
     </PropertyGroup>
 
     <Error Text="$(AssemblyName) is expected to depend on %(ExpectedDependencies.Identity). $(DependencyMismatchErrorText)"
-           Condition="!($([System.String]::Copy('$(ResolvedDependenciesList)').Contains('%(ExpectedDependencies.Identity)')))" />
+           Condition="!($([System.String]::Copy('$(ResolvedDependenciesList)').Contains('%(ExpectedDependencies.Identity)')))"
+           ContinueOnError="true" />
     <Error Text="$(AssemblyName) is not expected to depend on %(ResolvedDependencies.FusionName). $(DependencyMismatchErrorText)"
-           Condition="!($([System.String]::Copy('$(ExpectedDependenciesList)').Contains('%(ResolvedDependencies.FusionName)')))" />
+           Condition="!($([System.String]::Copy('$(ExpectedDependenciesList)').Contains('%(ResolvedDependencies.FusionName)')))"
+           ContinueOnError="true" />
   </Target>
 
 </Project>

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -205,8 +205,14 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // DotnetHost is the path to dotnet.exe. Can be only on Windows.
-                result.PropertiesToAdd.Should().NotBeNull().And.HaveCount(2);
-                result.PropertiesToAdd.Should().ContainKey(DotnetHostExperimentalKey);
+                result.PropertiesToAdd.Should().NotBeNull()
+                                        .And.HaveCount(1)
+                                        .And.NotContainKey(DotnetHostExperimentalKey);
+                result.EnvironmentVariablesToAdd.Should().NotBeNull()
+                                                .And.BeEquivalentTo(new Dictionary<string, string?>
+                                                {
+                                                    ["DOTNET_HOST"] = Path.Combine(environment.GetProgramFilesDirectory(ProgramFiles.X64).FullName, "dotnet", "dotnet.exe")
+                                                });
             }
             else
             {
@@ -231,9 +237,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var localSdkRoot = Path.Combine("some", "local", "dir");
             var localSdkDotnetRoot = Path.Combine(environment.TestDirectory.FullName, localSdkRoot, "dotnet");
             var ambientSdkDotnetRoot = Path.Combine(environment.GetProgramFilesDirectory(ProgramFiles.X64).FullName, "dotnet");
-            var ambientMSBuildSkRoot = environment.CreateSdkDirectory(ProgramFiles.X64, "Some.Test.Sdk", "1.2.3");
-            var localPathMSBuildSdkRoot = environment.CreateSdkDirectory(localSdkRoot, "Some.Test.Sdk", "1.2.4");
-            var ambientDotnetBinary = environment.CreateMuxerAndAddToPath(ProgramFiles.X64);
+            var _ambientMSBuildSkRoot = environment.CreateSdkDirectory(ProgramFiles.X64, "Some.Test.Sdk", "1.2.3");
+            var _localPathMSBuildSdkRoot = environment.CreateSdkDirectory(localSdkRoot, "Some.Test.Sdk", "1.2.4");
+            var _ambientDotnetBinary = environment.CreateMuxerAndAddToPath(ProgramFiles.X64);
             var localDotnetBinary = environment.CreateMuxer(localSdkRoot);
             environment.CreateGlobalJson(environment.TestDirectory, "1.2.3", [localSdkDotnetRoot, ambientSdkDotnetRoot]);
 
@@ -249,9 +255,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 context,
                 new MockFactory());
             result.Success.Should().BeTrue();
-            result.PropertiesToAdd.Should().NotBeNull().And.HaveCount(2);
-            result.PropertiesToAdd.Should().ContainKey(DotnetHostExperimentalKey);
-            result.PropertiesToAdd[DotnetHostExperimentalKey].Should().Be(localDotnetBinary);
+            result.PropertiesToAdd.Should().NotBeNull().And.HaveCount(1).And.ContainKey(MSBuildTaskHostRuntimeVersion);
+            result.EnvironmentVariablesToAdd.Should().NotBeNull().And.BeEquivalentTo(new Dictionary<string, string?>
+            {
+                [DotnetHostExperimentalKey] = localDotnetBinary
+            });
         }
 
         [Theory]
@@ -325,8 +333,13 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // DotnetHost is the path to dotnet.exe. Can be only on Windows.
-                result.PropertiesToAdd.Should().NotBeNull().And.HaveCount(4);
-                result.PropertiesToAdd.Should().ContainKey(DotnetHostExperimentalKey);
+                result.PropertiesToAdd.Should().NotBeNull().And.HaveCount(3);
+                result.PropertiesToAdd.Should().NotContainKey(DotnetHostExperimentalKey);
+                result.EnvironmentVariablesToAdd.Should().NotBeNull()
+                                                .And.BeEquivalentTo(new Dictionary<string, string?>
+                                                {
+                                                    ["DOTNET_HOST"] = Path.Combine(environment.GetProgramFilesDirectory(ProgramFiles.X64).FullName, "dotnet", "dotnet.exe")
+                                                });
             }
             else
             {


### PR DESCRIPTION
Requires the MSBuild API changes from https://github.com/dotnet/sdk/pull/49740. This PR is targeting `main` only because our pipelines aren't set up to allow PR runs for branches/PRs that are themselves branched off off of darc-codeflow branches.

This uses the proper APIs for reporting env variables, but because it requires a newer version of the MSBuild APIs and those APIs have brought increased dependency bumps we probably need to take a deeper look at the coordination involved here.