### PR TITLE
Fix tests failing on Full Framework CI

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
@@ -13,19 +13,19 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.15")]
         public void It_builds_the_project_successfully_when_RAR_finds_all_references()
         {
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new[] { "/p:DisableTransitiveProjectReferences=true" });
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.15")]
         public void It_builds_the_project_successfully_with_static_graph_and_isolation()
         {
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new[] { "/graph" });
         }
 
-        [Fact]
+        [RequiresMSBuildVersionFact("17.15")]
         public void It_cleans_the_project_successfully_with_static_graph_and_isolation()
         {
             var (testAsset, outputDirectories) = BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new[] { "/graph", "/bl:build-{}.binlog" });


### PR DESCRIPTION
Add required MSBuild version to tests that were failing on Full Framework.

These tests were impacted by recent pruning changes to enable pruning for all target frameworks if any of the target frameworks is .NET 10 or higher.  However, that functionality depends on NuGet targets, and our Helix/CI machines don't have VS with updated versions of those targets.  So these tests will be skipped for full framework when the required version of MSBuild isn't available.