### PR TITLE
Remove FileLoggersCount from MSBuild telemetry event

### DIFF
--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -141,7 +141,7 @@ public sealed class MSBuildLogger : INodeLogger
             case LoggingConfigurationTelemetryEventName:
                 TrackEvent(telemetry, $"msbuild/{LoggingConfigurationTelemetryEventName}", args.Properties,
                     toBeHashed: [],
-                    toBeMeasured: ["FileLoggersCount"]);
+                    toBeMeasured: []);
                 break;
             case BuildcheckAcquisitionFailureEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildcheckAcquisitionFailureEventName}", args.Properties,


### PR DESCRIPTION
The change is related to SerialConsoleLogger deprecation: https://github.com/dotnet/msbuild/pull/12336
The property isn't needed anymore, since MSBuild will be operating on parallel logger only by default. 