### PR TITLE
Sort options alphabetically by name

### DIFF
--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.Help.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.Help.cs
@@ -143,6 +143,13 @@ internal partial class TestingPlatformCommand
                 value.Add(option.Value);
             }
         }
+
+        // Sort options alphabetically by name
+        foreach (var optionsList in builtInToOptions.Values)
+        {
+            optionsList.Sort((x, y) => string.Compare(x.Name, y.Name, StringComparison.OrdinalIgnoreCase));
+        }
+
         return builtInToOptions;
     }
 


### PR DESCRIPTION
This pull request introduces an improvement to the display of command line options in the testing platform command help. The main change is the addition of alphabetical sorting for options, making the help output more user-friendly and easier to scan.

Improvements to help output:

* Added logic to sort each list of `CommandLineOption` objects alphabetically by their `Name` property in the `GetAllOptions()` method in `TestingPlatformCommand.Help.cs`.

Fixes #50349