### PR TITLE
Update analyzer redirecting VS extension

### DIFF
--- a/documentation/general/analyzer-redirecting.md
+++ b/documentation/general/analyzer-redirecting.md
@@ -79,11 +79,6 @@ where `metadata.json` has `"SDKAnalyzers": "9.0.100-dev"`, because
 Analyzers that cannot be matched will continue to be loaded from the SDK
 (and will fail to load if they reference Roslyn that is newer than is in VS).
 
-### NGEN
-
-Note that these analyzers will have NGEN enabled for them when inserted to VS, which needs all the folders containing DLLs hard-coded in probing paths configuration file.
-That is also why the versions are part of a separate metadata file instead of the directory layout.
-
 ### Implementation
 
 Analyzer DLLs are contained in transport package `VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers`.

--- a/documentation/general/analyzer-redirecting.md
+++ b/documentation/general/analyzer-redirecting.md
@@ -29,6 +29,7 @@ Targeting an SDK (and hence also loading analyzers) with newer major version in 
 - Note that when `IAnalyzerAssemblyRedirector` is involved, Roslyn is free to not use shadow copy loading and instead load the DLLs directly.
 
 - It is possible to opt out of analyzer redirecting by setting environment variable `DOTNET_ANALYZER_REDIRECTING=0`.
+  That is an unsupported scenario though and compiler version mismatch errors will likely occur.
 
 ## Details
 

--- a/documentation/general/analyzer-redirecting.md
+++ b/documentation/general/analyzer-redirecting.md
@@ -28,6 +28,8 @@ Targeting an SDK (and hence also loading analyzers) with newer major version in 
 
 - Note that when `IAnalyzerAssemblyRedirector` is involved, Roslyn is free to not use shadow copy loading and instead load the DLLs directly.
 
+- It is possible to opt out of analyzer redirecting by setting environment variable `DOTNET_ANALYZER_REDIRECTING=0`.
+
 ## Details
 
 The VSIX contains some analyzers, for example:

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
@@ -43,6 +43,21 @@
           DestinationFiles="@(RuntimeAnalyzersContent->'$(OutputPath)\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')"
           UseHardlinksIfPossible="true" />
 
+    <!-- Replace Experimental=true with SystemComponent=true in the VS extension manifest. -->
+    <PropertyGroup>
+      <_VsixNamespace>
+        <Namespace Prefix="pm" Uri="http://schemas.microsoft.com/developer/vsx-schema/2011" />
+      </_VsixNamespace>
+    </PropertyGroup>
+    <XmlPoke XmlInputPath="$(OutputPath)\AnalyzerRedirecting\extension.vsixmanifest"
+             Namespaces="$(_VsixNamespace)"
+             Query="/pm:PackageManifest/pm:Installation/@Experimental"
+             Value="false" />
+    <XmlPoke XmlInputPath="$(OutputPath)\AnalyzerRedirecting\extension.vsixmanifest"
+             Namespaces="$(_VsixNamespace)"
+             Query="/pm:PackageManifest/pm:Installation/@SystemComponent"
+             Value="true" />
+
     <GenerateRuntimeAnalyzersSWR RuntimeAnalyzersLayoutDirectory="$(OutputPath)"
                                  OutputFile="$(SdkRuntimeAnalyzersSwrFile)" />
 

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -21,6 +21,7 @@
   <Target Name="GenerateLayout" Condition="'$(IsPackable)' == 'true'" DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
       <SdkRuntimeAnalyzersSwrFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.swr</SdkRuntimeAnalyzersSwrFile>
+      <SdkRuntimeAnalyzersMetadataFile>$(OutputPath)\metadata.json</SdkRuntimeAnalyzersMetadataFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -35,12 +36,26 @@
     <Error Condition="'@(RedistRuntimeAnalyzersContent)' == ''" Text="The 'RedistRuntimeAnalyzersContent' items are empty. This shouldn't happen!" />
     <Error Condition="'@(RedirectingRuntimeAnalyzersContent)' == ''" Text="The 'RedirectingRuntimeAnalyzersContent' items are empty. This shouldn't happen!" />
 
+    <!-- The custom task cannot access %(RecursiveDir) without this. -->
     <ItemGroup>
-      <RuntimeAnalyzersContent Include="@(RedistRuntimeAnalyzersContent);@(RedirectingRuntimeAnalyzersContent)" />
+      <RedistRuntimeAnalyzersContent Update="@(RedistRuntimeAnalyzersContent)">
+        <CustomRecursiveDir>%(RecursiveDir)</CustomRecursiveDir>      
+      </RedistRuntimeAnalyzersContent>
+      <RedirectingRuntimeAnalyzersContent Update="@(RedirectingRuntimeAnalyzersContent)">
+        <CustomRecursiveDir>%(RecursiveDir)</CustomRecursiveDir>
+      </RedirectingRuntimeAnalyzersContent>
+    </ItemGroup>
+
+    <ProcessRuntimeAnalyzerVersions Inputs="@(RedistRuntimeAnalyzersContent)" MetadataFilePath="$(SdkRuntimeAnalyzersMetadataFile)">
+      <Output TaskParameter="Outputs" ItemName="ProcessedRedistRuntimeAnalyzersContent" />
+    </ProcessRuntimeAnalyzerVersions>
+
+    <ItemGroup>
+      <RuntimeAnalyzersContent Include="@(ProcessedRedistRuntimeAnalyzersContent);@(RedirectingRuntimeAnalyzersContent)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(RuntimeAnalyzersContent)"
-          DestinationFiles="@(RuntimeAnalyzersContent->'$(OutputPath)\%(DeploymentSubpath)\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(RuntimeAnalyzersContent->'$(OutputPath)\%(DeploymentSubpath)\%(CustomRecursiveDir)%(Filename)%(Extension)')"
           UseHardlinksIfPossible="true" />
 
     <!-- Replace Experimental=true with SystemComponent=true in the VS extension manifest. -->
@@ -64,7 +79,8 @@
     <ItemGroup>
       <!-- Include the swr file in the nuget package for VS authoring -->
       <Content Include="$(SdkRuntimeAnalyzersSwrFile)" PackagePath="/" />
-      <Content Include="@(RuntimeAnalyzersContent)" PackagePath="/%(RuntimeAnalyzersContent.DeploymentSubpath)/%(RecursiveDir)%(Filename)%(Extension)" />
+      <Content Include="$(SdkRuntimeAnalyzersMetadataFile)" PackagePath="/" />
+      <Content Include="@(RuntimeAnalyzersContent)" PackagePath="/%(RuntimeAnalyzersContent.DeploymentSubpath)/%(RuntimeAnalyzersContent.CustomRecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/Microsoft.Net.Sdk.AnalyzerRedirecting.csproj
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/Microsoft.Net.Sdk.AnalyzerRedirecting.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" VersionOverride="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/SdkAnalyzerAssemblyRedirector.cs
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/SdkAnalyzerAssemblyRedirector.cs
@@ -13,6 +13,9 @@ using AnalyzerInfo = (string FullPath, string ProductVersion, string PathSuffix)
 
 namespace Microsoft.Net.Sdk.AnalyzerRedirecting;
 
+/// <summary>
+/// See <c>documentation/general/analyzer-redirecting.md</c>.
+/// </summary>
 [Export(typeof(IAnalyzerAssemblyRedirector))]
 public sealed class SdkAnalyzerAssemblyRedirector : IAnalyzerAssemblyRedirector
 {
@@ -39,10 +42,10 @@ public sealed class SdkAnalyzerAssemblyRedirector : IAnalyzerAssemblyRedirector
         var builder = ImmutableDictionary.CreateBuilder<string, List<AnalyzerInfo>>(StringComparer.OrdinalIgnoreCase);
 
         // Expects layout like:
-        // VsInstallDir\SDK\RuntimeAnalyzers\WindowsDesktopAnalyzers\8.0.8\analyzers\dotnet\System.Windows.Forms.Analyzers.dll
-        //                                   ~~~~~~~~~~~~~~~~~~~~~~~                                                           = topLevelDirectory
-        //                                                           ~~~~~                                                     = versionDirectory
-        //                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ = analyzerPath
+        // VsInstallDir\DotNetRuntimeAnalyzers\WindowsDesktopAnalyzers\8.0.8\analyzers\dotnet\System.Windows.Forms.Analyzers.dll
+        //                                     ~~~~~~~~~~~~~~~~~~~~~~~                                                           = topLevelDirectory
+        //                                                             ~~~~~                                                     = versionDirectory
+        //                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ = analyzerPath
 
         foreach (string topLevelDirectory in Directory.EnumerateDirectories(_insertedAnalyzersDirectory))
         {

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/SdkAnalyzerAssemblyRedirector.cs
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/SdkAnalyzerAssemblyRedirector.cs
@@ -35,7 +35,7 @@ public sealed class SdkAnalyzerAssemblyRedirector : IAnalyzerAssemblyRedirector
 
     [ImportingConstructor]
     public SdkAnalyzerAssemblyRedirector(SVsServiceProvider serviceProvider) : this(
-        Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\DotNetRuntimeAnalyzers")),
+        Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"CommonExtensions\Microsoft\DotNet")),
         serviceProvider.GetService<SVsActivityLog, IVsActivityLog>())
     {
     }

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/source.extension.vsixmanifest
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
-  <Installation Experimental="true">
+  <Installation Experimental="true" SystemComponent="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>

--- a/src/Microsoft.Net.Sdk.AnalyzerRedirecting/source.extension.vsixmanifest
+++ b/src/Microsoft.Net.Sdk.AnalyzerRedirecting/source.extension.vsixmanifest
@@ -13,10 +13,10 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,19.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Installation Experimental="true" SystemComponent="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,19.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
   </Installation>

--- a/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Cli.Build
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false, IEnumerable<string> filesToInclude = null)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = true, IEnumerable<string> filesToInclude = null)
         {
             string sourceFolder = Path.Combine(RuntimeAnalyzersLayoutDirectory, relativeSourcePath);
 

--- a/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Build
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = true, IEnumerable<string> filesToInclude = null)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false, IEnumerable<string> filesToInclude = null)
         {
             string sourceFolder = Path.Combine(RuntimeAnalyzersLayoutDirectory, relativeSourcePath);
 

--- a/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -19,11 +19,19 @@ namespace Microsoft.DotNet.Cli.Build
 
             // NOTE: Keep in sync with SdkAnalyzerAssemblyRedirector.
             // This is intentionally short to avoid long path problems.
-            const string installDir = @"DotNetRuntimeAnalyzers";
+            const string installDir = @"Common7\IDE\CommonExtensions\Microsoft\DotNet";
 
             AddFolder(sb,
-                      @"AnalyzerRedirecting",
-                      @"Common7\IDE\CommonExtensions\Microsoft\AnalyzerRedirecting",
+                      "",
+                      installDir,
+                      filesToInclude:
+                      [
+                          "metadata.json",
+                      ]);
+
+            AddFolder(sb,
+                      "AnalyzerRedirecting",
+                      @$"{installDir}\AnalyzerRedirecting",
                       filesToInclude:
                       [
                           "Microsoft.Net.Sdk.AnalyzerRedirecting.dll",
@@ -32,23 +40,23 @@ namespace Microsoft.DotNet.Cli.Build
                       ]);
 
             AddFolder(sb,
-                      @"AspNetCoreAnalyzers",
+                      "AspNetCoreAnalyzers",
                       @$"{installDir}\AspNetCoreAnalyzers");
 
             AddFolder(sb,
-                      @"NetCoreAnalyzers",
+                      "NetCoreAnalyzers",
                       @$"{installDir}\NetCoreAnalyzers");
 
             AddFolder(sb,
-                      @"WindowsDesktopAnalyzers",
+                      "WindowsDesktopAnalyzers",
                       @$"{installDir}\WindowsDesktopAnalyzers");
 
             AddFolder(sb,
-                      @"SDKAnalyzers",
+                      "SDKAnalyzers",
                       @$"{installDir}\SDKAnalyzers");
 
             AddFolder(sb,
-                      @"WebSDKAnalyzers",
+                      "WebSDKAnalyzers",
                       @$"{installDir}\WebSDKAnalyzers");
 
             File.WriteAllText(OutputFile, sb.ToString());

--- a/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
+++ b/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.DotNet.Build.Tasks;
+
+/// <summary>
+/// Extracts version numbers and saves them into a metadata file.
+/// </summary>
+public sealed class ProcessRuntimeAnalyzerVersions : Task
+{
+    [Required]
+    public ITaskItem[]? Inputs { get; set; }
+
+    [Required]
+    public string? MetadataFilePath { get; set; }
+
+    [Output]
+    public ITaskItem[]? Outputs { get; set; }
+
+    public override bool Execute()
+    {
+        var metadata = new Dictionary<string, string>();
+
+        // Extract version from a path like:
+        //   ...\packs\Microsoft.NetCore.App.Ref\<version>\analyzers\**\*.*
+        // The version segment is always the first segment in %(RecursiveDir).
+        foreach (var input in Inputs ?? [])
+        {
+            var deploymentSubpath = input.GetMetadata("DeploymentSubpath");
+            var recursiveDir = input.GetMetadata("CustomRecursiveDir");
+
+            var slashIndex = recursiveDir.IndexOfAny('/', '\\');
+            var version = recursiveDir.Substring(0, slashIndex);
+            var rest = recursiveDir.Substring(slashIndex + 1);
+
+            input.SetMetadata("CustomRecursiveDir", rest);
+
+            if (!metadata.TryGetValue(deploymentSubpath, out var existingVersion))
+            {
+                metadata.Add(deploymentSubpath, version);
+            }
+            else if (existingVersion != version)
+            {
+                Log.LogError($"Version mismatch for '{deploymentSubpath}': '{existingVersion}' != '{version}'. " +
+                    $"Expected only one version of '{input.GetMetadata("Identity")}'.");
+                return false;
+            }
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(MetadataFilePath)!);
+        File.WriteAllText(path: MetadataFilePath!, JsonSerializer.Serialize(metadata));
+
+        Outputs = Inputs;
+        return true;
+    }
+}

--- a/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
+++ b/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
@@ -28,6 +28,7 @@
   <UsingTask TaskName="GetRuntimePackRids" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="GetWorkloadSetFeatureBand" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="OverrideAndCreateBundledNETCoreAppPackageVersion" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="ProcessRuntimeAnalyzerVersions" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="RemoveAssetFromDepsPackages" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="ReplaceFilesWithSymbolicLinks" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" />

--- a/test/Microsoft.Net.Sdk.AnalyzerRedirecting.Tests/SdkAnalyzerAssemblyRedirectorTests.cs
+++ b/test/Microsoft.Net.Sdk.AnalyzerRedirecting.Tests/SdkAnalyzerAssemblyRedirectorTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+
 namespace Microsoft.Net.Sdk.AnalyzerRedirecting.Tests;
 
 public class SdkAnalyzerAssemblyRedirectorTests(ITestOutputHelper log) : SdkTest(log)
@@ -16,7 +18,8 @@ public class SdkAnalyzerAssemblyRedirectorTests(ITestOutputHelper log) : SdkTest
         TestDirectory testDir = _testAssetsManager.CreateTestDirectory(identifier: "RuntimeAnalyzers");
 
         var vsDir = Path.Combine(testDir.Path, "vs");
-        var vsAnalyzerPath = FakeDll(vsDir, @$"AspNetCoreAnalyzers\{a}\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
+        Metadata(vsDir, new() { { "AspNetCoreAnalyzers", a } });
+        var vsAnalyzerPath = FakeDll(vsDir, @$"AspNetCoreAnalyzers\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
         var sdkAnalyzerPath = FakeDll(testDir.Path, @$"sdk\packs\Microsoft.AspNetCore.App.Ref\{b}\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
 
         var resolver = new SdkAnalyzerAssemblyRedirector(vsDir);
@@ -30,7 +33,8 @@ public class SdkAnalyzerAssemblyRedirectorTests(ITestOutputHelper log) : SdkTest
         TestDirectory testDir = _testAssetsManager.CreateTestDirectory(identifier: "RuntimeAnalyzers");
 
         var vsDir = Path.Combine(testDir.Path, "vs");
-        FakeDll(vsDir, @"AspNetCoreAnalyzers\9.0.0-preview.5.24306.11\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
+        Metadata(vsDir, new() { { "AspNetCoreAnalyzers", "9.0.0-preview.5.24306.11" } });
+        FakeDll(vsDir, @"AspNetCoreAnalyzers\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
         var sdkAnalyzerPath = FakeDll(testDir.Path, @"sdk\packs\Microsoft.AspNetCore.App.Ref\9.0.0-preview.7.24406.2\analyzers\dotnet\vb", "Microsoft.AspNetCore.App.Analyzers");
 
         var resolver = new SdkAnalyzerAssemblyRedirector(vsDir);
@@ -50,7 +54,8 @@ public class SdkAnalyzerAssemblyRedirectorTests(ITestOutputHelper log) : SdkTest
         TestDirectory testDir = _testAssetsManager.CreateTestDirectory(identifier: "RuntimeAnalyzers");
 
         var vsDir = Path.Combine(testDir.Path, "vs");
-        FakeDll(vsDir, @$"AspNetCoreAnalyzers\{a}\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
+        Metadata(vsDir, new() { { "AspNetCoreAnalyzers", a } });
+        FakeDll(vsDir, @$"AspNetCoreAnalyzers\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
         var sdkAnalyzerPath = FakeDll(testDir.Path, @$"sdk\packs\Microsoft.AspNetCore.App.Ref\{b}\analyzers\dotnet\cs", "Microsoft.AspNetCore.App.Analyzers");
 
         var resolver = new SdkAnalyzerAssemblyRedirector(vsDir);
@@ -64,5 +69,12 @@ public class SdkAnalyzerAssemblyRedirectorTests(ITestOutputHelper log) : SdkTest
         Directory.CreateDirectory(Path.GetDirectoryName(dllPath));
         File.WriteAllText(dllPath, "");
         return dllPath;
+    }
+
+    private static void Metadata(string root, Dictionary<string, string> versions)
+    {
+        var metadataFilePath = Path.Combine(root, "metadata.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(metadataFilePath));
+        File.WriteAllText(metadataFilePath, JsonSerializer.Serialize(versions));
     }
 }


### PR DESCRIPTION
Follow up on https://github.com/dotnet/sdk/pull/42861.

- Added opt out env var.
- Set SystemComponent=true so the extension doesn't show up in the list of installed VS extensions.
- Added logging.
- Moved the deployed analyzers under CommonExtensions and removed version numbers from the layout (this was in preparation for enabling NGEN which was determined to not be needed after all, but I still think the new layout is better).