### PR TITLE
Fix inconsistent `tool exec` help

### DIFF
--- a/src/Cli/dotnet/CommonArguments.cs
+++ b/src/Cli/dotnet/CommonArguments.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DotNet.Cli
         public static DynamicArgument<PackageIdentityWithRange?> OptionalPackageIdentityArgument() =>
             new("packageId")
             {
-                HelpName = "PACKAGE_ID",
                 Description = CliStrings.PackageIdentityArgumentDescription,
                 CustomParser = (ArgumentResult argumentResult) => ParsePackageIdentityWithVersionSeparator(argumentResult.Tokens[0]?.Value),
                 Arity = ArgumentArity.ZeroOrOne,
@@ -23,7 +22,6 @@ namespace Microsoft.DotNet.Cli
         public static DynamicArgument<PackageIdentityWithRange> RequiredPackageIdentityArgument() =>
             new("packageId")
             {
-                HelpName = "PACKAGE_ID",
                 Description = CliStrings.PackageIdentityArgumentDescription,
                 CustomParser = (ArgumentResult argumentResult) => ParsePackageIdentityWithVersionSeparator(argumentResult.Tokens[0]?.Value)!.Value,
                 Arity = ArgumentArity.ExactlyOne,


### PR DESCRIPTION
Invoking `dotnet tool exec --help`.
Before:
```
Description:
  Executes a tool from source without permanently installing it.

Usage:
  dotnet tool execute <packageId> [<commandArguments>...] [options]

Arguments:
  <PACKAGE_ID>        Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and 
                      version separated by '@' like 'Newtonsoft.Json@13.0.3'.
  <commandArguments>  Arguments forwarded to the tool
```

After:
```
Description:
  Executes a tool from source without permanently installing it.

Usage:
  dotnet tool execute <packageId> [<commandArguments>...] [options]

Arguments:
  <packageId>         Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and 
                      version separated by '@' like 'Newtonsoft.Json@13.0.3'.
  <commandArguments>  Arguments forwarded to the tool
```