### PR TITLE
fix(#45761): Stop forwarding dotnet-watch run arguments to all commands

### DIFF
--- a/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
@@ -92,6 +92,11 @@ internal sealed class CommandLineOptions
         {
             rootCommand.Options.Add(watchOption);
         }
+        
+        rootCommand.Options.Add(longProjectOption);
+        rootCommand.Options.Add(shortProjectOption);
+        rootCommand.Options.Add(launchProfileOption);
+        rootCommand.Options.Add(noLaunchProfileOption);
 
         // We process all tokens that do not match any of the above options
         // to find the subcommand (the first unmatched token preceding "--")

--- a/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/CommandLineOptions.cs
@@ -92,7 +92,7 @@ internal sealed class CommandLineOptions
         {
             rootCommand.Options.Add(watchOption);
         }
-        
+
         rootCommand.Options.Add(longProjectOption);
         rootCommand.Options.Add(shortProjectOption);
         rootCommand.Options.Add(launchProfileOption);

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -117,18 +117,22 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
-        [CombinatorialData]
-        public void RunOptions_NotPassedThrough(
-            [CombinatorialValues("--launch-profile", "--no-launch-profile")] string option,
-            bool beforeCommand)
+        public void RunOptions_LaunchProfile_NotPassedThrough(bool beforeCommand)
         {
-            var options = VerifyOptions(beforeCommand ? [option, "test"] : ["test", option]);
+            var options = VerifyOptions(beforeCommand ? ["--launch-profile", "p", "test"] : ["test", "--launch-profile", "p"]);
             Assert.Equal("test", options.Command);
             AssertEx.SequenceEqual([], options.CommandArguments);
         }
 
         [Theory]
-        [CombinatorialData]
+        public void RunOptions_NoLaunchProfile_NotPassedThrough(bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? ["--no-launch-profile", "test"] : ["test", "--no-launch-profile"]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
         public void RunOption_Project_NotPassedThrough(bool beforeCommand)
         {
             var options = VerifyOptions(beforeCommand ? ["--project", "MyProject.csproj", "test"] : ["test", "--project", "MyProject.csproj"]);

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -118,6 +118,26 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         [Theory]
         [CombinatorialData]
+        public void RunOptions_NotPassedThrough(
+            [CombinatorialValues("--launch-profile", "--no-launch-profile")] string option,
+            bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? [option, "test"] : ["test", option]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RunOption_Project_NotPassedThrough(bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? ["--project", "MyProject.csproj", "test"] : ["test", "--project", "MyProject.csproj"]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
+        [CombinatorialData]
         public void WatchOptions_NotPassedThrough(
             [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
             bool beforeCommand)

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -117,6 +117,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
+        [CombinatorialData]
         public void RunOptions_LaunchProfile_NotPassedThrough(bool beforeCommand)
         {
             var options = VerifyOptions(beforeCommand ? ["--launch-profile", "p", "test"] : ["test", "--launch-profile", "p"]);
@@ -125,6 +126,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
+        [CombinatorialData]
         public void RunOptions_NoLaunchProfile_NotPassedThrough(bool beforeCommand)
         {
             var options = VerifyOptions(beforeCommand ? ["--no-launch-profile", "test"] : ["test", "--no-launch-profile"]);
@@ -133,6 +135,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         }
 
         [Theory]
+        [CombinatorialData]
         public void RunOption_Project_NotPassedThrough(bool beforeCommand)
         {
             var options = VerifyOptions(beforeCommand ? ["--project", "MyProject.csproj", "test"] : ["test", "--project", "MyProject.csproj"]);


### PR DESCRIPTION
Fixes: #45761, #45634, and maybe a regression of #34949.


## Context

### Watch CLI
```
dotnet watch [<command>]
  [--list]
  [--no-hot-reload] [--non-interactive]
  [--project <PROJECT>]
  [-q|--quiet] [-v|--verbose]
  [--version]
  [--] <forwarded arguments> 

dotnet watch -?|-h|--help
```

## Problem
`dotnet-watch` has `-p`, `--project`, `--launch-profile`, and `--no-launch-profile` as possible arguments.  A user can not use these arguments without `dotnet-watch` forwarding them.  These arguments only work with the `run` command, and will cause an error if passed to any command but `run`.
