### PR TITLE
Better handling of `--results-directory`

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -66,10 +66,17 @@ internal static class MSBuildUtility
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(TestCommandParser.GetCommand())
             .Concat(binLogArgs);
 
+        string? resultsDirectory = parseResult.GetValue(TestingPlatformOptions.ResultsDirectoryOption);
+        if (resultsDirectory is not null)
+        {
+            resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), resultsDirectory);
+        }
+
         PathOptions pathOptions = new(
             parseResult.GetValue(TestingPlatformOptions.ProjectOption),
             parseResult.GetValue(TestingPlatformOptions.SolutionOption),
-            parseResult.GetValue(TestingPlatformOptions.DirectoryOption));
+            parseResult.GetValue(TestingPlatformOptions.DirectoryOption),
+            resultsDirectory);
 
         return new BuildOptions(
             pathOptions,

--- a/src/Cli/dotnet/Commands/Test/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/Options.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal record TestOptions(bool HasFilterMode, bool IsHelp);
 
-internal record PathOptions(string? ProjectPath, string? SolutionPath, string? DirectoryPath);
+internal record PathOptions(string? ProjectPath, string? SolutionPath, string? DirectoryPath, string? ResultsDirectoryPath);
 
 internal record BuildOptions(
     PathOptions PathOptions,

--- a/src/Cli/dotnet/Commands/Test/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplication.cs
@@ -104,6 +104,11 @@ internal sealed class TestApplication(TestModule module, BuildOptions buildOptio
             builder.Append($" {TestingPlatformOptions.HelpOption.Name}");
         }
 
+        if (_buildOptions.PathOptions.ResultsDirectoryPath is { } resultsDirectoryPath)
+        {
+            builder.Append($" {TestingPlatformOptions.ResultsDirectoryOption.Name} {ArgumentEscaper.EscapeSingleArg(resultsDirectoryPath)}");
+        }
+
         foreach (var arg in _buildOptions.UnmatchedTokens)
         {
             builder.Append($" {ArgumentEscaper.EscapeSingleArg(arg)}");

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -235,6 +235,7 @@ internal static class TestCommandParser
         command.Options.Add(TestingPlatformOptions.DirectoryOption);
         command.Options.Add(TestingPlatformOptions.TestModulesFilterOption);
         command.Options.Add(TestingPlatformOptions.TestModulesRootDirectoryOption);
+        command.Options.Add(TestingPlatformOptions.ResultsDirectoryOption);
         command.Options.Add(TestingPlatformOptions.MaxParallelTestModulesOption);
         command.Options.Add(CommonOptions.ArchitectureOption);
         command.Options.Add(CommonOptions.PropertiesOption);

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
@@ -43,6 +43,13 @@ internal static class TestingPlatformOptions
         HelpName = CliCommandStrings.CmdRootPathName,
     };
 
+    public static readonly Option<string> ResultsDirectoryOption = new("--results-directory")
+    {
+        Description = CliCommandStrings.CmdResultsDirectoryDescription,
+        HelpName = CliCommandStrings.CmdPathToResultsDirectory,
+        Arity = ArgumentArity.ExactlyOne
+    };
+
     public static readonly Option<string> MaxParallelTestModulesOption = new("--max-parallel-test-modules")
     {
         Description = CliCommandStrings.CmdMaxParallelTestModulesDescription,


### PR DESCRIPTION
The --results-directory part of #49709