### PR TITLE
Change MaxParallelTestModulesOption to int

### DIFF
--- a/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformCommand.cs
@@ -177,7 +177,8 @@ internal partial class TestingPlatformCommand : Command, ICustomHelp
 
     private static int GetDegreeOfParallelism(ParseResult parseResult)
     {
-        if (!int.TryParse(parseResult.GetValue(TestingPlatformOptions.MaxParallelTestModulesOption), out int degreeOfParallelism) || degreeOfParallelism <= 0)
+        var degreeOfParallelism = parseResult.GetValue(TestingPlatformOptions.MaxParallelTestModulesOption);
+        if (degreeOfParallelism <= 0)
             degreeOfParallelism = Environment.ProcessorCount;
         return degreeOfParallelism;
     }

--- a/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/TestingPlatformOptions.cs
@@ -56,7 +56,7 @@ internal static class TestingPlatformOptions
         Arity = ArgumentArity.ExactlyOne
     };
 
-    public static readonly Option<string> MaxParallelTestModulesOption = new("--max-parallel-test-modules")
+    public static readonly Option<int> MaxParallelTestModulesOption = new("--max-parallel-test-modules")
     {
         Description = CliCommandStrings.CmdMaxParallelTestModulesDescription,
         HelpName = CliCommandStrings.CmdNumberName


### PR DESCRIPTION
This pull request refactors the handling of the `--max-parallel-test-modules` command-line option to improve type safety and simplify parsing logic. The most important changes are grouped below:

Command-line option type update:
* Changed the type of `MaxParallelTestModulesOption` from `Option<string>` to `Option<int>` in `TestingPlatformOptions`, ensuring that the option value is parsed as an integer directly.

Parsing logic simplification:
* Updated the `GetDegreeOfParallelism` method in `TestingPlatformCommand.cs` to remove manual string-to-int parsing, leveraging the new integer type for `MaxParallelTestModulesOption`. This also makes the logic clearer and less error-prone.

Fixes https://github.com/dotnet/sdk/issues/50526