### PR TITLE
Retry bundle generation a couple times to hopefully reduce CI instability

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -124,7 +124,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     Log.LogMessage(MessageImportance.High, $"Unable to access file during bundling. Retrying {RetryCount} more times...");
                     RetryCount--;
-                    await Task.Delay(_jitter.Next(50, 150));
+                    await Task.Delay(_jitter.Next(10, 50));
                 }
             }
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -1,19 +1,25 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.NET.HostModel.Bundle;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GenerateBundle : TaskBase
+    public class GenerateBundle : TaskBase, ICancelableTask
     {
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly Random _jitter =
+#if NET
+            Random.Shared;
+#else
+            new Random();
+#endif
+
         [Required]
-        public ITaskItem[] FilesToBundle { get; set; }
+        public ITaskItem[] FilesToBundle { get; set; } = null!;
         [Required]
-        public string AppHostName { get; set; }
+        public string AppHostName { get; set; } = null!;
         [Required]
         public bool IncludeSymbols { get; set; }
         [Required]
@@ -21,11 +27,11 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public bool IncludeAllContent { get; set; }
         [Required]
-        public string TargetFrameworkVersion { get; set; }
+        public string TargetFrameworkVersion { get; set; } = null!;
         [Required]
-        public string RuntimeIdentifier { get; set; }
+        public string RuntimeIdentifier { get; set; } = null!;
         [Required]
-        public string OutputDir { get; set; }
+        public string OutputDir { get; set; } = null!;
         [Required]
         public bool ShowDiagnosticOutput { get; set; }
         [Required]
@@ -33,9 +39,18 @@ namespace Microsoft.NET.Build.Tasks
         public bool EnableMacOsCodeSign { get; set; } = true;
 
         [Output]
-        public ITaskItem[] ExcludedFiles { get; set; }
+        public ITaskItem[] ExcludedFiles { get; set; } = null!;
+
+        public int? RetryCount { get; set; } = 3;
+
+        public void Cancel() => _cancellationTokenSource.Cancel();
 
         protected override void ExecuteCore()
+        {
+            ExecuteWithRetry().GetAwaiter().GetResult();
+        }
+
+        private async Task ExecuteWithRetry()
         {
             OSPlatform targetOS = RuntimeIdentifier.StartsWith("win") ? OSPlatform.Windows :
                                   RuntimeIdentifier.StartsWith("osx") ? OSPlatform.OSX :
@@ -78,7 +93,9 @@ namespace Microsoft.NET.Build.Tasks
                                           bundleRelativePath: item.GetMetadata(MetadataKeys.RelativePath)));
             }
 
-            bundler.GenerateBundle(fileSpec);
+            // GenerateBundle has been throwing IOException intermittently in CI runs when accessing the singlefilehost binary specifically.
+            // We hope that it's a Defender issue and that a quick retry will paper over the intermittent delay it.
+            await DoWithRetry(() => bundler.GenerateBundle(fileSpec));
 
             // Certain files are excluded from the bundle, based on BundleOptions.
             // For example:
@@ -86,7 +103,30 @@ namespace Microsoft.NET.Build.Tasks
             //    hostfxr and hostpolicy are excluded until singlefilehost is available.
             // Return the set of excluded files in ExcludedFiles, so that they can be placed in the publish directory.
 
-            ExcludedFiles = FilesToBundle.Zip(fileSpec, (item, spec) => (spec.Excluded) ? item : null).Where(x => x != null).ToArray();
+            ExcludedFiles = FilesToBundle.Zip(fileSpec, (item, spec) => (spec.Excluded) ? item : null).Where(x => x != null).ToArray()!;
+        }
+
+        public async Task DoWithRetry(Action action)
+        {
+            bool triedOnce = false;
+            while (RetryCount > 0 || !triedOnce)
+            {
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    break;
+                }
+                try
+                {
+                    action();
+                    break;
+                }
+                catch (IOException) when (RetryCount > 0)
+                {
+                    Log.LogMessage(MessageImportance.High, $"Unable to access file during bundling. Retrying {RetryCount} more times...");
+                    RetryCount--;
+                    await Task.Delay(_jitter.Next(50, 150));
+                }
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs
@@ -94,7 +94,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             // GenerateBundle has been throwing IOException intermittently in CI runs when accessing the singlefilehost binary specifically.
-            // We hope that it's a Defender issue and that a quick retry will paper over the intermittent delay it.
+            // We hope that it's a Defender issue and that a quick retry will paper over the intermittent delay.
             await DoWithRetry(() => bundler.GenerateBundle(fileSpec));
 
             // Certain files are excluded from the bundle, based on BundleOptions.


### PR DESCRIPTION
We get the following callstack on several of our single-file publishing tests:

```
Microsoft.NET.Publish.targets(1132,5): error MSB4018: The "GenerateBundle" task failed unexpectedly. 
Microsoft.NET.Publish.targets(1132,5): error MSB4018: System.IO.IOException: The process cannot access the file '/private/tmp/helix/working/B98A09DE/t/dotnetSdkTests.lUYZADv9/It_can_disabl---A27CFE0E/CetCompat/obj/Debug/net10.0/win-x64/singlefilehost.exe' because it is being used by another process. 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Init(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Int64& fileLength, UnixFileMode& filePermissions) 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException) 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at System.IO.File.OpenRead(String path) 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.NET.HostModel.Bundle.Bundler.GenerateBundle(IReadOnlyList`1 fileSpecs) 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.NET.Build.Tasks.GenerateBundle.ExecuteCore() in /_/src/Tasks/Microsoft.NET.Build.Tasks/GenerateBundle.cs:line 81 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.NET.Build.Tasks.TaskBase.Execute() in /_/src/Tasks/Common/TaskBase.cs:line 36 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Execute() 
Microsoft.NET.Publish.targets(1132,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

we _think_ this could be defender, so we want to put a bit of jitter and retry around this Task to see if that smooths things out.