### PR TITLE
Fix dotnet/sdk#49921 by making the dgspec inner build silent

### DIFF
--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
@@ -89,7 +89,10 @@ internal class PackageAddCommand(ParseResult parseResult) : CommandBase(parseRes
             $"-property:RestoreDotnetCliToolReferences=false",
 
             // Output should not include MSBuild version header
-            "-nologo"
+            "-nologo",
+
+            // Set verbosity to quiet to avoid cluttering the output for this 'inner' build
+            "-v:quiet"
         ];
 
         var result = new MSBuildForwardingApp(args).Execute();


### PR DESCRIPTION
The inner build creating the dgspec that the package add command relied on needs to set for silent running, as do other 'inner' builds that happen in the CLI.