### PR TITLE
Add Base Interface for Install

### DIFF
--- a/src/Installer/dnup/BootstrapperController.cs
+++ b/src/Installer/dnup/BootstrapperController.cs
@@ -10,11 +10,11 @@ using Spectre.Console;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;
 
-public class DotnetInstaller : IDotnetInstaller
+public class BootstrapperController : IBootstrapperController
 {
     private readonly IEnvironmentProvider _environmentProvider;
 
-    public DotnetInstaller(IEnvironmentProvider? environmentProvider = null)
+    public BootstrapperController(IEnvironmentProvider? environmentProvider = null)
     {
         _environmentProvider = environmentProvider ?? new EnvironmentProvider();
     }

--- a/src/Installer/dnup/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dnup/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -19,7 +19,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
     private readonly bool? _updateGlobalJson = result.GetValue(SdkInstallCommandParser.UpdateGlobalJsonOption);
     private readonly bool _interactive = result.GetValue(SdkInstallCommandParser.InteractiveOption);
 
-    private readonly IDotnetInstaller _dotnetInstaller = new EnvironmentVariableMockDotnetInstaller();
+    private readonly IBootstrapperController _dotnetInstaller = new EnvironmentVariableMockDotnetInstaller();
     private readonly IReleaseInfoProvider _releaseInfoProvider = new EnvironmentVariableMockReleaseInfoProvider();
 
     public override int Execute()
@@ -37,7 +37,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
         var globalJsonInfo = _dotnetInstaller.GetGlobalJsonInfo(Environment.CurrentDirectory);
 
         string? currentInstallPath;
-        InstallType defaultInstallState =  _dotnetInstaller.GetConfiguredInstallType(out currentInstallPath);
+        InstallType defaultInstallState = _dotnetInstaller.GetConfiguredInstallType(out currentInstallPath);
 
         string? resolvedInstallPath = null;
 
@@ -239,7 +239,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
         return 0;
     }
 
-    
+
 
     string? ResolveChannelFromGlobalJson(string globalJsonPath)
     {
@@ -253,7 +253,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
         return false;
     }
 
-    class EnvironmentVariableMockDotnetInstaller : IDotnetInstaller
+    class EnvironmentVariableMockDotnetInstaller : IBootstrapperController
     {
         public GlobalJsonInfo GetGlobalJsonInfo(string initialDirectory)
         {

--- a/src/Installer/dnup/DnupSharedManifest.cs
+++ b/src/Installer/dnup/DnupSharedManifest.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+internal class DnupSharedManifest : IDnupManifest
+{
+    public IEnumerable<DotnetInstall> GetInstalledVersions()
+    {
+        return [];
+    }
+
+    public void AddInstalledVersion(DotnetInstall version)
+    {
+    }
+
+    public void RemoveInstalledVersion(DotnetInstall version)
+    {
+    }
+}

--- a/src/Installer/dnup/IBootstrapperController.cs
+++ b/src/Installer/dnup/IBootstrapperController.cs
@@ -8,7 +8,7 @@ using Spectre.Console;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;
 
-public interface IDotnetInstaller
+public interface IBootstrapperController
 {
     GlobalJsonInfo GetGlobalJsonInfo(string initialDirectory);
 

--- a/src/Installer/dnup/IDnupManifest.cs
+++ b/src/Installer/dnup/IDnupManifest.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper
+{
+    internal interface IDnupManifest
+    {
+        IEnumerable<DotnetInstall> GetInstalledVersions();
+        void AddInstalledVersion(DotnetInstall version);
+        void RemoveInstalledVersion(DotnetInstall version);
+    }
+}

--- a/src/Installer/dnup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dnup/InstallerOrchestratorSingleton.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+internal class InstallerOrchestratorSingleton
+{
+    private static readonly InstallerOrchestratorSingleton _instance = new();
+
+    private InstallerOrchestratorSingleton()
+    {
+    }
+
+    public static InstallerOrchestratorSingleton Instance => _instance;
+
+    private ScopedMutex directoryToMutex(string directory) => new ScopedMutex("Global\\" + directory.GetHashCode());
+
+    private ScopedMutex finalizeLock() => new ScopedMutex("Global\\Finalize");
+
+    public void Install(DotnetInstallRequest installRequest)
+    {
+        // Map InstallRequest to DotnetInstallObject by converting channel to fully specified version
+
+        // Grab the mutex on the directory to operate on from installRequest
+        // Check if the install already exists, if so, return
+        // If not, release the mutex and begin the installer.prepare
+        // prepare will download the correct archive to a random user protected folder
+        // it will then verify the downloaded archive signature / hash.
+        //
+
+        // Once prepare is over, grab the finalize lock, then grab the directory lock
+        // Check once again if the install exists, if so, return.
+        // Run installer.finalize which will extract to the directory to install to.
+        // validate the install, then write to the dnup shared manifest
+        // Release
+
+        // Clean up the temp folder
+    }
+
+    // Add a doc string mentioning you must hold a mutex over the directory
+    private IEnumerable<DotnetInstall> GetExistingInstalls(string directory)
+    {
+        using (var lockScope = directoryToMutex(directory))
+        {
+            if (lockScope.HasHandle)
+            {
+                // TODO: Implement logic to get existing installs
+                return Enumerable.Empty<DotnetInstall>();
+            }
+            return Enumerable.Empty<DotnetInstall>();
+        }
+    }
+
+    private bool InstallAlreadyExists(string directory)
+    {
+        using (var lockScope = directoryToMutex(directory))
+        {
+            if (lockScope.HasHandle)
+            {
+                // TODO: Implement logic to check if install already exists
+                return false;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Installer/dnup/ScopedMutex.cs
+++ b/src/Installer/dnup/ScopedMutex.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+public class ScopedMutex : IDisposable
+{
+    private readonly Mutex _mutex;
+    private bool _hasHandle;
+
+    public ScopedMutex(string name)
+    {
+        _mutex = new Mutex(false, name);
+        _hasHandle = _mutex.WaitOne(TimeSpan.FromSeconds(10), false);
+    }
+
+    public bool HasHandle => _hasHandle;
+
+    public void Dispose()
+    {
+        if (_hasHandle)
+        {
+            _mutex.ReleaseMutex();
+        }
+        _mutex.Dispose();
+    }
+}


### PR DESCRIPTION
I renamed the DotnetInstaller in an aim to refactor the logic out some more. I think we could have the controller logic that talks to the CLI / UI layer be separate from the class that does the actual install logic to better follow the single responsibility principle and simplify the code into more pieces.