### PR TITLE
[release/10.0.1xx] Update ProcessFrameworkReferences and ResolveAppHosts to not look for runtime-specific assets for the any RID

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -112,7 +112,7 @@ namespace Microsoft.NET.Build.Tasks
                 runtimeIdentifier,
                 string.IsNullOrWhiteSpace(platformLibraryName));
 
-            _isPortable = _isFrameworkDependent && string.IsNullOrEmpty(_runtimeIdentifier);
+            _isPortable = _isFrameworkDependent && (string.IsNullOrEmpty(_runtimeIdentifier) || _runtimeIdentifier == "any");
 
             if (_isFrameworkDependent != true || _isPortable != true)
             {
@@ -317,7 +317,7 @@ namespace Microsoft.NET.Build.Tasks
              * 1. If runtimeAssemblyGroups, nativeLibraryGroups, dependencies, and resourceAssemblies are all empty, remove this runtimeLibrary as well as any dependencies on it.
              * 2. Add all runtimeLibraries to a list of to-be-processed libraries called libraryCandidatesForRemoval
              * 3. libraryCandidatesForRemoval.Pop() --> if there are no runtimeAssemblyGroups, nativeLibraryGroups, or resourceAssemblies, and either dependencies is empty or all
-             *      dependencies have something else that depends on them, remove it (and from libraryCandidatesForRemoval), adding everything that depends on this to 
+             *      dependencies have something else that depends on them, remove it (and from libraryCandidatesForRemoval), adding everything that depends on this to
              *      libraryCandidatesForRemoval if it isn't already there
              * Repeat 3 until libraryCandidatesForRemoval is empty
              */
@@ -483,8 +483,8 @@ namespace Microsoft.NET.Build.Tasks
                 runtimeSignature: string.Empty,
                 _isPortable);
 
-            // Compute the runtime fallback graph 
-            // 
+            // Compute the runtime fallback graph
+            //
             // If the input RuntimeGraph is empty, or we're not compiling
             // for a specific RID, then an runtime fallback graph is empty
             //

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -31,6 +31,11 @@ namespace Microsoft.NET.Build.Tasks
 
         public string RuntimeIdentifier { get; set; }
 
+        /// <summary>
+        /// Strips the RID if it's any, because that's not reasonable
+        /// </summary>
+        private string EffectiveRuntimeIdentifier => string.IsNullOrEmpty(RuntimeIdentifier) ? null : RuntimeIdentifier == "any" ? null : RuntimeIdentifier;
+
         public string PlatformLibraryName { get; set; }
 
         public ITaskItem[] RuntimeFrameworks { get; set; }
@@ -95,7 +100,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool IncludeProjectsNotInAssetsFile { get; set; }
 
-        // List of runtime identifer (platform part only) to validate for runtime assets
+        // List of runtime identifier (platform part only) to validate for runtime assets
         // If set, the task will warn on any RIDs that aren't in the list
         public string[] ValidRuntimeIdentifierPlatformsForAssets { get; set; }
 
@@ -137,7 +142,7 @@ namespace Microsoft.NET.Build.Tasks
                 LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
                 projectContext = lockFile.CreateProjectContext(
                     TargetFramework,
-                    RuntimeIdentifier,
+                    EffectiveRuntimeIdentifier,
                     PlatformLibraryName,
                     RuntimeFrameworks,
                     IsSelfContained);
@@ -226,7 +231,7 @@ namespace Microsoft.NET.Build.Tasks
                     RuntimeFrameworks,
                     isSelfContained: IsSelfContained,
                     platformLibraryName: PlatformLibraryName,
-                    runtimeIdentifier: RuntimeIdentifier,
+                    runtimeIdentifier: EffectiveRuntimeIdentifier,
                     targetFramework: TargetFramework);
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.NET.Build.Tasks
         public static bool IsFrameworkDependent(ITaskItem[] runtimeFrameworks, bool isSelfContained, string runtimeIdentifier, bool hasPlatformLibrary)
         {
             return (hasPlatformLibrary || runtimeFrameworks?.Any() == true) &&
-                (!isSelfContained || string.IsNullOrEmpty(runtimeIdentifier));
+                (!isSelfContained || (string.IsNullOrEmpty(runtimeIdentifier) || runtimeIdentifier == "any"));
         }
 
         public static LockFileTargetLibrary GetLibrary(this LockFileTarget lockFileTarget, string libraryName)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -335,6 +335,7 @@ namespace Microsoft.NET.Build.Tasks
                 var runtimeRequiredByDeployment
                     = (SelfContained || ReadyToRunEnabled) &&
                       !string.IsNullOrEmpty(RuntimeIdentifier) &&
+                      RuntimeIdentifier != "any" &&
                       selectedRuntimePack != null &&
                       !string.IsNullOrEmpty(selectedRuntimePack.Value.RuntimePackNamePatterns);
 
@@ -369,6 +370,13 @@ namespace Microsoft.NET.Build.Tasks
                         if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == RuntimeIdentifier)
                         {
                             //  We've already processed this RID
+                            continue;
+                        }
+
+                        if (runtimeIdentifier == "any")
+                        {
+                            // The `any` RID represents a platform-agnostic target. As such, it has no
+                            // platform-specific runtime pack associated with it.
                             continue;
                         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveAppHosts.cs
@@ -188,6 +188,13 @@ namespace Microsoft.NET.Build.Tasks
             {
                 foreach (var otherRuntimeIdentifier in OtherRuntimeIdentifiers)
                 {
+                    // The 'any' RID represents a platform-agnostic platform. As such, it has no
+                    // apphost pack associated with it.
+                    if (otherRuntimeIdentifier == "any")
+                    {
+                        continue;
+                    }
+
                     //  Download any apphost packages for other runtime identifiers.
                     //  This allows you to specify the list of RIDs in RuntimeIdentifiers and only restore once,
                     //  and then build for each RuntimeIdentifier without restoring separately.

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -28,12 +28,28 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             public string ToolPackageVersion { get; set; } = "1.0.0";
             public string ToolCommandName { get; set; } = "TestTool";
             public string[]? AdditionalPackageTypes { get; set; } = null;
-
             public bool NativeAOT { get; set { field = value; this.RidSpecific = value; } } = false;
             public bool SelfContained { get; set { field = value; this.RidSpecific = value; } } = false;
             public bool Trimmed { get; set { field = value; this.RidSpecific = value; } } = false;
+
+            /// <summary>
+            /// If set, the generated tool will include the <c>any</c> RID in the list of RIDs to target.
+            /// This will cause a framework-dependent, platform-agnostic package to be created.
+            /// </summary>
             public bool IncludeAnyRid { get; set { field = value; } } = false;
+
+            /// <summary>
+            /// If set, the generated tool will target all of the RIDs specified in <see cref="ToolsetInfo.LatestRuntimeIdentifiers"/>.
+            /// Defaults to <see langword="false"/>.
+            /// </summary>
             public bool RidSpecific { get; set; } = false;
+
+            /// <summary>
+            /// If set, the generated tool will include the current executing platform's RID in the list of RIDs to target
+            /// (which is otherwise made of <see cref="ToolsetInfo.LatestRuntimeIdentifiers"/>.) If set to <see langword="false"/>,
+            /// the current RID will be stripped from that set.
+            /// Defaults to <see langword="true"/>.
+            /// </summary>
             public bool IncludeCurrentRid { get; set; } = true;
 
             public string GetIdentifier() {


### PR DESCRIPTION
This manually backports https://github.com/dotnet/sdk/pull/50421 because the action didn't work for whatever reason. We want this for RC2 so that users using the `any` RID for a platform-agnostic fallback tool while also using the RID-specific tools are able to use self-contained versions of those RID-specific tools.