### PR TITLE
Remove directory option in dotnet test

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2631,6 +2631,9 @@ Proceed?</value>
   <data name="TestCommandUseTestModules" xml:space="preserve">
     <value>Specifying dlls or executables for 'dotnet test' should be via '--test-modules'.</value>
   </data>
+  <data name="TestCommandUseDirectoryWithSwitch" xml:space="preserve">
+    <value>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</value>
+  </data>
   <data name="PackCmdVersionDescription" xml:space="preserve">
     <value>The version of the package to create</value>
   </data>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2628,9 +2628,6 @@ Proceed?</value>
   <data name="TestCommandUseProject" xml:space="preserve">
     <value>Specifying a project for 'dotnet test' should be via '--project'.</value>
   </data>
-  <data name="TestCommandUseDirectory" xml:space="preserve">
-    <value>Specifying a directory for 'dotnet test' should be via '--directory'.</value>
-  </data>
   <data name="TestCommandUseTestModules" xml:space="preserve">
     <value>Specifying dlls or executables for 'dotnet test' should be via '--test-modules'.</value>
   </data>

--- a/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
@@ -41,7 +41,7 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationA
         }
         else
         {
-            path = PathUtility.GetFullPath(pathOptions.DirectoryPath ?? Directory.GetCurrentDirectory());
+            path = PathUtility.GetFullPath(Directory.GetCurrentDirectory());
             msBuildExitCode = RunBuild(path);
         }
 

--- a/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildHandler.cs
@@ -32,12 +32,18 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationA
         if (!string.IsNullOrEmpty(pathOptions.ProjectPath))
         {
             path = PathUtility.GetFullPath(pathOptions.ProjectPath);
-            msBuildExitCode = RunBuild(path, isSolution: false);
+
+            msBuildExitCode = Directory.Exists(path)
+                ? RunBuild(path, expectProject: true)
+                : RunBuild(path, isSolution: false);
         }
         else if (!string.IsNullOrEmpty(pathOptions.SolutionPath))
         {
             path = PathUtility.GetFullPath(pathOptions.SolutionPath);
-            msBuildExitCode = RunBuild(path, isSolution: true);
+
+            msBuildExitCode = Directory.Exists(path)
+                ? RunBuild(path, expectSolution: true)
+                : RunBuild(path, isSolution: true);
         }
         else
         {
@@ -54,9 +60,27 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationA
         return true;
     }
 
-    private int RunBuild(string directoryPath)
+    private int RunBuild(string directoryPath, bool expectProject = false, bool expectSolution = false)
     {
-        (bool solutionOrProjectFileFound, string message) = SolutionAndProjectUtility.TryGetProjectOrSolutionFilePath(directoryPath, out string projectOrSolutionFilePath, out bool isSolution);
+        bool solutionOrProjectFileFound;
+        string message;
+        string projectOrSolutionFilePath;
+        bool isSolution;
+
+        if (expectProject)
+        {
+            (solutionOrProjectFileFound, message) = SolutionAndProjectUtility.TryGetProjectFilePath(directoryPath, out projectOrSolutionFilePath);
+            isSolution = false;
+        }
+        else if (expectSolution)
+        {
+            (solutionOrProjectFileFound, message) = SolutionAndProjectUtility.TryGetSolutionFilePath(directoryPath, out projectOrSolutionFilePath);
+            isSolution = true;
+        }
+        else
+        {
+            (solutionOrProjectFileFound, message) = SolutionAndProjectUtility.TryGetProjectOrSolutionFilePath(directoryPath, out projectOrSolutionFilePath, out isSolution);
+        }
 
         if (!solutionOrProjectFileFound)
         {

--- a/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MSBuildUtility.cs
@@ -87,7 +87,6 @@ internal static class MSBuildUtility
         PathOptions pathOptions = new(
             parseResult.GetValue(TestingPlatformOptions.ProjectOption),
             parseResult.GetValue(TestingPlatformOptions.SolutionOption),
-            parseResult.GetValue(TestingPlatformOptions.DirectoryOption),
             resultsDirectory,
             configFile,
             diagnosticOutputDirectory);

--- a/src/Cli/dotnet/Commands/Test/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/Options.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal record TestOptions(bool HasFilterMode, bool IsHelp);
 
-internal record PathOptions(string? ProjectPath, string? SolutionPath, string? DirectoryPath, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
+internal record PathOptions(string? ProjectPath, string? SolutionPath, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 
 internal record BuildOptions(
     PathOptions PathOptions,
@@ -14,6 +14,6 @@ internal record BuildOptions(
     Utils.VerbosityOptions? Verbosity,
     bool NoLaunchProfile,
     bool NoLaunchProfileArguments,
-    int DegreeOfParallelism, 
+    int DegreeOfParallelism,
     List<string> UnmatchedTokens,
     IEnumerable<string> MSBuildArgs);

--- a/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/SolutionAndProjectUtility.cs
@@ -56,13 +56,39 @@ internal static class SolutionAndProjectUtility
         // If there is more than one project file in the current directory we may be able to figure it out
         else if (actualProjectFiles.Length > 1)
         {
-            var (found, filePath, message) = TryResolveAmbiguousProjects(actualProjectFiles);
-            if (!found)
+            // We have more than one project, it is ambiguous at the moment
+            bool isAmbiguousProject = true;
+
+            // If there are exactly two projects and one of them is a .proj use that one and ignore the other
+            if (actualProjectFiles.Length == 2)
             {
-                return (false, message ?? string.Format(CliStrings.MoreThanOneProjectInDirectory, directory));
+                string firstPotentialProjectExtension = Path.GetExtension(actualProjectFiles[0]);
+                string secondPotentialProjectExtension = Path.GetExtension(actualProjectFiles[1]);
+
+                // If the two projects have the same extension we can't decide which one to pick
+                if (!string.Equals(firstPotentialProjectExtension, secondPotentialProjectExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Check to see if the first project is the proj, if it is use it
+                    if (string.Equals(firstPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
+                    {
+                        projectOrSolutionFilePath = actualProjectFiles[0];
+                        // We have made a decision
+                        isAmbiguousProject = false;
+                    }
+                    // If the first project is not the proj check to see if the second one is the proj, if so use it
+                    else if (string.Equals(secondPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
+                    {
+                        projectOrSolutionFilePath = actualProjectFiles[1];
+                        // We have made a decision
+                        isAmbiguousProject = false;
+                    }
+                }
             }
-            projectOrSolutionFilePath = filePath!;
-            isSolution = false;
+
+            if (isAmbiguousProject)
+            {
+                return (false, string.Format(CliStrings.MoreThanOneProjectInDirectory, directory));
+            }
         }
         // if there are no project, solution filter, or solution files in the directory, we can't build
         else if (actualProjectFiles.Length == 0 &&
@@ -110,14 +136,7 @@ internal static class SolutionAndProjectUtility
             return (true, string.Empty);
         }
 
-        // Multiple projects found - try to resolve ambiguity
-        var (found, filePath, message) = TryResolveAmbiguousProjects(actualProjectFiles);
-        if (found)
-        {
-            projectFilePath = filePath!;
-        }
-
-        return (found, message ?? string.Format(CliStrings.MoreThanOneProjectInDirectory, directory));
+        return (false, string.Format(CliStrings.MoreThanOneProjectInDirectory, directory));
     }
 
     public static (bool SolutionFileFound, string Message) TryGetSolutionFilePath(string directory, out string solutionFilePath)
@@ -145,44 +164,6 @@ internal static class SolutionAndProjectUtility
         return (true, string.Empty);
     }
 
-    /// <summary>
-    /// Helper method to resolve ambiguous projects when there are multiple project files.
-    /// Follows the same logic as MSBuild: if there are exactly two projects and one is a .proj, use that one.
-    /// </summary>
-    private static (bool Found, string? FilePath, string? Message) TryResolveAmbiguousProjects(string[] projectFiles)
-    {
-        // We have more than one project, it is ambiguous at the moment
-        bool isAmbiguousProject = true;
-        string? selectedFilePath = null;
-
-        // If there are exactly two projects and one of them is a .proj use that one and ignore the other
-        if (projectFiles.Length == 2)
-        {
-            string firstPotentialProjectExtension = Path.GetExtension(projectFiles[0]);
-            string secondPotentialProjectExtension = Path.GetExtension(projectFiles[1]);
-
-            // If the two projects have the same extension we can't decide which one to pick
-            if (!string.Equals(firstPotentialProjectExtension, secondPotentialProjectExtension, StringComparison.OrdinalIgnoreCase))
-            {
-                // Check to see if the first project is the proj, if it is use it
-                if (string.Equals(firstPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
-                {
-                    selectedFilePath = projectFiles[0];
-                    // We have made a decision
-                    isAmbiguousProject = false;
-                }
-                // If the first project is not the proj check to see if the second one is the proj, if so use it
-                else if (string.Equals(secondPotentialProjectExtension, ".proj", StringComparison.OrdinalIgnoreCase))
-                {
-                    selectedFilePath = projectFiles[1];
-                    // We have made a decision
-                    isAmbiguousProject = false;
-                }
-            }
-        }
-
-        return (!isAmbiguousProject, selectedFilePath, null);
-    }
     private static string[] GetSolutionFilePaths(string directory) => [
             .. Directory.GetFiles(directory, CliConstants.SolutionExtensionPattern, SearchOption.TopDirectoryOnly),
             .. Directory.GetFiles(directory, CliConstants.SolutionXExtensionPattern, SearchOption.TopDirectoryOnly)

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.Extensions.Configuration;
 
@@ -232,7 +231,6 @@ internal static class TestCommandParser
         command.SetAction(parseResult => command.Run(parseResult));
         command.Options.Add(TestingPlatformOptions.ProjectOption);
         command.Options.Add(TestingPlatformOptions.SolutionOption);
-        command.Options.Add(TestingPlatformOptions.DirectoryOption);
         command.Options.Add(TestingPlatformOptions.TestModulesFilterOption);
         command.Options.Add(TestingPlatformOptions.TestModulesRootDirectoryOption);
         command.Options.Add(TestingPlatformOptions.ResultsDirectoryOption);

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
@@ -6,13 +6,11 @@
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Extensions;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Cli.Commands;
-using Microsoft.TemplateEngine.Cli.Help;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal partial class TestingPlatformCommand : System.CommandLine.Command, ICustomHelp
+internal partial class TestingPlatformCommand : Command, ICustomHelp
 {
     private MSBuildHandler _msBuildHandler;
     private TerminalTestReporter _output;
@@ -47,7 +45,7 @@ internal partial class TestingPlatformCommand : System.CommandLine.Command, ICus
     {
         ValidationUtility.ValidateMutuallyExclusiveOptions(parseResult);
         ValidationUtility.ValidateSolutionOrProjectOrDirectoryOrModulesArePassedCorrectly(parseResult);
-        
+
         PrepareEnvironment(parseResult, out TestOptions testOptions, out int degreeOfParallelism);
 
         InitializeOutput(degreeOfParallelism, parseResult, testOptions.IsHelp);

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.CommandLine;
-using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -21,13 +20,6 @@ internal static class TestingPlatformOptions
     {
         Description = CliCommandStrings.CmdSolutionDescription,
         HelpName = CliCommandStrings.CmdSolutionPathName,
-        Arity = ArgumentArity.ExactlyOne
-    };
-
-    public static readonly Option<string> DirectoryOption = new("--directory")
-    {
-        Description = CliCommandStrings.CmdDirectoryDescription,
-        HelpName = CliCommandStrings.CmdDirectoryPathName,
         Arity = ArgumentArity.ExactlyOne
     };
 

--- a/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
@@ -57,12 +57,12 @@ internal static class ValidationUtility
 
         if (!string.IsNullOrEmpty(pathOptions.ProjectPath))
         {
-            return ValidateProjectFilePath(pathOptions.ProjectPath, output);
+            return ValidateProjectPath(pathOptions.ProjectPath, output);
         }
 
         if (!string.IsNullOrEmpty(pathOptions.SolutionPath))
         {
-            return ValidateSolutionFilePath(pathOptions.SolutionPath, output);
+            return ValidateSolutionPath(pathOptions.SolutionPath, output);
         }
 
         return true;
@@ -105,26 +105,40 @@ internal static class ValidationUtility
         }
     }
 
-    private static bool ValidateSolutionFilePath(string filePath, TerminalTestReporter output)
+    private static bool ValidateSolutionPath(string path, TerminalTestReporter output)
     {
-        if (!CliConstants.SolutionExtensions.Contains(Path.GetExtension(filePath)))
+        // If it's a directory, just check if it exists
+        if (Directory.Exists(path))
         {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, filePath));
+            return true;
+        }
+
+        // If it's not a directory, validate as a file path
+        if (!CliConstants.SolutionExtensions.Contains(Path.GetExtension(path)))
+        {
+            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, path));
             return false;
         }
 
-        return ValidateFilePathExists(filePath, output);
+        return ValidateFilePathExists(path, output);
     }
 
-    private static bool ValidateProjectFilePath(string filePath, TerminalTestReporter output)
+    private static bool ValidateProjectPath(string path, TerminalTestReporter output)
     {
-        if (!Path.GetExtension(filePath).EndsWith("proj", StringComparison.OrdinalIgnoreCase))
+        // If it's a directory, just check if it exists
+        if (Directory.Exists(path))
         {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, filePath));
+            return true;
+        }
+
+        // If it's not a directory, validate as a file path
+        if (!Path.GetExtension(path).EndsWith("proj", StringComparison.OrdinalIgnoreCase))
+        {
+            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, path));
             return false;
         }
 
-        return ValidateFilePathExists(filePath, output);
+        return ValidateFilePathExists(path, output);
     }
 
     private static bool ValidateFilePathExists(string filePath, TerminalTestReporter output)

--- a/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
@@ -102,6 +102,10 @@ internal static class ValidationUtility
             {
                 throw new GracefulException(CliCommandStrings.TestCommandUseTestModules);
             }
+            else if (Directory.Exists(token))
+            {
+                throw new GracefulException(CliCommandStrings.TestCommandUseDirectoryWithSwitch);
+            }
         }
     }
 

--- a/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/ValidationUtility.cs
@@ -23,9 +23,6 @@ internal static class ValidationUtility
             if (parseResult.HasOption(TestingPlatformOptions.TestModulesFilterOption))
                 count++;
 
-            if (parseResult.HasOption(TestingPlatformOptions.DirectoryOption))
-                count++;
-
             if (parseResult.HasOption(TestingPlatformOptions.SolutionOption))
                 count++;
 
@@ -68,12 +65,6 @@ internal static class ValidationUtility
             return ValidateSolutionFilePath(pathOptions.SolutionPath, output);
         }
 
-        if (!string.IsNullOrEmpty(pathOptions.DirectoryPath) && !Directory.Exists(pathOptions.DirectoryPath))
-        {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdNonExistentDirectoryErrorDescription, pathOptions.DirectoryPath));
-            return false;
-        }
-
         return true;
     }
 
@@ -104,10 +95,6 @@ internal static class ValidationUtility
                      token.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
             {
                 throw new GracefulException(CliCommandStrings.TestCommandUseProject);
-            }
-            else if (Directory.Exists(token))
-            {
-                throw new GracefulException(CliCommandStrings.TestCommandUseDirectory);
             }
             else if ((token.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
                       token.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) &&

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3047,11 +3047,6 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">Zadání adresáře pro dotnet test by mělo být prostřednictvím --directory.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Zadání projektu pro dotnet test by mělo být prostřednictvím --project.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3047,6 +3047,11 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Zadání projektu pro dotnet test by mělo být prostřednictvím --project.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3047,11 +3047,6 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">Die Angabe eines Verzeichnisses für „dotnet test“ sollte über „--directory“ erfolgen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Die Angabe eines Projekts für „dotnet test“ sollte über „--project“ erfolgen.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3047,6 +3047,11 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Die Angabe eines Projekts für „dotnet test“ sollte über „--project“ erfolgen.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3047,6 +3047,11 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La especificación de un proyecto para 'dotnet test' debe hacerse mediante '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3047,11 +3047,6 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">La especificación de un directorio para 'dotnet test' debe hacerse mediante '--directory'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La especificación de un proyecto para 'dotnet test' debe hacerse mediante '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3047,6 +3047,11 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La spécification d’un projet pour « dotnet test » doit se faire via « --project ».</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3047,11 +3047,6 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">La spécification d’un répertoire pour « dotnet test » doit se faire via « --directory ».</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La spécification d’un projet pour « dotnet test » doit se faire via « --project ».</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3047,11 +3047,6 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">La specifica di una directory per 'dotnet test' deve avvenire tramite '--directory'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La specifica di un progetto per 'dotnet test' deve avvenire tramite '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3047,6 +3047,11 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">La specifica di un progetto per 'dotnet test' deve avvenire tramite '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3047,11 +3047,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">'dotnet test' のディレクトリを指定するには、'--directory' を使用する必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">'dotnet test' のプロジェクトを指定するには、'--project' を使用する必要があります。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3047,6 +3047,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">'dotnet test' のプロジェクトを指定するには、'--project' を使用する必要があります。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3047,6 +3047,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">'dotnet test'에 대한 프로젝트를 지정하려면 '--project'를 통해 지정해야 합니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3047,11 +3047,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">'dotnet test'에 대한 디렉터리를 지정하려면 '--directory'를 통해 지정해야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">'dotnet test'에 대한 프로젝트를 지정하려면 '--project'를 통해 지정해야 합니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3047,6 +3047,11 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Określanie projektu dla „dotnet test” powinno być za pomocą „--project”.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3047,11 +3047,6 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">Określenie katalogu dla elementu „dotnet test” powinno być za pomocą katalogu „--directory”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Określanie projektu dla „dotnet test” powinno być za pomocą „--project”.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3047,6 +3047,11 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">A especificação de um projeto para 'dotnet test' deve ser feita por meio de '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3047,11 +3047,6 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">A especificação de um diretório para 'dotnet test' deve ser feita por meio de '--directory'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">A especificação de um projeto para 'dotnet test' deve ser feita por meio de '--project'.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3047,11 +3047,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">Указание каталога для "dotnet test" следует выполнять через "--directory".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Указание проекта для "dotnet test" следует выполнять через "--project".</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3047,6 +3047,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">Указание проекта для "dotnet test" следует выполнять через "--project".</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3047,6 +3047,11 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">‘dotnet test’ için bir proje belirlemek ‘--project’ ile yapılmalıdır.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3047,11 +3047,6 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">‘dotnet test’ için bir dizin belirtmek ‘--directory’ ile yapılmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">‘dotnet test’ için bir proje belirlemek ‘--project’ ile yapılmalıdır.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3047,11 +3047,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">应通过 "--directory" 为 "dotnet test" 指定目录。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">应通过 "--project" 为 "dotnet test" 指定项目。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3047,6 +3047,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">应通过 "--project" 为 "dotnet test" 指定项目。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3047,6 +3047,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestCommandUseDirectoryWithSwitch">
+        <source>Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</source>
+        <target state="new">Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">指定 'dotnet test' 的專案應透過 '--project'。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3047,11 +3047,6 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">OUTPUT_DIR</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestCommandUseDirectory">
-        <source>Specifying a directory for 'dotnet test' should be via '--directory'.</source>
-        <target state="translated">指定 'dotnet test' 的目錄應透過 '--directory'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="TestCommandUseProject">
         <source>Specifying a project for 'dotnet test' should be via '--project'.</source>
         <target state="translated">指定 'dotnet test' 的專案應透過 '--project'。</target>

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 var result = new DotnetTestCommand(_log, false)
                 .WithWorkingDirectory(outputDirectory)
 #pragma warning disable SA1010 // Opening square brackets should be spaced correctly - false positive. Current formatting is good.
-                .Execute(isMTP ? ["--directory", outputDirectory] : [outputDirectory]);
+                .Execute(isMTP ? ["--project", outputDirectory] : [outputDirectory]);
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly
 
                 result.Should().Pass();

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
-        public void RunWithDirectoryAsProjectOption_ShouldReturnExitCodeSuccess(string configuration)
+        public void RunWithDirectoryAsProjectOption_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
 
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
-        public void RunWithSolutionFilterAsSolutionOption_ShouldReturnExitCodeSuccess(string configuration)
+        public void RunWithSolutionFilterAsSolutionOption_ShouldReturnExitGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
 
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
         [InlineData(TestingConstants.Debug)]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -141,13 +141,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             string testProjectPath = $"TestProject{Path.DirectorySeparatorChar}TestProject.csproj";
             string testSolutionPath = "MultiTestProjectSolutionWithTests.sln";
-            string testDirectoryPath = "TestProjects";
 
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute(TestingPlatformOptions.ProjectOption.Name, testProjectPath,
                                              TestingPlatformOptions.SolutionOption.Name, testSolutionPath,
-                                             TestingPlatformOptions.DirectoryOption.Name, testDirectoryPath,
                                              TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             result.StdErr.Should().Contain(CliCommandStrings.CmdMultipleBuildPathOptionsErrorDescription);
@@ -216,23 +214,23 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
-        [InlineData(TestingConstants.Debug)]
-        [InlineData(TestingConstants.Release)]
-        [Theory]
-        public void RunWithNonExistentDirectoryPath_ShouldReturnExitCodeGenericFailure(string configuration)
-        {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
+        //[InlineData(TestingConstants.Debug)]
+        //[InlineData(TestingConstants.Release)]
+        //[Theory]
+        //public void RunWithNonExistentDirectoryPath_ShouldReturnExitCodeGenericFailure(string configuration)
+        //{
+        //    TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
 
-            string directoryPath = "Directory";
+        //    string directoryPath = "Directory";
 
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .Execute(TestingPlatformOptions.DirectoryOption.Name, directoryPath,
-                                             TestingPlatformOptions.ConfigurationOption.Name, configuration);
+        //    CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+        //                            .WithWorkingDirectory(testInstance.Path)
+        //                            .Execute(TestingPlatformOptions.DirectoryOption.Name, directoryPath,
+        //                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentDirectoryErrorDescription, directoryPath));
-            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
-        }
+        //    result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentDirectoryErrorDescription, directoryPath));
+        //    result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+        //}
 
         //  https://github.com/dotnet/sdk/issues/49665
         [InlineData(TestingConstants.Debug)]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
-        [Theory]
+        [PlatformSpecificTheory(TestPlatforms.Any & ~TestPlatforms.OSX)]
         public void RunWithDirectoryAsProjectOption_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -235,24 +235,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
-        //[InlineData(TestingConstants.Debug)]
-        //[InlineData(TestingConstants.Release)]
-        //[Theory]
-        //public void RunWithNonExistentDirectoryPath_ShouldReturnExitCodeGenericFailure(string configuration)
-        //{
-        //    TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
-
-        //    string directoryPath = "Directory";
-
-        //    CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-        //                            .WithWorkingDirectory(testInstance.Path)
-        //                            .Execute(TestingPlatformOptions.DirectoryOption.Name, directoryPath,
-        //                                     TestingPlatformOptions.ConfigurationOption.Name, configuration);
-
-        //    result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentDirectoryErrorDescription, directoryPath));
-        //    result.ExitCode.Should().Be(ExitCodes.GenericFailure);
-        //}
-
         //  https://github.com/dotnet/sdk/issues/49665
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -156,27 +156,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
-        public void RunWithSolutionFilterAsSolutionOption_ShouldReturnExitGenericFailure(string configuration)
-        {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
-
-            string solutionFilterPath = "SolutionFilter";
-
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .Execute(TestingPlatformOptions.SolutionOption.Name, solutionFilterPath,
-                                             TestingPlatformOptions.ConfigurationOption.Name, configuration);
-
-            // Validate that only TestProject ran because the solution filter only includes that project
-            Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
-            Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
-
-            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
-        }
-
-        [InlineData(TestingConstants.Debug)]
-        [InlineData(TestingConstants.Release)]
-        [Theory]
         public void RunWithBothProjectAndSolutionOptions_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [InlineData(TestingConstants.Debug)]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
             Assert.DoesNotMatch(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
-            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+            result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
         [InlineData(TestingConstants.Debug)]

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
@@ -39,6 +39,29 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [Fact]
+        public void TestCommandShouldValidateDirectoryArgumentAndProvideHelpfulMessage()
+        {
+            var testDir = _testAssetsManager.CreateTestDirectory();
+            var subDir = Path.Combine(testDir.Path, "test_directory");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(testDir.Path, "dotnet.config"),
+                """
+                [dotnet.test.runner]
+                name = Microsoft.Testing.Platform
+                """);
+
+            var result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testDir.Path)
+                .Execute("test_directory");
+
+            result.ExitCode.Should().NotBe(0);
+            if (!TestContext.IsLocalized())
+            {
+                result.StdErr.Should().Contain("Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.");
+            }
+        }
+
+        [Fact]
         public void TestCommandShouldValidateDllArgumentAndProvideHelpfulMessage()
         {
             var testDir = _testAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Tools.Test.Utilities;
-
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
     public class TestCommandValidationTests : SdkTest
@@ -19,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         public void TestCommandShouldValidateFileArgumentsAndProvideHelpfulMessages(string filename, string expectedErrorStart)
         {
             var testDir = _testAssetsManager.CreateTestDirectory();
-            
+
             // Create the test file
             var testFilePath = Path.Combine(testDir.Path, filename);
             File.WriteAllText(testFilePath, "dummy content");
@@ -41,33 +39,10 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [Fact]
-        public void TestCommandShouldValidateDirectoryArgumentAndProvideHelpfulMessage()
-        {
-            var testDir = _testAssetsManager.CreateTestDirectory();
-            var subDir = Path.Combine(testDir.Path, "test_directory");
-            Directory.CreateDirectory(subDir);
-            File.WriteAllText(Path.Combine(testDir.Path, "dotnet.config"),
-                """
-                [dotnet.test.runner]
-                name = Microsoft.Testing.Platform
-                """);
-
-            var result = new DotnetTestCommand(Log, disableNewOutput: false)
-                .WithWorkingDirectory(testDir.Path)
-                .Execute("test_directory");
-
-            result.ExitCode.Should().NotBe(0);
-            if (!TestContext.IsLocalized())
-            {
-                result.StdErr.Should().Contain("Specifying a directory for 'dotnet test' should be via '--directory'.");
-            }
-        }
-
-        [Fact]
         public void TestCommandShouldValidateDllArgumentAndProvideHelpfulMessage()
         {
             var testDir = _testAssetsManager.CreateTestDirectory();
-            
+
             // Create a dummy dll file
             var dllPath = Path.Combine(testDir.Path, "test.dll");
             File.WriteAllText(dllPath, "dummy dll content");


### PR DESCRIPTION
This pull request refactors how the `dotnet test` CLI command handles directory inputs, removing the `--directory` option and improving project/solution file resolution logic. The changes simplify the user experience by allowing directories to be passed to `--project` or `--solution` and enhance ambiguity handling when multiple project files are present. Validation and error messaging have also been updated to reflect these improvements.

**Command-line interface and options:**

* Removed the `--directory` option from the CLI, parser, and options definitions, so directories should now be specified using `--project` or `--solution`. [[1]](diffhunk://#diff-d791453b9e99984688fe9c182a38dec434b04e028f51b9220a0bffd262226d4aL27-L33) [[2]](diffhunk://#diff-34d6b31f5b061385213268fe8d24bded4abbac22ad56b7489e17aab5ddeac980L8-R8) [[3]](diffhunk://#diff-7c7370f29da8cda13770d91a4a81dab25cd605427d361859464c6ae12a21de94L235)
* Updated resource strings and translations to reflect the new guidance for specifying directories. [[1]](diffhunk://#diff-d2c1a5f8094b80f8041f0e9b0f8a304dee663ccfa6a68febdbdd273835dcfa37L2631-R2636) [[2]](diffhunk://#diff-0d78abc746101c6669ca53c2c625866abe9cb24241b992d33e451091ec26407aL3050-R3052) [[3]](diffhunk://#diff-a66d819a98404f6cd4adab0d5ede8b80b00a3673b01ee7bbcb1911472e0714fbL3050-R3052)

**Project and solution resolution logic:**

* Refactored `MSBuildHandler` to distinguish between directory and file inputs for project/solution options, using new helper methods to resolve the correct file when a directory is given. [[1]](diffhunk://#diff-a268399d6e0736bdcadc9999cccdb1cbea5e498320ea170ce7cfe7fe2f6cdd0fL35-R50) [[2]](diffhunk://#diff-a268399d6e0736bdcadc9999cccdb1cbea5e498320ea170ce7cfe7fe2f6cdd0fL57-R83)
* Added `TryGetProjectFilePath` and `TryGetSolutionFilePath` methods in `SolutionAndProjectUtility` to handle directories and resolve ambiguities when multiple project files are present. [[1]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0R91-R185) [[2]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L60-R65)

**Validation improvements:**

* Updated validation logic to handle directories passed to `--project`/`--solution` and provide more accurate error messages. [[1]](diffhunk://#diff-0ed19be2eb72ec0ffdb1e53ed06b83d8d9cc72827cb6a957292c9caaa86f4326L63-R65) [[2]](diffhunk://#diff-0ed19be2eb72ec0ffdb1e53ed06b83d8d9cc72827cb6a957292c9caaa86f4326L108-R145)
* Removed validation and references for the deprecated `--directory` option. [[1]](diffhunk://#diff-0ed19be2eb72ec0ffdb1e53ed06b83d8d9cc72827cb6a957292c9caaa86f4326L26-L28) [[2]](diffhunk://#diff-05ea5ed00051f6828498b8723feeff80803a2488831aebc1e6c6863355923e73L90)

**General code cleanup:**

* Removed unused `using` statements and simplified some type references for clarity and consistency. [[1]](diffhunk://#diff-bdc1edb8c94f27ba7f210739dc62c931c4e1779a637cf41968591181c879fcd0L4) [[2]](diffhunk://#diff-f8dabf4b4ff22652cc4b9725ac6613754aad84ed77783ef1852fb85e189d1037L9-R13) [[3]](diffhunk://#diff-d791453b9e99984688fe9c182a38dec434b04e028f51b9220a0bffd262226d4aL7) [[4]](diffhunk://#diff-7c7370f29da8cda13770d91a4a81dab25cd605427d361859464c6ae12a21de94L5)


Fixes https://github.com/dotnet/sdk/issues/50325