### PR TITLE
[release/9.0.3xx] Fix forwarding DOTNET_ROOT

### DIFF
--- a/src/Cli/dotnet/commands/dotnet-test/Program.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/Program.cs
@@ -238,10 +238,8 @@ namespace Microsoft.DotNet.Tools.Test
                 }
             }
 
-            // Set DOTNET_PATH if it isn't already set in the environment as it is required
-            // by the testhost which uses the apphost feature (Windows only).
-            (bool hasRootVariable, string rootVariableName, string rootValue) = VSTestForwardingApp.GetRootVariable();
-            if (!hasRootVariable)
+            Dictionary<string, string> variables = VSTestForwardingApp.GetVSTestRootVariables();
+            foreach (var (rootVariableName, rootValue) in variables)
             {
                 testCommand.EnvironmentVariable(rootVariableName, rootValue);
                 VSTestTrace.SafeWriteTrace(() => $"Root variable set {rootVariableName}:{rootValue}");

--- a/test/TestAssets/TestProjects/VSTestForwardDotnetRootEnvironmentVariables/Tests.cs
+++ b/test/TestAssets/TestProjects/VSTestForwardDotnetRootEnvironmentVariables/Tests.cs
@@ -16,7 +16,7 @@ namespace TestNamespace
             // This project is compiled, and executed by the tests in "test/dotnet-test.Tests/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs"
             foreach (DictionaryEntry env in Environment.GetEnvironmentVariables())
             {
-                if (env.Key.ToString().Contains("VSTEST_WINAPPHOST_"))
+                if (env.Key.ToString().Contains("VSTEST_"))
                 {
                     Console.WriteLine($"{env.Key.ToString()}={env.Value.ToString()}");
                 }

--- a/test/dotnet-test.Tests/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
@@ -33,7 +33,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .Should().Contain("Total tests: 1")
                     .And.Contain("Passed: 1")
                     .And.Contain("Passed TestForwardDotnetRootEnvironmentVariables")
-                    .And.Contain("VSTEST_WINAPPHOST_");
+                    .And.Contain("VSTEST_DOTNET_ROOT_PATH")
+                    .And.Contain("VSTEST_DOTNET_ROOT_ARCHITECTURE");
             }
 
             result.ExitCode.Should().Be(0);


### PR DESCRIPTION
Manually backporting https://github.com/dotnet/sdk/pull/49634/files to fix forwarding dotnet_root for testhosts built against net6 and newer.

Fix https://github.com/dotnet/sdk/issues/49436