### PR TITLE
Remove NETStandard.Library.Ref from Version.Details.xml/.props

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -136,8 +136,6 @@ This file should be imported by eng/Versions.props
     <SystemTextEncodingCodePagesPackageVersion>10.0.0-rc.2.25416.109</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextJsonPackageVersion>10.0.0-rc.2.25416.109</SystemTextJsonPackageVersion>
     <SystemWindowsExtensionsPackageVersion>10.0.0-rc.2.25416.109</SystemWindowsExtensionsPackageVersion>
-    <!-- dotnet/core-setup dependencies -->
-    <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
     <!-- microsoft/testfx dependencies -->
     <MicrosoftTestingPlatformPackageVersion>1.9.0-preview.25427.3</MicrosoftTestingPlatformPackageVersion>
     <MSTestPackageVersion>3.11.0-preview.25427.3</MSTestPackageVersion>
@@ -274,8 +272,6 @@ This file should be imported by eng/Versions.props
     <SystemTextEncodingCodePagesVersion>$(SystemTextEncodingCodePagesPackageVersion)</SystemTextEncodingCodePagesVersion>
     <SystemTextJsonVersion>$(SystemTextJsonPackageVersion)</SystemTextJsonVersion>
     <SystemWindowsExtensionsVersion>$(SystemWindowsExtensionsPackageVersion)</SystemWindowsExtensionsVersion>
-    <!-- dotnet/core-setup dependencies -->
-    <NETStandardLibraryRefVersion>$(NETStandardLibraryRefPackageVersion)</NETStandardLibraryRefVersion>
     <!-- microsoft/testfx dependencies -->
     <MicrosoftTestingPlatformVersion>$(MicrosoftTestingPlatformPackageVersion)</MicrosoftTestingPlatformVersion>
     <MSTestVersion>$(MSTestPackageVersion)</MSTestVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,12 +58,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e</Sha>
     </Dependency>
-    <!-- Change blob version in GenerateInstallerLayout.targets if this is unpinned to service targeting pack -->
-    <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Build" Version="17.15.0-preview-25416-109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>7f2a07b481a3d24677ebcf6a45e7e27c8ff95a4e</Sha>


### PR DESCRIPTION
This won't get updated anymore and we're already setting/overriding NETStandardLibraryRefPackageVersion in Versions.props