### PR TITLE
Run the man page script against the release branch so that GA gets the latest

### DIFF
--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4
+        with:
+          ref: release/10.0.1xx
 
       - name: Update man-pages
         run: |
@@ -38,7 +40,7 @@ jobs:
             git checkout -b $branch
             git commit -m "$title"
             git push -u origin $branch --force
-            gh pr create --base main --head $branch --title "$title" --body "$body"
+            gh pr create --base release/10.0.1xx --head $branch --title "$title" --body "$body"
           fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
It's running against main now and attempts to backport those changes didn't work. Target 10.0.1xx with this for now?
https://github.com/dotnet/sdk/pull/50306