### PR TITLE
Move pruning defaults back to the NuGet.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -53,10 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
  
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
           DependsOnTargets="ProcessFrameworkReferences"
-          Condition="'$(RestoreEnablePackagePruning)' == 'true'
-          AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-          AND '$(TargetFrameworkVersion)' != ''
-          AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0'))">
+          Condition="'$(RestoreEnablePackagePruning)' == 'true'">
 
     <PropertyGroup>
       <PrunePackageDataRoot Condition="'$(PrunePackageDataRoot)' == ''">$(NetCoreRoot)\sdk\$(NETCoreSdkVersion)\PrunePackageData\</PrunePackageDataRoot>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -57,7 +57,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(RestoreEnablePackagePruning)' == 'true'
           AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
           AND '$(TargetFrameworkVersion)' != ''
-          AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')))
+          AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0')))
           OR ('$(TargetFrameworkIdentifier)' != '.NETCoreApp'))">
     <PropertyGroup>
       <PrunePackageDataRoot Condition="'$(PrunePackageDataRoot)' == ''">$(NetCoreRoot)\sdk\$(NETCoreSdkVersion)\PrunePackageData\</PrunePackageDataRoot>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -50,11 +50,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </CreateWindowsSdkKnownFrameworkReferences>
   </Target>
- 
+  
+  <!-- TODO: https://github.com/dotnet/sdk/issues/49917 Remove the framework based condition when the data for netcoreapp2.1 and below is fixed-->
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
           DependsOnTargets="ProcessFrameworkReferences"
-          Condition="'$(RestoreEnablePackagePruning)' == 'true'">
-
+          Condition="'$(RestoreEnablePackagePruning)' == 'true'
+          AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+          AND '$(TargetFrameworkVersion)' != ''
+          AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')))
+          OR ('$(TargetFrameworkIdentifier)' != '.NETCoreApp'))">
     <PropertyGroup>
       <PrunePackageDataRoot Condition="'$(PrunePackageDataRoot)' == ''">$(NetCoreRoot)\sdk\$(NETCoreSdkVersion)\PrunePackageData\</PrunePackageDataRoot>
       <PrunePackageTargetingPackRoots Condition="'$(PrunePackageTargetingPackRoots)' == ''">$(NetCoreTargetingPackRoot)</PrunePackageTargetingPackRoots>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -316,21 +316,21 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         [InlineData("net9.0")]
         [InlineData("net8.0")]
-        // [InlineData("net7.0", false)] TODO: https://github.com/NuGet/Home/issues/14424
-        // [InlineData("net6.0", false)] TODO: https://github.com/NuGet/Home/issues/14424
-        // [InlineData("netcoreapp3.1")] TODO: https://github.com/NuGet/Home/issues/14424
-        // [InlineData("netcoreapp3.0")] TODO: https://github.com/NuGet/Home/issues/14424
-        [InlineData("netcoreapp2.1", false)]
-        [InlineData("netcoreapp2.0", false)]
+        [InlineData("net7.0")]
+        [InlineData("net6.0")]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("netcoreapp3.0")]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp1.1", false)]
         [InlineData("netcoreapp1.0", false)]
-        [InlineData("netstandard2.1", false)]
-        [InlineData("netstandard2.0", false)]
+        [InlineData("netstandard2.1")]
+        [InlineData("netstandard2.0")]
         [InlineData("netstandard1.1", false)]
         [InlineData("netstandard1.0", false)]
         [InlineData("net451", false)]
-        [InlineData("net462", false)]
-        [InlineData("net481", false)]
+        [InlineData("net462")]
+        [InlineData("net481")]
         public void PrunePackageDataSucceeds(string targetFramework, bool shouldPrune = true)
         {
             var nugetFramework = NuGetFramework.Parse(targetFramework);

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -320,8 +320,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net6.0")]
         [InlineData("netcoreapp3.1")]
         [InlineData("netcoreapp3.0")]
-        [InlineData("netcoreapp2.1")]
-        [InlineData("netcoreapp2.0")]
+        [InlineData("netcoreapp2.1", false)] //TODO: https://github.com/dotnet/sdk/issues/49917
+        [InlineData("netcoreapp2.0", false)] //TODO: https://github.com/dotnet/sdk/issues/49917
         [InlineData("netcoreapp1.1", false)]
         [InlineData("netcoreapp1.0", false)]
         [InlineData("netstandard2.1")]


### PR DESCRIPTION
Related to https://github.com/NuGet/Home/issues/14424. 

We basically want NuGet to control the frameworks we enable pruning for. With the current version, customers are not enable to enable/disable pruning for frameworks net7.0 and older.

This changes fixes that. 

Note that we need https://github.com/dotnet/sdk/pull/49854 to be merged first.