### PR TITLE
Remove Idle target workaround

### DIFF
--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -35,17 +35,13 @@
     <ProjectReference Include="..\redist\redist.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <!-- These project references ensure that package references for WiX extensions are correctly restored. The Idle target is a no-op as the
-         projects are built later when computed properties are available. These properties do not exist when projects are evaluated. -->
-    <ProjectReference Include="windows\msis\placeholder\placeholder.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true"
-                      Targets="Idle" />
-    <ProjectReference Include="windows\msis\templates\templates.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true"
-                      Targets="Idle" />
-    <ProjectReference Include="windows\msis\toolset\toolset.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true"
-                      Targets="Idle" />
-    <ProjectReference Include="windows\bundles\sdk\bundle.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true"
-                      Targets="Idle" />
+  <!-- These P2Ps ensure that package references for WiX extensions are correctly restored. The MSBuildRestoreSessionId condition makes sure that these
+       projects are only restored. They get built later when computed properties are available. These properties do not exist when projects are evaluated. -->
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT' and '$(MSBuildRestoreSessionId)' != ''">
+    <ProjectReference Include="windows\msis\placeholder\placeholder.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="windows\msis\templates\templates.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="windows\msis\toolset\toolset.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="windows\bundles\sdk\bundle.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Layout/pkg/windows/Directory.Build.targets
+++ b/src/Layout/pkg/windows/Directory.Build.targets
@@ -36,10 +36,6 @@
     </PropertyGroup>
   </Target>
 
-  <!-- This target does nothing. It's intended to allow ProjectReference items to specify a target that has
-       no build impact, but allow projects to participate in restore operations.  -->
-  <Target Name="Idle" />
-
   <!-- This target is intended to catch changes that require someone to investigate. -->
   <Target Name="ValidateBuild" BeforeTargets="CoreCompile">
     <!-- Bundles must target x86 for back compat. -->


### PR DESCRIPTION
Instead of defining an empty "Idle" target, condition the P2Ps on restore. The `MSBuildRestoreSessionId` is only set during restore and not build.