### PR TITLE
Disable the test leg in CI build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -21,7 +21,7 @@ parameters:
 - name: runTestBuild
   displayName: Run A Test Build
   type: boolean
-  default: true
+  default: false
 - name: enableArm64Job
   displayName: Enables the ARM64 job
   type: boolean


### PR DESCRIPTION
OneLocBuild requires the full build to be successful. Currently, we don't really monitor CI test results so this shouldn't be on by default as it's just burning resources and making one loc build less likely to succeed.