### PR TITLE
Unskip test case

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
+++ b/test/Microsoft.NET.Publish.Tests/PublishItemsOutputGroupOutputsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Publish.Tests
 
         [Theory]
         [InlineData(true, false)]
-        [InlineData(true, true, Skip = "https://github.com/dotnet/sdk/issues/49926")]
+        [InlineData(true, true)]
         [InlineData(false, false)]
         public void RunPublishItemsOutputGroupOutputsTest(bool specifyRid, bool singleFile)
         {


### PR DESCRIPTION
Re-enable the test case: RunPublishItemsOutputGroupOutputsTest(specifyRid: true, singleFile: true)