### PR TITLE
Fix pr-main-warning.yml

### DIFF
--- a/.github/workflows/pr-main-warning.yml
+++ b/.github/workflows/pr-main-warning.yml
@@ -1,12 +1,12 @@
 name: PR Main Branch Warning
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches:
       - main
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
Use `pull_request_target` event trigger so the action runs in the context of the base branch and use `pull-requests: write` so it can actually post a comment to the PR.