### PR TITLE
Update to the July implicit version for the 1xx branch

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,8 +38,8 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>17</VersionFeature80>
-    <VersionFeature90>6</VersionFeature90>
+    <VersionFeature80>18</VersionFeature80>
+    <VersionFeature90>7</VersionFeature90>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
1xx and main should stay on N-2 which is two behind the prerelease version