### PR TITLE
Add activity spans for template creation and most tool usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -280,6 +280,10 @@ dotnet_diagnostic.IDE0200.severity = none
 dotnet_diagnostic.IDE0240.severity = warning
 
 # Additional rules for template engine source code
+
+# Default severity for analyzer diagnostics with category 'StyleCop.CSharp.SpacingRules'
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = none
+
 [{src,test}/**{Microsoft.TemplateEngine.*,dotnet-new?*}/**.cs]
 # Default analyzed API surface = 'public' (public APIs)
 dotnet_code_quality.api_surface = public

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs
@@ -6,15 +6,27 @@ using System.Diagnostics;
 namespace Microsoft.DotNet.Cli.Utils;
 
 /// <summary>
-/// Contains helpers for working with <see cref="System.Diagnostics.Activity">Activities</see> in the .NET CLI.
+/// Contains helpers for working with <see cref="Activity">Activities</see> in the .NET CLI.
 /// </summary>
 public static class Activities
 {
-
     /// <summary>
     /// The main entrypoint for creating <see cref="Activity">Activities</see> in the .NET CLI.
     /// All activities created in the CLI should use this <see cref="ActivitySource"/>, to allow
     /// consumers to easily filter and trace CLI activities.
     /// </summary>
     public static ActivitySource Source { get; } = new("dotnet-cli", Product.Version);
+
+    /// <summary>
+    /// The environment variable used to transfer the chain of parent activity IDs.
+    /// This should be used when constructing new sub-processes in order to
+    /// track spans across calls.
+    /// </summary>
+    public const string TRACEPARENT = nameof(TRACEPARENT);
+    /// <summary>
+    /// The environment variable used to transfer the trace state of the parent activities.
+    /// This should be used when constructing new sub-processes in order to
+    /// track spans across calls.
+    /// </summary>
+    public const string TRACESTATE = nameof(TRACESTATE);
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -156,9 +156,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             CancellationTokenSource cancellationTokenSource = new();
             cancellationTokenSource.CancelAfter(ConstraintEvaluationTimeout);
 
-#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
             Task<IReadOnlyList<TemplateConstraintResult>> constraintsEvaluation = ValidateConstraintsAsync(constraintManager, args.Template, args.IsForceFlagSpecified ? cancellationTokenSource.Token : cancellationToken);
-#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 
             if (!args.IsForceFlagSpecified)
             {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -37,6 +37,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal async Task<NewCommandStatus> InvokeTemplateAsync(TemplateCommandArgs templateArgs, CancellationToken cancellationToken)
         {
+            using var invokerActivity = Activities.Source.StartActivity("invoker-invoking");
             cancellationToken.ThrowIfCancellationRequested();
 
             CliTemplateInfo templateToRun = templateArgs.Template;
@@ -158,6 +159,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             try
             {
+                using var templateCreationActivity = Activities.Source.StartActivity("actual-instantiate-template");
                 instantiateResult = await _templateCreator.InstantiateAsync(
                     templateArgs.Template,
                     templateArgs.Name,
@@ -306,6 +308,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private NewCommandStatus HandlePostActions(ITemplateCreationResult creationResult, TemplateCommandArgs args)
         {
+            using var postActionActivity = Activities.Source.StartActivity("post-actions");
             PostActionExecutionStatus result = _postActionDispatcher.Process(creationResult, args.IsDryRun, args.AllowScripts ?? AllowRunScripts.Prompt);
 
             return result switch

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2627,6 +2627,9 @@ Proceed?</value>
   <data name="ToolDownloadNeedsConfirmation" xml:space="preserve">
     <value>Tool package download needs confirmation. Run in interactive mode or use the "--yes" command-line option to confirm.</value>
     <comment>{Locked="--yes"}</comment>
+  </data>
+  <data name="ToolInstallPackageIdMissing" xml:space="preserve">
+    <value>A package ID was not specified for tool installation.</value>
   </data>
   <data name="TestCommandUseSolution" xml:space="preserve">
     <value>Specifying a solution for 'dotnet test' should be via '--solution'.</value>

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -41,8 +41,12 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
     public override int Execute()
     {
-        VersionRange versionRange = _parseResult.GetVersionRange();
+        VersionRange? versionRange = _parseResult.GetVersionRange();
         PackageId packageId = new PackageId(_packageToolIdentityArgument.Id);
+
+        var toolLocationActivity = Activities.Source.StartActivity("find-tool");
+        toolLocationActivity?.SetTag("packageId", packageId.ToString());
+        toolLocationActivity?.SetTag("versionRange", versionRange?.ToString() ?? "latest");
 
         //  Look in local tools manifest first, but only if version is not specified
         if (versionRange == null)
@@ -51,6 +55,9 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
             if (_toolManifestFinder.TryFindPackageId(packageId, out var toolManifestPackage))
             {
+                toolLocationActivity?.SetTag("kind", "local");
+                toolLocationActivity?.Stop();
+
                 var toolPackageRestorer = new ToolPackageRestorer(
                     _toolPackageDownloader,
                     _sources,
@@ -82,6 +89,8 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
                 additionalFeeds: _addSource);
 
         (var bestVersion, var packageSource) = _toolPackageDownloader.GetNuGetVersion(packageLocation, packageId, _verbosity, versionRange, _restoreActionConfig);
+        toolLocationActivity?.SetTag("kind", "one-shot");
+        toolLocationActivity?.Stop();
 
         //  TargetFramework is null, which means to use the current framework.  Global tools can override the target framework to use (or select assets for),
         //  but we don't support this for local or one-shot tools.
@@ -119,6 +128,10 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
                 restoreActionConfig: _restoreActionConfig);
         }
 
+        using var toolExecuteActivity = Activities.Source.StartActivity("execute-tool");
+        toolExecuteActivity?.SetTag("packageId", packageId.ToString());
+        toolExecuteActivity?.SetTag("version", toolPackage.Version.ToString());
+        toolExecuteActivity?.SetTag("source", toolPackage.Command.Runner);
         var commandSpec = ToolCommandSpecCreator.CreateToolCommandSpec(toolPackage.Command.Name.Value, toolPackage.Command.Executable.Value, toolPackage.Command.Runner, _allowRollForward, _forwardArguments);
         var command = CommandFactoryUsingResolver.Create(commandSpec);
         var result = command.Execute();

--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -45,8 +45,8 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
         PackageId packageId = new PackageId(_packageToolIdentityArgument.Id);
 
         var toolLocationActivity = Activities.Source.StartActivity("find-tool");
-        toolLocationActivity?.SetTag("packageId", packageId.ToString());
-        toolLocationActivity?.SetTag("versionRange", versionRange?.ToString() ?? "latest");
+        toolLocationActivity?.SetTag("tool.package.id", packageId.ToString());
+        toolLocationActivity?.SetTag("tool.package.version", versionRange?.ToString() ?? "latest");
 
         //  Look in local tools manifest first, but only if version is not specified
         if (versionRange == null)
@@ -55,7 +55,7 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
 
             if (_toolManifestFinder.TryFindPackageId(packageId, out var toolManifestPackage))
             {
-                toolLocationActivity?.SetTag("kind", "local");
+                toolLocationActivity?.SetTag("tool.exec.kind", "local");
                 toolLocationActivity?.Stop();
 
                 var toolPackageRestorer = new ToolPackageRestorer(
@@ -89,7 +89,7 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
                 additionalFeeds: _addSource);
 
         (var bestVersion, var packageSource) = _toolPackageDownloader.GetNuGetVersion(packageLocation, packageId, _verbosity, versionRange, _restoreActionConfig);
-        toolLocationActivity?.SetTag("kind", "one-shot");
+        toolLocationActivity?.SetTag("tool.exec.kind", "one-shot");
         toolLocationActivity?.Stop();
 
         //  TargetFramework is null, which means to use the current framework.  Global tools can override the target framework to use (or select assets for),
@@ -129,9 +129,9 @@ internal class ToolExecuteCommand(ParseResult result, ToolManifestFinder? toolMa
         }
 
         using var toolExecuteActivity = Activities.Source.StartActivity("execute-tool");
-        toolExecuteActivity?.SetTag("packageId", packageId.ToString());
-        toolExecuteActivity?.SetTag("version", toolPackage.Version.ToString());
-        toolExecuteActivity?.SetTag("source", toolPackage.Command.Runner);
+        toolExecuteActivity?.SetTag("tool.package.id", packageId.ToString());
+        toolExecuteActivity?.SetTag("tool.package.version", toolPackage.Version.ToString());
+        toolExecuteActivity?.SetTag("tool.runner", toolPackage.Command.Runner);
         var commandSpec = ToolCommandSpecCreator.CreateToolCommandSpec(toolPackage.Command.Name.Value, toolPackage.Command.Executable.Value, toolPackage.Command.Runner, _allowRollForward, _forwardArguments);
         var command = CommandFactoryUsingResolver.Create(commandSpec);
         var result = command.Execute();

--- a/src/Cli/dotnet/Commands/Tool/Install/ParseResultExtension.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ParseResultExtension.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using NuGet.Versioning;
@@ -11,7 +9,7 @@ namespace Microsoft.DotNet.Cli.Commands.Tool.Install;
 
 internal static class ParseResultExtension
 {
-    public static VersionRange GetVersionRange(this ParseResult parseResult)
+    public static VersionRange? GetVersionRange(this ParseResult parseResult)
     {
         var packageVersionFromIdentityArgument = parseResult.GetValue(ToolInstallCommandParser.PackageIdentityArgument).VersionRange?.OriginalString;
         var packageVersionFromVersionOption = parseResult.GetValue(ToolInstallCommandParser.VersionOption);
@@ -22,7 +20,7 @@ internal static class ParseResultExtension
             throw new GracefulException(CliStrings.PackageIdentityArgumentVersionOptionConflict);
         }
 
-        string packageVersion = packageVersionFromIdentityArgument ?? packageVersionFromVersionOption;
+        string? packageVersion = packageVersionFromIdentityArgument ?? packageVersionFromVersionOption;
 
         bool prerelease = parseResult.GetValue(ToolInstallCommandParser.PrereleaseOption);
 
@@ -39,10 +37,10 @@ internal static class ParseResultExtension
             packageVersion = "*-*";
         }
 
-        VersionRange versionRange = null;
+        VersionRange? versionRange = null;
 
         // accept 'bare' versions and interpret 'bare' versions as NuGet exact versions
-        if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out NuGetVersion version2))
+        if (!string.IsNullOrEmpty(packageVersion) && NuGetVersion.TryParse(packageVersion, out NuGetVersion? version2))
         {
             return new VersionRange(minVersion: version2, includeMinVersion: true, maxVersion: version2, includeMaxVersion: true, originalString: "[" + packageVersion + "]");
         }

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
@@ -142,7 +142,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     {
         using var _activity = Activities.Source.StartActivity("install-tool");
         _activity?.DisplayName = $"Install {packageId}";
-        _activity?.SetTag("toolId", packageId);
+        _activity?.SetTag("tool.package.id", packageId);
 
         if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
         {
@@ -171,7 +171,8 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         {
             NuGetVersion nugetVersion = GetBestMatchNugetVersion(packageId, versionRange, toolPackageDownloader);
             _activity?.DisplayName = $"Install {packageId}@{nugetVersion}";
-            _activity?.SetTag("toolVersion", nugetVersion);
+            _activity?.SetTag("tool.package.id", packageId);
+            _activity?.SetTag("tool.package.version", nugetVersion);
 
             if (ToolVersionAlreadyInstalled(oldPackageNullable, nugetVersion))
             {

--- a/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Install/ToolInstallGlobalOrToolPathCommand.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
-using System.Transactions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
@@ -16,7 +13,6 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.ShellShim;
 using Microsoft.DotNet.Cli.Commands.Tool.Update;
-using Microsoft.DotNet.Cli.Commands.Tool.Common;
 using Microsoft.DotNet.Cli.Commands.Tool.Uninstall;
 using Microsoft.DotNet.Cli.Commands.Tool.List;
 
@@ -26,7 +22,7 @@ internal delegate IShellShimRepository CreateShellShimRepository(string appHostS
 
 internal delegate (IToolPackageStore, IToolPackageStoreQuery, IToolPackageDownloader) CreateToolPackageStoresAndDownloader(
     DirectoryPath? nonGlobalLocation = null,
-    IEnumerable<string> forwardRestoreArguments = null);
+    IEnumerable<string>? forwardRestoreArguments = null);
 
 internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 {
@@ -35,36 +31,36 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     private readonly CreateShellShimRepository _createShellShimRepository;
     private readonly CreateToolPackageStoresAndDownloaderAndUninstaller _createToolPackageStoreDownloaderUninstaller;
     private readonly ShellShimTemplateFinder _shellShimTemplateFinder;
-    private readonly IToolPackageStoreQuery _store;
+    private readonly IToolPackageStoreQuery? _store;
 
     private readonly PackageId? _packageId;
-    private readonly string _configFilePath;
-    private readonly string _framework;
-    private readonly string[] _source;
-    private readonly string[] _addSource;
+    private readonly string? _configFilePath;
+    private readonly string? _framework;
+    private readonly string[]? _source;
+    private readonly string[]? _addSource;
     private readonly bool _global;
     private readonly VerbosityOptions _verbosity;
-    private readonly string _toolPath;
-    private readonly string _architectureOption;
+    private readonly string? _toolPath;
+    private readonly string? _architectureOption;
     private readonly IEnumerable<string> _forwardRestoreArguments;
     private readonly bool _allowRollForward;
     private readonly bool _allowPackageDowngrade;
     private readonly bool _updateAll;
-    private readonly string _currentWorkingDirectory;
+    private readonly string? _currentWorkingDirectory;
     private readonly bool? _verifySignatures;
 
-    internal readonly RestoreActionConfig restoreActionConfig;
+    internal readonly RestoreActionConfig _restoreActionConfig;
 
     public ToolInstallGlobalOrToolPathCommand(
         ParseResult parseResult,
         PackageId? packageId = null,
-        CreateToolPackageStoresAndDownloaderAndUninstaller createToolPackageStoreDownloaderUninstaller = null,
-        CreateShellShimRepository createShellShimRepository = null,
-        IEnvironmentPathInstruction environmentPathInstruction = null,
-        IReporter reporter = null,
-        INuGetPackageDownloader nugetPackageDownloader = null,
-        IToolPackageStoreQuery store = null,
-        string currentWorkingDirectory = null,
+        CreateToolPackageStoresAndDownloaderAndUninstaller? createToolPackageStoreDownloaderUninstaller = null,
+        CreateShellShimRepository? createShellShimRepository = null,
+        IEnvironmentPathInstruction? environmentPathInstruction = null,
+        IReporter? reporter = null,
+        INuGetPackageDownloader? nugetPackageDownloader = null,
+        IToolPackageStoreQuery? store = null,
+        string? currentWorkingDirectory = null,
         bool? verifySignatures = null)
         : base(parseResult)
     {
@@ -92,11 +88,11 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         var configOption = parseResult.GetValue(ToolInstallCommandParser.ConfigOption);
         var sourceOption = parseResult.GetValue(ToolInstallCommandParser.AddSourceOption);
         var packageSourceLocation = new PackageSourceLocation(string.IsNullOrEmpty(configOption) ? null : new FilePath(configOption), additionalSourceFeeds: sourceOption, basePath: _currentWorkingDirectory);
-        restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
+        _restoreActionConfig = new RestoreActionConfig(DisableParallel: parseResult.GetValue(ToolCommandRestorePassThroughOptions.DisableParallelOption),
             NoCache: parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoCacheOption) || parseResult.GetValue(ToolCommandRestorePassThroughOptions.NoHttpCacheOption),
             IgnoreFailedSources: parseResult.GetValue(ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption),
             Interactive: parseResult.GetValue(ToolCommandRestorePassThroughOptions.InteractiveRestoreOption));
-        nugetPackageDownloader ??= new NuGetPackageDownloader.NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: restoreActionConfig, verbosityOptions: _verbosity, verifySignatures: verifySignatures ?? true);
+        nugetPackageDownloader ??= new NuGetPackageDownloader.NuGetPackageDownloader(tempDir, verboseLogger: new NullLogger(), restoreActionConfig: _restoreActionConfig, verbosityOptions: _verbosity, verifySignatures: verifySignatures ?? true, shouldUsePackageSourceMapping: true);
         _shellShimTemplateFinder = new ShellShimTemplateFinder(nugetPackageDownloader, tempDir, packageSourceLocation);
         _store = store;
 
@@ -125,10 +121,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     {
         if (_updateAll)
         {
-            var toolListCommand = new ToolListGlobalOrToolPathCommand(
-                _parseResult
-                , toolPath => { return _store; }
-                );
+            var toolListCommand = new ToolListGlobalOrToolPathCommand(_parseResult, toolPath => { return _store; });
             var toolIds = toolListCommand.GetPackages(null, null);
             foreach (var toolId in toolIds)
             {
@@ -136,15 +129,25 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             }
             return 0;
         }
-        else
+
+        if (_packageId is null)
         {
-            return ExecuteInstallCommand((PackageId)_packageId);
+            throw new GracefulException(CliCommandStrings.ToolInstallPackageIdMissing);
         }
+
+        return ExecuteInstallCommand((PackageId)_packageId);
     }
 
     private int ExecuteInstallCommand(PackageId packageId)
     {
-        ValidateArguments();
+        using var _activity = Activities.Source.StartActivity("install-tool");
+        _activity?.DisplayName = $"Install {packageId}";
+        _activity?.SetTag("toolId", packageId);
+
+        if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
+        {
+            throw new GracefulException(string.Format(CliCommandStrings.ToolInstallNuGetConfigurationFileDoesNotExist, Path.GetFullPath(_configFilePath)));
+        }
 
         DirectoryPath? toolPath = null;
         if (!string.IsNullOrEmpty(_toolPath))
@@ -152,7 +155,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             toolPath = new DirectoryPath(_toolPath);
         }
 
-        VersionRange versionRange = _parseResult.GetVersionRange();
+        VersionRange? versionRange = _parseResult.GetVersionRange();
 
         (IToolPackageStore toolPackageStore,
          IToolPackageStoreQuery toolPackageStoreQuery,
@@ -162,22 +165,24 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         var appHostSourceDirectory = ShellShimTemplateFinder.GetDefaultAppHostSourceDirectory();
         IShellShimRepository shellShimRepository = _createShellShimRepository(appHostSourceDirectory, toolPath);
 
-        IToolPackage oldPackageNullable = GetOldPackage(toolPackageStoreQuery, packageId);
+        IToolPackage? oldPackageNullable = GetOldPackage(toolPackageStoreQuery, packageId);
 
-        if (oldPackageNullable != null)
+        if (oldPackageNullable is not null)
         {
             NuGetVersion nugetVersion = GetBestMatchNugetVersion(packageId, versionRange, toolPackageDownloader);
+            _activity?.DisplayName = $"Install {packageId}@{nugetVersion}";
+            _activity?.SetTag("toolVersion", nugetVersion);
 
             if (ToolVersionAlreadyInstalled(oldPackageNullable, nugetVersion))
             {
                 _reporter.WriteLine(string.Format(CliCommandStrings.ToolAlreadyInstalled, oldPackageNullable.Id, oldPackageNullable.Version.ToNormalizedString()).Green());
                 return 0;
-            }   
+            }
         }
 
         TransactionalAction.Run(() =>
         {
-            if (oldPackageNullable != null)
+            if (oldPackageNullable is not null)
             {
                 RunWithHandlingUninstallError(() =>
                 {
@@ -188,8 +193,9 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
 
             RunWithHandlingInstallError(() =>
             {
+                var toolPackageDownloaderActivity = Activities.Source.StartActivity("download-tool-package");
                 IToolPackage newInstalledPackage = toolPackageDownloader.InstallPackage(
-                new PackageLocation(nugetConfig: GetConfigFile(), sourceFeedOverrides: _source, additionalFeeds: _addSource),
+                    new PackageLocation(nugetConfig: GetConfigFile(), sourceFeedOverrides: _source, additionalFeeds: _addSource),
                     packageId: packageId,
                     versionRange: versionRange,
                     targetFramework: _framework,
@@ -197,12 +203,13 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                     isGlobalTool: true,
                     isGlobalToolRollForward: _allowRollForward,
                     verifySignatures: _verifySignatures ?? true,
-                    restoreActionConfig: restoreActionConfig
+                    restoreActionConfig: _restoreActionConfig
                 );
+                toolPackageDownloaderActivity?.Dispose();
 
                 EnsureVersionIsHigher(oldPackageNullable, newInstalledPackage, _allowPackageDowngrade);
 
-                NuGetFramework framework;
+                NuGetFramework? framework;
                 if (string.IsNullOrEmpty(_framework) && newInstalledPackage.Frameworks.Count() > 0)
                 {
                     framework = newInstalledPackage.Frameworks
@@ -211,13 +218,12 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                 }
                 else
                 {
-                    framework = string.IsNullOrEmpty(_framework) ?
-                        null :
-                        NuGetFramework.Parse(_framework);
+                    framework = string.IsNullOrEmpty(_framework) ? null : NuGetFramework.Parse(_framework);
                 }
+                var shimActivity = Activities.Source.StartActivity("create-shell-shim");
                 string appHostSourceDirectory = _shellShimTemplateFinder.ResolveAppHostSourceDirectoryAsync(_architectureOption, framework, RuntimeInformation.ProcessArchitecture).Result;
-
                 shellShimRepository.CreateShim(newInstalledPackage.Command, newInstalledPackage.PackagedShims);
+                shimActivity?.Dispose();
 
                 foreach (string w in newInstalledPackage.Warnings)
                 {
@@ -231,47 +237,36 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
                 PrintSuccessMessage(oldPackageNullable, newInstalledPackage);
             }, packageId);
         });
+
         return 0;
     }
 
-    private NuGetVersion GetBestMatchNugetVersion(PackageId packageId, VersionRange versionRange, IToolPackageDownloader toolPackageDownloader)
+    private NuGetVersion GetBestMatchNugetVersion(PackageId packageId, VersionRange? versionRange, IToolPackageDownloader toolPackageDownloader)
     {
         return toolPackageDownloader.GetNuGetVersion(
             packageLocation: new PackageLocation(nugetConfig: GetConfigFile(), sourceFeedOverrides: _source, additionalFeeds: _addSource),
             packageId: packageId,
             versionRange: versionRange,
             verbosity: _verbosity,
-            restoreActionConfig: restoreActionConfig
+            restoreActionConfig: _restoreActionConfig
         ).version;
     }
 
-    private static bool ToolVersionAlreadyInstalled(IToolPackage oldPackageNullable, NuGetVersion nuGetVersion)
+    private static bool ToolVersionAlreadyInstalled(IToolPackage? oldPackageNullable, NuGetVersion nuGetVersion)
     {
         return oldPackageNullable != null && oldPackageNullable.Version == nuGetVersion;
     }
 
-    private static void EnsureVersionIsHigher(IToolPackage oldPackageNullable, IToolPackage newInstalledPackage, bool allowDowngrade)
+    private static void EnsureVersionIsHigher(IToolPackage? oldPackageNullable, IToolPackage newInstalledPackage, bool allowDowngrade)
     {
         if (oldPackageNullable != null && newInstalledPackage.Version < oldPackageNullable.Version && !allowDowngrade)
         {
             throw new GracefulException(
-                [
-                    string.Format(CliCommandStrings.UpdateToLowerVersion,
-                        newInstalledPackage.Version.ToNormalizedString(),
-                        oldPackageNullable.Version.ToNormalizedString())
-                ],
-                isUserError: false);
-        }
-    }
-
-    private void ValidateArguments()
-    {
-        if (!string.IsNullOrEmpty(_configFilePath) && !File.Exists(_configFilePath))
-        {
-            throw new GracefulException(
-                string.Format(
-                    CliCommandStrings.ToolInstallNuGetConfigurationFileDoesNotExist,
-                    Path.GetFullPath(_configFilePath)));
+            [
+                string.Format(CliCommandStrings.UpdateToLowerVersion,
+                    newInstalledPackage.Version.ToNormalizedString(),
+                    oldPackageNullable.Version.ToNormalizedString())
+            ], isUserError: false);
         }
     }
 
@@ -288,9 +283,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 string.Format(CliCommandStrings.UpdateToolFailed, packageId)
             };
-            message.AddRange(
-                InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
-
+            message.AddRange(InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
 
             throw new GracefulException(
                 messages: message,
@@ -303,7 +296,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
     {
         try
         {
-            uninstallAction();           
+            uninstallAction();
         }
         catch (Exception ex)
             when (ToolUninstallCommandLowLevelErrorConverter.ShouldConvertToUserFacingError(ex))
@@ -312,8 +305,7 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 string.Format(CliCommandStrings.UpdateToolFailed, packageId)
             };
-            message.AddRange(
-                ToolUninstallCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
+            message.AddRange(ToolUninstallCommandLowLevelErrorConverter.GetUserFacingMessages(ex, packageId));
 
             throw new GracefulException(
                 messages: message,
@@ -333,29 +325,25 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
         return configFile;
     }
 
-    private static IToolPackage GetOldPackage(IToolPackageStoreQuery toolPackageStoreQuery, PackageId packageId)
+    private static IToolPackage? GetOldPackage(IToolPackageStoreQuery toolPackageStoreQuery, PackageId packageId)
     {
-        IToolPackage oldPackageNullable;
+        IToolPackage? oldPackageNullable;
         try
         {
             oldPackageNullable = toolPackageStoreQuery.EnumeratePackageVersions(packageId).SingleOrDefault();
         }
         catch (InvalidOperationException)
         {
-            throw new GracefulException(
-                messages:
-                [
-                    string.Format(
-                        CliCommandStrings.ToolUpdateToolHasMultipleVersionsInstalled,
-                        packageId),
-                ],
-                isUserError: false);
+            throw new GracefulException(messages:
+            [
+                string.Format(CliCommandStrings.ToolUpdateToolHasMultipleVersionsInstalled, packageId)
+            ], isUserError: false);
         }
 
         return oldPackageNullable;
     }
 
-    private void PrintSuccessMessage(IToolPackage oldPackage, IToolPackage newInstalledPackage)
+    private void PrintSuccessMessage(IToolPackage? oldPackage, IToolPackage newInstalledPackage)
     {
         if (!_verbosity.IsQuiet())
         {
@@ -381,7 +369,6 @@ internal class ToolInstallGlobalOrToolPathCommand : CommandBase
             {
                 _reporter.WriteLine(
                     string.Format(
-                        
                         newInstalledPackage.Version.IsPrerelease ?
                         CliCommandStrings.UpdateSucceededPreVersionNoChange : CliCommandStrings.UpdateSucceededStableVersionNoChange,
                         newInstalledPackage.Id, newInstalledPackage.Version).Green());

--- a/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Run/ToolRunCommand.cs
@@ -1,27 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandFactory;
 using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
-using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolManifest;
-using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Run;
 
 internal class ToolRunCommand(
     ParseResult result,
-    LocalToolsCommandResolver localToolsCommandResolver = null,
-    ToolManifestFinder toolManifest = null) : CommandBase(result)
+    LocalToolsCommandResolver? localToolsCommandResolver = null,
+    ToolManifestFinder? toolManifest = null) : CommandBase(result)
 {
-    private readonly string _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
-    private readonly IEnumerable<string> _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
+    private readonly string? _toolCommandName = result.GetValue(ToolRunCommandParser.CommandNameArgument);
+    private readonly IEnumerable<string>? _forwardArgument = result.GetValue(ToolRunCommandParser.CommandArgument);
 
     private readonly LocalToolsCommandResolver _localToolsCommandResolver = localToolsCommandResolver ?? new LocalToolsCommandResolver(toolManifest);
     public bool _allowRollForward = result.GetValue(ToolRunCommandParser.RollForwardOption);
@@ -30,14 +24,15 @@ internal class ToolRunCommand(
     {
         return ExecuteCommand(_localToolsCommandResolver, _toolCommandName, _forwardArgument, _allowRollForward);
     }
-    public static int ExecuteCommand(LocalToolsCommandResolver commandResolver, string toolCommandName, IEnumerable<string> argumentsToForward, bool allowRollForward)
+
+    public static int ExecuteCommand(LocalToolsCommandResolver commandResolver, string? toolCommandName, IEnumerable<string>? argumentsToForward, bool allowRollForward)
     {
+        using var _ = Activities.Source.StartActivity("execute-local-tool");
         CommandSpec commandSpec = commandResolver.ResolveStrict(new CommandResolverArguments()
         {
             // since LocalToolsCommandResolver is a resolver, and all resolver input have dotnet-
             CommandName = $"dotnet-{toolCommandName}",
             CommandArguments = argumentsToForward,
-
         }, allowRollForward);
 
         if (commandSpec == null)

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3246,6 +3246,11 @@ Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Nahradit všechny zdroje balíčků NuGet, které se mají použít při instalaci, těmito zdroji.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3246,6 +3246,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Ersetzen alle NuGet-Paketquellen für die Nutzung während der Installation durch diese.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3246,6 +3246,11 @@ La herramienta "{1}" (versión '{2}') se instaló correctamente.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Reemplazar todos los orígenes de paquetes NuGet que se usarán durante la instalación por estos.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3246,6 +3246,11 @@ L'outil '{1}' (version '{2}') a été installé correctement.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Remplacer toutes les sources de package NuGet à utiliser pendant l’installation par celles-ci.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3246,6 +3246,11 @@ Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Sostituire tutte le origini del pacchetto NuGet da usare durante l'installazione con queste.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">インストール中に使用するすべての NuGet パッケージ ソースをこれらに置き換えます。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">설치 중에 사용할 모든 NuGet 패키지 원본을 이러한 패키지 원본으로 바꿉니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3246,6 +3246,11 @@ Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Zastąp je wszystkimi źródłami pakietów NuGet, które mają być używane podczas instalacji.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3246,6 +3246,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Substitua todas as fontes de pacote NuGet a serem usadas durante a instalação por estas.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Замените ими все источники пакетов NuGet, которые будут использоваться при установке.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">Yükleme sırasında kullanılacak tüm NuGet paket kaynaklarını bu kaynaklarla değiştirin.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">将安装期间要使用的所有 NuGet 包源替换为这些源。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3246,6 +3246,11 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolInstallPackageIdMissing">
+        <source>A package ID was not specified for tool installation.</source>
+        <target state="new">A package ID was not specified for tool installation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolInstallSourceOptionDescription">
         <source>Replace all NuGet package sources to use during installation with these.</source>
         <target state="translated">以這些套件取代安裝期間使用的所有 NuGet 套件來源。</target>

--- a/src/Cli/dotnet/InteractiveConsole.cs
+++ b/src/Cli/dotnet/InteractiveConsole.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Cli.Commands;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli;
 
@@ -29,6 +30,8 @@ public static class InteractiveConsole
         {
             return null;
         }
+
+        using var _ = Activities.Source.StartActivity("confirm-run-from-source");
 
         Console.Write(AddPromptOptions(message));
 

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -66,9 +66,11 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
         string? folderToDeleteOnFailure = null;
         return TransactionalAction.Run(() =>
         {
+            var _downloadActivity = Activities.Source.StartActivity("download-tool");
+            _downloadActivity?.DisplayName = $"Downloading tool {packageId}@{packageVersion}";
             var packagePath = nugetPackageDownloader.DownloadPackageAsync(packageId, packageVersion, packageSourceLocation,
                         includeUnlisted: includeUnlisted, downloadFolder: new DirectoryPath(packagesRootPath)).ConfigureAwait(false).GetAwaiter().GetResult();
-
+            _downloadActivity?.Stop();
             folderToDeleteOnFailure = Path.GetDirectoryName(packagePath);
 
             // look for package on disk and read the version
@@ -81,6 +83,7 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
 
                 var packageHash = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(reader.GetNuspec()));
                 var hashPath = versionFolderPathResolver.GetHashPath(packageId.ToString(), version);
+
                 Directory.CreateDirectory(Path.GetDirectoryName(hashPath)!);
                 File.WriteAllText(hashPath, packageHash);
             }
@@ -90,8 +93,10 @@ internal class ToolPackageDownloader : ToolPackageDownloaderBase
                 Reporter.Output.WriteLine($"Extracting package {packageId}@{packageVersion} to {packagePath}");
             }
             // Extract the package
+            var _extractActivity = Activities.Source.StartActivity("extract-tool");
             var nupkgDir = versionFolderPathResolver.GetInstallPath(packageId.ToString(), version);
             nugetPackageDownloader.ExtractPackageAsync(packagePath, new DirectoryPath(nupkgDir)).ConfigureAwait(false).GetAwaiter().GetResult();
+            _extractActivity?.Stop();
 
             return version;
         }, rollback: () =>

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
@@ -187,8 +187,10 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
                 //  Create parent directory in global tool store, for example dotnet\tools\.store\powershell
                 _fileSystem.Directory.CreateDirectory(toolStoreTargetDirectory.GetParentPath().Value);
 
+                var _moveContentActivity = Activities.Source.StartActivity("move-global-tool-content");
                 //  Move tool files from stage to final location
                 FileAccessRetrier.RetryOnMoveAccessFailure(() => _fileSystem.Directory.Move(_globalToolStageDir.Value, toolStoreTargetDirectory.Value));
+                _moveContentActivity?.Dispose();
 
                 rollbackDirectory = toolStoreTargetDirectory.Value;
 
@@ -374,6 +376,7 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
         ToolPackageInstance toolPackageInstance
         )
     {
+        using var _updateRuntimeConfigActivity = Activities.Source.StartActivity("update-runtimeconfig");
         var runtimeConfigFilePath = Path.ChangeExtension(toolPackageInstance.Command.Executable.Value, ".runtimeconfig.json");
 
         // Update the runtimeconfig.json file

--- a/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             var parseResult = Parser.Parse($"dotnet tool install -g {PackageId} --ignore-failed-sources");
             var toolInstallCommand = new ToolInstallGlobalOrToolPathCommand(parseResult);
-            toolInstallCommand.restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+            toolInstallCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             var parseResult = Parser.Parse($"dotnet tool update -g {_packageId} --ignore-failed-sources");
             var toolUpdateCommand = new ToolUpdateGlobalOrToolPathCommand(parseResult);
-            toolUpdateCommand._toolInstallGlobalOrToolPathCommand.restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
+            toolUpdateCommand._toolInstallGlobalOrToolPathCommand._restoreActionConfig.IgnoreFailedSources.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
This PR continues the slicing off of the sub-parts of https://github.com/dotnet/sdk/pull/49409 because it's so big.

This part builds on the previous PR, which introduced the ActivitySource for the CLI and the System.Diagnostics.DiagnosticsSource PackageReference. It adds activity usage to `dotnet new` invocation, and many parts of `dotnet tool` usage (including `dnx` and package downloading).

None of these actually light up in the current `main` branch because there are no _listeners_ for the activities created.