### PR TITLE
[watch] Fix /bl option parsing, use it for build logging

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Build/BuildReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Build/BuildReporter.cs
@@ -7,13 +7,13 @@ using Microsoft.Build.Logging;
 
 namespace Microsoft.DotNet.Watch;
 
-internal sealed class BuildReporter(IReporter reporter, EnvironmentOptions environmentOptions)
+internal sealed class BuildReporter(IReporter reporter, GlobalOptions options, EnvironmentOptions environmentOptions)
 {
     public IReporter Reporter => reporter;
     public EnvironmentOptions EnvironmentOptions => environmentOptions;
 
     public Loggers GetLoggers(string projectPath, string operationName)
-        => new(reporter, environmentOptions.GetTestBinLogPath(projectPath, operationName));
+        => new(reporter, environmentOptions.GetBinLogPath(projectPath, operationName, options));
 
     public void ReportWatchedFiles(Dictionary<string, FileItem> fileItems)
     {

--- a/src/BuiltInTools/dotnet-watch/Build/EvaluationResult.cs
+++ b/src/BuiltInTools/dotnet-watch/Build/EvaluationResult.cs
@@ -38,11 +38,12 @@ internal sealed class EvaluationResult(IReadOnlyDictionary<string, FileItem> fil
         string rootProjectPath,
         IEnumerable<string> buildArguments,
         IReporter reporter,
+        GlobalOptions options,
         EnvironmentOptions environmentOptions,
         bool restore,
         CancellationToken cancellationToken)
     {
-        var buildReporter = new BuildReporter(reporter, environmentOptions);
+        var buildReporter = new BuildReporter(reporter, options, environmentOptions);
 
         // See https://github.com/dotnet/project-system/blob/main/docs/well-known-project-properties.md
 

--- a/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
@@ -75,12 +75,6 @@ internal sealed class CommandLineOptions
         var launchProfileOption = new Option<string>("--launch-profile", "-lp") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
         var noLaunchProfileOption = new Option<bool>("--no-launch-profile") { Hidden = true, Arity = ArgumentArity.Zero };
 
-        //var binaryLogOption = new Option<string>(s_binaryLogOptionNames[0], [.. s_binaryLogOptionNames])
-        //{
-        //    Arity = ArgumentArity.ZeroOrOne,
-        //    CustomParser = static r => r.Tokens.FirstOrDefault()?.ToString() ?? ""
-        //};
-
         var rootCommand = new RootCommand(Resources.Help)
         {
             Directives = { new EnvironmentVariablesDirective() },
@@ -95,7 +89,6 @@ internal sealed class CommandLineOptions
         rootCommand.Options.Add(shortProjectOption);
         rootCommand.Options.Add(launchProfileOption);
         rootCommand.Options.Add(noLaunchProfileOption);
-        //rootCommand.Options.Add(binaryLogOption);
 
         // We process all tokens that do not match any of the above options
         // to find the subcommand (the first unmatched token preceding "--")

--- a/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
@@ -5,6 +5,8 @@ using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Data;
+using System.Diagnostics;
+using Microsoft.Build.Logging;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Extensions;
@@ -15,18 +17,27 @@ internal sealed class CommandLineOptions
 {
     public const string DefaultCommand = "run";
 
+    private static readonly ImmutableArray<string> s_binaryLogOptionNames = ["-bl", "/bl", "-binaryLogger", "--binaryLogger", "/binaryLogger"];
+
     public bool List { get; init; }
-    required public GlobalOptions GlobalOptions { get; init; }
+    public required GlobalOptions GlobalOptions { get; init; }
 
     public string? ProjectPath { get; init; }
     public string? TargetFramework { get; init; }
     public bool NoLaunchProfile { get; init; }
     public string? LaunchProfileName { get; init; }
 
-    public string? ExplicitCommand { get; init; }
-
+    /// <summary>
+    /// Arguments passed to <see cref="Command"/>.
+    /// </summary>
     public required IReadOnlyList<string> CommandArguments { get; init; }
+
+    /// <summary>
+    /// Arguments passed to `dotnet build` and to design-time build evaluation.
+    /// </summary>
     public required IReadOnlyList<string> BuildArguments { get; init; }
+
+    public string? ExplicitCommand { get; init; }
 
     public string Command => ExplicitCommand ?? DefaultCommand;
 
@@ -64,6 +75,12 @@ internal sealed class CommandLineOptions
         var launchProfileOption = new Option<string>("--launch-profile", "-lp") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
         var noLaunchProfileOption = new Option<bool>("--no-launch-profile") { Hidden = true, Arity = ArgumentArity.Zero };
 
+        //var binaryLogOption = new Option<string>(s_binaryLogOptionNames[0], [.. s_binaryLogOptionNames])
+        //{
+        //    Arity = ArgumentArity.ZeroOrOne,
+        //    CustomParser = static r => r.Tokens.FirstOrDefault()?.ToString() ?? ""
+        //};
+
         var rootCommand = new RootCommand(Resources.Help)
         {
             Directives = { new EnvironmentVariablesDirective() },
@@ -78,6 +95,7 @@ internal sealed class CommandLineOptions
         rootCommand.Options.Add(shortProjectOption);
         rootCommand.Options.Add(launchProfileOption);
         rootCommand.Options.Add(noLaunchProfileOption);
+        //rootCommand.Options.Add(binaryLogOption);
 
         // We process all tokens that do not match any of the above options
         // to find the subcommand (the first unmatched token preceding "--")
@@ -128,6 +146,7 @@ internal sealed class CommandLineOptions
             Output = output,
             Error = output
         });
+
         if (!rootCommandInvoked)
         {
             // help displayed:
@@ -145,10 +164,16 @@ internal sealed class CommandLineOptions
             }
         }
 
-        var commandArguments = GetCommandArguments(parseResult, watchOptions, explicitCommand);
+        var commandArguments = GetCommandArguments(parseResult, watchOptions, explicitCommand, out var binLogToken, out var binLogPath);
 
         // We assume that forwarded options, if any, are intended for dotnet build.
-        var buildArguments = buildOptions.Select(option => ((IForwardedOption)option).GetForwardingFunction()(parseResult)).SelectMany(args => args).ToArray();
+        var buildArguments = buildOptions.Select(option => ((IForwardedOption)option).GetForwardingFunction()(parseResult)).SelectMany(args => args).ToList();
+
+        if (binLogToken != null)
+        {
+            buildArguments.Add(binLogToken);
+        }
+
         var targetFrameworkOption = (Option<string>?)buildOptions.SingleOrDefault(option => option.Name == "--framework");
 
         return new()
@@ -160,6 +185,7 @@ internal sealed class CommandLineOptions
                 NoHotReload = parseResult.GetValue(noHotReloadOption),
                 NonInteractive = parseResult.GetValue(NonInteractiveOption),
                 Verbose = parseResult.GetValue(verboseOption),
+                BinaryLogPath = ParseBinaryLogFilePath(binLogPath),
             },
 
             CommandArguments = commandArguments,
@@ -173,12 +199,36 @@ internal sealed class CommandLineOptions
         };
     }
 
+    /// <summary>
+    /// Parses the value of msbuild option `-binaryLogger[:[LogFile=]output.binlog[;ProjectImports={None,Embed,ZipFile}]]`.
+    /// Emulates https://github.com/dotnet/msbuild/blob/7f69ea906c29f2478cc05423484ad185de66e124/src/Build/Logging/BinaryLogger/BinaryLogger.cs#L481.
+    /// See https://github.com/dotnet/msbuild/issues/12256
+    /// </summary>
+    internal static string? ParseBinaryLogFilePath(string? value)
+        => value switch
+        {
+            null => null,
+            _ => (from parameter in value.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                  where !string.Equals(parameter, "ProjectImports=None", StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(parameter, "ProjectImports=Embed", StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(parameter, "ProjectImports=ZipFile", StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(parameter, "OmitInitialInfo", StringComparison.OrdinalIgnoreCase)
+                  let path = (parameter.StartsWith("LogFile=", StringComparison.OrdinalIgnoreCase) ? parameter["LogFile=".Length..] : parameter).Trim('"')
+                  let pathWithExtension = path.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) ? path : $"{path}.binlog"
+                  select pathWithExtension)
+                 .LastOrDefault("msbuild.binlog")
+        };
+
     private static IReadOnlyList<string> GetCommandArguments(
         ParseResult parseResult,
         IReadOnlyList<Option> watchOptions,
-        Command? explicitCommand)
+        Command? explicitCommand,
+        out string? binLogToken,
+        out string? binLogPath)
     {
         var arguments = new List<string>();
+        binLogToken = null;
+        binLogPath = null;
 
         foreach (var child in parseResult.CommandResult.Children)
         {
@@ -199,22 +249,10 @@ internal sealed class CommandLineOptions
                     continue;
                 }
 
-                // Some options _may_ be computed or have defaults, so not all may have an IdentifierToken.
-                    // For those that do not, use the Option's Name instead.
-                    var optionNameToForward = optionResult.IdentifierToken?.Value ?? optionResult.Option.Name;
+                var optionNameToForward = GetOptionNameToForward(optionResult);
                 if (optionResult.Tokens.Count == 0 && !optionResult.Implicit)
                 {
                     arguments.Add(optionNameToForward);
-                }
-                else if (optionResult.Option.Name == "--property")
-                {
-                    foreach (var token in optionResult.Tokens)
-                    {
-                        // While dotnet-build allows "/p Name=Value", dotnet-msbuild does not.
-                        // Any command that forwards args to dotnet-msbuild will fail if we don't use colon.
-                        // See https://github.com/dotnet/sdk/issues/44655.
-                        arguments.Add($"{optionNameToForward}:{token.Value}");
-                    }
                 }
                 else
                 {
@@ -227,8 +265,6 @@ internal sealed class CommandLineOptions
             }
         }
 
-        var tokens = parseResult.UnmatchedTokens.ToArray();
-
         // Assuming that all tokens after "--" are unmatched:
         var dashDashIndex = IndexOf(parseResult.Tokens, t => t.Value == "--");
         var unmatchedTokensBeforeDashDash = parseResult.UnmatchedTokens.Count - (dashDashIndex >= 0 ? parseResult.Tokens.Count - dashDashIndex - 1 : 0);
@@ -240,10 +276,32 @@ internal sealed class CommandLineOptions
         {
             var token = parseResult.UnmatchedTokens[i];
 
-            if (i < unmatchedTokensBeforeDashDash && !seenCommand && token == explicitCommand?.Name)
+            if (i < unmatchedTokensBeforeDashDash)
             {
-                seenCommand = true;
-                continue;
+                if (!seenCommand && token == explicitCommand?.Name)
+                {
+                    seenCommand = true;
+                    continue;
+                }
+
+                // Workaround: commands do not have forwarding option for -bl
+                // https://github.com/dotnet/sdk/issues/49989
+                foreach (var name in s_binaryLogOptionNames)
+                {
+                    if (token.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (token.Length == name.Length)
+                        {
+                            binLogToken = token;
+                            binLogPath = "";
+                        }
+                        else if (token.Length > name.Length + 1 && token[name.Length] == ':')
+                        {
+                            binLogToken = token;
+                            binLogPath = token[(name.Length + 1)..];
+                        }
+                    }
+                }
             }
 
             if (!dashDashInserted && i >= unmatchedTokensBeforeDashDash)
@@ -257,6 +315,11 @@ internal sealed class CommandLineOptions
 
         return arguments;
     }
+
+    private static string GetOptionNameToForward(OptionResult optionResult)
+        // Some options _may_ be computed or have defaults, so not all may have an IdentifierToken.
+        // For those that do not, use the Option's Name instead.
+        => optionResult.IdentifierToken?.Value ?? optionResult.Option.Name;
 
     private static Command? TryGetSubcommand(ParseResult parseResult)
     {

--- a/src/BuiltInTools/dotnet-watch/CommandLine/EnvironmentOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/EnvironmentOptions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Watch
             TestOutput: EnvironmentVariables.TestOutputDir
         );
 
-        private static int s_uniqueLogId;
+        private int _uniqueLogId;
 
         public bool RunningAsTest { get => (TestFlags & TestFlags.RunningAsTest) != TestFlags.None; }
 
@@ -64,9 +64,9 @@ namespace Microsoft.DotNet.Watch
             return muxerPath;
         }
 
-        public string? GetTestBinLogPath(string projectPath, string operationName)
-            => TestFlags.HasFlag(TestFlags.RunningAsTest)
-                ? Path.Combine(TestOutput, $"Watch.{operationName}.{Path.GetFileName(projectPath)}.{Interlocked.Increment(ref s_uniqueLogId)}.binlog")
-                : null;
+        public string? GetBinLogPath(string projectPath, string operationName, GlobalOptions options)
+            => options.BinaryLogPath != null
+               ? $"{Path.Combine(WorkingDirectory, options.BinaryLogPath)[..^".binlog".Length]}-dotnet-watch.{operationName}.{Path.GetFileName(projectPath)}.{Interlocked.Increment(ref _uniqueLogId)}.binlog"
+               : null;
     }
 }

--- a/src/BuiltInTools/dotnet-watch/CommandLine/GlobalOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/GlobalOptions.cs
@@ -9,4 +9,10 @@ internal sealed class GlobalOptions
     public bool Verbose { get; init; }
     public bool NoHotReload { get; init; }
     public bool NonInteractive { get; init; }
+
+    /// <summary>
+    /// Path to binlog file (absolute or relative to working directory, includes .binlog extension),
+    /// or null to not generate binlog files.
+    /// </summary>
+    public string? BinaryLogPath { get; init; }
 }

--- a/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/ScopedCssFileHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Graph;
 
 namespace Microsoft.DotNet.Watch
 {
-    internal sealed class ScopedCssFileHandler(IReporter reporter, ProjectNodeMap projectMap, BrowserConnector browserConnector, EnvironmentOptions environmentOptions)
+    internal sealed class ScopedCssFileHandler(IReporter reporter, ProjectNodeMap projectMap, BrowserConnector browserConnector, GlobalOptions options, EnvironmentOptions environmentOptions)
     {
         private const string BuildTargetName = TargetNames.GenerateComputedBuildStaticWebAssets;
 
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Watch
                 return;
             }
 
-            var buildReporter = new BuildReporter(reporter, environmentOptions);
+            var buildReporter = new BuildReporter(reporter, options, environmentOptions);
 
             var buildTasks = projectsToRefresh.Select(projectNode => Task.Run(() =>
             {

--- a/src/BuiltInTools/dotnet-watch/Program.cs
+++ b/src/BuiltInTools/dotnet-watch/Program.cs
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.Watch
                 rootProjectOptions.ProjectPath,
                 rootProjectOptions.BuildArguments,
                 processRunner,
-                new BuildReporter(reporter, environmentOptions));
+                new BuildReporter(reporter, options.GlobalOptions, environmentOptions));
 
             if (await fileSetFactory.TryCreateAsync(requireProjectGraph: null, cancellationToken) is not { } evaluationResult)
             {

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose /bl:DotnetRun.binlog",
+      "commandLineArgs": "--verbose -bl",
       "workingDirectory": "E:\\sdk\\artifacts\\tmp\\Debug\\Aspire_BuildE---04F22750\\WatchAspire.AppHost",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)",
@@ -10,9 +10,7 @@
         "DCP_IDE_NOTIFICATION_TIMEOUT_SECONDS": "100000",
         "DCP_IDE_NOTIFICATION_KEEPALIVE_SECONDS": "100000",
         "DOTNET_WATCH_PROCESS_CLEANUP_TIMEOUT_MS": "100000",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "1",
-        "__DOTNET_WATCH_TEST_FLAGS": "",
-        "__DOTNET_WATCH_TEST_OUTPUT_DIR": "$(RepoRoot)\\artifacts\\tmp\\Debug"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "1"
       }
     }
   }

--- a/src/BuiltInTools/dotnet-watch/Watch/BuildEvaluator.cs
+++ b/src/BuiltInTools/dotnet-watch/Watch/BuildEvaluator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Watch
                 _context.RootProjectOptions.ProjectPath,
                 _context.RootProjectOptions.BuildArguments,
                 _context.ProcessRunner,
-                new BuildReporter(_context.Reporter, _context.EnvironmentOptions));
+                new BuildReporter(_context.Reporter, _context.Options, _context.EnvironmentOptions));
 
         public IReadOnlyList<string> GetProcessArguments(int iteration)
         {

--- a/src/BuiltInTools/dotnet-watch/Watch/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Watch/MsBuildFileSetFactory.cs
@@ -155,11 +155,6 @@ namespace Microsoft.DotNet.Watch
                 "/t:" + TargetName
             };
 
-            if (EnvironmentOptions.GetTestBinLogPath(rootProjectFile, "GenerateWatchList") is { } binLogPath)
-            {
-                arguments.Add($"/bl:{binLogPath}");
-            }
-
             arguments.AddRange(buildArguments);
 
             // Set dotnet-watch reserved properties after the user specified propeties,

--- a/test/dotnet-watch.Tests/Build/EvaluationTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationTests.cs
@@ -425,7 +425,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var options = TestOptions.GetEnvironmentOptions(workingDirectory: testDirectory, muxerPath: MuxerPath);
             var processRunner = new ProcessRunner(options.ProcessCleanupTimeout);
-            var buildReporter = new BuildReporter(_reporter, options);
+            var buildReporter = new BuildReporter(_reporter, new GlobalOptions(), options);
 
             var filesetFactory = new MSBuildFileSetFactory(projectA, buildArguments: ["/p:_DotNetWatchTraceOutput=true"], processRunner, buildReporter);
 
@@ -484,7 +484,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var options = TestOptions.GetEnvironmentOptions(workingDirectory: Path.GetDirectoryName(project1Path)!, muxerPath: MuxerPath);
             var processRunner = new ProcessRunner(options.ProcessCleanupTimeout);
-            var buildReporter = new BuildReporter(_reporter, options);
+            var buildReporter = new BuildReporter(_reporter, new GlobalOptions(), options);
 
             var factory = new MSBuildFileSetFactory(project1Path, buildArguments: [], processRunner, buildReporter);
             var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
@@ -523,7 +523,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 var options = TestOptions.GetEnvironmentOptions(workingDirectory: testDir, muxerPath: MuxerPath) with { TestOutput = testDir };
                 var processRunner = new ProcessRunner(options.ProcessCleanupTimeout);
                 var buildArguments = targetFramework != null ? new[] { "/p:TargetFramework=" + targetFramework } : [];
-                var buildReporter = new BuildReporter(_reporter, options);
+                var buildReporter = new BuildReporter(_reporter, new GlobalOptions(), options);
                 var factory = new MSBuildFileSetFactory(rootProjectPath, buildArguments, processRunner, buildReporter);
                 var targetsResult = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
                 Assert.NotNull(targetsResult);

--- a/test/dotnet-watch.Tests/CommandLine/BinaryLoggerTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/BinaryLoggerTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+[Collection(nameof(InProcBuildTestCollection))]
+public class BinaryLoggerTests
+{
+    [Theory]
+    [InlineData(null, null, false)]
+    [InlineData("", "msbuild.binlog")]
+    [InlineData("path.binlog", "path.binlog")]
+    [InlineData("LogFile=path.binlog", "path.binlog")]
+    [InlineData("LogFile=path.binlog;ProjectImports=None", "path.binlog")]
+    [InlineData("ProjectImports=None", "msbuild.binlog")]
+    [InlineData("ProjectImports=Embed", "msbuild.binlog")]
+    [InlineData("ProjectImports=ZipFile", "msbuild.binlog")]
+    [InlineData("ProjectImports=ZipFile.binlog", "ProjectImports=ZipFile.binlog")]
+    [InlineData("ProjectImports=ZipFilx", "ProjectImports=ZipFilx.binlog", false)] // we append .binlog to the path if it's not already there
+    [InlineData("OmitInitialInfo", "msbuild.binlog")]
+    [InlineData("ProjectImports=None;path1.binlog;LogFile=path2.binlog", "path2.binlog")]
+    [InlineData("path", "path.binlog", false)] // we append .binlog to the path if it's not already there
+    [InlineData("\"\"\"path{}\"", "path{}.binlog", false)] // wildcard {} not supported
+    public void ParseBinaryLogFilePath(string? value, string? expected, bool matchesMSBuildImpl = true)
+    {
+        Assert.Equal(expected, CommandLineOptions.ParseBinaryLogFilePath(value));
+
+        if (!matchesMSBuildImpl)
+        {
+            return;
+        }
+
+        Assert.NotNull(value);
+        Assert.NotNull(expected);
+
+        var dir = TestContext.Current.TestExecutionDirectory;
+        Directory.SetCurrentDirectory(dir);
+
+        var bl = new BinaryLogger() { Parameters = value };
+        bl.Initialize(new EventSource());
+
+        var actualPath = bl.GetType().GetProperty("FilePath", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)?.GetValue(bl);
+        if (actualPath != null)
+        {
+            Assert.Equal(Path.Combine(dir, expected), actualPath);
+        }
+
+        bl.Shutdown();
+    }
+
+    private class EventSource : IEventSource
+    {
+        public event BuildMessageEventHandler MessageRaised { add { } remove { } }
+        public event BuildErrorEventHandler ErrorRaised { add { } remove { } }
+        public event BuildWarningEventHandler WarningRaised { add { } remove { } }
+        public event BuildStartedEventHandler BuildStarted { add { } remove { } }
+        public event BuildFinishedEventHandler BuildFinished { add { } remove { } }
+        public event ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+        public event ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+        public event TargetStartedEventHandler TargetStarted { add { } remove { } }
+        public event TargetFinishedEventHandler TargetFinished { add { } remove { } }
+        public event TaskStartedEventHandler TaskStarted { add { } remove { } }
+        public event TaskFinishedEventHandler TaskFinished { add { } remove { } }
+        public event CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+        public event BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+        public event AnyEventHandler AnyEventRaised { add { } remove { } }
+    }
+}

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -3,6 +3,10 @@
 
 #nullable disable
 
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
+
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class CommandLineOptionsTests
@@ -118,11 +122,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         [Theory]
         [CombinatorialData]
-        public void WatchOptions_NotPassedThrough_BeforeCommand(
+        public void WatchOptions_NotPassedThrough(
             [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
-            bool before)
+            bool beforeCommand)
         {
-            var options = VerifyOptions(before ? [option, "test"] : ["test", option]);
+            var options = VerifyOptions(beforeCommand ? [option, "test"] : ["test", option]);
             Assert.Equal("test", options.Command);
             AssertEx.SequenceEqual([], options.CommandArguments);
         }
@@ -283,18 +287,55 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
+        [InlineData("-bl")]
+        [InlineData("/bl")]
+        [InlineData("/bl:X.binlog")]
+        [InlineData("-binaryLogger")]
+        [InlineData("/binaryLogger")]
+        [InlineData("--binaryLogger:LogFile=output.binlog;ProjectImports=None")]
+        public void BinaryLoggerOption_AfterDashDash(string option)
+        {
+            var options1 = VerifyOptions(["--", option]);
+
+            AssertEx.SequenceEqual(["--", option], options1.CommandArguments);
+            AssertEx.SequenceEqual(["--property:NuGetInteractive=false"], options1.BuildArguments);
+
+            var options2 = VerifyOptions([option, "A", "--", "-bl:XXX"]);
+
+            AssertEx.SequenceEqual([option, "A", "--", "-bl:XXX"], options2.CommandArguments);
+            AssertEx.SequenceEqual(["--property:NuGetInteractive=false", option], options2.BuildArguments);
+        }
+
+        [Theory]
+        [InlineData("-bl:")]
+        [InlineData("/bl:")]
+        [InlineData("-binaryLogger:")]
+        [InlineData("/binaryLogger:")]
+        public void BinaryLoggerOption_NoValue(string option)
+        {
+            var options = VerifyOptions([option]);
+
+            AssertEx.SequenceEqual([option], options.CommandArguments);
+            AssertEx.SequenceEqual(["--property:NuGetInteractive=false"], options.BuildArguments);
+        }
+
+        [Theory]
         [CombinatorialData]
         public void OptionsSpecifiedBeforeOrAfterRun(bool afterRun)
         {
             var args = new[] { "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" };
-            args = afterRun ? args.Prepend("run").ToArray() : args.Append("run").ToArray();
+            args = afterRun ? [.. args.Prepend("run")] : [.. args.Append("run")];
 
             var options = VerifyOptions(args);
 
             Assert.Equal("P", options.ProjectPath);
             Assert.Equal("F", options.TargetFramework);
+
+            // the forwarding function of --property property joins the properties with `:`:
             AssertEx.SequenceEqual(["--property:TargetFramework=F", "--property:P1=V1", "--property:P2=V2", NugetInteractiveProperty], options.BuildArguments);
-            AssertEx.SequenceEqual(["--project", "P", "--framework", "F", "--property:P1=V1", "--property:P2=V2"], options.CommandArguments);
+
+            // it's ok to keep the two arguments and not to join them with `:` since `run` command handles these options correctly
+            AssertEx.SequenceEqual(["--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
         }
 
         public enum ArgPosition
@@ -346,7 +387,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             AssertEx.SequenceEqual(["--property:P1=V1", "--property:P2=V2", NugetInteractiveProperty], options.BuildArguments);
 
             // options must be repeated since --property does not support multiple args
-            AssertEx.SequenceEqual(["--property:P1=V1", "--property:P2=V2"], options.CommandArguments);
+            AssertEx.SequenceEqual(["--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
         }
 
         [Theory]
@@ -421,6 +462,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData(new[] { "--framework", "net9.0" }, new[] { "--property:TargetFramework=net9.0", NugetInteractiveProperty })]
         [InlineData(new[] { "--runtime", "arm64" }, new[] { "--property:RuntimeIdentifier=arm64", "--property:_CommandLineDefinedRuntimeIdentifier=true", NugetInteractiveProperty })]
         [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
+        [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1", NugetInteractiveProperty }, new[] { "/p", "b=1" })] // it's ok to split the argument into two since `dotnet run` handles `/p b=1`
         [InlineData(new[] { "--interactive" }, new[] { "--property:NuGetInteractive=true" })]
         [InlineData(new[] { "--no-restore" }, new[] { NugetInteractiveProperty, "-restore:false" })]
         [InlineData(new[] { "--sc" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
@@ -429,10 +471,30 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData(new[] { "--verbosity", "q" }, new[] { NugetInteractiveProperty, "--verbosity:q" })]
         [InlineData(new[] { "--arch", "arm", "--os", "win" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=win-arm" })]
         [InlineData(new[] { "--disable-build-servers" }, new[] { NugetInteractiveProperty, "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
-        public void ForwardedBuildOptions(string[] args, string[] buildArgs)
+        [InlineData(new[] { "-bl" }, new[] { NugetInteractiveProperty, "-bl" })]
+        [InlineData(new[] { "/bl" }, new[] { NugetInteractiveProperty, "/bl" })]
+        [InlineData(new[] { "/bl:X.binlog" }, new[] { NugetInteractiveProperty, "/bl:X.binlog" })]
+        [InlineData(new[] { "-binaryLogger" }, new[] { NugetInteractiveProperty, "-binaryLogger" })]
+        [InlineData(new[] { "/binaryLogger" }, new[] { NugetInteractiveProperty, "/binaryLogger" })]
+        [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { NugetInteractiveProperty, "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+        public void ForwardedBuildOptions_Run(string[] args, string[] buildArgs, string[] commandArgs = null)
         {
-            var options = VerifyOptions(["run", .. args]);
-            AssertEx.SequenceEqual(buildArgs, options.BuildArguments);
+            var runOptions = VerifyOptions(["run", .. args]);
+            AssertEx.SequenceEqual(buildArgs, runOptions.BuildArguments);
+            AssertEx.SequenceEqual(commandArgs ?? args, runOptions.CommandArguments);
+        }
+
+        [Theory]
+        [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1" }, Skip = "https://github.com/dotnet/sdk/issues/44655")]
+        [InlineData(new[] { "--property", "b=1" }, new[] { "--property", "b=1" }, Skip = "https://github.com/dotnet/sdk/issues/44655")]
+        [InlineData(new[] { "/p:b=1" }, new[] { "/p:b=1" }, Skip = "https://github.com/dotnet/sdk/issues/44655")]
+        [InlineData(new[] { "/bl" }, new[] { "/bl" })]
+        [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+        public void ForwardedBuildOptions_Test(string[] args, string[] commandArgs)
+        {
+            var runOptions = VerifyOptions(["test", .. args]);
+            AssertEx.SequenceEqual(["--property:NuGetInteractive=false", "--target:VSTest", .. commandArgs], runOptions.BuildArguments);
+            AssertEx.SequenceEqual(commandArgs, runOptions.CommandArguments);
         }
 
         [Fact]

--- a/test/dotnet-watch.Tests/CommandLine/EnvironmentOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/EnvironmentOptionsTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class BuildReporterTests
+{
+    [Fact]
+    public void GetBinLogPath()
+    {
+        var root = Path.GetTempPath();
+        var projectPath = Path.Combine(root, "project.csproj");
+        var workingDirectory = Path.Combine(root, "working");
+        var envOptions = TestOptions.GetEnvironmentOptions(workingDirectory);
+
+        AssertEx.Equal(Path.Combine(workingDirectory, "msbuild-dotnet-watch.Restore.project.csproj.1.binlog"),
+            envOptions.GetBinLogPath(
+                projectPath: projectPath,
+                operationName: "Restore",
+                new GlobalOptions() { BinaryLogPath = "msbuild.binlog" }));
+
+        AssertEx.Equal(Path.Combine(root, "logs", "test-dotnet-watch.Build.project.csproj.2.binlog"),
+            envOptions.GetBinLogPath(
+                projectPath: projectPath,
+                operationName: "Build",
+                new GlobalOptions() { BinaryLogPath = Path.Combine(root, "logs", "test.binlog") }));
+
+    }
+}

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: string.Join(",", arguments))
                 .WithSource();
 
+            App.DotnetWatchArgs.Clear();
             App.Start(testAsset, arguments);
 
             Assert.Equal(expectedApplicationArgs, await App.AssertOutputLineStartsWith("Arguments = "));

--- a/test/dotnet-watch.Tests/TestUtilities/MockFileSetFactory.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/MockFileSetFactory.cs
@@ -7,7 +7,7 @@ internal class MockFileSetFactory() : MSBuildFileSetFactory(
     rootProjectFile: "test.csproj",
     buildArguments: [],
     new ProcessRunner((TestOptions.GetEnvironmentOptions(Environment.CurrentDirectory, "dotnet") is var options ? options : options).ProcessCleanupTimeout),
-    new BuildReporter(NullReporter.Singleton, options))
+    new BuildReporter(NullReporter.Singleton, new GlobalOptions(), options))
 {
     public Func<EvaluationResult?>? TryCreateImpl;
 

--- a/test/dotnet-watch.Tests/TestUtilities/WatchableApp.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/WatchableApp.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         public AwaitableProcess Process { get; private set; }
 
-        public List<string> DotnetWatchArgs { get; } = ["--verbose", "/bl:DotnetRun.binlog"];
+        public List<string> DotnetWatchArgs { get; } = ["--verbose", "-bl"];
 
         public Dictionary<string, string> EnvironmentVariables { get; } = [];
 
@@ -122,9 +122,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
         public Task AssertExiting()
             => AssertOutputLineStartsWith(ExitingMessage);
 
-        public void Start(TestAsset asset, IEnumerable<string> arguments, string relativeProjectDirectory = null, string workingDirectory = null, TestFlags testFlags = TestFlags.None)
+        public void Start(TestAsset asset, IEnumerable<string> arguments, string relativeProjectDirectory = null, string workingDirectory = null, TestFlags testFlags = TestFlags.RunningAsTest)
         {
-            testFlags |= TestFlags.RunningAsTest;
+            if (testFlags != TestFlags.None)
+            {
+                testFlags |= TestFlags.RunningAsTest;
+            }
 
             var projectDirectory = (relativeProjectDirectory != null) ? Path.Combine(asset.Path, relativeProjectDirectory) : asset.Path;
 


### PR DESCRIPTION
The option is now forwarded to the command dotnet-watch is executing (`dotnet run`, `dotnet test`, etc.) and also used for logging dotnet-watch invoked build operations: `dotnet build` and design-time build.