### PR TITLE
Update copilot-setup-steps.yml for MCP servers

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,3 +31,18 @@ jobs:
       - name: Check dotnet version
         run: |
           dotnet --version
+
+      # For MCP servers like nuget's
+      - name: Install .NET 10.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.x
+          dotnet-quality: preview
+
+      # for MCP servers
+      - name: Install .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x          

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,4 +45,4 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.x          
+            8.x


### PR DESCRIPTION
This is necessary for the NuGet MCP server to run when Copilot is creating PR's. It only adds a few seconds to set up and does not affect the local dotnet used by the repo.