### PR TITLE
Update loc files for templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.cs.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metoda testovacího přípravku TestCleanup",
   "postActions/restoreNugetPackages/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Spustit dotnet restore",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otevře Test1.cs v editoru."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.de.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Fixierungsmethode \"TestCleanup\"",
   "postActions/restoreNugetPackages/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" ausführen",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Öffnet Test1.cs im Editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.en.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture method",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens Test1.cs in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.es.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de accesorio TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abrir Test1.cs en el editor."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.fr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Méthode de fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Exécutez « dotnet restore »",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Ouvre Test1.cs dans l’éditeur"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.it.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metodo fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Esegui 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Apre Test1.cs nell'editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ja.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup フィクスチャ メソッド",
   "postActions/restoreNugetPackages/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' を実行する",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "エディターで Test1.cs を開きます"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ko.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture 메서드",
   "postActions/restoreNugetPackages/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' 실행",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "편집기에서 Test1.cs 열기"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.pl.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup — metoda początkowa",
   "postActions/restoreNugetPackages/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Uruchom polecenie „dotnet restore”",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otwiera plik Test1.cs w edytorze"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de acessório TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaura os pacotes do NuGet exigidos por este projeto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Executa \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abre o Test1.cs no editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.ru.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Метод работы со средствами TestCleanup",
   "postActions/restoreNugetPackages/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Открывает Test1.cs редакторе"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.tr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup düzen yöntemi",
   "postActions/restoreNugetPackages/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" çalıştır",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Test1.cs'yi düzenleyicide açar"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固定例程方法",
   "postActions/restoreNugetPackages/description": "还原此项目所需的 NuGet 包。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "运行 \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在编辑器中打开 Test1.cs"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固件方法",
   "postActions/restoreNugetPackages/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "執行 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在編輯器中開啟 Test1.cs"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.cs.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metoda testovacího přípravku TestCleanup",
   "postActions/restoreNugetPackages/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Spustit dotnet restore",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otevře Test1.fs v editoru."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.de.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Fixierungsmethode \"TestCleanup\"",
   "postActions/restoreNugetPackages/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" ausführen",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Öffnet Test1.fs im Editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.en.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture method",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens Test1.fs in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.es.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de accesorio TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abrir Test1.fs en el editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.fr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Méthode de fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Exécutez « dotnet restore »",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Ouvre Test1.fs dans l’éditeur"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.it.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metodo fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Esegui 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Apre Test1.fs nell'editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ja.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup フィクスチャ メソッド",
   "postActions/restoreNugetPackages/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' を実行する",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "エディターで Test1.fs を開きます"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ko.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture 메서드",
   "postActions/restoreNugetPackages/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' 실행",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "편집기에서 Test1.fs 열기"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.pl.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup — metoda początkowa",
   "postActions/restoreNugetPackages/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Uruchom polecenie „dotnet restore”",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otwiera plik Test1.fs w edytorze"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de acessório TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaura os pacotes do NuGet exigidos por este projeto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Executa \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abre o Test1.fs no editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.ru.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Метод работы со средствами TestCleanup",
   "postActions/restoreNugetPackages/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Открывает Test1.fs в редакторе"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.tr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup düzen yöntemi",
   "postActions/restoreNugetPackages/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" çalıştır",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Test1.fs'yi düzenleyicide açar"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固定例程方法",
   "postActions/restoreNugetPackages/description": "还原此项目所需的 NuGet 包。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "运行 \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在编辑器中打开 Test1.fs"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固件方法",
   "postActions/restoreNugetPackages/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "執行 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在編輯器中開啟 Test1.fs"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metoda testovacího přípravku TestCleanup",
   "postActions/restoreNugetPackages/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Spustit dotnet restore",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otevře Test1.vb v editoru."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Fixierungsmethode \"TestCleanup\"",
   "postActions/restoreNugetPackages/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" ausführen",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Öffnet Test1.vb im Editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture method",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens Test1.vb in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de accesorio TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abrir Test1.vb en el editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Méthode de fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Exécutez « dotnet restore »",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Ouvre Test1.vb dans l’éditeur"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metodo fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Esegui 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Apre Test1.vb nell'editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup フィクスチャ メソッド",
   "postActions/restoreNugetPackages/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' を実行する",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "エディターで Test1.vb を開きます"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture 메서드",
   "postActions/restoreNugetPackages/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' 실행",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "편집기에서 Test1.vb 열기"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup — metoda początkowa",
   "postActions/restoreNugetPackages/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Uruchom polecenie „dotnet restore”",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otwiera plik Test1.vb w edytorze"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de acessório TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaura os pacotes do NuGet exigidos por este projeto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Executa \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abre o Test1.vb no editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Метод работы со средствами TestCleanup",
   "postActions/restoreNugetPackages/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Открывает Test1.vb в редакторе"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup düzen yöntemi",
   "postActions/restoreNugetPackages/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" çalıştır",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Test1.vb'yi düzenleyicide açar"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固定例程方法",
   "postActions/restoreNugetPackages/description": "还原此项目所需的 NuGet 包。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "运行 \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在编辑器中打开 Test1.vb"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -52,5 +52,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固件方法",
   "postActions/restoreNugetPackages/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "執行 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在編輯器中開啟 Test1.vb"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.cs.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metoda testovacího přípravku TestCleanup",
   "postActions/restoreNugetPackages/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Spustit dotnet restore",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otevře Test1.cs v editoru."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.de.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Fixierungsmethode \"TestCleanup\"",
   "postActions/restoreNugetPackages/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" ausführen",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Öffnet Test1.cs im Editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.en.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture method",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens Test1.cs in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.es.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de accesorio TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abrir Test1.cs en el editor."
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.fr.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Méthode de fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Exécutez « dotnet restore »",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Ouvre Test1.cs dans l’éditeur"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.it.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Metodo fixture TestCleanup",
   "postActions/restoreNugetPackages/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Esegui 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Apre Test1.cs nell'editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ja.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup フィクスチャ メソッド",
   "postActions/restoreNugetPackages/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' を実行する",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "エディターで Test1.cs を開きます"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ko.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup fixture 메서드",
   "postActions/restoreNugetPackages/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "'dotnet restore' 실행",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "편집기에서 Test1.cs 열기"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.pl.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup — metoda początkowa",
   "postActions/restoreNugetPackages/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Uruchom polecenie „dotnet restore”",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Otwiera plik Test1.cs w edytorze"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Método de acessório TestCleanup",
   "postActions/restoreNugetPackages/description": "Restaura os pacotes do NuGet exigidos por este projeto.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Executa \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Abre o Test1.cs no editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.ru.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "Метод работы со средствами TestCleanup",
   "postActions/restoreNugetPackages/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Открывает Test1.cs редакторе"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.tr.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup düzen yöntemi",
   "postActions/restoreNugetPackages/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "\"dotnet restore\" çalıştır",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Test1.cs'yi düzenleyicide açar"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固定例程方法",
   "postActions/restoreNugetPackages/description": "还原此项目所需的 NuGet 包。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "运行 \"dotnet restore\"",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在编辑器中打开 Test1.cs"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -57,5 +57,7 @@
   "symbols/Fixture/choices/TestCleanup/description": "TestCleanup 固件方法",
   "postActions/restoreNugetPackages/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "執行 'dotnet restore'",
+  "postActions/createOrUpdateDotnetConfig/description": "Create or update 'dotnet.config' file required by Microsoft.Testing.Platform.",
+  "postActions/createOrUpdateDotnetConfig/manualInstructions/default/text": "Manually create 'dotnet.config' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "在編輯器中開啟 Test1.cs"
 }


### PR DESCRIPTION
This pull request adds new localization entries to support a post-action for creating or updating the `dotnet.config` file, which is required by Microsoft.Testing.Platform, in both MSTest-CSharp and MSTest-FSharp project templates. The changes ensure that instructions for this post-action are available in all supported languages.

Localization updates for new post-action:

* Added `"postActions/createOrUpdateDotnetConfig/description"` and `"postActions/createOrUpdateDotnetConfig/manualInstructions/default/text"` entries to all MSTest-CSharp localization files (`templatestrings.cs.json`, `templatestrings.de.json`, `templatestrings.en.json`, `templatestrings.es.json`, `templatestrings.fr.json`, `templatestrings.it.json`, `templatestrings.ja.json`, `templatestrings.ko.json`, `templatestrings.pl.json`, `templatestrings.pt-BR.json`, `templatestrings.ru.json`, `templatestrings.tr.json`, `templatestrings.zh-Hans.json`, `templatestrings.zh-Hant.json`) to provide translated descriptions and manual instructions for creating or updating the `dotnet.config` file. [[1]](diffhunk://#diff-55e7f0b41f9e0b2e7b6c39ef55a6fe05302064f72cc1913903b464057a771201R55-R56) [[2]](diffhunk://#diff-585d231fa23dfb05d6acbe46e711015c86ade2d2aec2f3ee9110cf316a9f4177R55-R56) [[3]](diffhunk://#diff-007070cbc618adc3b6fb0f877ab836f1294137c2bb89305edea01cdd80eae8a8R55-R56) [[4]](diffhunk://#diff-44ba1c4961e235ca4e1d876de56f2c43abdb36a62c7b007575883a38a12cbd2eR55-R56) [[5]](diffhunk://#diff-73b1f12dabb2d23a5565773d4fca833e17b97dadb02651eb7a872b89e0bea201R55-R56) [[6]](diffhunk://#diff-e53f235b957897e045948b33699268e8e2585c3e1be28618113b18acc1f03323R55-R56) [[7]](diffhunk://#diff-c69a81fd5cfe43a3dc2f6c09a8241e30a552fecc7a6dca78168c45f1148d2378R55-R56) [[8]](diffhunk://#diff-3c2b8e46d19334793c78cb71489f914294e83a4eda634ebed4252bcff39b27cbR55-R56) [[9]](diffhunk://#diff-fdf6b86173f475ae397104952e87ed0a58a7258af9d04c44159a41ad00762a8eR55-R56) [[10]](diffhunk://#diff-e505cb116547cfe40ce4b1af3e66a62c1e4f7a4a86a63bd4651bcebd01cf589bR55-R56) [[11]](diffhunk://#diff-43dfae8f0db79e340ebe1e2c9e42cde71c3d1c30087b99fcec508ba9f0716c3dR55-R56) [[12]](diffhunk://#diff-b4c04463aca60442b8dc3c0638b7d8c366efeaa6d31a366cb758e4bd2ddef4d6R55-R56) [[13]](diffhunk://#diff-957438819dddce0e9676279930bbfee204905df4b7d5066ca67ea7e41565eaffR55-R56) [[14]](diffhunk://#diff-657eccdb8781eba5cf9b4ffd421864e3ddf19836800750d5967bf73f75f3e1afR55-R56)
* Added the same new entries to all MSTest-FSharp localization files (`templatestrings.cs.json`, `templatestrings.de.json`, `templatestrings.en.json`, `templatestrings.es.json`, `templatestrings.fr.json`, `templatestrings.it.json`) for consistency across both template types. [[1]](diffhunk://#diff-60b280e9b84a4e507d0b4a16db71e0aa15f30b1787bfe72ccabd26a71adbcaf6R55-R56) [[2]](diffhunk://#diff-6357e960d9907b747f2c32b065880db37df90fb12a2973df4140a6352b75d7bbR55-R56) [[3]](diffhunk://#diff-62dc338d0c19642f4b3d55eec8fcd0a2d0cf35fef627f489daafb79a033aaf53R55-R56) [[4]](diffhunk://#diff-e93990eb62f38fd09a575aafe6c5e298f3f67ddf176202cbc144294668b3a8b7R55-R56) [[5]](diffhunk://#diff-7e5136cd2f68f081716f2be51adde05692b9597442be8b44b1e4d2636ce21637R55-R56) [[6]](diffhunk://#diff-69678b6b130bbfb0e515d0d5eb5d00eda9e98762d4ad9988b193c124793a3319R55-R56)