### PR TITLE
[Static Web Assets] Unconditionally emit the weak ETag for RC1

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets
@@ -170,7 +170,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BrotliCompressionLevel Condition="'$(_BlazorBrotliCompressionLevel)' != ''">$(_BlazorBrotliCompressionLevel)</BrotliCompressionLevel>
 
     <!-- Attach weak ETag to compressed assets -->
-    <AttachWeakETagToCompressedAssetsDuringDevelopment Condition="'$(AttachWeakETagToCompressedAssetsDuringDevelopment)' == '' and '$(Configuration)' == 'Debug'">true</AttachWeakETagToCompressedAssetsDuringDevelopment>
+    <AttachWeakETagToCompressedAssetsDuringDevelopment>true</AttachWeakETagToCompressedAssetsDuringDevelopment>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Description

We did a fix to remove weak ETags attached to some HTTP responses that we generate and that broke `dotnet run -c Release` because of a development feature that looks specifically for it to match different representations of a file.

## Customer Impact

`dotnet run -c Release` will fail unless `AttachWeakETagToCompressedAssetsDuringDevelopment` is specifically set in that configuration

## Regression?

- [X] Yes
- [ ] No

9.0

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This is essentially reverting to the behavior from previous versions.

## Verification

- [ ] Manual (required)
- [ ] Automated