### PR TITLE
Add Bypass to VS shortcut

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -112,7 +112,7 @@ function CreateVSShortcut()
   $wsShell = New-Object -ComObject WScript.Shell
   $shortcut = $wsShell.CreateShortcut($shortcutPath)
   $shortcut.TargetPath = $powershellPath
-  $shortcut.Arguments = "-WindowStyle Hidden -Command ""$commandToLaunch"""
+  $shortcut.Arguments = "-WindowStyle Hidden -ExecutionPolicy Bypass -Command ""$commandToLaunch"""
   $shortcut.IconLocation = $devenvPath
   $shortcut.WindowStyle = 7 # Minimized
   $shortcut.Save()


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/49748

## Summary

When creating the above PR, I added `-ExecutionPolicy Bypass` to calls of `powershell` when doing the SDK build. However, I missed a point in which we call `powershell.exe` outside of the build... the VS shortcut. We generate this shortcut so you can use it to automatically load the `sdk-build-env` when using the shortcut (for development purposes). Without this change, new machines which have the execution policy set to `Restricted` by default will not be able to use this shortcut for development (it won't run the script).

