### PR TITLE
fix #50008 by bumping precedence so the 10 template is treated as the primary

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/.template.config/template.json
@@ -8,7 +8,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "Create an empty solution containing no projects",
   "groupIdentity": "ItemSolution",
-  "precedence": "100",
+  "precedence": "101",
   "identity": "Microsoft.Standard.QuickStarts.Solution",
   "shortName": [
     "sln",


### PR DESCRIPTION
Fixes #50008 

Templates are parsed from all configured providers, and then grouped by 'groupIdentity' into TemplateGroups.
When a template is _instantiated_, the TemplateGroup is chosen based on the identity of the template provided by the user in the command, and then the Templates in the [TemplateGroup are ordered by Precedence and the maximum one is chosen](https://github.com/dotnet/sdk/blob/4284ea102618605f83abf8cb4bf30b6acf6d811c/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.cs#L88) for parsing all of the rest of the arguments to the template.

In general, the problem in #50008 doesn't happen with the 'core' project templates because we bump the template precedence each release. We haven't done this with the `item` templates because they generally haven't changed much and it's not been part of our muscle memory. We should make this a thing in the future for any template changes - in fact we should probably just keep item template precedence in line with the project template precedence. 