### PR TITLE
Add more properties to `targetframeworkeval` telemetry event

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -137,7 +137,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TFTelemetry Include="TargetPlatformIdentifier" Value="$(TargetPlatformIdentifier)" />
       <TFTelemetry Include="UseMonoRuntime" Value="$(UseMonoRuntime)" />
       <TFTelemetry Include="PublishAot" Value="$(PublishAot)" />
-
+      <TFTelemetry Include="Configuration" Value="$(Configuration)" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -137,6 +137,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TFTelemetry Include="TargetPlatformIdentifier" Value="$(TargetPlatformIdentifier)" />
       <TFTelemetry Include="UseMonoRuntime" Value="$(UseMonoRuntime)" />
       <TFTelemetry Include="PublishAot" Value="$(PublishAot)" />
+      <TFTelemetry Include="PublishTrimmed" Value="$(PublishTrimmed)" />
+      <TFTelemetry Include="PublishSelfContained" Value="$(PublishSelfContained)" />
+      <TFTelemetry Include="PublishReadyToRun" Value="$(PublishReadyToRun)" />
+      <TFTelemetry Include="PublishReadyToRunComposite" Value="$(PublishReadyToRunComposite)" />
+      <TFTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" />    
       <TFTelemetry Include="Configuration" Value="$(Configuration)" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -134,6 +134,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TFTelemetry Include="OutputType" Value="$(OutputType)" />
       <TFTelemetry Include="UseArtifactsOutput" Value="$(UseArtifactsOutput)" />
       <TFTelemetry Include="ArtifactsPathLocationType" Value="$(_ArtifactsPathLocationType)" />
+      <TFTelemetry Include="TargetPlatformIdentifier" Value="$(TargetPlatformIdentifier)" />
+      <TFTelemetry Include="UseMonoRuntime" Value="$(UseMonoRuntime)" />
+      <TFTelemetry Include="PublishAot" Value="$(PublishAot)" />
+
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -11,6 +11,27 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
+        private string CreateTargetFrameworkEvalTelemetryJson(
+            string targetFrameworkVersion,
+            string targetPlatformIdentifier = "null",
+            string runtimeIdentifier = "null",
+            string selfContained = "null",
+            string useApphost = "null",
+            string outputType = "Library",
+            string useArtifactsOutput = "null",
+            string artifactsPathLocationType = "null",
+            string useMonoRuntime = "null",
+            string publishAot = "null",
+            string publishTrimmed = "null",
+            string publishSelfContained = "null",
+            string publishReadyToRun = "null",
+            string publishReadyToRunComposite = "false",
+            string publishProtocol = "null",
+            string configuration = "Debug")
+        {
+            return $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{targetFrameworkVersion}\",\"RuntimeIdentifier\":\"{runtimeIdentifier}\",\"SelfContained\":\"{selfContained}\",\"UseApphost\":\"{useApphost}\",\"OutputType\":\"{outputType}\",\"UseArtifactsOutput\":\"{useArtifactsOutput}\",\"ArtifactsPathLocationType\":\"{artifactsPathLocationType}\",\"TargetPlatformIdentifier\":\"{targetPlatformIdentifier}\",\"UseMonoRuntime\":\"{useMonoRuntime}\",\"PublishAot\":\"{publishAot}\",\"PublishTrimmed\":\"{publishTrimmed}\",\"PublishSelfContained\":\"{publishSelfContained}\",\"PublishReadyToRun\":\"{publishReadyToRun}\",\"PublishReadyToRunComposite\":\"{publishReadyToRunComposite}\",\"PublishProtocol\":\"{publishProtocol}\",\"Configuration\":\"{configuration}\"}}";
+        }
+
         [CoreMSBuildOnlyFact]
         public void It_collects_TargetFramework_version_and_other_properties()
         {
@@ -32,7 +53,8 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}}");
+                .Contain(CreateTargetFrameworkEvalTelemetryJson(
+                    $".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}"));
         }
 
         [CoreMSBuildOnlyFact]
@@ -59,11 +81,13 @@ namespace Microsoft.NET.Build.Tests
 
             result
                 .StdOut.Should()
-                .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"Windows\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}")
+                .Contain(CreateTargetFrameworkEvalTelemetryJson(
+                    ".NETFramework,Version=v4.6", 
+                    targetPlatformIdentifier: "Windows",
+                    publishReadyToRunComposite: "null"))
                 .And
-                .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}}");
+                .Contain(CreateTargetFrameworkEvalTelemetryJson(
+                    $".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}"));
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}");
         }
 
         [CoreMSBuildOnlyFact]
@@ -60,10 +60,10 @@ namespace Microsoft.NET.Build.Tests
             result
                 .StdOut.Should()
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}")
+                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}")
                 .And
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\"}}");
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}");
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tests
             buildCommand
                 .Execute(TelemetryTestLogger)
                 .StdOut.Should()
-                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}");
+                .Contain($"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}}");
         }
 
         [CoreMSBuildOnlyFact]
@@ -60,10 +60,10 @@ namespace Microsoft.NET.Build.Tests
             result
                 .StdOut.Should()
                 .Contain(
-                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}")
+                    "{\"EventName\":\"targetframeworkeval\",\"Properties\":{\"TargetFrameworkVersion\":\".NETFramework,Version=v4.6\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"Windows\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}")
                 .And
                 .Contain(
-                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\"}}");
+                    $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}\",\"RuntimeIdentifier\":\"null\",\"SelfContained\":\"null\",\"UseApphost\":\"null\",\"OutputType\":\"Library\",\"UseArtifactsOutput\":\"null\",\"ArtifactsPathLocationType\":\"null\",\"TargetPlatformIdentifier\":\"null\",\"UseMonoRuntime\":\"null\",\"PublishAot\":\"null\",\"Configuration\":\"Debug\"}}");
         }
     }
 }


### PR DESCRIPTION
## Description
Adding properties (`TargetPlatformIdentifier`, `UseMonoRuntime`, `PublishAot`, `Configuration`) needed for mobile-related telemetry tracking to `targetframeworkeval` event.

Additionally, adding more publish-related (`PublishTrimmed`, `PublishSelfContained`, `PublishReadyToRun`, `PublishReadyToRunComposite`, `PublishProtocol`)  properties to make `targetframeworkeval` the center piece for property tracking.

### Sample Output Telemetry
```json
{
    "EventName": "targetframeworkeval",
    "Properties": {
        "TargetFrameworkVersion": ".NETCoreApp,Version=v10.0",
        "RuntimeIdentifier": "android-arm64",
        "SelfContained": "true",
        "UseApphost": "false",
        "OutputType": "Library",
        "UseArtifactsOutput": "null",
        "ArtifactsPathLocationType": "null",
        "TargetPlatformIdentifier": "android",
        "UseMonoRuntime": "true",
        "PublishAot": "false",
        "PublishTrimmed": "null",
        "PublishSelfContained": "null",
        "PublishReadyToRun": "false",
        "PublishReadyToRunComposite": "false",
        "PublishProtocol": "null",
        "Configuration": "Debug"
    },
    "Timestamp": "2025-09-12T12:27:52.710113+01:00",
    "ThreadId": 12,
    "Message": null,
    "HelpKeyword": null,
    "SenderName": null,
    "BuildEventContext": {
        "EvaluationId": -1,
        "NodeId": 1,
        "TargetId": 45,
        "ProjectContextId": 15,
        "TaskId": 39,
        "ProjectInstanceId": 2,
        "SubmissionId": 0,
        "BuildRequestId": -2063244756
    }
}
```

## Testing
Tested locally by installing `android` workload to `.dotnet/dotnet` and running the following tests:

Publish:
```
[CoreMSBuildOnlyTheory]
[InlineData(ToolsetInfo.CurrentTargetFramework)]
public void It_collects_Mobile_properties_for_publish(string targetFramework)
{
    Type loggerType = typeof(LogTelemetryToStdOutForTest);
    var TelemetryTestLogger = new[]
        {
            "--property:TargetPlatformIdentifier=android",
            "--property:RuntimeIdentifier=android-arm64",
            "--property:UseMonoRuntime=true",
            "--property:PublishAot=false",
            $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
        };

    var testProject = CreateTestProject(targetFramework, "MobileTelemetryPublishTest");
    var testProjectInstance = _testAssetsManager.CreateTestProject(testProject);
    var publishCommand = new PublishCommand(testProjectInstance);
    publishCommand.Execute(TelemetryTestLogger).StdOut.Should.Contain(...)
```

Build:
```
[CoreMSBuildOnlyFact]
public void It_collects_Mobile_properties_for_build()
{
    string targetFramework = ToolsetInfo.CurrentTargetFramework;
    var testProject = new TestProject()
    {
        Name = "MobileTelemetryBuildTest",
        TargetFrameworks = targetFramework,
    };
    Type loggerType = typeof(LogTelemetryToStdOutForTest);
    var telemetryArgs = new[]
        {
            "--property:TargetPlatformIdentifier=android",
            "--property:RuntimeIdentifier=android-arm64",
            "--property:UseMonoRuntime=false",
            "--property:PublishAot=false",
            $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
        };
    var testAsset = _testAssetsManager.CreateTestProject(testProject);

    var buildCommand = new BuildCommand(testAsset);

    buildCommand
        .Execute(telemetryArgs)
        .StdOut.Should()
        .Contain(...)
```

Another testing was done by locally modified version of SDK, where I modified the .target files and verified that the mobile telemetry targets get executed for `dotnet new android` app.

## Future Work
- Add `SessionId` that allows pairing `targetframeworkeval` events with `build`/`publish` and other .NET CLI commands.