### PR TITLE
Handle escaping of command-line arguments in dotnet test

### DIFF
--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -96,6 +96,7 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
         // So, we keep that first always.
         // RunArguments is intentionally not escaped. It can contain multiple arguments and spaces there shouldn't cause the whole
         // value to be wrapped in double quotes. This matches dotnet run behavior.
+        // In short, it's expected to already be escaped properly.
         StringBuilder builder = new(Module.RunProperties.RunArguments);
 
         if (testOptions.IsHelp)

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -94,17 +94,19 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
         // In the case of UseAppHost=false, RunArguments is set to `exec $(TargetPath)`:
         // https://github.com/dotnet/sdk/blob/333388c31d811701e3b6be74b5434359151424dc/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1411
         // So, we keep that first always.
+        // RunArguments is intentionally not escaped. It can contain multiple arguments and spaces there shouldn't cause the whole
+        // value to be wrapped in double quotes. This matches dotnet run behavior.
         StringBuilder builder = new(Module.RunProperties.RunArguments);
 
         if (testOptions.IsHelp)
         {
-            builder.Append($" {TestingPlatformOptions.HelpOption.Name} ");
+            builder.Append($" {TestingPlatformOptions.HelpOption.Name}");
         }
 
-        var args = _buildOptions.UnmatchedTokens;
-        builder.Append(args.Count != 0
-            ? args.Aggregate((a, b) => $"{a} {b}")
-            : string.Empty);
+        foreach (var arg in _buildOptions.UnmatchedTokens)
+        {
+            builder.Append($" {ArgumentEscaper.EscapeSingleArg(arg)}");
+        }
 
         builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeNameDescription.Name)}");
 

--- a/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/Program.cs
+++ b/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/Program.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+
+var builder = new StringBuilder();
+for (int i = 0; i < args.Length; i++)
+{
+    builder.AppendLine($"args[{i}]={args[i]}");
+}
+
+throw new Exception(builder.ToString());

--- a/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/TestAppPrintingCommandLineArguments.csproj
+++ b/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/TestAppPrintingCommandLineArguments.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+  </PropertyGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/dotnet.config
+++ b/test/TestAssets/TestProjects/TestAppPrintingCommandLineArguments/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -168,23 +168,21 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                              "My other arg with spaces",
                                              "Arg ending with backslash and containing spaces\\",
                                              "ArgWithoutSpacesEndingWith\\");
-            if (!TestContext.IsLocalized())
-            {
-                result.StdOut.Should().Contain("""
-                    args[0]=--hello
-                    args[1]=world
-                    args[2]=
-                    args[3]=world2
-                    args[4]=--list-tests
-                    args[5]=Another arg with spaces
-                    args[6]=My other arg with spaces
-                    args[7]=Arg ending with backslash and containing spaces\
-                    args[8]=ArgWithoutSpacesEndingWith\
-                    args[9]=--server
-                    args[10]=dotnettestcli
-                    args[11]=--dotnet-test-pipe
-                    """);
-            }
+
+            result.StdOut.Should().Contain("""
+                args[0]=--hello
+                args[1]=world
+                args[2]=
+                args[3]=world2
+                args[4]=--list-tests
+                args[5]=Another arg with spaces
+                args[6]=My other arg with spaces
+                args[7]=Arg ending with backslash and containing spaces\
+                args[8]=ArgWithoutSpacesEndingWith\
+                args[9]=--server
+                args[10]=dotnettestcli
+                args[11]=--dotnet-test-pipe
+                """);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -170,18 +170,18 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                              "ArgWithoutSpacesEndingWith\\");
 
             result.StdOut.Should().Contain("""
-                args[0]=--hello
-                args[1]=world
-                args[2]=
-                args[3]=world2
-                args[4]=--list-tests
-                args[5]=Another arg with spaces
-                args[6]=My other arg with spaces
-                args[7]=Arg ending with backslash and containing spaces\
-                args[8]=ArgWithoutSpacesEndingWith\
-                args[9]=--server
-                args[10]=dotnettestcli
-                args[11]=--dotnet-test-pipe
+                 args[0]=--hello
+                  args[1]=world
+                  args[2]=
+                  args[3]=world2
+                  args[4]=--list-tests
+                  args[5]=Another arg with spaces
+                  args[6]=My other arg with spaces
+                  args[7]=Arg ending with backslash and containing spaces\
+                  args[8]=ArgWithoutSpacesEndingWith\
+                  args[9]=--server
+                  args[10]=dotnettestcli
+                  args[11]=--dotnet-test-pipe
                 """);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49962