### PR TITLE
Fix CA1859 improperly handling default interface implementations

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
@@ -268,12 +268,19 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     return;
                 }
 
-                // if any of the methods that are invoked on toType are explicit implementations of interface methods, then we don't want
-                // to recommend upgrading the type otherwise it would break those call sites
                 if (targets != null)
                 {
                     foreach (var t in targets)
                     {
+                        // if any of the methods that are invoked on fromType are default implementations of interface methods,
+                        // then we don't want to recommend upgrading the type because it would break those call sites.
+                        if (!t.IsAbstract && fromType.TypeKind is TypeKind.Interface)
+                        {
+                            return;
+                        }
+
+                        // if any of the methods that are invoked on toType are explicit implementations of interface methods,
+                        // then we don't want to recommend upgrading the type because it would break those call sites.
                         var check = toType;
                         while (check != null)
                         {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
@@ -663,6 +663,32 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        [WorkItem(7093, "https://github.com/dotnet/roslyn-analyzers/issues/7093")]
+        public static async Task ShouldNotTrigger6()
+        {
+            const string Source = @"
+#nullable enable
+                interface IFoo
+                {
+                    int M() => 42;
+                }
+                public class C : IFoo
+                {
+                }
+                public class Use
+                {
+                    static int Bar()
+                    {
+                        IFoo f = new C();
+                        return f.M();
+                    }
+                }
+                ";
+
+            await TestCSAsync(Source);
+        }
+
+        [Fact]
         public static async Task ShouldTrigger_InterpolatedString_Mameof()
         {
             const string Source = @"

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
@@ -663,7 +663,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
-        [WorkItem(7093, "https://github.com/dotnet/roslyn-analyzers/issues/7093")]
+        [WorkItem(50328, "https://github.com/dotnet/sdk/issues/50328")]
         public static async Task ShouldNotTrigger6()
         {
             const string Source = @"


### PR DESCRIPTION
This fixes https://github.com/dotnet/sdk/issues/50328.

Question: is the `WorkItem` referring to the issue still relevant now that the roslyn-analyzers repo is being archived?

cc: @Dean-NC, @geeknoid, @Youssef1313, @ViktorHofer 