### PR TITLE
Remove setting copilot firewall env var in copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,10 +14,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Allow Copilot to access Visual Studio assets URLs needed for NuGet restore
-  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: "vsblob.vsassets.io"
-
 jobs:
 
   copilot-setup-steps:


### PR DESCRIPTION
This no longer works in the .yml.

You need to configure it in the UI now: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-firewall#allowlisting-additional-hosts-in-the-agents-firewall

@marcpopMSFT would you mind adding `vsblob.vsassets.io` to the repo settings ^