### PR TITLE
Fix build issue and test issue in PR 49905

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -103,6 +103,7 @@
          numbers of the shared frameworks. -->
     <MicrosoftWindowsDesktopAppRuntimePackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftWindowsDesktopAppRuntimePackageVersion>
     <MicrosoftWindowsDesktopAppRefPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftWindowsDesktopAppRefPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</MicrosoftNETSdkWindowsDesktopPackageVersion>
     <MicrosoftWindowsDesktopAppInternalPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</MicrosoftWindowsDesktopAppInternalPackageVersion>
 
     <HostFxrVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</HostFxrVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -276,6 +276,11 @@
     <EmscriptenVersionNet7>3.1.12</EmscriptenVersionNet7>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/wpf -->
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>10.0.0-preview.7.25372.102</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftDotNetWpfProjectTemplatesPackageVersion>10.0.0-preview.7.25372.102</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Infrastructure and test only dependencies">
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <MicrosoftDotNetScenarioTestsSdkTemplateTestsVersion>10.0.0-preview.24602.1</MicrosoftDotNetScenarioTestsSdkTemplateTestsVersion>

--- a/test/dotnet.Tests/CommandTests/Build/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Build/GivenDotnetBuildBuildsCsproj.cs
@@ -401,7 +401,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
         public void It_uses_correct_runtime_help_description(string command)
         {
             var output = new StringWriter();
-            var parseResult = localCopy.Parse(new string[] { command, "-h" });
+            var parseResult = Parser.Parse(new string[] { command, "-h" });
             parseResult.Invoke(new()
             {
                 Output = output,

--- a/test/dotnet.Tests/CommandTests/Workload/Uninstall/GivenDotnetWorkloadUninstall.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Uninstall/GivenDotnetWorkloadUninstall.cs
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.Cli.Workload.Uninstall.Tests
                 command.AddRange(args);
             }
 
-            var uninstallParseResult = Parser.Parse(command);
+            var uninstallParseResult = Parser.Parse([.. command]);
             var workloadResolverFactory = new MockWorkloadResolverFactory(dotnetRoot, sdkFeatureVersion, workloadResolver, userProfileDir);
             var uninstallCommand = new WorkloadUninstallCommand(uninstallParseResult, reporter: _reporter, workloadResolverFactory, nugetDownloader);
             return uninstallCommand.Execute();

--- a/test/dotnet.Tests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryFilterTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TopLevelCommandNameShouldBeSentToTelemetryWithoutPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "build" });
+            var parseResult = Parser.Parse(["build" ]);
             TelemetryEventEntry.SendFiltered(parseResult);
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
                   e.Properties.ContainsKey("verb") &&
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TopLevelCommandNameShouldBeSentToTelemetryWithPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "build" });
+            var parseResult = Parser.Parse(["build"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 12345 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
                   e.Properties.ContainsKey("verb") &&
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TopLevelCommandNameShouldBeSentToTelemetryWithZeroPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "build" });
+            var parseResult = Parser.Parse(["build"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 0 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
                   e.Properties.ContainsKey("verb") &&
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TopLevelCommandNameShouldBeSentToTelemetryWithSomeZeroPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "build" });
+            var parseResult = Parser.Parse(["build"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 23456 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
                   e.Properties.ContainsKey("verb") &&
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void SubLevelCommandNameShouldBeSentToTelemetryWithoutPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "new", "console" });
+            var parseResult = Parser.Parse(["new", "console"]);
             TelemetryEventEntry.SendFiltered(parseResult);
             _fakeTelemetry
                 .LogEntries.Should()
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void SubLevelCommandNameShouldBeSentToTelemetryWithPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "new", "console" });
+            var parseResult = Parser.Parse(["new", "console"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 34567 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
                     e.Properties.ContainsKey("argument") &&
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void SubLevelCommandNameShouldBeSentToTelemetryWithZeroPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "new", "console" });
+            var parseResult = Parser.Parse(["new", "console"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 0 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
                     e.Properties.ContainsKey("argument") &&
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void SubLevelCommandNameShouldBeSentToTelemetryWithSomeZeroPerformanceData()
         {
-            var parseResult = Parser.Parse(new List<string>() { "new", "console" });
+            var parseResult = Parser.Parse(["new", "console"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 45678 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
                     e.Properties.ContainsKey("argument") &&
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Tests
         public void WorkloadSubLevelCommandNameAndArgumentShouldBeSentToTelemetry()
         {
             var parseResult =
-                Parser.Parse(new List<string>() { "workload", "install", "microsoft-ios-sdk-full" });
+                Parser.Parse(["workload", "install", "microsoft-ios-sdk-full"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult,
                 new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 23456 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tests
         public void ToolsSubLevelCommandNameAndArgumentShouldBeSentToTelemetry()
         {
             var parseResult =
-                Parser.Parse(new List<string>() { "tool", "install", "dotnet-format" });
+                Parser.Parse(["tool", "install", "dotnet-format"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult,
                 new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 23456 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Tests
         public void WhenCalledWithDiagnosticWorkloadSubLevelCommandNameAndArgumentShouldBeSentToTelemetry()
         {
             var parseResult =
-                Parser.Parse(new List<string>() { "-d", "workload", "install", "microsoft-ios-sdk-full" });
+                Parser.Parse(["-d", "workload", "install", "microsoft-ios-sdk-full"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult,
                 new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 23456 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.Tests
         public void WhenCalledWithMissingArgumentWorkloadSubLevelCommandNameAndArgumentShouldBeSentToTelemetry()
         {
             var parseResult =
-                Parser.Parse(new List<string>() { "-d", "workload", "install" });
+                Parser.Parse(["-d", "workload", "install"]);
             TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult,
                 new Dictionary<string, double>() { { "Startup Time", 0 }, { "Parse Time", 23456 } }));
             _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "sublevelparser/command" &&


### PR DESCRIPTION
Fix build issue and test issue in https://github.com/dotnet/sdk/pull/49905.

Restore the change at Directory.Build.props or add 10.0.0-preview.7.25372.102 to the eng/Versions.props maybe resolve the build issue in PR 49905.

And fix the failure test cases which with error message: cannot convert from 'System.Collections.Generic.List<string>' to 'string'.
