### PR TITLE
Allow `any`-RID builds to resolve assets like completely-RID-less builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -56,6 +56,13 @@ namespace Microsoft.NET.Build.Tasks
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>
+        /// The `any` RID can be passed to indicate that the assets should be resolved as a RID-agnostic application.
+        /// We use this field to detect that case and ensure that we treat `any` the same as no RID at all.
+        /// Essentially, if you see use of `RuntimeIdentifier` directly, you should ask "why?".
+        /// </summary>
+        private string EffectiveRuntimeIdentifier => !string.IsNullOrEmpty(RuntimeIdentifier) && RuntimeIdentifier != "any" ? RuntimeIdentifier : null;
+
+        /// <summary>
         /// The platform library name for resolving copy local assets.
         /// </summary>
         public string PlatformLibraryName { get; set; }
@@ -478,6 +485,8 @@ namespace Microsoft.NET.Build.Tasks
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(CompilerApiVersion ?? "");
                     writer.Write(ProjectPath);
+                    // we want to ensure uniqueness of results, so even though `any` is No RID for purposes of Task logic,
+                    // we continue to treat it distinctly for hashing
                     writer.Write(RuntimeIdentifier ?? "");
                     if (ShimRuntimeIdentifiers != null)
                     {
@@ -730,7 +739,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (task.DesignTimeBuild)
                 {
                     _compileTimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, runtimeIdentifier: null);
-                    _runtimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, _task.RuntimeIdentifier);
+                    _runtimeTarget = _lockFile.GetTargetAndReturnNullIfNotFound(_targetFramework, runtimeIdentifier: _task.EffectiveRuntimeIdentifier);
                     if (_compileTimeTarget == null)
                     {
                         _compileTimeTarget = new LockFileTarget();
@@ -745,7 +754,7 @@ namespace Microsoft.NET.Build.Tasks
                 else
                 {
                     _compileTimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, runtimeIdentifier: null);
-                    _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, _task.RuntimeIdentifier);
+                    _runtimeTarget = _lockFile.GetTargetAndThrowIfNotFound(_targetFramework, runtimeIdentifier: _task.EffectiveRuntimeIdentifier);
                 }
 
 
@@ -1271,11 +1280,11 @@ namespace Microsoft.NET.Build.Tasks
 
             private void WriteUnsupportedRuntimeIdentifierMessageIfNecessary()
             {
-                if (_task.EnsureRuntimePackageDependencies && !string.IsNullOrEmpty(_task.RuntimeIdentifier))
+                if (_task.EnsureRuntimePackageDependencies && !string.IsNullOrEmpty(_task.EffectiveRuntimeIdentifier))
                 {
                     if (_compileTimeTarget.Libraries.Count >= _runtimeTarget.Libraries.Count)
                     {
-                        WriteItem(string.Format(Strings.UnsupportedRuntimeIdentifier, _task.RuntimeIdentifier));
+                        WriteItem(string.Format(Strings.UnsupportedRuntimeIdentifier, _task.EffectiveRuntimeIdentifier));
                         WriteMetadata(MetadataKeys.Severity, nameof(LogLevel.Error));
                     }
                 }

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -130,6 +130,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             }
 
             testProject.SourceFiles.Add("Program.cs", "Console.WriteLine(\"Hello Tool!\");");
+            testProject.PackageReferences.Add(new("Microsoft.Data.Sqlite", version: "9.0.8"));
 
             var testAssetManager = new TestAssetsManager(log);
             var testAsset = testAssetManager.CreateTestProject(testProject, identifier: toolSettings.GetIdentifier());


### PR DESCRIPTION
Fixes #50312

The `any` RID sits at the top of the RID graph and is compatible with all RIDs - which means in order to run it must get runtime-specific assets from _all_ RIDs. 

This change makes `ResolvePackageAssets` treat `any` like `null` for purposes of asking the NuGet Lockfile for target-specific assets. This makes the LockFile return the complete set of RID-specific assets for package dependencies.