### PR TITLE
Remove promote-nuget-client.yml from .vsts-ci.yml

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -285,7 +285,3 @@ extends:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022
               os: windows
-
-        - template: /eng/pipelines/templates/jobs/promote-nuget-client.yml@self
-          parameters:
-            assetName: NuGet.Protocol


### PR DESCRIPTION
This was overlooked in https://github.com/dotnet/sdk/pull/50021 and currently causes the internal build to fail.