### PR TITLE
Retry all errors to handle curl (18)

### DIFF
--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -166,7 +166,23 @@ function DownloadArchive {
     archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/Private.SourceBuilt.$archiveType.$archiveVersion.$archiveRid.tar.gz"
 
     echo "  Downloading source-built $archiveType from $archiveUrl..."
-    (cd "$packagesArchiveDir" && curl -f --retry 5 -O "$archiveUrl")
+    (
+      cd "$packagesArchiveDir" &&
+      for i in {1..5}; do
+        if curl -f --retry 5 -O "$archiveUrl"; then
+          exit 0
+        else
+          case $? in
+            18)
+              sleep 3
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+        fi
+      done
+    )
   elif [ "$isRequired" == true ]; then
     echo "  ERROR: $notFoundMessage"
     exit 1


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5282

[9.0 build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2771690&view=logs&j=b6435147-44aa-5796-6ab4-b10e913f3700&t=c05f2612-f833-558e-dd87-2353e7add7f2) (internal Microsoft link) failed to download files with curl 18.