### PR TITLE
[8.0.1xx] detect .NET 10 RID-specific tools and provide a more actionable error

### DIFF
--- a/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
@@ -52,14 +52,23 @@ namespace Microsoft.DotNet.ToolPackage
                 throw new ToolConfigurationException(CommonLocalizableStrings.ToolSettingsMoreThanOneCommand);
             }
 
-            if (dotNetCliTool.Commands[0].Runner != "dotnet")
+            // if there is no runner, this could be an entirely different _kind_ of tool.
+            if (string.IsNullOrWhiteSpace(dotNetCliTool.Commands[0].Runner))
             {
-                throw new ToolConfigurationException(
-                    string.Format(
-                        CommonLocalizableStrings.ToolSettingsUnsupportedRunner,
-                        dotNetCliTool.Commands[0].Name,
-                        dotNetCliTool.Commands[0].Runner));
+                if (warnings.Count != 0)
+                {
+                    throw new ToolConfigurationException(warnings[0]);
+                }
             }
+
+            if (dotNetCliTool.Commands[0].Runner != "dotnet")
+                {
+                    throw new ToolConfigurationException(
+                        string.Format(
+                            CommonLocalizableStrings.ToolSettingsUnsupportedRunner,
+                            dotNetCliTool.Commands[0].Name,
+                            dotNetCliTool.Commands[0].Runner));
+                }
 
             return new ToolConfiguration(
                 dotNetCliTool.Commands[0].Name,

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -20,7 +20,7 @@ public class CreateNewImageTests
         _testOutput = testOutput;
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public void CreateNewImage_Baseline()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -69,7 +69,7 @@ public class CreateNewImageTests
         return new(task.GeneratedContainerConfiguration);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public void ParseContainerProperties_EndToEnd()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -132,7 +132,7 @@ public class CreateNewImageTests
     /// <summary>
     /// Creates a console app that outputs the environment variable added to the image.
     /// </summary>
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public void Tasks_EndToEnd_With_EnvironmentVariable_Validation()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -215,7 +215,7 @@ public class CreateNewImageTests
             .And.HaveStdOut("Foo");
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
     {
         const string RootlessBase ="dotnet/rootlessbase";

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -17,7 +17,7 @@ public class DockerRegistryTests
         _loggerFactory = new TestLoggerFactory(testOutput);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task GetFromRegistry()
     {
         var loggerFactory = new TestLoggerFactory(_testOutput);
@@ -37,7 +37,7 @@ public class DockerRegistryTests
         Assert.NotNull(downloadedImage);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task WriteToPrivateBasicRegistry()
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(WriteToPrivateBasicRegistry));

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerTestsCollection.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerTestsCollection.cs
@@ -5,7 +5,9 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [CollectionDefinition("Docker tests")]
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class DockerTestsCollection : ICollectionFixture<DockerTestsFixture>
+// TODO: skipped due to docker infra instability - need to use new ACR.
+// See https://github.com/dotnet/sdk/issues/49300
+public class DockerTestsCollection // : ICollectionFixture<DockerTestsFixture>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     // This class has no code, and is never created. Its purpose is simply

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -38,7 +38,7 @@ public class EndToEndTests : IDisposable
         _loggerFactory.Dispose();
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task ApiEndToEndWithRegistryPushAndPull()
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(ApiEndToEndWithRegistryPushAndPull));
@@ -85,7 +85,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task ApiEndToEndWithLocalLoad()
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(ApiEndToEndWithLocalLoad));
@@ -126,7 +126,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task ApiEndToEndWithArchiveWritingAndLoad()
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(ApiEndToEndWithArchiveWritingAndLoad));
@@ -210,7 +210,7 @@ public class EndToEndTests : IDisposable
     }
 
 
-    [DockerAvailableTheory()]
+    [DockerAvailableTheory(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     [InlineData("webapi", false)]
     [InlineData("webapi", true)]
     [InlineData("worker", false)]
@@ -386,7 +386,7 @@ public class EndToEndTests : IDisposable
         privateNuGetAssets.Delete(true);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public void EndToEnd_NoAPI_Console()
     {
         DirectoryInfo newProjectDir = new DirectoryInfo(Path.Combine(TestSettings.TestArtifactsDirectory, "CreateNewImageTest"));
@@ -473,7 +473,7 @@ public class EndToEndTests : IDisposable
     [DockerSupportsArchInlineData("linux/386", "linux-x86", "/app", Skip = "There's no apphost for linux-x86 so we can't execute self-contained, and there's no .NET runtime base image for linux-x86 so we can't execute framework-dependent.")]
     [DockerSupportsArchInlineData("windows/amd64", "win-x64", "C:\\app")]
     [DockerSupportsArchInlineData("linux/amd64", "linux-x64", "/app")]
-    [DockerAvailableTheory]
+    [DockerAvailableTheory(Skip = "https://github.com/dotnet/sdk/issues/49300")]
     public async Task CanPackageForAllSupportedContainerRIDs(string dockerPlatform, string rid, string workingDir)
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(CanPackageForAllSupportedContainerRIDs));


### PR DESCRIPTION
# Customer Impact

The current error when installing .NET 10's RID-specific packages is not as helpful as we expected on lower-then-10 SDKs:

```
>dotnet tool install -g perla --prerelease --interactive
Tool 'dotnet-codetesting' failed to update due to the following:
The settings file in the tool's NuGet package is invalid: Command 'dotnet-codetesting' uses unsupported runner ''.
Tool 'dotnet-codetesting' failed to install. Contact the tool author for assistance.
```

This message doesn't direct the user towards a resolution to the problem, and we've had reports for internal and external users that they are lost trying to respond to this. This definitely wasn't our _intent_ - we thought that our existing version-based error message, which is more actionable, would activate on those SDKs.

We already have some detection of the version mis-match that's latent here, but didn't surface it to the user. This minimal change makes the error experience slightly more directed:

```
> dotnet tool install -g perla --prerelease --interactive
The settings file in the tool's NuGet package is invalid: Format version is higher than supported. This tool may not be supported in this SDK version. Update your SDK.
Tool 'perla' failed to install. Contact the tool author for assistance.
```
This isn't an _ideal_ experience, but is a change scoped small enough to not be too risky to take in servicing across the 8.0.1xx and onwards releases.

# Regression

No-ish? The UX for installing unsupported tools in general has always been not-great, but this is uniquely not-great.

# Testing

Manual testing as shown above. We don't have ready-to-go RID-specific tools to test against on the 8.x SDK branches.

# Risk

Low - this fallback only occurs after several other kinds of validation have already taken place.