### PR TITLE
Fix recognizing `dotnet ./file.cs` with special arguments

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -286,8 +286,7 @@ public class Program
         {
             // If we didn't match any built-in commands, and a C# file path is the first argument,
             // parse as `dotnet run file.cs ..rest_of_args` instead.
-            if (parseResult.CommandResult.Command is RootCommand
-                && parseResult.GetValue(Parser.DotnetSubCommand) is { } unmatchedCommandOrFile
+            if (parseResult.GetValue(Parser.DotnetSubCommand) is { } unmatchedCommandOrFile
                 && VirtualProjectBuildingCommand.IsValidEntryPointPath(unmatchedCommandOrFile))
             {
                 List<string> otherTokens = new(parseResult.Tokens.Count - 1);

--- a/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.Equal(solutionFileFullPath, solutionFiles[0]);
         }
 
-        [Fact(DisplayName = nameof(AddProjectToSolutionPostActionFindSlnxFileAtOutputPath))]
+        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/49923
         public void AddProjectToSolutionPostActionFindSlnxFileAtOutputPath()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -142,14 +142,34 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             {s_program}
             """);
 
+        string expectedOutput = """
+            Hello from Program
+            Release config
+            """;
+
         new DotnetCommand(Log, "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass()
-            .And.HaveStdOut("""
-                Hello from Program
-                Release config
-                """);
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "./Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, $".{Path.DirectorySeparatorChar}Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, Path.Join(testInstance.Path, "Program.cs"))
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
 
         new DotnetCommand(Log, "Program.cs", "-c", "Debug")
             .WithWorkingDirectory(testInstance.Path)
@@ -165,6 +185,16 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().Pass()
             .And.HaveStdOut("""
                 echo args:arg1;arg2
+                Hello from Program
+                Release config
+                """);
+
+        new DotnetCommand(Log, "Program.cs", "build")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("""
+                echo args:build
                 Hello from Program
                 Release config
                 """);


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49892.

If `dotnet ./Program.cs build` is encountered, the command line is parsed as the `BuildCommand`, not `RootCommand`, hence I'm removing the check (which I don't think is necessary).