### PR TITLE
Make duplicate deb/rpm packages so we can sign them with the new PMC key

### DIFF
--- a/src/Installer/redist-installer/targets/GenerateDebs.targets
+++ b/src/Installer/redist-installer/targets/GenerateDebs.targets
@@ -92,6 +92,7 @@
     <PropertyGroup>
       <InstallerOutputDirectory>$(ArtifactsShippingPackagesDir)</InstallerOutputDirectory>
       <SdkDebInstallerFile>$(InstallerOutputDirectory)$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkDebInstallerFile>
+      <NewKeyDebInstallerFile>$(InstallerOutputDirectory)$(NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</NewKeyDebInstallerFile>
       <SdkDebianIntermediateDirectory>$(IntermediateOutputPath)debian/sdk/</SdkDebianIntermediateDirectory>
       <DotNetDebToolOutputDirectory>$(SdkDebianIntermediateDirectory)deb-tool-output</DotNetDebToolOutputDirectory>
       <DebianTestResultsXmlFile>$(SdkDebianIntermediateDirectory)debian-testResults.xml</DebianTestResultsXmlFile>
@@ -220,7 +221,7 @@
 
       <AspNetVersionPatchSeparator>$(AspNetSimpleVersion.LastIndexOf('.'))</AspNetVersionPatchSeparator>
       <AspNetSimpleVersion Condition=" '$(AspNetVersionPatchSeparator)' != -1 ">$(AspNetSimpleVersion.Substring(0, $(AspNetVersionPatchSeparator)))</AspNetSimpleVersion>
-      
+
       <!-- dotnet-runtime package may not currently be available -->
       <InstallAspNetCoreSharedFxArgs>--ignore-depends=dotnet-runtime-$(AspNetSimpleVersion)</InstallAspNetCoreSharedFxArgs>
     </PropertyGroup>
@@ -315,7 +316,12 @@
       OverwriteReadOnlyFiles="True"
       SkipUnchangedFiles="False"
       UseHardlinksIfPossible="False" />
-
+    <Copy
+      DestinationFiles="$(NewKeyDebInstallerFile)"
+      SourceFiles="@(GeneratedDebFiles)"
+      OverwriteReadOnlyFiles="True"
+      SkipUnchangedFiles="False"
+      UseHardlinksIfPossible="False"/>
     <!-- Proactively remove all possible Shared Framework and Debian Packages -->
     <ItemGroup>
       <SetupDebPackageToRemove Include="$(SdkDebianPackageName)" />
@@ -374,7 +380,7 @@
     <DotNetTest ProjectPath="$(EndToEndTestProject)"
                 EnvironmentVariables="@(TestSdkDebTaskEnvironmentVariables)"
                 ToolPath="$(DebianInstalledDirectory)" />-->
-  
+
     <!-- Clean up Packages -->
     <!-- The following line is needed. So it won't warning dotnet folder is not empty after uninstall -->
     <Exec Command="sudo rm -rf /usr/share/dotnet/sdk/NuGetFallbackFolder" />

--- a/src/Installer/redist-installer/targets/GenerateRPMs.targets
+++ b/src/Installer/redist-installer/targets/GenerateRPMs.targets
@@ -198,6 +198,12 @@
       OverwriteReadOnlyFiles="True"
       SkipUnchangedFiles="False"
       UseHardlinksIfPossible="False" />
+
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+      DestinationFiles="$(NewKeyRpmFile)"
+      OverwriteReadOnlyFiles="True"
+      SkipUnchangedFiles="False"
+      UseHardlinksIfPossible="False"/>
   </Target>
 
   <Target Name="SetupRpmProps"
@@ -212,6 +218,7 @@
       <RpmFile>$(SdkRPMInstallerFile)</RpmFile>
       <MarinerRpmFile>$(ArtifactsShippingPackagesDir)$(MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</MarinerRpmFile>
       <Mariner2RpmFile>$(ArtifactsShippingPackagesDir)$(Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</Mariner2RpmFile>
+      <NewKeyRpmFile>$(ArtifactsShippingPackagesDir)$(NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</NewKeyRpmFile>
       <!-- Need to acquire manpage files from CLI repo: https://github.com/dotnet/cli/issues/10266 -->
       <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
       <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>

--- a/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
+++ b/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
@@ -54,6 +54,8 @@
       <!-- Mariner RPM names -->
       <MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.1-$(InstallerTargetArchitecture)</MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
       <Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.2-$(InstallerTargetArchitecture)</Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
+      <!-- NewKey RPM and Deb names-->
+      <NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-newkey-$(InstallerTargetArchitecture)</NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Contributes to dotnet/arcade#16047

# Make duplicate deb/rpm packages so we can sign them with the new PMC key

## Description

PMC has added a new signing key for packages published to repositories for new Linux distributions they will add support for, such as Debian 13 and SLES vNext. Packages pushed to these feeds must be signed with the new key. Existing feeds will maintain the same keys. The .NET signing infrastructure requires us to have separate copies of the package files to have them signed with different keys. This PR introduces separate copies of the DEB and RPM installers to be signed with the new signing keys.

Contributes to https://github.com/dotnet/arcade/issues/16047

## Customer Impact

Without this change, we can't ship `.deb` installers for Debian 13. With this change, we can.

## Regression?

- [ ] Yes
- [X] No


## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [X] Yes
- [ ] No
- [ ] N/A
