### PR TITLE
Add globalJson property for global.json state to toplevelparser/command event

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -230,7 +230,18 @@ public class Program
         }
         PerformanceLogEventSource.Log.TelemetrySaveIfEnabledStart();
         performanceData.Add("Startup Time", startupTime.TotalMilliseconds);
-        TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, performanceData));
+
+        string globalJsonState = string.Empty;
+        if (TelemetryClient.Enabled)
+        {
+            // Get the global.json state to report in telemetry along with this command invocation.
+            // We don't care about the actual SDK resolution, just the global.json information,
+            // so just pass empty string as executable directory for resolution.
+            NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory);
+            globalJsonState = result.GlobalJsonState;
+        }
+
+        TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, performanceData, globalJsonState));
         PerformanceLogEventSource.Log.TelemetrySaveIfEnabledStop();
 
         int exitCode;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -80,6 +80,7 @@ namespace Microsoft.DotNet.NativeWrapper
             resolved_sdk_dir = 0,
             global_json_path = 1,
             requested_version = 2,
+            global_json_state = 3,
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
@@ -21,6 +21,11 @@ namespace Microsoft.DotNet.NativeWrapper
         public string? RequestedVersion;
 
         /// <summary>
+        /// Result of the global.json search
+        /// </summary>
+        public string? GlobalJsonState;
+
+        /// <summary>
         /// True if a global.json was found but there was no compatible SDK, so it was ignored. 
         /// </summary>
         public bool FailedToResolveSDKSpecifiedInGlobalJson;
@@ -37,6 +42,9 @@ namespace Microsoft.DotNet.NativeWrapper
                     break;
                 case Interop.hostfxr_resolve_sdk2_result_key_t.requested_version:
                     RequestedVersion = value;
+                    break;
+                case Interop.hostfxr_resolve_sdk2_result_key_t.global_json_state:
+                    GlobalJsonState = value;
                     break;
             }
         }

--- a/test/dotnet.Tests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryFilterTest.cs
@@ -51,6 +51,20 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
+        public void TopLevelCommandNameShouldBeSentToTelemetryWithGlobalJsonState()
+        {
+            string globalJsonState = "invalid_data";
+            var parseResult = Parser.Parse(["build"]);
+            TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, new Dictionary<string, double>(), globalJsonState));
+            _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                  e.Properties.ContainsKey("verb") &&
+                  e.Properties["verb"] == Sha256Hasher.Hash("BUILD") &&
+                  e.Measurement == null &&
+                  e.Properties.ContainsKey("globalJson") &&
+                  e.Properties["globalJson"] == Sha256Hasher.HashWithNormalizedCasing(globalJsonState));
+        }
+
+        [Fact]
         public void TopLevelCommandNameShouldBeSentToTelemetryWithZeroPerformanceData()
         {
             var parseResult = Parser.Parse(["build"]);


### PR DESCRIPTION
Including the state of `global.json` in telemetry events for SDK commands.
- Update `hostfxr` bindings for `hostfxr_resolve_sdk2` for global.json state added in https://github.com/dotnet/runtime/pull/118418
- Determine global.json state before emitting telemetry event for SDK command invocation - call into `hostfxr` to determine global.json state per https://github.com/dotnet/sdk/issues/50058#issuecomment-3156050377
- Include global.json state as a `globalJson` property in `toplevelparser/command` event

Resolves https://github.com/dotnet/sdk/issues/50058

cc @dotnet/appmodel @AaronRobinsonMSFT @richlander 