### PR TITLE
[wasm] Don't call .NET runtime if browser refresh script for HotReload is missing

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
+++ b/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
@@ -1,6 +1,10 @@
+let isHotReloadEnabled = false;
+
 export async function onRuntimeConfigLoaded(config) {
     // If we have 'aspnetcore-browser-refresh', configure mono runtime for HotReload.
     if (config.debugLevel !== 0 && globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']")) {
+        isHotReloadEnabled = true;
+
         if (!config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]) {
             config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
         }
@@ -14,6 +18,10 @@ export async function onRuntimeConfigLoaded(config) {
 }
 
 export async function onRuntimeReady({ getAssemblyExports }) {
+    if (!isHotReloadEnabled) {
+        return;
+    }
+    
     const exports = await getAssemblyExports("Microsoft.DotNet.HotReload.WebAssembly.Browser");
     await exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.InitializeAsync(document.baseURI);
 


### PR DESCRIPTION
The scenario that happens is: 
- Application is published in debug, meaning the HotReload package is referenced
- Since it's publish, ILLink will remove all un-referenced assemblies
- Running the publish output results in calling JSExport that has been ILLinked out

To mitigate it, we don't call JSExport when browser refresh script is not used

Related to https://github.com/dotnet/runtime/issues/118442