### PR TITLE
Add the missing netcore installer to the bundle

### DIFF
--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -249,7 +249,8 @@
       <_DotNetMsiPackages Include="$(DownloadsFolder)$(DownloadedHostFxrInstallerFileName);
                                    $(DownloadsFolder)$(DownloadedSharedHostInstallerFileName);
                                    $(DownloadsFolder)$(DownloadedSharedFrameworkInstallerFileName);
-                                   $(DownloadsFolder)$(DownloadedNetCoreAppHostPackInstallerFileName)"/>
+                                   $(DownloadsFolder)$(DownloadedNetCoreAppHostPackInstallerFileName);
+                                   $(DownloadsFolder)$(DownloadedNetCoreAppTargetingPackInstallerFileName)"/>
 
       <!-- ASP.NET Core Runtime -->
       <_DotNetMsiPackages Include="$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxInstallerFileName);


### PR DESCRIPTION
Fixes  #50079

I checked and all of the other <downloaded* items appear to be included so this is the only one missing.