### PR TITLE
Set finalizer's detect condition

### DIFF
--- a/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
@@ -159,23 +159,22 @@
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
 
       <!--
-        The finalizer is not an installation package. It's detected based on the bundle's installation state (WixBundleInstalled).
-        
-        User action        | Install | Repair  | Modify  | Uninstall | Uninstall (Upgrade)
-        WixBundleInstalled | FALSE   | TRUE    | TRUE    | TRUE      | TRUE 
-        WixBundleAction    | 6       | 8       | 7       | 4         | 4
-        Finalizer (Plan)   | None    | Execute | Execute | Execute   | Execute
-        
-        Setting an InstallCondition will cause Burn to remove the package if it evaluates to FALSE and
-        the bundle is being installed, repaired, or modified. This breaks upgrades. We cannot use
-        WixBundleAction in the DetectCondition because it's not finalized until the planning phase completes (after
-        the detect phase). See https://github.com/orgs/wixtoolset/discussions/9017 for more detail.
-        
-        The finalizer also takes the bundle action as a parameter to ensure it no-ops, but logs the action. -->
+        The finalizer is not an installation package (ExePackage@Bundle="no"). For an install, the finalizer has no
+        effect, but must be detected as absent. When an install is cancelled, the engine re-eavaluates package state. If
+        a package is detected as present the resume mode is set to BURN_RESUME_MODE_ARP and causes the bundle registration
+        to remain. When the bundle is removed, it finalizer must be detected as installed to ensure it executes.
+
+        Setting the detect condition to WixBundleInstalled causes the finalzier state to track the bundle state. This causes
+        the finalizer to run during install, repair and uninstall actions. We can't use WixBundleAction in 
+        ExePackage@DetectCondition because it's value is only final after planning completes after the detect phase.
+        See https://github.com/orgs/wixtoolset/discussions/9017 for more detail.
+
+        Instead, we pass WixBundleAction to the finalizer as parameter when the package is applied. This allows the finalizer
+        to no-op during an install and repair, but clean up when the bundle is being remvoed. -->
       <ExePackage SourceFile="$(FinalizerExeSourceFile)"
                   Bundle="no"
                   Cache="keep"
-                  DetectCondition="1=1"
+                  DetectCondition="WixBundleInstalled"
                   Id="Finalizer"
                   InstallArguments="&quot;[WixBundleLog_Finalizer]&quot; $(Version) $(TargetArchitecture) [WixBundleAction]"
                   UninstallArguments="&quot;[WixBundleLog_Finalizer]&quot; $(Version) $(TargetArchitecture) [WixBundleAction]"


### PR DESCRIPTION
This fixes #50521 

## Manual Testing Results

### Install with cancellation

* The finalizer is detected as absent and planned for execution
* The bundle action is passed to the finalizer (WixBundleAction=6)
* When the install is cancelled, the finalizer state is detected as absent and resume mode is set to `None` allowing registration information to be removed.

```
[0EFC:1544][2025-08-29T13:15:37]i301: Applying execute package: Finalizer, action: Install, path: C:\ProgramData\Package Cache\28E37ED702324B1DB2F93D8DB75B05366577A396023929F824DA6F7CB6DF9A87\finalizer.exe, arguments: '"C:\ProgramData\Package Cache\28E37ED702324B1DB2F93D8DB75B05366577A396023929F824DA6F7CB6DF9A87\finalizer.exe" "C:\Users\WDAGUtilityAccount\AppData\Local\Temp\Microsoft_.NET_SDK_10.0.100-dev_(x64)_20250829131530_000_Finalizer.log" 10.0.100-dev x64 6'
[0CD0:0BAC][2025-08-29T13:15:31]i052: Condition 'WixBundleInstalled' evaluates to false.
[0CD0:0BAC][2025-08-29T13:15:31]i101: Detected package: Finalizer, state: Absent, cached: No, install registration state: Absent, cache registration state: Absent
[0CD0:0BAC][2025-08-29T13:15:44]i373: Calculating whether to keep registration
[0CD0:0BAC][2025-08-29T13:15:44]i374:   package: Finalizer, install registration state: Absent, cache registration state: Absent
[0EFC:1544][2025-08-29T13:15:44]i371: Updating session, registration key: SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4B732CB9-47E2-4799-8828-6102E114D0DC}, resume: None, restart initiated: No, disable resume: No
```

### Normal uninstall

* The finalizer is detected as present
* The bundle action is passed to the finalizer (WixBundleAction=4)

```
[097C:09D0][2025-08-29T13:17:44]i052: Condition 'WixBundleInstalled' evaluates to true.
[097C:09D0][2025-08-29T13:17:44]i101: Detected package: Finalizer, state: Present, cached: Yes, install registration state: Present, cache registration state: Present
[1C64:084C][2025-08-29T13:19:21]i301: Applying execute package: Finalizer, action: Uninstall, path: C:\ProgramData\Package Cache\28E37ED702324B1DB2F93D8DB75B05366577A396023929F824DA6F7CB6DF9A87\finalizer.exe, arguments: '"C:\ProgramData\Package Cache\28E37ED702324B1DB2F93D8DB75B05366577A396023929F824DA6F7CB6DF9A87\finalizer.exe" "C:\Users\WDAGUtilityAccount\AppData\Local\Temp\Microsoft_.NET_SDK_10.0.100-dev_(x64)_20250829131744_020_Finalizer.log" 10.0.100-dev x64 4'
```
