### PR TITLE
ensure that the run commands operates on minimal verbosity by default

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -354,7 +354,7 @@ public class RunCommand
         else
         {
             // Apply defaults if the user didn't expressly set the verbosity.
-            // Setting RunCommmandVerbosity to minimal ensures that we keep the previous launchsettings
+            // Setting RunCommandVerbosity to minimal ensures that we keep the previous launchsettings
             // and related diagnostics messages on by default.
             RunCommandVerbosity = VerbosityOptions.minimal;
             return msbuildArgs.CloneWithVerbosity(VerbosityOptions.quiet);

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -70,6 +70,12 @@ public class RunCommand
     public bool NoLaunchProfile { get; }
 
     /// <summary>
+    /// The verbosity of the run-portion of this command specifically. If implicit builds are performed, they will always happen
+    /// at a quiet verbosity by default, but it's important that we enable separate verbosity for the run command itself.
+    /// </summary>
+    public VerbosityOptions RunCommandVerbosity { get; private set; }
+
+    /// <summary>
     /// True to ignore command line arguments specified by launch profile.
     /// </summary>
     public bool NoLaunchProfileArguments { get; }
@@ -208,7 +214,7 @@ public class RunCommand
             return true;
         }
 
-        if (MSBuildArgs.Verbosity?.IsQuiet() != true)
+        if (!RunCommandVerbosity.IsQuiet())
         {
             Reporter.Output.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
@@ -339,11 +345,20 @@ public class RunCommand
     {
         msbuildArgs = msbuildArgs.CloneWithAdditionalArgs("-nologo");
 
-        if (msbuildArgs.Verbosity is null)
+        if (msbuildArgs.Verbosity is VerbosityOptions userVerbosity)
         {
+            // if the had a desired verbosity, we use that for the run command
+            RunCommandVerbosity = userVerbosity;
+            return msbuildArgs;
+        }
+        else
+        {
+            // Apply defaults if the user didn't expressly set the verbosity.
+            // Setting RunCommmandVerbosity to minimal ensures that we keep the previous launchsettings
+            // and related diagnostics messages on by default.
+            RunCommandVerbosity = VerbosityOptions.minimal;
             return msbuildArgs.CloneWithVerbosity(VerbosityOptions.quiet);
         }
-        return msbuildArgs;
     }
 
     internal ICommand GetTargetCommand(Func<ProjectCollection, ProjectInstance>? projectFactory)
@@ -356,7 +371,7 @@ public class RunCommand
             return CreateCommandForCscBuiltProgram(EntryPointFileFullPath);
         }
 
-        FacadeLogger? logger = LoggerUtility.DetermineBinlogger([..MSBuildArgs.OtherMSBuildArgs], "dotnet-run");
+        FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. MSBuildArgs.OtherMSBuildArgs], "dotnet-run");
         var project = EvaluateProject(ProjectFileFullPath, projectFactory, MSBuildArgs, logger);
         ValidatePreconditions(project);
         InvokeRunArgumentsTarget(project, NoBuild, logger, MSBuildArgs);

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -347,7 +347,7 @@ public class RunCommand
 
         if (msbuildArgs.Verbosity is VerbosityOptions userVerbosity)
         {
-            // if the had a desired verbosity, we use that for the run command
+            // if the user had a desired verbosity, we use that for the run command
             RunCommandVerbosity = userVerbosity;
             return msbuildArgs;
         }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1597,7 +1597,8 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                 Message: ''
                 """);
 
-        new DotnetCommand(Log, "run", "Program.cs")
+        // quiet runs here so that launch-profile useage messages don't impact test assertions
+        new DotnetCommand(Log, "run", "-v", "q", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass()
@@ -1607,7 +1608,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                 Message: 'PropertiesLaunchSettingsJson1'
                 """);
 
-        new DotnetCommand(Log, "run", "-lp", "TestProfile2", "Program.cs")
+        new DotnetCommand(Log, "run", "-v", "q", "-lp", "TestProfile2", "Program.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass()
@@ -1634,7 +1635,8 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(Path.Join(testInstance.Path, "Second.cs"), source);
         File.WriteAllText(Path.Join(testInstance.Path, "Second.run.json"), s_launchSettings.Replace("TestProfileMessage", "Second"));
 
-        new DotnetCommand(Log, "run", "First.cs")
+        // do these runs with quiet verbosity so that default run output doesn't impact the tests
+        new DotnetCommand(Log, "run", "-v", "q", "First.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass()
@@ -1643,7 +1645,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                 Message: 'First1'
                 """);
 
-        new DotnetCommand(Log, "run", "Second.cs")
+        new DotnetCommand(Log, "run", "-v", "q",  "Second.cs")
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
             .Should().Pass()


### PR DESCRIPTION
Fixes #50111 

The Run command has two logical parts:

* building the app to be run
* running the app

These parts have different 'effective' verbosities by default. If a user specifies a verbosity it applies to both parts, but in the absence of a user-supplied verbosity the build portion should be silent, and the run portion should be 'minimal' - the default for other commands on the CLI.

<img width="1106" height="293" alt="image" src="https://github.com/user-attachments/assets/74d5dbc8-7f8c-4c3d-aeaf-279492190a66" />