### PR TITLE
update dotnet-cli PathToApplicationDefinition help text

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1348,7 +1348,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>passed</value>
   </data>
   <data name="PathToApplicationDefinition" xml:space="preserve">
-    <value>The path to an application .dll file to execute.</value>
+    <value>The path to an application .dll file to execute or a C# file to run.</value>
   </data>
   <data name="PendingReboot" xml:space="preserve">
     <value>The machine has a pending reboot. The workload operation will continue, but you may need to restart.</value>


### PR DESCRIPTION
add C# file since we support dotnet run file for C# now

<img width="2311" height="627" alt="image" src="https://github.com/user-attachments/assets/ac9b855a-b83e-4efe-90fb-c432a1cecbc6" />
