### PR TITLE
_MTPBuild should only build if MTP project

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
@@ -18,6 +18,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   <Import Condition="Exists('$(VSTestTargets)')" Project="$(VSTestTargets)" />
   <Target Name="_MTPBuild">
-    <CallTarget Targets="Build" />
+    <CallTarget Targets="Build" Condition="'$(IsTestingPlatformApplication)'=='true'" />
   </Target>
 </Project>

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/ClassLibrary/Class1.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/ClassLibrary/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace ClassLibrary
+{
+	public class Class1
+	{
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/ClassLibrary/ClassLibrary.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/ClassLibrary/ClassLibrary.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProject/Program.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProjectWithClassLibraryDifferentTFMs.sln
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/TestProjectWithClassLibraryDifferentTFMs.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.35712.36 main
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{4868FD55-C56D-445C-9F83-A063302EC78F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{729A12AB-4D79-4756-A776-C7BB63D30A4F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4868FD55-C56D-445C-9F83-A063302EC78F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4868FD55-C56D-445C-9F83-A063302EC78F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4868FD55-C56D-445C-9F83-A063302EC78F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4868FD55-C56D-445C-9F83-A063302EC78F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{729A12AB-4D79-4756-A776-C7BB63D30A4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{729A12AB-4D79-4756-A776-C7BB63D30A4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{729A12AB-4D79-4756-A776-C7BB63D30A4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{729A12AB-4D79-4756-A776-C7BB63D30A4F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E2F590CA-47E0-4145-924B-3E398540BA45}
+	EndGlobalSection
+EndGlobal

--- a/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/dotnet.config
+++ b/test/TestAssets/TestProjects/TestProjectWithClassLibraryDifferentTFMs/dotnet.config
@@ -1,0 +1,2 @@
+[dotnet.test.runner]
+name= "Microsoft.Testing.Platform"

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -345,17 +345,23 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
 
-        [InlineData(TestingConstants.Debug)]
-        [InlineData(TestingConstants.Release)]
         [Theory]
-        public void RunOnProjectWithClassLibrary_ShouldReturnExitCodeSuccess(string configuration)
+        [CombinatorialData]
+        public void RunOnProjectWithClassLibrary_ShouldReturnExitCodeSuccess(
+            [CombinatorialValues(TestingConstants.Debug, TestingConstants.Release)] string configuration,
+            [CombinatorialValues("TestProjectWithClassLibrary", "TestProjectWithClassLibraryDifferentTFMs")] string assetName,
+            bool useFrameworkOption)
         {
-            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectWithClassLibrary", Guid.NewGuid().ToString())
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset(assetName, Guid.NewGuid().ToString())
                 .WithSource();
+
+            string[] args = useFrameworkOption
+                ? new[] { TestingPlatformOptions.ConfigurationOption.Name, configuration, TestingPlatformOptions.FrameworkOption.Name, ToolsetInfo.CurrentTargetFramework }
+                : new[] { TestingPlatformOptions.ConfigurationOption.Name, configuration };
 
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
-                                    .Execute(TestingPlatformOptions.ConfigurationOption.Name, configuration);
+                                    .Execute(args);
 
             if (!TestContext.IsLocalized())
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/50307

FYI @dsplaisted @baronfel 

The scenario is:

- Solution with two projects
- First project is a test project targeting netX.0
- Second project is a class lib targeting any other different TFM (e.g, netstandard2.0), and it's **not** test project.
- First project references the second project.
- User does `dotnet test --framework netX.0`
    - Previous behavior, we will attempt to build the classlib with netX.0. But as netX.0 wasn't part of restore, this fails.
    - New behavior, we will attempt to only build the test projects. This is aligned with the existing behavior for VSTest, and is potentially a performance improvement for scenarios where a solution has some projects that are not present in the dependency graph of test projects, as we will not need to build such projects altogether.