### PR TITLE
Draft, remove _ComputeTargetFrameworkItems from _MTPBuild

### DIFF
--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -100,7 +100,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   =================================================================================
   -->
 
-  <Target Name="_MTPBuild" DependsOnTargets="_ComputeTargetFrameworkItems">
+  <Target Name="_MTPBuild">
     <CallTarget Targets="Build" />
   </Target>
 


### PR DESCRIPTION
I need to understand the exact case the breaks without this, if any. I'm not even sure if we have good test coverage for this (if it's really needed).