### PR TITLE
[Blazor][HotReload] Include refresh script for enhanced navigation

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -169,7 +169,8 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             if (request.Headers.TryGetValue("Sec-Fetch-Dest", out var values) &&
                 !StringValues.IsNullOrEmpty(values) &&
-                !string.Equals(values[0], "document", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(values[0], "document", StringComparison.OrdinalIgnoreCase) &&
+                !IsProgressivelyEnhancedNavigation(context.Request))
             {
                 // See https://github.com/dotnet/aspnetcore/issues/37326.
                 // Only inject scripts that are destined for a browser page.
@@ -191,6 +192,13 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             }
 
             return false;
+        }
+
+        private static bool IsProgressivelyEnhancedNavigation(HttpRequest request)
+        {
+            // For enhanced nav, the Blazor JS code controls the "accept" header precisely, so we can be very specific about the format
+            var accept = request.Headers.Accept;
+            return accept.Count == 1 && string.Equals(accept[0]!, "text/html; blazor-enhanced-nav=on", StringComparison.Ordinal);
         }
 
         internal void Test_SetEnvironment(string dotnetModifiableAssemblies, string aspnetcoreBrowserTools)

--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -196,6 +196,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
         private static bool IsProgressivelyEnhancedNavigation(HttpRequest request)
         {
+            // This is an exact copy from https://github.com/dotnet/aspnetcore/blob/bb2d778dc66aa998ea8e26db0e98e7e01423ff78/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs#L327-L332
             // For enhanced nav, the Blazor JS code controls the "accept" header precisely, so we can be very specific about the format
             var accept = request.Headers.Accept;
             return accept.Count == 1 && string.Equals(accept[0]!, "text/html; blazor-enhanced-nav=on", StringComparison.Ordinal);


### PR DESCRIPTION
This PR ensures that `aspnetcore-refresh-browser.js` script is included in the response for enhanced navigation requests.
Because such navigation is invoked using `fetch`, the `Sec-Fetch-Dest` header has value `empty`. This fetch request is carrying additional value `blazor-enhanced-nav=on` in `Accept` header. The code added to `BrowserRefreshMiddleware` is exact copy from [aspnetcore/EndpointHtmlRenderer.Streaming.cs#L327-L332](https://github.com/dotnet/aspnetcore/blob/bb2d778dc66aa998ea8e26db0e98e7e01423ff78/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs#L327-L332)

Contributes to https://github.com/dotnet/aspnetcore/issues/63455