### PR TITLE
Generate pruning data correctly

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -52,9 +52,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
   
   <!-- TODO: https://github.com/dotnet/sdk/issues/49917 Remove the framework based condition when the data for netcoreapp2.1 and below is fixed-->
+  <!-- Package pruning is expected to be enable for all TFMs for multi-targeted projects, so still generate the pruning data when RestoreEnablePackagePruning is '' which implies a multi-targeted project. -->
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
           DependsOnTargets="ProcessFrameworkReferences"
-          Condition="'$(RestoreEnablePackagePruning)' == 'true'
+          Condition="('$(RestoreEnablePackagePruning)' == 'true' OR '$(RestoreEnablePackagePruning)' == '')
           AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
           AND '$(TargetFrameworkVersion)' != ''
           AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0')))

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -331,7 +331,9 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net451", false)]
         [InlineData("net462")]
         [InlineData("net481")]
-        public void PrunePackageDataSucceeds(string targetFramework, bool shouldPrune = true)
+        [InlineData("net9.0", true, "")]
+        [InlineData("netstandard2.1", true, "")]
+        public void PrunePackageDataSucceeds(string targetFramework, bool shouldPrune = true, string enablePackagePruning = "True")
         {
             var nugetFramework = NuGetFramework.Parse(targetFramework);
 
@@ -342,7 +344,7 @@ namespace Microsoft.NET.Build.Tests
                     TargetFrameworks = targetFramework
                 };
 
-                testProject.AdditionalProperties["RestoreEnablePackagePruning"] = "True";
+                testProject.AdditionalProperties["RestoreEnablePackagePruning"] = enablePackagePruning;
 
                 if (!string.IsNullOrEmpty(frameworkReference))
                 {
@@ -442,6 +444,49 @@ namespace Microsoft.NET.Build.Tests
 
             items2.Should().BeEquivalentTo(items1);
 
+        }
+
+        [CoreMSBuildOnlyTheory]
+        [InlineData("net10.0;net9.0", true)]
+        [InlineData("net10.0;net8.0", true)]
+        [InlineData("net6.0;net7.0", false)]
+        public void WithMultitargetedProjects_PruningsDefaultsAreApplies(string frameworks, bool prunePackages)
+        {
+            var referencedProject = new TestProject("ReferencedProject")
+            {
+                TargetFrameworks = frameworks,
+                IsExe = false
+            };
+            referencedProject.PackageReferences.Add(new TestPackageReference("System.Text.Json", "6.0.0"));
+            referencedProject.AdditionalProperties["RestoreEnablePackagePruning"] = "false";
+
+            var testProject = new TestProject()
+            {
+                TargetFrameworks = frameworks,
+            };
+
+            testProject.ReferencedProjects.Add(referencedProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: prunePackages.ToString());
+
+            var buildCommand = new BuildCommand(testAsset);
+
+            buildCommand.Execute().Should().Pass();
+
+            var assetsFilePath = Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "project.assets.json");
+            var lockFile = LockFileUtilities.GetLockFile(assetsFilePath, new NullLogger());
+
+            foreach(var lockFileTarget in lockFile.Targets)
+            {
+                if (prunePackages)
+                {
+                    lockFileTarget.Libraries.Should().NotContain(library => library.Name.Equals("System.Text.Json", StringComparison.OrdinalIgnoreCase));
+                }
+                else
+                {
+                    lockFileTarget.Libraries.Should().Contain(library => library.Name.Equals("System.Text.Json", StringComparison.OrdinalIgnoreCase));
+                }
+            }
         }
 
         static List<KeyValuePair<string, string>> ParsePrunePackageReferenceJson(string json)


### PR DESCRIPTION
## Customer Impact

This PR is the SDK side of changing the package pruning defaults to be enabled for .NET 10 projects only, including ones that multi-target .NET 10.
Design details at https://github.com/NuGet/Home/blob/dev/accepted/2025/prune-package-reference-rollout-take-2.md.

Without this change multi-targeted projects will not get data. 

SDK side of https://github.com/NuGet/NuGet.Client/pull/6696. 
Due to the fact that we want pruning (inner build feature) to be enabled for the full project when one of the TFMs is .NET 10, in multitargeted projects we should always generate the pruning data and let NuGet decide whether to use it. 

## Regression

No, NET 10 is the first time we're enabling the feature by default and this behavior is more restrictive than the P1-P7 behaviors.

## Testing

Automation added in this PR. 
The equivalent functionality is already tested on NuGet side as well.

## Risk

Low, it enables pruning for more scenarios such as .NET 10 multi-targeting, but the P7 default itself is more permissive (it enables for net8.0 and above).
