### PR TITLE
Add a details section for the dotnet info output

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.md
@@ -29,5 +29,11 @@ Include the exception you get when facing this issue
 -->
 
 ### Further technical details
-- Include the output of `dotnet --info`
+<details><summary>details of dotnet --info</summary>
+<p>
+<!-- 
+Include the `dotnet --info` output here
+-->
+</p>
+</details>
 - The IDE (VS / VS Code/ VS4Mac) you're running on, and its version


### PR DESCRIPTION
fixes #49912
Not everyone knows all the markdown tricks so including this in the template will help folks make the output a bit less verbose while still including it.