### PR TITLE
Update MSTest templates to v4

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25415.9">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -43,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25415.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/3.10.0">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -18,11 +18,6 @@
   </ItemGroup>
 <!--#endif-->
 <!--#else-->
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
 <!--#endif-->
@@ -41,12 +36,6 @@
 <!--#if (TestRunner == "Microsoft.Testing.Platform")-->
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 <!--#endif-->
   </PropertyGroup>
 
@@ -54,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="3.10.0" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,5 +1,5 @@
 <!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/3.10.0">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -18,11 +18,6 @@
   </ItemGroup>
 <!--#endif-->
 <!--#else-->
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
 <!--#endif-->
@@ -46,12 +41,6 @@
 <!--#if (TestRunner == "Microsoft.Testing.Platform")-->
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 <!--#endif-->
   </PropertyGroup>
 
@@ -59,7 +48,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="3.10.0" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,5 +1,5 @@
 <!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25415.9">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -48,7 +48,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25415.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25415.9">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -43,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25415.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/3.10.0">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -18,11 +18,6 @@
   </ItemGroup>
 <!--#endif-->
 <!--#else-->
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
 <!--#endif-->
@@ -41,12 +36,6 @@
 <!--#if (TestRunner == "Microsoft.Testing.Platform")-->
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 <!--#endif-->
   </PropertyGroup>
 
@@ -54,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="3.10.0" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/3.10.0">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -19,11 +19,6 @@
   </ItemGroup>
 <!--#endif-->
 <!--#else-->
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
 <!--#endif-->
@@ -42,12 +37,6 @@
 <!--#if (TestRunner == "Microsoft.Testing.Platform")-->
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <!--
-      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
-      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
-      -->
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 <!--#endif-->
   </PropertyGroup>
 
@@ -56,7 +45,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
     <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.51.0" />
-    <PackageReference Include="MSTest" Version="3.10.0" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -44,7 +44,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.51.0" />
+    <PackageReference Include="Microsoft.Playwright.MSTest.v4" Version="1.55.0-beta-4" />
     <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.0-preview.25372.6">
+<Project Sdk="MSTest.Sdk/4.0.0-preview.25415.9">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0</TargetFramework>
@@ -45,7 +45,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
     <PackageReference Include="Microsoft.Playwright.MSTest.v4" Version="1.55.0-beta-4" />
-    <PackageReference Include="MSTest" Version="4.0.0-preview.25372.6" />
+    <PackageReference Include="MSTest" Version="4.0.0-preview.25415.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 result.Should().Pass();
 
                 result.StdOut.Should().Contain("Passed!");
-                result.StdOut.Should().MatchRegex(@"Passed:\s*1");
+                result.StdOut.Should().MatchRegex(isMTP ? "succeeded: 1" : @"Passed:\s*1");
             }
 
             // After executing dotnet new and before cleaning up

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -193,7 +193,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             if (runDotnetTest)
             {
-                if (testRunner == "Microsoft.Testing.Platform")
+                var isMTP = testRunner == "Microsoft.Testing.Platform";
+                if (isMTP)
                 {
                     File.WriteAllText(Path.Combine(outputDirectory, "dotnet.config"), """
                         [dotnet.test.runner]
@@ -203,7 +204,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
                 var result = new DotnetTestCommand(_log, false)
                 .WithWorkingDirectory(outputDirectory)
-                .Execute(outputDirectory);
+#pragma warning disable SA1010 // Opening square brackets should be spaced correctly - false positive. Current formatting is good.
+                .Execute(isMTP ? ["--directory", outputDirectory] : [outputDirectory]);
+#pragma warning restore SA1010 // Opening square brackets should be spaced correctly
 
                 result.Should().Pass();
 

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -193,6 +193,14 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             if (runDotnetTest)
             {
+                if (testRunner == "Microsoft.Testing.Platform")
+                {
+                    File.WriteAllText(Path.Combine(outputDirectory, "dotnet.config"), """
+                        [dotnet.test.runner]
+                        name = "Microsoft.Testing.Platform"
+                        """);
+                }
+
                 var result = new DotnetTestCommand(_log, false)
                 .WithWorkingDirectory(outputDirectory)
                 .Execute(outputDirectory);


### PR DESCRIPTION
### Description
 
We would like to update templates for MSTest to version 4 that is currently under development and that we will ship just before net10 is finalized. We want to make this change now, to have our changes dogfooded, and keep pushing newer versions mstest v4 previews into the templates until the release of .NET.

### Customer Impact

Users creating new test projects for mstest will use v4, while previously they would use v3. Users are able to change the versions back to their preferred version by editing the generated files. Or they can migrate their other projects to v4 using this migration guide: https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-migration-v3-v4 Breaking changes to v4 were kept to minimum.

NOTE: [MSTest support policy](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-intro#mstest-support-policy) explicitly states:

> The MSTest team only supports the latest released version and strongly encourages its users and customers to always update to latest version to benefit from new improvements and security patches.

### Regression?

No.

### Risk

Low.

Users are able to easily revert their dependency versions to target MSTest v3. Once MSTest v4 is finalized, it will become the official release of MSTest and the only supported version of MSTest. Which is why we want to make the change now.

### Link the PR to the original issue and to the PR to main.

### Note any packaging impact. (If the changes touch code in a package that we ship out of band (OOB) then we will need to take care to ensure those packages ship.)

No impact.

### Note any ref pack impact.

No impact.
