### PR TITLE
Allow users to override packaging implementation in generated tool packages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -76,7 +76,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
 
     <!-- Tool implementation files are not included in the primary package when the tool has RID-specific packages.  So only pack the tool implementation
        (and only depend on publish) if there are no RID-specific packages, or if the RuntimeIdentifier is set. -->
-    <_ToolPackageShouldIncludeImplementation Condition=" '$(PackAsTool)' == 'true' And
+    <_ToolPackageShouldIncludeImplementation Condition=" '$(_ToolPackageShouldIncludeImplementation)' == '' And '$(PackAsTool)' == 'true' And
                                                   ('$(_UserSpecifiedToolPackageRids)' == ''
                                                      or '$(RuntimeIdentifier)' != '')">true</_ToolPackageShouldIncludeImplementation>
     <_ToolPackageShouldIncludeImplementation Condition="'$(_ToolPackageShouldIncludeImplementation)' == ''">false</_ToolPackageShouldIncludeImplementation>
@@ -411,8 +411,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
   <Target Name="_CreateRIDSpecificToolPackages"
     Condition="'$(RuntimeIdentifier)' == ''
       and $(_HasRIDSpecificTools)
-      and !$(_InnerToolsPublishAot)
-      and !$(_ToolPackageShouldIncludeImplementation)">
+      and !$(_InnerToolsPublishAot)">
     <PropertyGroup>
         <_PackageRids>$(ToolPackageRuntimeIdentifiers)</_PackageRids>
         <_PackageRids Condition="'$(_PackageRids)' == ''">$(RuntimeIdentifiers)</_PackageRids>


### PR DESCRIPTION
In some back-compat cases it may be useful to be able to make a Tool package that both appears as a v1-tool (so a FDD tool) and a v2-tool manifest package (so its tool XML contains a list of RID-specific implementations).  Today this is very hard to do because the `_ToolPackageShouldIncludeImplementation` is only ever derived from other properties of the build and cannot be set by a sufficiently-motivated user. This PR looses this restrictions. While this loosening on its own is not enough to fully make a cross-compatible tool package (users will also need to [XmlPoke the tool xml file](https://github.com/dotnet/aspire/commit/55e0bdc9796f3ea3da4c54402969d07610179f16#diff-116e1002224c78c0c36ccbea73571898e68ec06e8ddc108897630b19763ddd81R23-R35)) this is the only true _blocker_ to making this compatibility possible.