### PR TITLE
Fix some error messages in dotnet test

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1784,11 +1784,7 @@ The default is to publish a framework-dependent application.</value>
 Ensure you have a runnable project type.
 A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</value>
-    <comment>{0} is project file path.</comment>
-    <comment>{1} is dotnet framework version.</comment>
-    <comment>{2} is the project output type.</comment>
-	<comment>{Locked="OutputType"}</comment>
-	<comment>{Locked="Exe"}</comment>
+    <comment>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</comment>
   </data>
   <data name="RunCommandExceptionUnableToRunSpecifyFramework" xml:space="preserve">
     <value>Unable to run your project

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1782,11 +1782,13 @@ The default is to publish a framework-dependent application.</value>
   <data name="RunCommandExceptionUnableToRun" xml:space="preserve">
     <value>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</value>
     <comment>{0} is project file path.</comment>
     <comment>{1} is dotnet framework version.</comment>
     <comment>{2} is the project output type.</comment>
+	<comment>{Locked="OutputType"}</comment>
+	<comment>{Locked="Exe"}</comment>
   </data>
   <data name="RunCommandExceptionUnableToRunSpecifyFramework" xml:space="preserve">
     <value>Unable to run your project

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1780,16 +1780,13 @@ The default is to publish a framework-dependent application.</value>
     <value>Couldn't find a project to run. Ensure a project exists in {0}, or pass the path to the project using {1}.</value>
   </data>
   <data name="RunCommandExceptionUnableToRun" xml:space="preserve">
-    <value>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</value>
-  </data>
-  <data name="TestCommandExceptionUnableToRun" xml:space="preserve">
     <value>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</value>
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</value>
+    <comment>{0} is project file path.</comment>
+    <comment>{1} is dotnet framework version.</comment>
+    <comment>{2} is the project output type.</comment>
   </data>
   <data name="RunCommandExceptionUnableToRunSpecifyFramework" xml:space="preserve">
     <value>Unable to run your project

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1785,6 +1785,12 @@ Ensure you have a runnable project type and ensure '{0}' supports this project.
 A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
 The current {1} is '{2}'.</value>
   </data>
+  <data name="TestCommandExceptionUnableToRun" xml:space="preserve">
+    <value>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</value>
+  </data>
   <data name="RunCommandExceptionUnableToRunSpecifyFramework" xml:space="preserve">
     <value>Unable to run your project
 Your project targets multiple frameworks. Specify which framework to run using '{0}'.</value>

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -511,8 +511,8 @@ public class RunCommand
         throw new GracefulException(
                 string.Format(
                     CliCommandStrings.RunCommandExceptionUnableToRun,
-                    "dotnet run",
-                    "OutputType",
+                    project.GetPropertyValue("MSBuildProjectFullPath"),
+                    Product.TargetFrameworkVersion,
                     project.GetPropertyValue("OutputType")));
     }
 

--- a/src/Cli/dotnet/Commands/Run/RunProperties.cs
+++ b/src/Cli/dotnet/Commands/Run/RunProperties.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Execution;
-using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Run;
@@ -46,44 +45,5 @@ internal sealed record RunProperties(
         }
 
         return this;
-    }
-
-    internal static RunProperties GetPropsFromProject(ProjectInstance project)
-    {
-        var result = new RunProperties(
-            Command: project.GetPropertyValue("RunCommand"),
-            Arguments: project.GetPropertyValue("RunArguments"),
-            WorkingDirectory: project.GetPropertyValue("RunWorkingDirectory"),
-            RuntimeIdentifier: project.GetPropertyValue("RuntimeIdentifier"),
-            DefaultAppHostRuntimeIdentifier: project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"),
-            TargetFrameworkVersion: project.GetPropertyValue("TargetFrameworkVersion"));
-
-        if (string.IsNullOrEmpty(result.Command))
-        {
-            ThrowUnableToRunError(project);
-        }
-
-        return result;
-    }
-
-    internal static void ThrowUnableToRunError(ProjectInstance project)
-    {
-        string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
-        if (!string.IsNullOrEmpty(targetFrameworks))
-        {
-            string targetFramework = project.GetPropertyValue("TargetFramework");
-            if (string.IsNullOrEmpty(targetFramework))
-            {
-                throw new GracefulException(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework");
-            }
-        }
-
-        throw new GracefulException(
-                string.Format(
-                    CliCommandStrings.TestCommandExceptionUnableToRun,
-                    project.GetPropertyValue(ProjectProperties.ProjectFullPath),
-                    "dotnet test",
-                    "OutputType",
-                    project.GetPropertyValue("OutputType")));
     }
 }

--- a/src/Cli/dotnet/Commands/Run/RunProperties.cs
+++ b/src/Cli/dotnet/Commands/Run/RunProperties.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Execution;
+using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Run;
@@ -45,5 +46,44 @@ internal sealed record RunProperties(
         }
 
         return this;
+    }
+
+    internal static RunProperties GetPropsFromProject(ProjectInstance project)
+    {
+        var result = new RunProperties(
+            Command: project.GetPropertyValue("RunCommand"),
+            Arguments: project.GetPropertyValue("RunArguments"),
+            WorkingDirectory: project.GetPropertyValue("RunWorkingDirectory"),
+            RuntimeIdentifier: project.GetPropertyValue("RuntimeIdentifier"),
+            DefaultAppHostRuntimeIdentifier: project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"),
+            TargetFrameworkVersion: project.GetPropertyValue("TargetFrameworkVersion"));
+
+        if (string.IsNullOrEmpty(result.Command))
+        {
+            ThrowUnableToRunError(project);
+        }
+
+        return result;
+    }
+
+    internal static void ThrowUnableToRunError(ProjectInstance project)
+    {
+        string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
+        if (!string.IsNullOrEmpty(targetFrameworks))
+        {
+            string targetFramework = project.GetPropertyValue("TargetFramework");
+            if (string.IsNullOrEmpty(targetFramework))
+            {
+                throw new GracefulException(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework");
+            }
+        }
+
+        throw new GracefulException(
+                string.Format(
+                    CliCommandStrings.TestCommandExceptionUnableToRun,
+                    project.GetPropertyValue(ProjectProperties.ProjectFullPath),
+                    "dotnet test",
+                    "OutputType",
+                    project.GetPropertyValue("OutputType")));
     }
 }

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -229,6 +229,8 @@ internal static class SolutionAndProjectUtility
         }
 
         string targetFramework = project.GetPropertyValue(ProjectProperties.TargetFramework);
+		string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
+
 
         // Only get run properties if IsTestingPlatformApplication is true
         RunProperties runProperties;
@@ -244,8 +246,9 @@ internal static class SolutionAndProjectUtility
             {
                 throw new GracefulException(
                     string.Format(
-                        CliCommandStrings.RunCommandExceptionUnableToRun,
-                        "dotnet test",
+                        CliCommandStrings.TestCommandExceptionUnableToRun,
+						projectFullPath,
+						"dotnet test",
                         "OutputType",
                         project.GetPropertyValue("OutputType")));
             }
@@ -258,8 +261,6 @@ internal static class SolutionAndProjectUtility
                 null,
                 null);
         }
-
-        string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
 
         // TODO: Support --launch-profile and pass it here.
         var launchSettings = TryGetLaunchProfileSettings(Path.GetDirectoryName(projectFullPath)!, Path.GetFileNameWithoutExtension(projectFullPath), project.GetPropertyValue(ProjectProperties.AppDesignerFolder), buildOptions, profileName: null);
@@ -290,7 +291,7 @@ internal static class SolutionAndProjectUtility
                 }
             }
 
-            return RunProperties.FromProject(project);
+            return RunProperties.GetPropsFromProject(project);
         }
     }
 

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
 using System.Diagnostics;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -230,20 +229,34 @@ internal static class SolutionAndProjectUtility
         }
 
         string targetFramework = project.GetPropertyValue(ProjectProperties.TargetFramework);
-        RunProperties runProperties = GetRunProperties(project, loggers);
 
-        // dotnet run throws the same if RunCommand is null or empty.
-        // In dotnet test, we are additionally checking that RunCommand is not dll.
-        // In any "default" scenario, RunCommand is never dll.
-        // If we found it to be dll, that is user explicitly setting RunCommand incorrectly.
-        if (string.IsNullOrEmpty(runProperties.Command) || runProperties.Command.HasExtension(CliConstants.DLLExtension))
+        // Only get run properties if IsTestingPlatformApplication is true
+        RunProperties runProperties;
+        if (isTestingPlatformApplication)
         {
-            throw new GracefulException(
-                string.Format(
-                    CliCommandStrings.RunCommandExceptionUnableToRun,
-                    "dotnet test",
-                    "OutputType",
-                    project.GetPropertyValue("OutputType")));
+            runProperties = GetRunProperties(project, loggers);
+
+            // dotnet run throws the same if RunCommand is null or empty.
+            // In dotnet test, we are additionally checking that RunCommand is not dll.
+            // In any "default" scenario, RunCommand is never dll.
+            // If we found it to be dll, that is user explicitly setting RunCommand incorrectly.
+            if (string.IsNullOrEmpty(runProperties.Command) || runProperties.Command.HasExtension(CliConstants.DLLExtension))
+            {
+                throw new GracefulException(
+                    string.Format(
+                        CliCommandStrings.RunCommandExceptionUnableToRun,
+                        "dotnet test",
+                        "OutputType",
+                        project.GetPropertyValue("OutputType")));
+            }
+        }
+        else
+        {
+            // For VSTest test projects, create minimal RunProperties
+            runProperties = new RunProperties(
+                project.GetPropertyValue(ProjectProperties.TargetPath),
+                null,
+                null);
         }
 
         string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -229,7 +229,7 @@ internal static class SolutionAndProjectUtility
         }
 
         string targetFramework = project.GetPropertyValue(ProjectProperties.TargetFramework);
-		string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
+        string projectFullPath = project.GetPropertyValue(ProjectProperties.ProjectFullPath);
 
 
         // Only get run properties if IsTestingPlatformApplication is true
@@ -246,10 +246,9 @@ internal static class SolutionAndProjectUtility
             {
                 throw new GracefulException(
                     string.Format(
-                        CliCommandStrings.TestCommandExceptionUnableToRun,
-						projectFullPath,
-						"dotnet test",
-                        "OutputType",
+                        CliCommandStrings.RunCommandExceptionUnableToRun,
+                        projectFullPath,
+                        Product.TargetFrameworkVersion,
                         project.GetPropertyValue("OutputType")));
             }
         }
@@ -291,7 +290,7 @@ internal static class SolutionAndProjectUtility
                 }
             }
 
-            return RunProperties.GetPropsFromProject(project);
+            return RunProperties.FromProject(project);
         }
     }
 

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2680,7 +2680,7 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Projekt se nedá spustit.
 Ověřte prosím, že máte spustitelný typ projektu, a zajistěte, aby tento projekt podporoval {0}.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3052,6 +3052,17 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">Zadání adresáře pro dotnet test by mělo být prostřednictvím --directory.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2678,15 +2678,15 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Projekt se nedá spustit.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Projekt se nedá spustit.
 Ověřte prosím, že máte spustitelný typ projektu, a zajistěte, aby tento projekt podporoval {0}.
 Cílem spustitelného projektu by mělo být TFM (například net5.0) a jeho OutputType by měl být Exe.
 Aktuální {1} je {2}.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Ověřte prosím, že máte spustitelný typ projektu, a zajistěte, aby tento projekt podporoval {0}.
 Cílem spustitelného projektu by mělo být TFM (například net5.0) a jeho OutputType by měl být Exe.
 Aktuální {1} je {2}.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2678,15 +2678,15 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Ihr Projekt kann nicht ausgeführt werden.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Ihr Projekt kann nicht ausgeführt werden.
 Stellen Sie sicher, dass der Projekttyp ausführbar ist und "{0}" dieses Projekt unterstützt.
 Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den OutputType "Exe" verwenden.
 {1} lautet aktuell "{2}".</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2680,7 +2680,7 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Ihr Projekt kann nicht ausgeführt werden.
 Stellen Sie sicher, dass der Projekttyp ausführbar ist und "{0}" dieses Projekt unterstützt.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3052,6 +3052,17 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">Die Angabe eines Verzeichnisses für „dotnet test“ sollte über „--directory“ erfolgen.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Stellen Sie sicher, dass der Projekttyp ausführbar ist und "{0}" dieses Projekt unterstützt.
 Ein ausführbares Projekt muss ein ausführbares TFM (z. B. net5.0) und den OutputType "Exe" verwenden.
 {1} lautet aktuell "{2}".</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2678,15 +2678,15 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">No se puede ejecutar el proyecto.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">No se puede ejecutar el proyecto.
 Asegúrese de tener un tipo de proyecto ejecutable y asegúrese de que "{0}" admita este proyecto.
 Un proyecto ejecutable debe tener como destino un TFM ejecutable (por ejemplo, net5.0) y tener como OutputType "Exe".
 El valor actual de {1} es "{2}".</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Asegúrese de tener un tipo de proyecto ejecutable y asegúrese de que "{0}" admita este proyecto.
 Un proyecto ejecutable debe tener como destino un TFM ejecutable (por ejemplo, net5.0) y tener como OutputType "Exe".
 El valor actual de {1} es "{2}".</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3052,6 +3052,17 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">La especificación de un directorio para 'dotnet test' debe hacerse mediante '--directory'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2680,7 +2680,7 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">No se puede ejecutar el proyecto.
 Asegúrese de tener un tipo de proyecto ejecutable y asegúrese de que "{0}" admita este proyecto.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3052,6 +3052,17 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">La spécification d’un répertoire pour « dotnet test » doit se faire via « --directory ».</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Vérifiez que vous avez un type de projet exécutable et que '{0}' prend en charge ce projet.
 Un projet exécutable doit cibler un TFM exécutable (par exemple, net5.0) et avoir OutputType 'Exe'.
 Le {1} actuel est '{2}'.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2680,7 +2680,7 @@ La valeur par défaut est de publier une application dépendante du framework.</
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Impossible d'exécuter votre projet.
 Vérifiez que vous avez un type de projet exécutable et que '{0}' prend en charge ce projet.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2678,15 +2678,15 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Impossible d'exécuter votre projet.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Impossible d'exécuter votre projet.
 Vérifiez que vous avez un type de projet exécutable et que '{0}' prend en charge ce projet.
 Un projet exécutable doit cibler un TFM exécutable (par exemple, net5.0) et avoir OutputType 'Exe'.
 Le {1} actuel est '{2}'.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2680,7 +2680,7 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Non è possibile eseguire il progetto.
 Assicurarsi che sia presente un tipo di progetto eseguibile e che '{0}' supporti tale progetto.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2678,15 +2678,15 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Non è possibile eseguire il progetto.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Non è possibile eseguire il progetto.
 Assicurarsi che sia presente un tipo di progetto eseguibile e che '{0}' supporti tale progetto.
 Un progetto eseguibile deve essere destinato a un TFM eseguibile, ad esempio net5.0, inoltre OutputType deve essere impostato su 'Exe'.
 Il valore corrente di {1} è '{2}'.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3052,6 +3052,17 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">La specifica di una directory per 'dotnet test' deve avvenire tramite '--directory'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Assicurarsi che sia presente un tipo di progetto eseguibile e che '{0}' supporti tale progetto.
 Un progetto eseguibile deve essere destinato a un TFM eseguibile, ad esempio net5.0, inoltre OutputType deve essere impostato su 'Exe'.
 Il valore corrente di {1} è '{2}'.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2678,15 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">プロジェクトを実行できません。
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">プロジェクトを実行できません。
 プロジェクト タイプが実行可能であること、このプロジェクトが '{0}' でサポートされていることを確認してください。
 実行可能なプロジェクトは実行可能な TFM (たとえば、net5.0) を対象としている必要があり、OutputType 'Exe' が必要です。
 現在の {1} は '{2}' です。</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2680,7 +2680,7 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">プロジェクトを実行できません。
 プロジェクト タイプが実行可能であること、このプロジェクトが '{0}' でサポートされていることを確認してください。

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3052,6 +3052,17 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">'dotnet test' のディレクトリを指定するには、'--directory' を使用する必要があります。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 プロジェクト タイプが実行可能であること、このプロジェクトが '{0}' でサポートされていることを確認してください。
 実行可能なプロジェクトは実行可能な TFM (たとえば、net5.0) を対象としている必要があり、OutputType 'Exe' が必要です。
 現在の {1} は '{2}' です。</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3052,6 +3052,17 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">'dotnet test'에 대한 디렉터리를 지정하려면 '--directory'를 통해 지정해야 합니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 실행 가능한 프로젝트 형식이 있고 '{0}'에서 이 프로젝트를 지원하는지 확인하세요.
 실행 가능한 프로젝트는 실행 가능한 TFM(예: net5.0)을 대상으로 하고 OutputType 'Exe'가 있어야 합니다.
 현재 {1}은(는) '{2}'입니다.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2678,15 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">프로젝트를 실행할 수 없습니다.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">프로젝트를 실행할 수 없습니다.
 실행 가능한 프로젝트 형식이 있고 '{0}'에서 이 프로젝트를 지원하는지 확인하세요.
 실행 가능한 프로젝트는 실행 가능한 TFM(예: net5.0)을 대상으로 하고 OutputType 'Exe'가 있어야 합니다.
 현재 {1}은(는) '{2}'입니다.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2680,7 +2680,7 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">프로젝트를 실행할 수 없습니다.
 실행 가능한 프로젝트 형식이 있고 '{0}'에서 이 프로젝트를 지원하는지 확인하세요.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3052,6 +3052,17 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">Określenie katalogu dla elementu „dotnet test” powinno być za pomocą katalogu „--directory”.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2680,7 +2680,7 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Nie można uruchomić projektu.
 Upewnij się, że używany typ projektu umożliwia uruchamianie oraz że element „{0}” obsługuje ten projekt.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2678,15 +2678,15 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Nie można uruchomić projektu.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Nie można uruchomić projektu.
 Upewnij się, że używany typ projektu umożliwia uruchamianie oraz że element „{0}” obsługuje ten projekt.
 Projekt z możliwością uruchamiania musi mieć moniker TFM z możliwością uruchomienia (np. net5.0) i typ OutputType „Exe”.
 Bieżący element {1}: „{2}”.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Upewnij się, że używany typ projektu umożliwia uruchamianie oraz że element „{0}” obsługuje ten projekt.
 Projekt z możliwością uruchamiania musi mieć moniker TFM z możliwością uruchomienia (np. net5.0) i typ OutputType „Exe”.
 Bieżący element {1}: „{2}”.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Verifique se você tem um tipo de projeto executável e se '{0}' dá suporte a esse projeto.
 Um projeto executável deve ter como destino um TFM executável (por exemplo, o net5.0) e ter o OutputType 'Exe'.
 O {1} atual é '{2}'.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2680,7 +2680,7 @@ O padrão é publicar uma aplicação dependente de framework.</target>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Não é possível executar o projeto.
 Verifique se você tem um tipo de projeto executável e se '{0}' dá suporte a esse projeto.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2678,15 +2678,15 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Não é possível executar o projeto.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Não é possível executar o projeto.
 Verifique se você tem um tipo de projeto executável e se '{0}' dá suporte a esse projeto.
 Um projeto executável deve ter como destino um TFM executável (por exemplo, o net5.0) e ter o OutputType 'Exe'.
 O {1} atual é '{2}'.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3052,6 +3052,17 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">A especificação de um diretório para 'dotnet test' deve ser feita por meio de '--directory'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2680,7 +2680,7 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Не удалось запустить проект.
 Убедитесь, что тип проекта поддерживает запуск и что "{0}" поддерживает этот проект.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Убедитесь, что тип проекта поддерживает запуск и что "{0}" поддерживает этот проект.
 Запускаемый проект должен быть предназначен для TFM с поддержкой запуска (например, net5.0) и иметь тип выходных данных "EXE".
 Текущий {1} — "{2}".</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3052,6 +3052,17 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">Указание каталога для "dotnet test" следует выполнять через "--directory".</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2678,15 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Не удалось запустить проект.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Не удалось запустить проект.
 Убедитесь, что тип проекта поддерживает запуск и что "{0}" поддерживает этот проект.
 Запускаемый проект должен быть предназначен для TFM с поддержкой запуска (например, net5.0) и иметь тип выходных данных "EXE".
 Текущий {1} — "{2}".</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2678,15 +2678,15 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">Projeniz çalıştırılamıyor.
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">Projeniz çalıştırılamıyor.
 Çalıştırılabilir bir proje türüne sahip olduğunuzdan ve bu projenin '{0}' tarafından desteklendiğinden emin olun.
 Çalıştırılabilir proje, çalıştırılabilir bir TFM’yi (örneğin, net5.0) hedeflemeli ve OutputType değeri 'Exe' olmalıdır.
 Geçerli {1}: '{2}'.</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3052,6 +3052,17 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">‘dotnet test’ için bir dizin belirtmek ‘--directory’ ile yapılmalıdır.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 Çalıştırılabilir bir proje türüne sahip olduğunuzdan ve bu projenin '{0}' tarafından desteklendiğinden emin olun.
 Çalıştırılabilir proje, çalıştırılabilir bir TFM’yi (örneğin, net5.0) hedeflemeli ve OutputType değeri 'Exe' olmalıdır.
 Geçerli {1}: '{2}'.</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2680,7 +2680,7 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">Projeniz çalıştırılamıyor.
 Çalıştırılabilir bir proje türüne sahip olduğunuzdan ve bu projenin '{0}' tarafından desteklendiğinden emin olun.

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 请确保你具有可运行的项目类型且“{0}”支持此项目。
 可运行的项目应面向可运行的 TFM (例如 net5.0)且其 OutputType 为 "Exe"。
 当前的 {1} 为“{2}”。</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2680,7 +2680,7 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">无法运行项目。
 请确保你具有可运行的项目类型且“{0}”支持此项目。

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3052,6 +3052,17 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">应通过 "--directory" 为 "dotnet test" 指定目录。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2678,15 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">无法运行项目。
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">无法运行项目。
 请确保你具有可运行的项目类型且“{0}”支持此项目。
 可运行的项目应面向可运行的 TFM (例如 net5.0)且其 OutputType 为 "Exe"。
 当前的 {1} 为“{2}”。</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2686,7 +2686,7 @@ The current OutputType is '{2}'.</source>
 請確定您有可執行的專案類型，並確定 '{0}' 支援此專案。
 可執行的專案應以可執行的 TFM (例如 net5.0) 為目標，且 OutputType 應為 'Exe'。
 目前的 {1} 為 '{2}'。</target>
-        <note>{0} is project file path.</note>
+        <note>{0} is project file path. {1} is dotnet framework version. {2} is the project output type.{Locked="OutputType"}{Locked="Exe"}</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2678,15 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRun">
-        <source>Unable to run your project.
-Ensure you have a runnable project type and ensure '{0}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {1} is '{2}'.</source>
-        <target state="translated">無法執行您的專案。
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type.
+A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+The current OutputType is '{2}'.</source>
+        <target state="needs-review-translation">無法執行您的專案。
 請確定您有可執行的專案類型，並確定 '{0}' 支援此專案。
 可執行的專案應以可執行的 TFM (例如 net5.0) 為目標，且 OutputType 應為 'Exe'。
 目前的 {1} 為 '{2}'。</target>
-        <note />
+        <note>{0} is project file path.</note>
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">
         <source>Unable to run your project
@@ -3050,17 +3050,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
       <trans-unit id="TestCmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TestCommandExceptionUnableToRun">
-        <source>Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</source>
-        <target state="new">Unable to proceed with project '{0}'.
-Ensure you have a runnable project type and ensure '{1}' supports this project.
-A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
-The current {2} is '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestCommandUseDirectory">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2680,7 +2680,7 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="RunCommandExceptionUnableToRun">
         <source>Unable to proceed with project '{0}'.
 Ensure you have a runnable project type.
-A runnable project should target a runnable TFM (for instance, {1}) and have OutputType 'Exe'.
+A runnable project should target a runnable TFM (for instance, net{1}) and have OutputType 'Exe'.
 The current OutputType is '{2}'.</source>
         <target state="needs-review-translation">無法執行您的專案。
 請確定您有可執行的專案類型，並確定 '{0}' 支援此專案。

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3052,6 +3052,17 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandExceptionUnableToRun">
+        <source>Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</source>
+        <target state="new">Unable to proceed with project '{0}'.
+Ensure you have a runnable project type and ensure '{1}' supports this project.
+A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
+The current {2} is '{3}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseDirectory">
         <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
         <target state="translated">指定 'dotnet test' 的目錄應透過 '--directory'。</target>

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/AnotherTestProject/AnotherTestProject.csproj
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/AnotherTestProject/AnotherTestProject.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+	<ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/AnotherTestProject/Operations.cs
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/AnotherTestProject/Operations.cs
@@ -1,0 +1,9 @@
+﻿namespace Calculator.Core;
+
+public class Operations
+{
+	public double Add(double a, double b) => a + b;
+	public double Subtract(double a, double b) => a - b;
+	public double Multiply(double a, double b) => a * b;
+	public double Divide(double a, double b) => a / b;
+}

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects.sln
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35415.258
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherTestProject", "OtherTestProject\OtherTestProject.csproj", "{8683AE78-764B-46C2-98D4-8A3031CBA27E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnotherTestProject", "AnotherTestProject\AnotherTestProject.csproj", "{2604B2BA-D36A-461D-9BB3-207E4253051C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8683AE78-764B-46C2-98D4-8A3031CBA27E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8683AE78-764B-46C2-98D4-8A3031CBA27E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8683AE78-764B-46C2-98D4-8A3031CBA27E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8683AE78-764B-46C2-98D4-8A3031CBA27E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2604B2BA-D36A-461D-9BB3-207E4253051C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2604B2BA-D36A-461D-9BB3-207E4253051C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2604B2BA-D36A-461D-9BB3-207E4253051C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2604B2BA-D36A-461D-9BB3-207E4253051C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/OtherTestProject/OtherTestProject.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\AnotherTestProject\AnotherTestProject.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/OtherTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/OtherTestProject/Program.cs
@@ -1,0 +1,105 @@
+﻿//See https://aka.ms/new-console-template for more information
+
+//Opt -out telemetry
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+//testApplicationBuilder.AddMSTest(() => new[] { Assembly.GetEntryAssembly()! });
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage),
+		typeof(SessionFileArtifact),
+		typeof(FileArtifact), };
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new DiscoveredTestNodeStateProperty()),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test1",
+			DisplayName = "Test1",
+			Properties = new PropertyBag(new SkippedTestNodeStateProperty("OK skipped!")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test2",
+			DisplayName = "Test2",
+			Properties = new PropertyBag(new FailedTestNodeStateProperty(new Exception("this is a failed test"), "not OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test3",
+			DisplayName = "Test3",
+			Properties = new PropertyBag(new TimeoutTestNodeStateProperty(new Exception("this is a timeout exception"), "not OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test4",
+			DisplayName = "Test4",
+			Properties = new PropertyBag(new ErrorTestNodeStateProperty(new Exception("this is an exception"), "not OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test5",
+			DisplayName = "Test5",
+			Properties = new PropertyBag(new CancelledTestNodeStateProperty(new Exception("this is a cancelled exception"), "not OK")),
+		}));
+
+		await context.MessageBus.PublishAsync(this, new FileArtifact(new FileInfo("file.txt"), "file", "file description"));
+
+		await context.MessageBus.PublishAsync(this, new SessionFileArtifact(context.Request.Session.SessionUid, new FileInfo("sessionFile.txt"), "sessionFile", "description"));
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test6 id",
+			DisplayName = "Test6",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK"), new FileArtifactProperty(new FileInfo("testNodeFile.txt"), "testNodeFile", "description")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/dotnet.config
+++ b/test/TestAssets/TestProjects/ClassLibraryWithIsTestProjectAndOtherTestProjects/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -268,6 +268,26 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
+        public void RunTestProjectsWithClassLibraryHavingIsTestProjectAndMTPProject_ShouldReturnExitCodeGenericFailure(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("ClassLibraryWithIsTestProjectAndOtherTestProjects", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
+
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+        }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
         public void RunOnEmptyFolder_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("EmptyFolder", Guid.NewGuid().ToString())


### PR DESCRIPTION
This pull request improves error handling and messaging for the `dotnet test` command, especially when a project is not runnable or is misconfigured. It introduces a new error message for test command failures, refactors how run properties are retrieved, and ensures consistency in error reporting across different scenarios. Additionally, translations for the new error message have been added for multiple languages.

**Error handling and messaging improvements:**

* Added a new error message `TestCommandExceptionUnableToRun` for cases where `dotnet test` cannot proceed due to project misconfiguration, including details about the project, command, property, and current value. This message is now used instead of the generic run error in test scenarios. [[1]](diffhunk://#diff-d2c1a5f8094b80f8041f0e9b0f8a304dee663ccfa6a68febdbdd273835dcfa37R1787-R1792) [[2]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L243-R263)
* Updated resource files to include translations for `TestCommandExceptionUnableToRun` in all supported languages, ensuring consistent messaging for global users. [[1]](diffhunk://#diff-0d78abc746101c6669ca53c2c625866abe9cb24241b992d33e451091ec26407aR3055-R3065) [[2]](diffhunk://#diff-a66d819a98404f6cd4adab0d5ede8b80b00a3673b01ee7bbcb1911472e0714fbR3055-R3065) [[3]](diffhunk://#diff-c81cc56dff53b291b166c88d8d8e86277b90dad5c4ea3936f55e30313af429f3R3055-R3065) [[4]](diffhunk://#diff-4385c5705f0ae6c891aa0b7a6b5343a8434694197121f53e36d71bf8ee8cc7dbR3055-R3065) [[5]](diffhunk://#diff-7816343992c7903b00cfad883383e4f24f28a0fc50f8411756955284d71b3ec6R3055-R3065) [[6]](diffhunk://#diff-9da784b4fe262c34b26a15f902e810c211ee5a4134a53092ebedcfbbe647b7d8R3055-R3065) [[7]](diffhunk://#diff-5c672fbb585c53a641ee37a61aa7b310b8eb6f56a276b22c60947f6492f69baeR3055-R3065) [[8]](diffhunk://#diff-5e0f47f84f5dacaf299918027f4b55b30d8c4852895596a50e26805856f7ab7aR3055-R3065) [[9]](diffhunk://#diff-9343aa265cfdb3111df2cc6614dc82ee5f70308029a168d1bc56c660b20f3693R3055-R3065) [[10]](diffhunk://#diff-9794fe9fff5c7fce1e37585611de9adbc0cef806f8d998e43a6d2c817b9b35beR3055-R3065) [[11]](diffhunk://#diff-4769cc3ca1a22527dfa8522f6dd2c6a1178aff0d07e645ac85e85c3c8faaabc4R3055-R3065) [[12]](diffhunk://#diff-825066b042e3c62de60a610ad78ab123d57f4f5e3dc05578615baf934b17ff64R3055-R3065)

**Code refactoring and logic changes:**

* Introduced `RunProperties.GetPropsFromProject` and `RunProperties.ThrowUnableToRunError` methods to centralize and clarify how run properties and related errors are handled for test projects.
* Updated `SolutionAndProjectUtility` logic to only retrieve run properties for platform test applications and to create minimal run properties for VSTest projects, improving robustness and clarity. [[1]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L233-R239) [[2]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L243-R263)
* Changed internal usage to call the new `GetPropsFromProject` method instead of the previous `FromProject` method, aligning with the new error handling flow.