### PR TITLE
TerminalTestReporter: Use executionId as dictionary key

### DIFF
--- a/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/Terminal/TerminalTestReporter.cs
@@ -61,6 +61,8 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private bool? _shouldShowPassedTests;
 
+    public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
+
 #if NET7_0_OR_GREATER
     // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
     // thread suspends, so the regex gets blamed incorrectly.
@@ -281,7 +283,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
         bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
         bool anyTestFailed = totalFailedTests > 0;
-        bool anyAssemblyFailed = _assemblies.Values.Any(a => !a.Success) || _handshakeFailuresCount > 0;
+        bool anyAssemblyFailed = _assemblies.Values.Any(a => !a.Success) || HasHandshakeFailure;
         bool runFailed = anyAssemblyFailed || anyTestFailed || notEnoughTests || allTestsWereSkipped || _wasCancelled;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 

--- a/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
@@ -13,6 +13,8 @@ internal sealed class TestApplicationsEventHandlers(TerminalTestReporter output)
     private readonly ConcurrentDictionary<TestApplication, (string ModulePath, string TargetFramework, string Architecture, string ExecutionId)> _executions = new();
     private readonly TerminalTestReporter _output = output;
 
+    public bool HasHandshakeFailure => _output.HasHandshakeFailure;
+
     public void OnHandshakeReceived(object sender, HandshakeArgs args)
     {
         var hostType = args.Handshake.Properties[HandshakeMessagePropertyNames.HostType];

--- a/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
@@ -145,11 +145,16 @@ internal sealed class TestApplicationsEventHandlers(TerminalTestReporter output)
 
         if (_executions.TryGetValue(testApplication, out var appInfo))
         {
-            _output.AssemblyRunCompleted(appInfo.ModulePath, appInfo.TargetFramework, appInfo.Architecture, appInfo.ExecutionId, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
+            _output.AssemblyRunCompleted(appInfo.ExecutionId, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
         }
         else
         {
-            _output.AssemblyRunCompleted(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
+            // TODO: Important before merge.
+            // Report this as "test process exited unexpectedly".
+            // This is either a crash before we received the handshake, or a test process that is not actually handshaking with us (e.g, empty entry point).
+            // AssemblyRunCompleted doesn't expect null executionId. So we cannot call it.
+            // Effectively, AssemblyRunCompleted isn't expected to be called without a corresponding AssemblyRunStarted.
+            // _output.AssemblyRunCompleted(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
         }
 
         LogTestProcessExit(args);

--- a/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
+++ b/src/Cli/dotnet/Commands/Test/TestApplicationEventHandlers.cs
@@ -149,12 +149,7 @@ internal sealed class TestApplicationsEventHandlers(TerminalTestReporter output)
         }
         else
         {
-            // TODO: Important before merge.
-            // Report this as "test process exited unexpectedly".
-            // This is either a crash before we received the handshake, or a test process that is not actually handshaking with us (e.g, empty entry point).
-            // AssemblyRunCompleted doesn't expect null executionId. So we cannot call it.
-            // Effectively, AssemblyRunCompleted isn't expected to be called without a corresponding AssemblyRunStarted.
-            // _output.AssemblyRunCompleted(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, architecture: null, null, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
+            _output.HandshakeFailure(testApplication.Module.TargetPath ?? testApplication.Module.ProjectFullPath, testApplication.Module.TargetFramework, args.ExitCode, string.Join(Environment.NewLine, args.OutputData), string.Join(Environment.NewLine, args.ErrorData));
         }
 
         LogTestProcessExit(args);

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
@@ -80,7 +80,9 @@ internal partial class TestingPlatformCommand : Command, ICustomHelp
         }
 
         _actionQueue.EnqueueCompleted();
-        return _actionQueue.WaitAllActions();
+        var exitCode = _actionQueue.WaitAllActions();
+        // Don't inline exitCode variable. We want to always call WaitAllActions first.
+        return _eventHandlers.HasHandshakeFailure ? ExitCode.GenericFailure : exitCode;
     }
 
     private void PrepareEnvironment(ParseResult parseResult, out TestOptions testOptions, out int degreeOfParallelism)


### PR DESCRIPTION
Closes https://github.com/dotnet/sdk/issues/49924