### PR TITLE
[9.0.3xx] detect .NET 10 RID-specific tools and provide a more actionable error

### DIFF
--- a/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolConfigurationDeserializer.cs
@@ -52,14 +52,23 @@ namespace Microsoft.DotNet.ToolPackage
                 throw new ToolConfigurationException(CommonLocalizableStrings.ToolSettingsMoreThanOneCommand);
             }
 
-            if (dotNetCliTool.Commands[0].Runner != "dotnet")
+            // if there is no runner, this could be an entirely different _kind_ of tool.
+            if (string.IsNullOrWhiteSpace(dotNetCliTool.Commands[0].Runner))
             {
-                throw new ToolConfigurationException(
-                    string.Format(
-                        CommonLocalizableStrings.ToolSettingsUnsupportedRunner,
-                        dotNetCliTool.Commands[0].Name,
-                        dotNetCliTool.Commands[0].Runner));
+                if (warnings.Count != 0)
+                {
+                    throw new ToolConfigurationException(warnings[0]);
+                }
             }
+
+            if (dotNetCliTool.Commands[0].Runner != "dotnet")
+                {
+                    throw new ToolConfigurationException(
+                        string.Format(
+                            CommonLocalizableStrings.ToolSettingsUnsupportedRunner,
+                            dotNetCliTool.Commands[0].Name,
+                            dotNetCliTool.Commands[0].Runner));
+                }
 
             return new ToolConfiguration(
                 dotNetCliTool.Commands[0].Name,


### PR DESCRIPTION
9.0.3xx port of https://github.com/dotnet/sdk/pull/50399

# Customer Impact

The current error when installing .NET 10's RID-specific packages is not as helpful as we expected on lower-then-10 SDKs:

```
>dotnet tool install -g perla --prerelease --interactive
Tool 'dotnet-codetesting' failed to update due to the following:
The settings file in the tool's NuGet package is invalid: Command 'dotnet-codetesting' uses unsupported runner ''.
Tool 'dotnet-codetesting' failed to install. Contact the tool author for assistance.
```

This message doesn't direct the user towards a resolution to the problem, and we've had reports for internal and external users that they are lost trying to respond to this. This definitely wasn't our _intent_ - we thought that our existing version-based error message, which is more actionable, would activate on those SDKs.

We already have some detection of the version mis-match that's latent here, but didn't surface it to the user. This minimal change makes the error experience slightly more directed:

```
> dotnet tool install -g perla --prerelease --interactive
The settings file in the tool's NuGet package is invalid: Format version is higher than supported. This tool may not be supported in this SDK version. Update your SDK.
Tool 'perla' failed to install. Contact the tool author for assistance.
```
This isn't an _ideal_ experience, but is a change scoped small enough to not be too risky to take in servicing across the 8.0.1xx and onwards releases.

# Regression

No-ish? The UX for installing unsupported tools in general has always been not-great, but this is uniquely not-great.

# Testing

Manual testing as shown above. We don't have ready-to-go RID-specific tools to test against on the 8.x SDK branches.

# Risk

Low - this fallback only occurs after several other kinds of validation have already taken place.