### PR TITLE
Fix ProductName for SDK placeholder

### DIFF
--- a/src/Layout/pkg/windows/Directory.Build.targets
+++ b/src/Layout/pkg/windows/Directory.Build.targets
@@ -6,7 +6,8 @@
     <!-- Example: Microsoft .NET SDK 10.0.100 -->
     <DefineConstants>$(DefineConstants);SdkBrandName=$(SdkBrandName)</DefineConstants>
     <!-- Example: Microsoft .NET SDK 10.0.100 (x64) -->
-    <DefineConstants>$(DefineConstants);SdkPlatformBrandName=$(SdkBrandName) ($(TargetArchitecture))</DefineConstants>
+    <SdkPlatformBrandName>$(SdkBrandName) ($(TargetArchitecture))</SdkPlatformBrandName>
+    <DefineConstants>$(DefineConstants);SdkPlatformBrandName=$(SdkPlatformBrandName)</DefineConstants>
 
     <!-- NativeMachine values match the expected values for image file machine constants
          https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants -->


### PR DESCRIPTION
Fixes the placeholder MSI ProductName

<img width="548" height="273" alt="image" src="https://github.com/user-attachments/assets/0b3fd9f6-54f7-4222-a3e2-4087c8e6555f" />

