### PR TITLE
Add support and tests for interpolating MSBuild properties and environment variables in launchProfile commandLineArgs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": ".NET Core Launch (console)",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet${/}sdk${/}10.0.100--dev${/}dotnet.dll",
+      "program": "${workspaceFolder}${/}artifacts${/}bin${/}redist${/}Debug${/}dotnet${/}sdk${/}10.0.100-dev${/}dotnet.dll",
       "args": [
       ],
       "env": {

--- a/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
@@ -110,10 +110,11 @@ internal abstract class RunApiInput
                 environmentVariables: ReadOnlyDictionary<string, string>.Empty,
                 msbuildRestoreProperties: ReadOnlyDictionary<string, string>.Empty);
 
+            
             runCommand.TryGetLaunchProfileSettingsIfNeeded(out var launchSettings);
-            var targetCommand = (Utils.Command)runCommand.GetTargetCommand(buildCommand.CreateProjectInstance);
-            runCommand.ApplyLaunchSettingsProfileToCommand(targetCommand, launchSettings);
-
+            (var targetCommand, var project) = runCommand.GetTargetCommand(buildCommand.CreateProjectInstance);
+            runCommand.ApplyLaunchSettingsProfileToCommand(targetCommand, launchSettings, project);
+            
             return new RunApiOutput.RunCommand
             {
                 ExecutablePath = targetCommand.CommandName,

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -227,7 +227,7 @@ public partial class RunCommand
                 return ambientEnvVarValue;
             }
 
-            return propertyName;
+            return match.Value;
         });
     }
 

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -249,6 +249,10 @@ internal static class SolutionAndProjectUtility
 
         // TODO: Support --launch-profile and pass it here.
         var launchSettings = TryGetLaunchProfileSettings(Path.GetDirectoryName(projectFullPath)!, Path.GetFileNameWithoutExtension(projectFullPath), project.GetPropertyValue(ProjectProperties.AppDesignerFolder), noLaunchProfile, profileName: null);
+        if (launchSettings is not null && launchSettings.CommandLineArgs is not null)
+        {
+            launchSettings.CommandLineArgs = project.ExpandString(launchSettings.CommandLineArgs);
+        }
 
         return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, isTestingPlatformApplication, isTestProject, launchSettings, project.GetPropertyValue(ProjectProperties.TargetPath));
 

--- a/test/TestAssets/TestProjects/TestAppWithLaunchSettings/Program.cs
+++ b/test/TestAssets/TestProjects/TestAppWithLaunchSettings/Program.cs
@@ -14,13 +14,9 @@ namespace ConsoleApplication
             Console.WriteLine($"env: DOTNET_LAUNCH_PROFILE={Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")}");
             Console.WriteLine($"env: ASPNETCORE_URLS={Environment.GetEnvironmentVariable("ASPNETCORE_URLS")}");
             Console.WriteLine($"env: Configuration={Environment.GetEnvironmentVariable("Configuration")}");
-            if (args.Length > 0)
+            foreach (var arg in args)
             {
-                Console.WriteLine(args[0]);
-            }
-            if (args.Length > 1)
-            {
-                Console.WriteLine(args[1]);
+                Console.WriteLine(arg);
             }
         }
     }


### PR DESCRIPTION
Fixes #50157 by doing the same kind of property-interpolation as the project-system does.

We choose the following 'layering':

* `-e` environment variables specified by the user
* property values from the project file
* ambient environment variables

It's worth noting that the direct-Csc usage of `dotnet run` doesn't support this feature because there is no ProjectInstance. It's possible that this gap could be filled with a proxy or a static set of Properties or something.