### PR TITLE
Add a series of changes to make devcontainer experiences nicer for this repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,5 +27,10 @@
     "DOTNET_ROOT": "${containerWorkspaceFolder}/.dotnet",
     "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR": "${containerWorkspaceFolder}/.dotnet",
     "NUGET_PACKAGES": "/home/vscode/.nuget/packages"
+  },
+  "remoteUser": "vscode",
+  "hostRequirements": {
+    "cpus": 16,
+    "memory": "32gb"
   }
 }

--- a/.devcontainer/scripts/post-creation.sh
+++ b/.devcontainer/scripts/post-creation.sh
@@ -1,4 +1,12 @@
+#! /usr/bin/env sh
+
 # Install SDK and tool dependencies before container starts
 # Also run the full restore on the repo so that go-to definition
 # and other language features will be available in C# files
 ./restore.sh
+# run the build so that everything is 'hot'
+./build.sh -tl:off
+# setup the IDE env to point to the local .dotnet folder so that assemblies/tools are loaded as expected
+# this script is run from repo root so shellcheck warning about relative-path lookups can be ignored
+# shellcheck disable=SC1091
+. ./artifacts/sdk-build-env.sh

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,17 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
       "name": ".NET Core Launch (console)",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev/dotnet.dll",
+      "program": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet${/}sdk${/}10.0.100--dev${/}dotnet.dll",
       "args": [
       ],
       "env": {
-        "MSBuildExtensionsPath": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev",
-        "MSBuildSDKsPath": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev/Sdks",
-        "DOTNET_ROOT": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet",
+        "MSBuildExtensionsPath": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet${/}sdk${/}10.0.100-dev",
+        "MSBuildSDKsPath": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet${/}sdk${/}10.0.100-dev${/}Sdks",
+        "DOTNET_ROOT": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet",
       },
       "stopAtEntry": false,
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,13 @@
       "name": ".NET Core Launch (console)",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev\\dotnet.dll",
+      "program": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev/dotnet.dll",
       "args": [
       ],
       "env": {
-        "MSBuildExtensionsPath": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev",
-        "MSBuildSDKsPath": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev\\Sdks",
-        "DOTNET_ROOT": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet",
+        "MSBuildExtensionsPath": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev",
+        "MSBuildSDKsPath": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet/sdk/10.0.100-dev/Sdks",
+        "DOTNET_ROOT": "${workspaceFolder}/artifacts/bin/redist/Debug/dotnet",
       },
       "stopAtEntry": false,
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev\\dotnet.dll",
+      "args": [
+      ],
+      "env": {
+        "MSBuildExtensionsPath": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev",
+        "MSBuildSDKsPath": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet\\sdk\\10.0.100-dev\\Sdks",
+        "DOTNET_ROOT": "${workspaceFolder}\\artifacts\\bin\\redist\\Debug\\dotnet",
+      },
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "requireExactSource": false
+    }
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+	"servers": {
+		"ms.docs": {
+			"url": "https://learn.microsoft.com/api/mcp",
+			"type": "http"
+		}
+	},
+	"inputs": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.testWindow.disableAutoDiscovery": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "dotnet.testWindow.disableAutoDiscovery": true
+    "dotnet.testWindow.disableAutoDiscovery": true,
+    "dotnet.defaultSolution": "sdk.slnx"
 }


### PR DESCRIPTION
* make devcontainer init script build the repo
* source the sdk-build-env script so that the IDE experience uses the local SDK
* setup simple launch configurations for debugging the redist CLI
* disable the CDK test explorer auto-discovery because it takes _forever_ - trigger it once and then don't change anything 
instead
* add MCP config so that copilot can access MS Learn docs