### PR TITLE
Avoid double disposal of terminal logger

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -340,6 +340,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             BuildManager.DefaultBuildManager.EndBuild();
+            consoleLogger = null; // avoid double disposal which would throw
 
             return 0;
         }
@@ -356,7 +357,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             }
 
             binaryLogger?.Value.ReallyShutdown();
-            consoleLogger.Shutdown();
+            consoleLogger?.Shutdown();
         }
 
         static Action<IDictionary<string, string>> AddRestoreGlobalProperties(ReadOnlyDictionary<string, string>? restoreProperties)


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/dotnet/sdk/pull/49841 - `dotnet run file.cs` results in "Unhandled exception: The CancellationTokenSource has been disposed." It only appears when using the terminal logger, hence no tests catch it (and I don't think it can be tested, see https://github.com/dotnet/msbuild/issues/12237).