### PR TITLE
Fix process framework references crash when null RID is passed

### DIFF
--- a/src/Common/NuGetUtils.NuGet.cs
+++ b/src/Common/NuGetUtils.NuGet.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;
 
@@ -27,7 +25,7 @@ namespace Microsoft.NET.Build.Tasks
             return separator == '\\' || separator == '/';
         }
 
-        public static string GetLockFileLanguageName(string projectLanguage)
+        public static string? GetLockFileLanguageName(string? projectLanguage)
         {
             switch (projectLanguage)
             {
@@ -37,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        public static NuGetFramework ParseFrameworkName(string frameworkName)
+        public static NuGetFramework? ParseFrameworkName(string? frameworkName)
         {
             return frameworkName == null ? null : NuGetFramework.Parse(frameworkName);
         }
@@ -75,7 +73,7 @@ namespace Microsoft.NET.Build.Tasks
             return IsAnalyzer() && FileMatchesProjectLanguage();
         }
 
-        public static string GetBestMatchingRid(RuntimeGraph runtimeGraph, string runtimeIdentifier,
+        public static string? GetBestMatchingRid(RuntimeGraph runtimeGraph, string? runtimeIdentifier,
             IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
         {
             return GetBestMatchingRidWithExclusion(runtimeGraph, runtimeIdentifier,
@@ -83,16 +81,22 @@ namespace Microsoft.NET.Build.Tasks
                 availableRuntimeIdentifiers, out wasInGraph);
         }
 
-        public static string GetBestMatchingRidWithExclusion(RuntimeGraph runtimeGraph, string runtimeIdentifier,
-            IEnumerable<string> runtimeIdentifiersToExclude,
+        public static string? GetBestMatchingRidWithExclusion(RuntimeGraph runtimeGraph, string? runtimeIdentifier,
+            IEnumerable<string>? runtimeIdentifiersToExclude,
             IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
         {
+            if (string.IsNullOrEmpty(runtimeIdentifier))
+            {
+                wasInGraph = false;
+                return null;
+            }
+
             wasInGraph = runtimeGraph.Runtimes.ContainsKey(runtimeIdentifier);
 
-            string bestMatch = null;
+            string? bestMatch = null;
 
             HashSet<string> availableRids = new(availableRuntimeIdentifiers, StringComparer.Ordinal);
-            HashSet<string> excludedRids = runtimeIdentifiersToExclude switch { null => null, _ => new HashSet<string>(runtimeIdentifiersToExclude, StringComparer.Ordinal) };
+            HashSet<string>? excludedRids = runtimeIdentifiersToExclude switch { null => null, _ => new HashSet<string>(runtimeIdentifiersToExclude, StringComparer.Ordinal) };
             foreach (var candidateRuntimeIdentifier in runtimeGraph.ExpandRuntime(runtimeIdentifier))
             {
                 if (bestMatch == null && availableRids.Contains(candidateRuntimeIdentifier))

--- a/src/Common/NuGetUtils.NuGet.cs
+++ b/src/Common/NuGetUtils.NuGet.cs
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Build.Tasks
             return IsAnalyzer() && FileMatchesProjectLanguage();
         }
 
-        public static string? GetBestMatchingRid(RuntimeGraph runtimeGraph, string? runtimeIdentifier,
+        public static string? GetBestMatchingRid(RuntimeGraph runtimeGraph, string runtimeIdentifier,
             IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
         {
             return GetBestMatchingRidWithExclusion(runtimeGraph, runtimeIdentifier,
@@ -81,16 +81,10 @@ namespace Microsoft.NET.Build.Tasks
                 availableRuntimeIdentifiers, out wasInGraph);
         }
 
-        public static string? GetBestMatchingRidWithExclusion(RuntimeGraph runtimeGraph, string? runtimeIdentifier,
+        public static string? GetBestMatchingRidWithExclusion(RuntimeGraph runtimeGraph, string runtimeIdentifier,
             IEnumerable<string>? runtimeIdentifiersToExclude,
             IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
         {
-            if (string.IsNullOrEmpty(runtimeIdentifier))
-            {
-                wasInGraph = false;
-                return null;
-            }
-
             wasInGraph = runtimeGraph.Runtimes.ContainsKey(runtimeIdentifier);
 
             string? bestMatch = null;

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -9,104 +9,232 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class ProcessFrameworkReferencesTests
     {
-        private MockTaskItem _validWindowsSDKKnownFrameworkReference
-            = new("Microsoft.Windows.SDK.NET.Ref",
-                new Dictionary<string, string>
-                {
-                    {"TargetFramework", "net5.0-windows10.0.18362"},
-                    {"RuntimeFrameworkName", "Microsoft.Windows.SDK.NET.Ref"},
-                    {"DefaultRuntimeFrameworkVersion", "10.0.18362.1-preview"},
-                    {"LatestRuntimeFrameworkVersion", "10.0.18362.1-preview"},
-                    {"TargetingPackName", "Microsoft.Windows.SDK.NET.Ref"},
-                    {"TargetingPackVersion", "10.0.18362.1-preview"},
-                    {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"},
-                    {"RuntimePackRuntimeIdentifiers", "any"},
-                    {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
-                    {"IsWindowsOnly", "true"},
-                });
+        // Shared runtime graph templates
+        private const string MinimalRuntimeGraph = """
+            {
+                "runtimes": {
+                    "any": {
+                        "#import": ["base"]
+                    },
+                    "base": {
+                        "#import": []
+                    }
+                }
+            }
+            """;
+        
+        private const string WindowsRuntimeGraph = """
+            {
+                "runtimes": {
+                    "any": {
+                        "#import": ["base"]
+                    },
+                    "base": {
+                        "#import": []
+                    },
+                    "win": {
+                        "#import": ["any"]
+                    },
+                    "win-x64": {
+                        "#import": ["win"]
+                    }
+                }
+            }
+            """;
+        
+        private const string MultiPlatformRuntimeGraph = """
+            {
+                "runtimes": {
+                    "any": {
+                        "#import": ["base"]
+                    },
+                    "base": {
+                        "#import": []
+                    },
+                    "win": {
+                        "#import": ["any"]
+                    },
+                    "win-x64": {
+                        "#import": ["win"]
+                    },
+                    "win-x86": {
+                        "#import": ["win"]
+                    },
+                    "linux-x64": {
+                        "#import": ["any"]
+                    },
+                    "osx": {
+                        "#import": ["any"]
+                    },
+                    "osx-arm64": {
+                        "#import": ["osx"]
+                    },
+                    "osx-x64": {
+                        "#import": ["osx"]
+                    }
+                }
+            }
+            """;
 
+        // Shared known framework references
+        private readonly MockTaskItem _validWindowsSDKKnownFrameworkReference = CreateKnownFrameworkReference(
+            "Microsoft.Windows.SDK.NET.Ref", "net5.0-windows10.0.18362", "10.0.18362.1-preview", 
+            additionalMetadata: new Dictionary<string, string> {
+                {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
+                {"IsWindowsOnly", "true"},
+                {"RuntimePackRuntimeIdentifiers", "any"},
+                {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"}
+            });
 
-        private MockTaskItem _netcoreAppKnownFrameworkReference =
-            new("Microsoft.NETCore.App",
-                new Dictionary<string, string>
-                {
-                    {"TargetFramework", "net5.0"},
-                    {"RuntimeFrameworkName", "Microsoft.NETCore.App"},
-                    {"DefaultRuntimeFrameworkVersion", "5.0.0-preview.4.20251.6"},
-                    {"LatestRuntimeFrameworkVersion", "5.0.0-preview.4.20251.6"},
-                    {"TargetingPackName", "Microsoft.NETCore.App.Ref"},
-                    {"TargetingPackVersion", "5.0.0-preview.4.20251.6"},
-                    {"RuntimePackNamePatterns", "Microsoft.NETCore.App.Runtime.**RID**"},
-                    {"RuntimePackRuntimeIdentifiers", "win-x64"},
-                });
+        private readonly MockTaskItem _netcoreAppKnownFrameworkReference = CreateKnownFrameworkReference(
+            "Microsoft.NETCore.App", "net5.0", "5.0.0-preview.4.20251.6", 
+            runtimePackPattern: "Microsoft.NETCore.App.Runtime.**RID**", 
+            runtimeIdentifiers: "win-x64");
 
-        [Fact]
-        public void It_resolves_FrameworkReferences()
+        // Helper methods for creating common test objects
+        private static MockTaskItem CreateKnownFrameworkReference(string name, string targetFramework, string version, 
+            string? runtimePackPattern = null, string? runtimeIdentifiers = null, Dictionary<string, string>? additionalMetadata = null)
+        {
+            var metadata = new Dictionary<string, string>
+            {
+                {"TargetFramework", targetFramework},
+                {"RuntimeFrameworkName", name},
+                {"DefaultRuntimeFrameworkVersion", version},
+                {"LatestRuntimeFrameworkVersion", version},
+                {"TargetingPackName", name.EndsWith(".Ref") ? name : $"{name}.Ref"},
+                {"TargetingPackVersion", version}
+            };
+            
+            if (runtimePackPattern != null) metadata["RuntimePackNamePatterns"] = runtimePackPattern;
+            if (runtimeIdentifiers != null) metadata["RuntimePackRuntimeIdentifiers"] = runtimeIdentifiers;
+            if (additionalMetadata != null)
+            {
+                foreach (var kvp in additionalMetadata)
+                    metadata[kvp.Key] = kvp.Value;
+            }
+            
+            return new MockTaskItem(name, metadata);
+        }
+        
+        private static MockTaskItem CreateKnownILCompilerPack(string targetFramework, string version, string runtimeIdentifiers)
+        {
+            return new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = targetFramework,
+                ["ILCompilerPackNamePattern"] = "runtime.**RID**.Microsoft.DotNet.ILCompiler",
+                ["ILCompilerPackVersion"] = version,
+                ["ILCompilerRuntimeIdentifiers"] = runtimeIdentifiers
+            });
+        }
+        
+        private static string CreateRuntimeGraphFile(string content)
+        {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, content);
+            return path;
+        }
+        
+        private static ProcessFrameworkReferences CreateTask(TaskConfiguration config)
         {
             var task = new ProcessFrameworkReferences
             {
-                BuildEngine = new MockBuildEngine(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App",
-                        new Dictionary<string, string>()
-                        {
-                            {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
-                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                            {"TargetingPackVersion", "1.9.0"}
-                        })
-                }
+                BuildEngine = config.UseCachingEngine ? new MockBuildEngine() : new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = config.EnableTargetingPackDownload,
+                EnableRuntimePackDownload = config.EnableRuntimePackDownload,
+                TargetFrameworkIdentifier = config.TargetFrameworkIdentifier ?? ".NETCoreApp",
+                TargetFrameworkVersion = config.TargetFrameworkVersion ?? "5.0",
+                NETCoreSdkRuntimeIdentifier = config.NETCoreSdkRuntimeIdentifier ?? "win-x64",
+                RuntimeIdentifier = config.RuntimeIdentifier,
+                SelfContained = config.SelfContained,
+                TargetLatestRuntimePatch = config.TargetLatestRuntimePatch,
+                TargetLatestRuntimePatchIsDefault = config.TargetLatestRuntimePatchIsDefault,
             };
-
-            task.Execute().Should().BeTrue();
-            task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
-            task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(1);
-            task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
-            task.RuntimeFrameworks[0].GetMetadata(MetadataKeys.Version).Should().Be("1.9.5");
+            
+            // Set nullable properties conditionally to avoid warnings
+            if (config.TargetPlatformIdentifier != null) task.TargetPlatformIdentifier = config.TargetPlatformIdentifier;
+            if (config.TargetPlatformVersion != null) task.TargetPlatformVersion = config.TargetPlatformVersion;
+            if (config.RuntimeGraphPath != null) task.RuntimeGraphPath = config.RuntimeGraphPath;
+            if (config.FrameworkReferences != null) task.FrameworkReferences = config.FrameworkReferences;
+            if (config.KnownFrameworkReferences != null) task.KnownFrameworkReferences = config.KnownFrameworkReferences;
+            if (config.KnownRuntimePacks != null) task.KnownRuntimePacks = config.KnownRuntimePacks;
+            if (config.KnownILLinkPacks != null) task.KnownILLinkPacks = config.KnownILLinkPacks;
+            if (config.KnownILCompilerPacks != null) task.KnownILCompilerPacks = config.KnownILCompilerPacks;
+            
+            // Set additional AOT/trimming properties
+            if (config.PublishAot.HasValue) task.PublishAot = config.PublishAot.Value;
+            if (config.PublishTrimmed.HasValue) task.PublishTrimmed = config.PublishTrimmed.Value;
+            if (config.RequiresILLinkPack.HasValue) task.RequiresILLinkPack = config.RequiresILLinkPack.Value;
+            if (config.EnableAotAnalyzer.HasValue) task.EnableAotAnalyzer = config.EnableAotAnalyzer.Value;
+            if (config.EnableTrimAnalyzer.HasValue) task.EnableTrimAnalyzer = config.EnableTrimAnalyzer.Value;
+            if (config.EnableSingleFileAnalyzer.HasValue) task.EnableSingleFileAnalyzer = config.EnableSingleFileAnalyzer.Value;
+            
+            if (!string.IsNullOrEmpty(config.NetCoreRoot)) task.NetCoreRoot = config.NetCoreRoot;
+            if (!string.IsNullOrEmpty(config.NETCoreSdkVersion)) task.NETCoreSdkVersion = config.NETCoreSdkVersion;
+            if (!string.IsNullOrEmpty(config.NETCoreSdkPortableRuntimeIdentifier)) task.NETCoreSdkPortableRuntimeIdentifier = config.NETCoreSdkPortableRuntimeIdentifier;
+            
+            // Missing assignment that was causing the issue
+            task.RuntimeIdentifiers = config.RuntimeIdentifiers;
+            
+            return task;
+        }
+        
+        private class TaskConfiguration
+        {
+            public bool UseCachingEngine { get; set; }
+            public bool EnableTargetingPackDownload { get; set; } = true;
+            public bool EnableRuntimePackDownload { get; set; }
+            public string? TargetFrameworkIdentifier { get; set; }
+            public string? TargetFrameworkVersion { get; set; }
+            public string? TargetPlatformIdentifier { get; set; }
+            public string? TargetPlatformVersion { get; set; }
+            public string? NETCoreSdkRuntimeIdentifier { get; set; }
+            public string? RuntimeIdentifier { get; set; }
+            public string[]? RuntimeIdentifiers { get; set; }
+            public bool SelfContained { get; set; }
+            public string? RuntimeGraphPath { get; set; }
+            public bool TargetLatestRuntimePatch { get; set; }
+            public bool TargetLatestRuntimePatchIsDefault { get; set; }
+            public MockTaskItem[]? FrameworkReferences { get; set; }
+            public MockTaskItem[]? KnownFrameworkReferences { get; set; }
+            public MockTaskItem[]? KnownRuntimePacks { get; set; }
+            public MockTaskItem[]? KnownILLinkPacks { get; set; }
+            public MockTaskItem[]? KnownILCompilerPacks { get; set; }
+            public bool? PublishAot { get; set; }
+            public bool? PublishTrimmed { get; set; }
+            public bool? RequiresILLinkPack { get; set; }
+            public bool? EnableAotAnalyzer { get; set; }
+            public bool? EnableTrimAnalyzer { get; set; }
+            public bool? EnableSingleFileAnalyzer { get; set; }
+            public string? NetCoreRoot { get; set; }
+            public string? NETCoreSdkVersion { get; set; }
+            public string? NETCoreSdkPortableRuntimeIdentifier { get; set; }
         }
 
-        [Fact]
-        public void Given_targetPlatform_and_targetPlatform_version_It_resolves_FrameworkReferences_()
+        [Theory]
+        [InlineData(false)] // Without target platform
+        [InlineData(true)]  // With target platform
+        public void It_resolves_AspNetCore_FrameworkReferences(bool withTargetPlatform)
         {
-            var task = new ProcessFrameworkReferences
+            var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", 
+                ToolsetInfo.CurrentTargetFramework, "1.9.5", additionalMetadata: new Dictionary<string, string> 
+                {
+                    {"LatestRuntimeFrameworkVersion", "1.9.6"},
+                    {"TargetingPackVersion", "1.9.0"}
+                });
+            
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockBuildEngine(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
+                UseCachingEngine = true,
                 TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
-                TargetPlatformIdentifier = "Windows",
-                TargetPlatformVersion = "10.0.18362",
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App",
-                        new Dictionary<string, string>()
-                        {
-                            {"TargetFramework", ToolsetInfo.CurrentTargetFramework},
-                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                            {"TargetingPackVersion", "1.9.0"}
-                        })
-                }
+                TargetPlatformIdentifier = withTargetPlatform ? "Windows" : null,
+                TargetPlatformVersion = withTargetPlatform ? "10.0.18362" : null,
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { aspNetCoreRef }
             };
-
+            
+            var task = CreateTask(config);
             task.Execute().Should().BeTrue();
-
+            
             task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
@@ -116,32 +244,20 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void It_does_not_resolve_FrameworkReferences_if_targetframework_doesnt_match()
         {
-            var task = new ProcessFrameworkReferences
+            var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", "netcoreapp3.0", "1.9.5");
+            
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockBuildEngine(),
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "2.0",
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.AspNetCore.App",
-                        new Dictionary<string, string>()
-                        {
-                            {"TargetFramework", "netcoreapp3.0"},
-                            {"RuntimeFrameworkName", "Microsoft.AspNetCore.App"},
-                            {"DefaultRuntimeFrameworkVersion", "1.9.5"},
-                            {"LatestRuntimeFrameworkVersion", "1.9.6"},
-                            {"TargetingPackName", "Microsoft.AspNetCore.App"},
-                            {"TargetingPackVersion", "1.9.0"}
-                        })
-                }
+                UseCachingEngine = true,
+                EnableTargetingPackDownload = false, // Explicitly disable to test non-resolution
+                TargetFrameworkVersion = "2.0", // Mismatched version
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { aspNetCoreRef }
             };
-
+            
+            var task = CreateTask(config);
             task.Execute().Should().BeTrue();
-
+            
             task.PackagesToDownload.Should().BeNull();
             task.RuntimeFrameworks.Should().BeNull();
         }
@@ -149,44 +265,27 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void Given_KnownFrameworkReferences_with_RuntimePackAlwaysCopyLocal_It_resolves_FrameworkReferences()
         {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            var windowsSDKRef = CreateKnownFrameworkReference("Microsoft.Windows.SDK.NET.Ref", 
+                "net5.0-windows10.0.17760", "10.0.17760.1-preview", 
+                additionalMetadata: new Dictionary<string, string> {
+                    {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
+                    {"IsWindowsOnly", "true"},
+                    {"RuntimePackRuntimeIdentifiers", "any"},
+                    {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"}
+                });
+                
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
+                EnableRuntimePackDownload = true,
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
-                EnableRuntimePackDownload = true,
-                RuntimeGraphPath =
-                    runtimeGraphPathPath,
-                FrameworkReferences =
-                    new[] { new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref",
-                        new Dictionary<string, string>
-                        {
-                            {"TargetFramework", $"net5.0-windows10.0.17760"},
-                            {"RuntimeFrameworkName", "Microsoft.Windows.SDK.NET.Ref"},
-                            {"DefaultRuntimeFrameworkVersion", "10.0.17760.1-preview"},
-                            {"LatestRuntimeFrameworkVersion", "10.0.17760.1-preview"},
-                            {"TargetingPackName", "Microsoft.Windows.SDK.NET.Ref"},
-                            {"TargetingPackVersion", "10.0.17760.1-preview"},
-                            {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"},
-                            {"RuntimePackRuntimeIdentifiers", "any"},
-                            {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
-                            {"IsWindowsOnly", "true"},
-                        }),
-                    _validWindowsSDKKnownFrameworkReference,
-                }
+                RuntimeGraphPath = CreateRuntimeGraphFile(MinimalRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { windowsSDKRef, _validWindowsSDKKnownFrameworkReference }
             };
-
+            
+            var task = CreateTask(config);
+            
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
@@ -194,69 +293,48 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
 
             task.Execute().Should().BeTrue();
-
             task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
-
-            task.RuntimeFrameworks.Should().BeNullOrEmpty(
-                "Should not contain RuntimePackAlwaysCopyLocal framework, or it will be put into runtimeconfig.json");
-
+            task.RuntimeFrameworks.Should().BeNullOrEmpty("Should not contain RuntimePackAlwaysCopyLocal framework");
+            
+            // Validate targeting pack
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
-            task.TargetingPacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
-            task.TargetingPacks[0].GetMetadata(MetadataKeys.NuGetPackageId).Should()
-                .Be("Microsoft.Windows.SDK.NET.Ref");
-            task.TargetingPacks[0].GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
-            task.TargetingPacks[0].GetMetadata(MetadataKeys.PackageConflictPreferredPackages).Should()
-                .Be("Microsoft.Windows.SDK.NET.Ref");
-            task.TargetingPacks[0].GetMetadata(MetadataKeys.RuntimeFrameworkName).Should()
-                .Be("Microsoft.Windows.SDK.NET.Ref");
-            task.TargetingPacks[0].GetMetadata(MetadataKeys.RuntimeIdentifier).Should().Be("");
-
+            var targetingPack = task.TargetingPacks[0];
+            targetingPack.ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            targetingPack.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
+            
+            // Validate runtime pack
             task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
-            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
-            task.RuntimePacks[0].GetMetadata(MetadataKeys.FrameworkName).Should().Be("Microsoft.Windows.SDK.NET.Ref");
-            task.RuntimePacks[0].GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
-            task.RuntimePacks[0].GetMetadata(MetadataKeys.RuntimePackAlwaysCopyLocal).Should().Be("true");
+            var runtimePack = task.RuntimePacks[0];
+            runtimePack.ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
+            runtimePack.GetMetadata(MetadataKeys.RuntimePackAlwaysCopyLocal).Should().Be("true");
         }
 
         [Fact]
         public void It_resolves_self_contained_FrameworkReferences_to_download()
         {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
+                EnableRuntimePackDownload = true,
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
                 RuntimeIdentifier = "win-x64",
-                RuntimeGraphPath =
-                    runtimeGraphPathPath,
                 SelfContained = true,
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences =
-                    new[]
-                    {
-                        new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
-                        new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
-                    },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference,
-                }
+                RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[] { _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference }
             };
+            
+            var task = CreateTask(config);
+            
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
                 task.Execute().Should().BeTrue();
-
                 task.PackagesToDownload.Should().NotBeNull().And.HaveCount(3);
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.Windows.SDK.NET.Ref");
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
@@ -271,218 +349,97 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void Given_reference_to_NETCoreApp_It_should_not_resolve_runtime_pack()
         {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
+                EnableRuntimePackDownload = true,
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeGraphPath =
-                    runtimeGraphPathPath,
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences =
-                    new[]
-                    {
-                        new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
-                        new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
-                    },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference,
-                }
+                RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[] { _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference }
             };
-
+            
+            var task = CreateTask(config);
+            
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
                 return;
             }
+            
             task.Execute().Should().BeTrue();
-
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);
-            task.TargetingPacks.Should().Contain(p =>
-                p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.Windows.SDK.NET.Ref");
-            task.TargetingPacks.Should()
-                .Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
-
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.Windows.SDK.NET.Ref");
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
             task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
-            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref",
-                "it should not resolve runtime pack for Microsoft.NETCore.App");
+            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref", "should not resolve runtime pack for Microsoft.NETCore.App");
         }
 
-        [Fact]
-        public void It_processes_RuntimeIdentifiers_without_RuntimeIdentifier()
+        [Theory]
+        [InlineData(null, new[] { "win-x64", "win-x86", "linux-x64" }, "Multiple RuntimeIdentifiers without RuntimeIdentifier")]
+        [InlineData("", new[] { "win-x64", "linux-x64" }, "Empty RuntimeIdentifier with RuntimeIdentifiers")]
+        [InlineData("any", new[] { "win-x64" }, "Any RID with RuntimeIdentifiers")]
+        [InlineData(null, new string[0], "No RuntimeIdentifier with empty RuntimeIdentifiers")]
+        [InlineData(null, null, "No RuntimeIdentifier with null RuntimeIdentifiers")]
+        public void It_processes_various_RuntimeIdentifier_scenarios(string? runtimeIdentifier, string[]? runtimeIdentifiers, string scenario)
         {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]},\"win-x86\":{\"#import\":[\"win\"]},\"linux-x64\":{\"#import\":[\"any\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net5.0", "5.0.0",
+                "Microsoft.NETCore.App.Runtime.**RID**", "win-x64;win-x86;linux-x64");
+                
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = null, // No RuntimeIdentifier
-                RuntimeIdentifiers = new[] { "win-x64", "win-x86", "linux-x64" }, // Multiple RuntimeIdentifiers
-                RuntimeGraphPath = runtimeGraphPathPath,
+                EnableRuntimePackDownload = true,
                 TargetLatestRuntimePatch = true,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App",
-                        new Dictionary<string, string>
-                        {
-                            {"TargetFramework", "net5.0"},
-                            {"RuntimeFrameworkName", "Microsoft.NETCore.App"},
-                            {"DefaultRuntimeFrameworkVersion", "5.0.0"},
-                            {"LatestRuntimeFrameworkVersion", "5.0.0"},
-                            {"TargetingPackName", "Microsoft.NETCore.App.Ref"},
-                            {"TargetingPackVersion", "5.0.0"},
-                            {"RuntimePackNamePatterns", "Microsoft.NETCore.App.Runtime.**RID**"},
-                            {"RuntimePackRuntimeIdentifiers", "win-x64;win-x86;linux-x64"},
-                        })
-                }
+                RuntimeIdentifier = runtimeIdentifier,
+                RuntimeIdentifiers = runtimeIdentifiers,
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { netCoreAppRef }
             };
-
-            task.Execute().Should().BeTrue();
-
-            // Should download targeting pack
+            
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue($"Task should succeed for scenario: {scenario}");
+            
             task.PackagesToDownload.Should().NotBeNull();
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-
-            // Runtime packs for RuntimeIdentifiers should be downloaded even without a primary RuntimeIdentifier
-            // This is the current behavior in ProcessFrameworkReferences.cs lines 376-400
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x86");
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64");
-        }
-
-        [Fact]
-        public void It_processes_RuntimeIdentifiers_with_empty_RuntimeIdentifier()
-        {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]},\"linux-x64\":{\"#import\":[\"any\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref", $"Should contain targeting pack for scenario: {scenario}");
+            
+            // Validate expected runtime packs based on scenario
+            if (runtimeIdentifiers != null && runtimeIdentifiers.Length > 0)
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = "", // Empty RuntimeIdentifier
-                RuntimeIdentifiers = new[] { "win-x64", "linux-x64" },
-                RuntimeGraphPath = runtimeGraphPathPath,
-                SelfContained = false,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences = new[]
+                foreach (var rid in runtimeIdentifiers)
                 {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference
+                    task.PackagesToDownload.Should().Contain(p => p.ItemSpec == $"Microsoft.NETCore.App.Runtime.{rid}", 
+                        $"Should contain runtime pack for {rid} in scenario: {scenario}");
                 }
-            };
-
-            task.Execute().Should().BeTrue();
-
-            // Should download targeting pack
-            task.PackagesToDownload.Should().NotBeNull();
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+            }
         }
 
-        [Fact]
-        public void It_handles_RuntimeIdentifiers_with_any_rid()
-        {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win-x64\":{\"#import\":[\"any\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+        // This test is now covered by the theory above
 
-            var task = new ProcessFrameworkReferences
-            {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = "any", // 'any' RID should be treated as null
-                RuntimeIdentifiers = new[] { "win-x64" },
-                RuntimeGraphPath = runtimeGraphPathPath,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference
-                }
-            };
-
-            task.Execute().Should().BeTrue();
-
-            // Should download targeting pack
-            task.PackagesToDownload.Should().NotBeNull();
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-
-            // With 'any' RID, EffectiveRuntimeIdentifier should be null
-            // But runtime pack for win-x64 in RuntimeIdentifiers should still be downloaded
-            // as per the implementation in ProcessFrameworkReferences.cs
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
-        }
+        // This test is now covered by the theory above
 
         [Fact]
         public void It_processes_RuntimeIdentifiers_with_AlwaysCopyLocal_and_no_RuntimeIdentifier()
         {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
+            var config = new TaskConfiguration
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
                 EnableRuntimePackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = null, // No RuntimeIdentifier
+                RuntimeIdentifier = null,
                 RuntimeIdentifiers = new[] { "win-x64" },
-                RuntimeGraphPath = runtimeGraphPathPath,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    _validWindowsSDKKnownFrameworkReference // This has RuntimePackAlwaysCopyLocal = true
-                }
+                RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { _validWindowsSDKKnownFrameworkReference }
             };
-
+            
+            var task = CreateTask(config);
+            
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
@@ -490,105 +447,58 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
 
             task.Execute().Should().BeTrue();
-
-            // Should have targeting pack
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
-
-            // Should have runtime pack even without RuntimeIdentifier due to AlwaysCopyLocal
             task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
         }
 
-        [Fact]
-        public void It_handles_null_RuntimeIdentifiers_array()
-        {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+        // This test is now covered by the theory above
 
-            var task = new ProcessFrameworkReferences
-            {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = null,
-                RuntimeIdentifiers = null, // Null RuntimeIdentifiers array
-                RuntimeGraphPath = runtimeGraphPathPath,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference
-                }
-            };
-
-            task.Execute().Should().BeTrue();
-
-            // Should still download targeting pack
-            task.PackagesToDownload.Should().NotBeNull();
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-        }
-
-        [Fact]
-        public void It_processes_empty_RuntimeIdentifiers_array()
-        {
-            const string minimalRuntimeGraphPathContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
-
-            var task = new ProcessFrameworkReferences
-            {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                EnableTargetingPackDownload = true,
-                TargetFrameworkIdentifier = ".NETCoreApp",
-                TargetFrameworkVersion = "5.0",
-                NETCoreSdkRuntimeIdentifier = "win-x64",
-                RuntimeIdentifier = null,
-                RuntimeIdentifiers = new string[] { }, // Empty RuntimeIdentifiers array
-                RuntimeGraphPath = runtimeGraphPathPath,
-                EnableRuntimePackDownload = true,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[]
-                {
-                    _netcoreAppKnownFrameworkReference
-                }
-            };
-
-            task.Execute().Should().BeTrue();
-
-            // Should still download targeting pack
-            task.PackagesToDownload.Should().NotBeNull();
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-        }
+        // This test is now covered by the theory above
 
         [Fact]
         public void It_handles_real_world_ridless_scenario_with_aot_and_trimming()
         {
             // This test reproduces the exact scenario from the reported issue
-            // where the task would crash due to null RID handling issues
-            const string runtimeGraphContent =
-                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"osx\":{\"#import\":[\"any\"]},\"osx-arm64\":{\"#import\":[\"osx\"]},\"osx-x64\":{\"#import\":[\"osx\"]}}}";
-            var runtimeGraphPathPath = Path.GetTempFileName();
-            File.WriteAllText(runtimeGraphPathPath, runtimeGraphContent);
-
-            var task = new ProcessFrameworkReferences
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.0-rc.2.25457.102",
+                "Microsoft.NETCore.App.Runtime.**RID**", "linux-arm;linux-arm64;osx-arm64;osx-x64;win-x64;win-x86");
+                
+            var macOSRef = CreateKnownFrameworkReference("Microsoft.macOS", "net10.0", "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
+                "Microsoft.macOS.Runtime.osx.net10.0_15.5", "osx-x64;osx-arm64", 
+                new Dictionary<string, string> {
+                    ["TargetingPackName"] = "Microsoft.macOS.Ref.net10.0_15.5",
+                    ["Profile"] = "macOS"
+                });
+                
+            var nativeAOTRuntimePack = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
             {
-                BuildEngine = new MockNeverCacheBuildEngine4(),
-                TargetFrameworkIdentifier = ".NETCoreApp",
+                ["TargetFramework"] = "net10.0",
+                ["RuntimeFrameworkName"] = "Microsoft.NETCore.App",
+                ["LatestRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
+                ["RuntimePackNamePatterns"] = "Microsoft.NETCore.App.Runtime.NativeAOT.**RID**",
+                ["RuntimePackRuntimeIdentifiers"] = "osx-arm64;osx-x64;win-x64;linux-x64",
+                ["RuntimePackLabels"] = "NativeAOT"
+            });
+            
+            var ilLinkPack = new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net10.0",
+                ["ILLinkPackVersion"] = "10.0.0-rc.2.25457.102"
+            });
+            
+            var ilCompilerPack = new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net10.0",
+                ["ILCompilerPackNamePattern"] = "runtime.**RID**.Microsoft.DotNet.ILCompiler",
+                ["ILCompilerPackVersion"] = "10.0.0-rc.2.25457.102",
+                ["ILCompilerRuntimeIdentifiers"] = "osx-x64;osx-arm64;win-x64;linux-x64"
+            });
+
+            var config = new TaskConfiguration
+            {
                 TargetFrameworkVersion = "10.0",
                 TargetPlatformIdentifier = "macOS",
                 TargetPlatformVersion = "15.5",
-                EnableTargetingPackDownload = true,
                 EnableRuntimePackDownload = true,
                 RequiresILLinkPack = true,
                 PublishAot = true,
@@ -598,118 +508,263 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableSingleFileAnalyzer = true,
                 NETCoreSdkRuntimeIdentifier = "osx-arm64",
                 NETCoreSdkPortableRuntimeIdentifier = "osx-arm64",
-                RuntimeIdentifier = null, // No primary RuntimeIdentifier (key to reproducing the issue)
-                RuntimeGraphPath = runtimeGraphPathPath,
+                RuntimeIdentifier = null, // Key: No primary RuntimeIdentifier
+                RuntimeIdentifiers = new[] { "osx-arm64", "osx-x64" }, // But has RuntimeIdentifiers
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
                 NetCoreRoot = "/usr/local/share/dotnet",
                 NETCoreSdkVersion = "10.0.100-rc.2.25457.102",
-                MinNonEolTargetFrameworkForAot = "net8.0",
-                MinNonEolTargetFrameworkForTrimming = "net8.0",
-                MinNonEolTargetFrameworkForSingleFile = "net8.0",
-                FirstTargetFrameworkVersionToSupportAotAnalyzer = "7.0",
-                FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0",
-                FirstTargetFrameworkVersionToSupportSingleFileAnalyzer = "6.0",
-                AotUseKnownRuntimePackForTarget = true,
-                DisableTransitiveFrameworkReferenceDownloads = true,
-                FrameworkReferences = new[]
-                {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
-                    {
-                        ["IsImplicitlyDefined"] = "true",
-                        ["PrivateAssets"] = "All",
-                        ["Pack"] = "false"
-                    }),
-                    new MockTaskItem("Microsoft.macOS", new Dictionary<string, string>
-                    {
-                        ["IsImplicitlyDefined"] = "true",
-                        ["PrivateAssets"] = "All",
-                        ["Pack"] = "false"
-                    })
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" }),
+                    new MockTaskItem("Microsoft.macOS", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
                 },
-                KnownFrameworkReferences = new[]
-                {
-                    // Microsoft.NETCore.App for net10.0
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
-                    {
-                        ["TargetFramework"] = "net10.0",
-                        ["RuntimeFrameworkName"] = "Microsoft.NETCore.App",
-                        ["DefaultRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
-                        ["LatestRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
-                        ["TargetingPackName"] = "Microsoft.NETCore.App.Ref",
-                        ["TargetingPackVersion"] = "10.0.0-rc.2.25457.102",
-                        ["RuntimePackNamePatterns"] = "Microsoft.NETCore.App.Runtime.**RID**",
-                        ["RuntimePackRuntimeIdentifiers"] = "linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64;linux-s390x;linux-loongarch64;linux-bionic-arm;linux-bionic-arm64;linux-bionic-x64;linux-bionic-x86;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-musl-loongarch64;android-arm64;android-x64"
-                    }),
-                    // Microsoft.macOS for net10.0
-                    new MockTaskItem("Microsoft.macOS", new Dictionary<string, string>
-                    {
-                        ["TargetFramework"] = "net10.0",
-                        ["RuntimeFrameworkName"] = "Microsoft.macOS",
-                        ["DefaultRuntimeFrameworkVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
-                        ["LatestRuntimeFrameworkVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
-                        ["TargetingPackName"] = "Microsoft.macOS.Ref.net10.0_15.5",
-                        ["TargetingPackVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
-                        ["RuntimePackNamePatterns"] = "Microsoft.macOS.Runtime.osx.net10.0_15.5",
-                        ["RuntimePackRuntimeIdentifiers"] = "osx-x64;osx-arm64",
-                        ["Profile"] = "macOS"
-                    })
-                },
-                KnownRuntimePacks = new[]
-                {
-                    // NativeAOT runtime pack for net10.0
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
-                    {
-                        ["TargetFramework"] = "net10.0",
-                        ["RuntimeFrameworkName"] = "Microsoft.NETCore.App",
-                        ["LatestRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
-                        ["RuntimePackNamePatterns"] = "Microsoft.NETCore.App.Runtime.NativeAOT.**RID**",
-                        ["RuntimePackRuntimeIdentifiers"] = "ios-arm64;iossimulator-arm64;iossimulator-x64;tvos-arm64;tvossimulator-arm64;tvossimulator-x64;maccatalyst-arm64;maccatalyst-x64;linux-bionic-arm64;linux-bionic-x64;osx-arm64;osx-x64;freebsd-arm64;freebsd-x64;linux-x64;linux-arm;linux-arm64;linux-loongarch64;linux-bionic-arm;linux-musl-x64;linux-musl-arm;linux-musl-arm64;linux-musl-loongarch64;win-x64;win-x86;win-arm64;browser-wasm;wasi-wasm;linux-riscv64;linux-musl-riscv64;android-arm64;android-x64",
-                        ["RuntimePackLabels"] = "NativeAOT"
-                    })
-                },
-                KnownILLinkPacks = new[]
-                {
-                    new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
-                    {
-                        ["TargetFramework"] = "net10.0",
-                        ["ILLinkPackVersion"] = "10.0.0-rc.2.25457.102"
-                    })
-                },
-                KnownILCompilerPacks = new[]
-                {
-                    new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
-                    {
-                        ["TargetFramework"] = "net10.0",
-                        ["ILCompilerPackNamePattern"] = "runtime.**RID**.Microsoft.DotNet.ILCompiler",
-                        ["ILCompilerRuntimePackNamePattern"] = "Microsoft.NETCore.App.Runtime.NativeAOT.**RID**",
-                        ["ILCompilerPackVersion"] = "10.0.0-rc.2.25457.102",
-                        ["ILCompilerRuntimeIdentifiers"] = "linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;win-arm64;win-x64;osx-x64;osx-arm64;freebsd-x64;freebsd-arm64;linux-arm;linux-musl-arm;linux-loongarch64;linux-musl-loongarch64;win-x86;linux-riscv64;linux-musl-riscv64"
-                    })
-                }
+                KnownFrameworkReferences = new[] { netCoreAppRef, macOSRef },
+                KnownRuntimePacks = new[] { nativeAOTRuntimePack },
+                KnownILLinkPacks = new[] { ilLinkPack },
+                KnownILCompilerPacks = new[] { ilCompilerPack }
             };
-
-            // This should not crash and should complete successfully
-            // The original issue was that null RuntimeIdentifier caused crashes
-            task.Execute().Should().BeTrue();
-
-            // Should have targeting packs for both frameworks
+            
+            var task = CreateTask(config);
+            
+            // Key validation: The task should complete successfully without crashing
+            // This was the main issue - null RuntimeIdentifier with RuntimeIdentifiers would crash
+            task.Execute().Should().BeTrue("Task should not crash with null RuntimeIdentifier but present RuntimeIdentifiers");
+            
+            // Validate that frameworks are processed correctly
             task.TargetingPacks.Should().NotBeNull();
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.macOS.Ref.net10.0_15.5");
-
-            // Should download necessary packages including tool packs for AOT/trimming
+            
+            // Validate that AOT tooling is processed
             task.PackagesToDownload.Should().NotBeNull();
-            task.ImplicitPackageReferences.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec.Contains("Microsoft.DotNet.ILCompiler"), "Should include AOT compiler tooling");
+        }
 
-            // Key validation: The task should complete successfully without crashing
-            // This was the main issue reported - the task would crash with null reference when
-            // there was no RuntimeIdentifier but RuntimeIdentifiers were present
+        [Fact]
+        public void It_handles_AOT_properties_without_failure()
+        {
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                SelfContained = true,
+                RuntimeIdentifier = "linux-x64",
+                EnableRuntimePackDownload = true,
+                NETCoreSdkRuntimeIdentifier = "linux-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { 
+                    CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "linux-x64")
+                },
+                KnownILCompilerPacks = new[] {
+                    CreateKnownILCompilerPack("net8.0", "8.0.0", "linux-x64;win-x64;osx-x64;osx-arm64")
+                },
+                PublishAot = true
+            };
+            
+            var task = CreateTask(config);
+            
+            task.Execute().Should().BeTrue("Task should handle AOT properties without failing");
+            
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64");
+        }
 
-            // Should include the targeting packs
+        [Fact]
+        public void It_handles_trimming_scenarios()
+        {
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                PublishTrimmed = true,
+                EnableTrimAnalyzer = true,
+                SelfContained = true,
+                RuntimeIdentifier = "win-x64",
+                EnableRuntimePackDownload = true,
+                RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { 
+                    CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "win-x64")
+                }
+            };
+            
+            var task = CreateTask(config);
+            task.FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0";
+            
+            task.Execute().Should().BeTrue("Trimming scenario should be handled");
+            
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
+        }
+
+        [Fact]
+        public void It_handles_combined_publish_properties()
+        {
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                SelfContained = true,
+                RuntimeIdentifier = "osx-arm64",
+                EnableRuntimePackDownload = true,
+                NETCoreSdkRuntimeIdentifier = "osx-arm64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { 
+                    CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "osx-arm64")
+                },
+                KnownILCompilerPacks = new[] {
+                    CreateKnownILCompilerPack("net8.0", "8.0.0", "linux-x64;win-x64;osx-x64;osx-arm64")
+                },
+                PublishAot = true,
+                PublishTrimmed = true
+            };
+            
+            var task = CreateTask(config);
+            
+            task.Execute().Should().BeTrue("Combined publish properties should be handled");
+            
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.osx-arm64");
+        }
+
+        [Fact]
+        public void It_handles_mobile_iOS_framework_references()
+        {
+            // Create compatible framework references with correct target framework
+            var netCoreRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "ios-arm64");
+            var iosFrameworkRef = CreateKnownFrameworkReference("Microsoft.iOS", "net8.0-ios17.0", "17.0.8478",
+                "Microsoft.iOS.Runtime.**RID**", "ios-arm64;iossimulator-x64;iossimulator-arm64",
+                new Dictionary<string, string> { ["Profile"] = "iOS" });
+                
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                TargetPlatformIdentifier = "iOS",
+                TargetPlatformVersion = "17.0",
+                EnableRuntimePackDownload = true,
+                RuntimeIdentifier = "ios-arm64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { 
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                    new MockTaskItem("Microsoft.iOS", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[] { netCoreRef, iosFrameworkRef }
+            };
+            
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue();
+            
+            // Should include both .NET and iOS targeting packs
+            task.TargetingPacks.Should().NotBeNull();
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.iOS.Ref");
+        }
+
+        [Theory]
+        [InlineData(true, true, true, "All analyzers enabled")]
+        [InlineData(true, true, false, "AOT and Trim analyzers only")]
+        [InlineData(false, false, true, "SingleFile analyzer only")]
+        [InlineData(true, false, false, "AOT analyzer only")]
+        public void It_handles_analyzer_combinations(bool aotAnalyzer, bool trimAnalyzer, bool singleFileAnalyzer, string scenario)
+        {
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0", // Ensure analyzers are supported
+                EnableTargetingPackDownload = true, // Need this for PackagesToDownload
+                EnableAotAnalyzer = aotAnalyzer,
+                EnableTrimAnalyzer = trimAnalyzer,
+                EnableSingleFileAnalyzer = singleFileAnalyzer,
+                RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { 
+                    CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "win-x64")
+                }
+            };
+            
+            var task = CreateTask(config);
+            // Set framework version thresholds for analyzer support
+            task.FirstTargetFrameworkVersionToSupportAotAnalyzer = "7.0";
+            task.FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0";
+            task.FirstTargetFrameworkVersionToSupportSingleFileAnalyzer = "6.0";
+            
+            task.Execute().Should().BeTrue($"Task should succeed for scenario: {scenario}");
+            task.PackagesToDownload.Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData("Android", "34.0", "android-arm64")]
+        [InlineData("macOS", "14.0", "osx-arm64")]
+        [InlineData("Windows", "10.0.19041.0", "win-x64")]
+        public void It_handles_different_target_platforms(string platformId, string platformVersion, string runtimeId)
+        {
+            var platformFrameworkRef = CreateKnownFrameworkReference($"Microsoft.{platformId}", "net8.0", "8.0.0",
+                $"Microsoft.{platformId}.Runtime.**RID**", runtimeId,
+                new Dictionary<string, string> { 
+                    ["Profile"] = platformId,
+                    ["IsWindowsOnly"] = (platformId == "Windows").ToString().ToLower()
+                });
+                
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                TargetPlatformIdentifier = platformId,
+                TargetPlatformVersion = platformVersion,
+                EnableRuntimePackDownload = true,
+                RuntimeIdentifier = runtimeId,
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { 
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                    new MockTaskItem($"Microsoft.{platformId}", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[] { 
+                    CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", runtimeId),
+                    platformFrameworkRef 
+                }
+            };
+            
+            var task = CreateTask(config);
+            
+            // Windows-only framework should fail on non-Windows
+            if (platformId == "Windows" && Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                task.Execute().Should().BeFalse("Windows-only framework should fail on non-Windows platforms");
+                return;
+            }
+            
+            task.Execute().Should().BeTrue($"Should handle {platformId} platform targeting");
+            task.TargetingPacks.Should().NotBeNull();
+        }
+
+
+        [Fact]
+        public void It_handles_complex_cross_compilation_RuntimeIdentifiers()
+        {
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0",
+                "Microsoft.NETCore.App.Runtime.**RID**", 
+                "linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;alpine-x64;alpine-arm64");
+                
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "8.0",
+                EnableRuntimePackDownload = true,
+                RuntimeIdentifier = null, // No primary RID
+                RuntimeIdentifiers = new[] { "linux-x64", "linux-musl-x64", "alpine-x64", "linux-arm64" }, // Mixed supported/unsupported
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
+                KnownFrameworkReferences = new[] { netCoreAppRef }
+            };
+            
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue("Should handle mixed supported/unsupported RIDs gracefully");
+            
+            task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.macOS.Ref.net10.0_15.5");
-
-            // Should include ILCompiler pack for AOT (validates that AOT processing works)
-            task.PackagesToDownload.Should().Contain(p => p.ItemSpec.StartsWith("runtime.") && p.ItemSpec.Contains("Microsoft.DotNet.ILCompiler"));
+            
+            // Should download runtime packs for supported RIDs only
+            var supportedRids = new[] { "linux-x64", "linux-musl-x64", "linux-arm64" };
+            foreach (var rid in supportedRids)
+            {
+                task.PackagesToDownload.Should().Contain(p => p.ItemSpec == $"Microsoft.NETCore.App.Runtime.{rid}",
+                    $"Should include runtime pack for supported RID: {rid}");
+            }
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new ProcessFrameworkReferences
             {
+                BuildEngine = new MockBuildEngine(),
                 EnableTargetingPackDownload = true,
                 TargetFrameworkIdentifier = ".NETCoreApp",
                 TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
@@ -79,6 +80,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new ProcessFrameworkReferences
             {
+                BuildEngine = new MockBuildEngine(),
                 EnableTargetingPackDownload = true,
                 TargetFrameworkIdentifier = ".NETCoreApp",
                 TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
@@ -116,6 +118,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var task = new ProcessFrameworkReferences
             {
+                BuildEngine = new MockBuildEngine(),
                 TargetFrameworkIdentifier = ".NETCoreApp",
                 TargetFrameworkVersion = "2.0",
                 FrameworkReferences = new[]
@@ -304,7 +307,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
                 return;
             }
-
             task.Execute().Should().BeTrue();
 
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -68,10 +68,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
 
             task.Execute().Should().BeTrue();
-
-            task.PackagesToDownload.Length.Should().Be(1);
-
-            task.RuntimeFrameworks.Length.Should().Be(1);
+            task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
+            task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
             task.RuntimeFrameworks[0].GetMetadata(MetadataKeys.Version).Should().Be("1.9.5");
         }
@@ -107,9 +105,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute().Should().BeTrue();
 
-            task.PackagesToDownload.Length.Should().Be(1);
-
-            task.RuntimeFrameworks.Length.Should().Be(1);
+            task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
+            task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
             task.RuntimeFrameworks[0].GetMetadata(MetadataKeys.Version).Should().Be("1.9.5");
         }
@@ -195,12 +192,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute().Should().BeTrue();
 
-            task.PackagesToDownload.Length.Should().Be(1);
+            task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
 
             task.RuntimeFrameworks.Should().BeNullOrEmpty(
                 "Should not contain RuntimePackAlwaysCopyLocal framework, or it will be put into runtimeconfig.json");
 
-            task.TargetingPacks.Length.Should().Be(1);
+            task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
             task.TargetingPacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
             task.TargetingPacks[0].GetMetadata(MetadataKeys.NuGetPackageId).Should()
                 .Be("Microsoft.Windows.SDK.NET.Ref");
@@ -211,7 +208,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Be("Microsoft.Windows.SDK.NET.Ref");
             task.TargetingPacks[0].GetMetadata(MetadataKeys.RuntimeIdentifier).Should().Be("");
 
-            task.RuntimePacks.Length.Should().Be(1);
+            task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
             task.RuntimePacks[0].GetMetadata(MetadataKeys.FrameworkName).Should().Be("Microsoft.Windows.SDK.NET.Ref");
             task.RuntimePacks[0].GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
@@ -257,7 +254,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 task.Execute().Should().BeTrue();
 
-                task.PackagesToDownload.Length.Should().Be(3);
+                task.PackagesToDownload.Should().NotBeNull().And.HaveCount(3);
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.Windows.SDK.NET.Ref");
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
@@ -310,13 +307,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute().Should().BeTrue();
 
-            task.TargetingPacks.Length.Should().Be(2);
+            task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);
             task.TargetingPacks.Should().Contain(p =>
                 p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.Windows.SDK.NET.Ref");
             task.TargetingPacks.Should()
                 .Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
 
-            task.RuntimePacks.Length.Should().Be(1);
+            task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref",
                 "it should not resolve runtime pack for Microsoft.NETCore.App");
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -319,5 +319,397 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref",
                 "it should not resolve runtime pack for Microsoft.NETCore.App");
         }
+
+        [Fact]
+        public void It_processes_RuntimeIdentifiers_without_RuntimeIdentifier()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]},\"win-x86\":{\"#import\":[\"win\"]},\"linux-x64\":{\"#import\":[\"any\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = null, // No RuntimeIdentifier
+                RuntimeIdentifiers = new[] { "win-x64", "win-x86", "linux-x64" }, // Multiple RuntimeIdentifiers
+                RuntimeGraphPath = runtimeGraphPathPath,
+                TargetLatestRuntimePatch = true,
+                EnableRuntimePackDownload = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App",
+                        new Dictionary<string, string>
+                        {
+                            {"TargetFramework", "net5.0"},
+                            {"RuntimeFrameworkName", "Microsoft.NETCore.App"},
+                            {"DefaultRuntimeFrameworkVersion", "5.0.0"},
+                            {"LatestRuntimeFrameworkVersion", "5.0.0"},
+                            {"TargetingPackName", "Microsoft.NETCore.App.Ref"},
+                            {"TargetingPackVersion", "5.0.0"},
+                            {"RuntimePackNamePatterns", "Microsoft.NETCore.App.Runtime.**RID**"},
+                            {"RuntimePackRuntimeIdentifiers", "win-x64;win-x86;linux-x64"},
+                        })
+                }
+            };
+
+            task.Execute().Should().BeTrue();
+
+            // Should download targeting pack
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+
+            // Runtime packs for RuntimeIdentifiers should be downloaded even without a primary RuntimeIdentifier
+            // This is the current behavior in ProcessFrameworkReferences.cs lines 376-400
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x86");
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64");
+        }
+
+        [Fact]
+        public void It_processes_RuntimeIdentifiers_with_empty_RuntimeIdentifier()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]},\"linux-x64\":{\"#import\":[\"any\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = "", // Empty RuntimeIdentifier
+                RuntimeIdentifiers = new[] { "win-x64", "linux-x64" },
+                RuntimeGraphPath = runtimeGraphPathPath,
+                SelfContained = false,
+                EnableRuntimePackDownload = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference
+                }
+            };
+
+            task.Execute().Should().BeTrue();
+
+            // Should download targeting pack
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+        }
+
+        [Fact]
+        public void It_handles_RuntimeIdentifiers_with_any_rid()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win-x64\":{\"#import\":[\"any\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = "any", // 'any' RID should be treated as null
+                RuntimeIdentifiers = new[] { "win-x64" },
+                RuntimeGraphPath = runtimeGraphPathPath,
+                EnableRuntimePackDownload = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference
+                }
+            };
+
+            task.Execute().Should().BeTrue();
+
+            // Should download targeting pack
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+
+            // With 'any' RID, EffectiveRuntimeIdentifier should be null
+            // But runtime pack for win-x64 in RuntimeIdentifiers should still be downloaded
+            // as per the implementation in ProcessFrameworkReferences.cs
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
+        }
+
+        [Fact]
+        public void It_processes_RuntimeIdentifiers_with_AlwaysCopyLocal_and_no_RuntimeIdentifier()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"win\":{\"#import\":[\"any\"]},\"win-x64\":{\"#import\":[\"win\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                EnableRuntimePackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.18362",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = null, // No RuntimeIdentifier
+                RuntimeIdentifiers = new[] { "win-x64" },
+                RuntimeGraphPath = runtimeGraphPathPath,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    _validWindowsSDKKnownFrameworkReference // This has RuntimePackAlwaysCopyLocal = true
+                }
+            };
+
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                task.Execute().Should().BeFalse("IsWindowsOnly=true");
+                return;
+            }
+
+            task.Execute().Should().BeTrue();
+
+            // Should have targeting pack
+            task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
+
+            // Should have runtime pack even without RuntimeIdentifier due to AlwaysCopyLocal
+            task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
+            task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
+        }
+
+        [Fact]
+        public void It_handles_null_RuntimeIdentifiers_array()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = null,
+                RuntimeIdentifiers = null, // Null RuntimeIdentifiers array
+                RuntimeGraphPath = runtimeGraphPathPath,
+                EnableRuntimePackDownload = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference
+                }
+            };
+
+            task.Execute().Should().BeTrue();
+
+            // Should still download targeting pack
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+        }
+
+        [Fact]
+        public void It_processes_empty_RuntimeIdentifiers_array()
+        {
+            const string minimalRuntimeGraphPathContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, minimalRuntimeGraphPathContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                EnableTargetingPackDownload = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "5.0",
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = null,
+                RuntimeIdentifiers = new string[] { }, // Empty RuntimeIdentifiers array
+                RuntimeGraphPath = runtimeGraphPathPath,
+                EnableRuntimePackDownload = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>())
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    _netcoreAppKnownFrameworkReference
+                }
+            };
+
+            task.Execute().Should().BeTrue();
+
+            // Should still download targeting pack
+            task.PackagesToDownload.Should().NotBeNull();
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+        }
+
+        [Fact]
+        public void It_handles_real_world_ridless_scenario_with_aot_and_trimming()
+        {
+            // This test reproduces the exact scenario from the reported issue
+            // where the task would crash due to null RID handling issues
+            const string runtimeGraphContent =
+                "{\"runtimes\":{\"any\":{\"#import\":[\"base\"]},\"base\":{\"#import\":[]},\"osx\":{\"#import\":[\"any\"]},\"osx-arm64\":{\"#import\":[\"osx\"]},\"osx-x64\":{\"#import\":[\"osx\"]}}}";
+            var runtimeGraphPathPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPathPath, runtimeGraphContent);
+
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "10.0",
+                TargetPlatformIdentifier = "macOS",
+                TargetPlatformVersion = "15.5",
+                EnableTargetingPackDownload = true,
+                EnableRuntimePackDownload = true,
+                RequiresILLinkPack = true,
+                PublishAot = true,
+                PublishTrimmed = true,
+                EnableAotAnalyzer = true,
+                EnableTrimAnalyzer = true,
+                EnableSingleFileAnalyzer = true,
+                NETCoreSdkRuntimeIdentifier = "osx-arm64",
+                NETCoreSdkPortableRuntimeIdentifier = "osx-arm64",
+                RuntimeIdentifier = null, // No primary RuntimeIdentifier (key to reproducing the issue)
+                RuntimeGraphPath = runtimeGraphPathPath,
+                NetCoreRoot = "/usr/local/share/dotnet",
+                NETCoreSdkVersion = "10.0.100-rc.2.25457.102",
+                MinNonEolTargetFrameworkForAot = "net8.0",
+                MinNonEolTargetFrameworkForTrimming = "net8.0",
+                MinNonEolTargetFrameworkForSingleFile = "net8.0",
+                FirstTargetFrameworkVersionToSupportAotAnalyzer = "7.0",
+                FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0",
+                FirstTargetFrameworkVersionToSupportSingleFileAnalyzer = "6.0",
+                AotUseKnownRuntimePackForTarget = true,
+                DisableTransitiveFrameworkReferenceDownloads = true,
+                FrameworkReferences = new[]
+                {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        ["IsImplicitlyDefined"] = "true",
+                        ["PrivateAssets"] = "All",
+                        ["Pack"] = "false"
+                    }),
+                    new MockTaskItem("Microsoft.macOS", new Dictionary<string, string>
+                    {
+                        ["IsImplicitlyDefined"] = "true",
+                        ["PrivateAssets"] = "All",
+                        ["Pack"] = "false"
+                    })
+                },
+                KnownFrameworkReferences = new[]
+                {
+                    // Microsoft.NETCore.App for net10.0
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        ["TargetFramework"] = "net10.0",
+                        ["RuntimeFrameworkName"] = "Microsoft.NETCore.App",
+                        ["DefaultRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
+                        ["LatestRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
+                        ["TargetingPackName"] = "Microsoft.NETCore.App.Ref",
+                        ["TargetingPackVersion"] = "10.0.0-rc.2.25457.102",
+                        ["RuntimePackNamePatterns"] = "Microsoft.NETCore.App.Runtime.**RID**",
+                        ["RuntimePackRuntimeIdentifiers"] = "linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64;linux-s390x;linux-loongarch64;linux-bionic-arm;linux-bionic-arm64;linux-bionic-x64;linux-bionic-x86;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-musl-loongarch64;android-arm64;android-x64"
+                    }),
+                    // Microsoft.macOS for net10.0
+                    new MockTaskItem("Microsoft.macOS", new Dictionary<string, string>
+                    {
+                        ["TargetFramework"] = "net10.0",
+                        ["RuntimeFrameworkName"] = "Microsoft.macOS",
+                        ["DefaultRuntimeFrameworkVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
+                        ["LatestRuntimeFrameworkVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
+                        ["TargetingPackName"] = "Microsoft.macOS.Ref.net10.0_15.5",
+                        ["TargetingPackVersion"] = "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
+                        ["RuntimePackNamePatterns"] = "Microsoft.macOS.Runtime.osx.net10.0_15.5",
+                        ["RuntimePackRuntimeIdentifiers"] = "osx-x64;osx-arm64",
+                        ["Profile"] = "macOS"
+                    })
+                },
+                KnownRuntimePacks = new[]
+                {
+                    // NativeAOT runtime pack for net10.0
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        ["TargetFramework"] = "net10.0",
+                        ["RuntimeFrameworkName"] = "Microsoft.NETCore.App",
+                        ["LatestRuntimeFrameworkVersion"] = "10.0.0-rc.2.25457.102",
+                        ["RuntimePackNamePatterns"] = "Microsoft.NETCore.App.Runtime.NativeAOT.**RID**",
+                        ["RuntimePackRuntimeIdentifiers"] = "ios-arm64;iossimulator-arm64;iossimulator-x64;tvos-arm64;tvossimulator-arm64;tvossimulator-x64;maccatalyst-arm64;maccatalyst-x64;linux-bionic-arm64;linux-bionic-x64;osx-arm64;osx-x64;freebsd-arm64;freebsd-x64;linux-x64;linux-arm;linux-arm64;linux-loongarch64;linux-bionic-arm;linux-musl-x64;linux-musl-arm;linux-musl-arm64;linux-musl-loongarch64;win-x64;win-x86;win-arm64;browser-wasm;wasi-wasm;linux-riscv64;linux-musl-riscv64;android-arm64;android-x64",
+                        ["RuntimePackLabels"] = "NativeAOT"
+                    })
+                },
+                KnownILLinkPacks = new[]
+                {
+                    new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
+                    {
+                        ["TargetFramework"] = "net10.0",
+                        ["ILLinkPackVersion"] = "10.0.0-rc.2.25457.102"
+                    })
+                },
+                KnownILCompilerPacks = new[]
+                {
+                    new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
+                    {
+                        ["TargetFramework"] = "net10.0",
+                        ["ILCompilerPackNamePattern"] = "runtime.**RID**.Microsoft.DotNet.ILCompiler",
+                        ["ILCompilerRuntimePackNamePattern"] = "Microsoft.NETCore.App.Runtime.NativeAOT.**RID**",
+                        ["ILCompilerPackVersion"] = "10.0.0-rc.2.25457.102",
+                        ["ILCompilerRuntimeIdentifiers"] = "linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;win-arm64;win-x64;osx-x64;osx-arm64;freebsd-x64;freebsd-arm64;linux-arm;linux-musl-arm;linux-loongarch64;linux-musl-loongarch64;win-x86;linux-riscv64;linux-musl-riscv64"
+                    })
+                }
+            };
+
+            // This should not crash and should complete successfully
+            // The original issue was that null RuntimeIdentifier caused crashes
+            task.Execute().Should().BeTrue();
+
+            // Should have targeting packs for both frameworks
+            task.TargetingPacks.Should().NotBeNull();
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
+            task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.macOS.Ref.net10.0_15.5");
+
+            // Should download necessary packages including tool packs for AOT/trimming
+            task.PackagesToDownload.Should().NotBeNull();
+            task.ImplicitPackageReferences.Should().NotBeNull();
+
+            // Key validation: The task should complete successfully without crashing
+            // This was the main issue reported - the task would crash with null reference when
+            // there was no RuntimeIdentifier but RuntimeIdentifiers were present
+
+            // Should include the targeting packs
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.macOS.Ref.net10.0_15.5");
+
+            // Should include ILCompiler pack for AOT (validates that AOT processing works)
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec.StartsWith("runtime.") && p.ItemSpec.Contains("Microsoft.DotNet.ILCompiler"));
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -240,6 +240,10 @@ namespace Microsoft.NET.Build.Tasks
                     }
                     Log.LogMessage(MessageImportance.Low, $"Selected {selectedPack.Name} with RIDs '{selectedPack.RuntimePackRuntimeIdentifiers}'");
                 }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, $"No runtime pack found for {knownFrameworkReference.Name}.");
+                }
 
                 TaskItem targetingPack = new(knownFrameworkReference.Name);
                 targetingPack.SetMetadata(MetadataKeys.NuGetPackageId, knownFrameworkReference.TargetingPackName);
@@ -466,7 +470,7 @@ namespace Microsoft.NET.Build.Tasks
                         Log.LogError(Strings.AotUnsupportedHostRuntimeIdentifier, NETCoreSdkRuntimeIdentifier);
                         return;
                     case ToolPackSupport.UnsupportedForTargetRuntimeIdentifier when EffectiveRuntimeIdentifier != null:
-                        Log.LogError(Strings.AotUnsupportedTargetRuntimeIdentifier, EffectiveRuntimeIdentifier ?? "<unspecified runtime identifier>");
+                        Log.LogError(Strings.AotUnsupportedTargetRuntimeIdentifier, EffectiveRuntimeIdentifier!);
                         return;
                     case ToolPackSupport.Supported:
                         break;
@@ -488,7 +492,7 @@ namespace Microsoft.NET.Build.Tasks
                     else if (IsAotCompatible || EnableAotAnalyzer)
                     {
                         if (!SilenceIsAotCompatibleUnsupportedWarning)
-                            Log.LogWarning(Strings.IsAotCompatibleUnsupported, MinNonEolTargetFrameworkForAot ?? "<missing target framework version>");
+                            Log.LogWarning(Strings.IsAotCompatibleUnsupported, MinNonEolTargetFrameworkForAot!);
                     }
                     else if (PublishTrimmed)
                     {
@@ -497,14 +501,14 @@ namespace Microsoft.NET.Build.Tasks
                     else if (IsTrimmable || EnableTrimAnalyzer)
                     {
                         if (!SilenceIsTrimmableUnsupportedWarning)
-                            Log.LogWarning(Strings.IsTrimmableUnsupported, MinNonEolTargetFrameworkForTrimming ?? "<missing target framework version>");
+                            Log.LogWarning(Strings.IsTrimmableUnsupported, MinNonEolTargetFrameworkForTrimming!);
                     }
                     else if (EnableSingleFileAnalyzer)
                     {
                         // There's no IsSingleFileCompatible setting. EnableSingleFileAnalyzer is the
                         // recommended way to ensure single-file compatibility for libraries.
                         if (!SilenceEnableSingleFileAnalyzerUnsupportedWarning)
-                            Log.LogWarning(Strings.EnableSingleFileAnalyzerUnsupported, MinNonEolTargetFrameworkForSingleFile ?? "<missing target framework version>");
+                            Log.LogWarning(Strings.EnableSingleFileAnalyzerUnsupported, MinNonEolTargetFrameworkForSingleFile!);
                     }
                     else
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -932,19 +932,25 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     var firstTargetFrameworkVersionToSupportAotAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportAotAnalyzer));
                     if ((IsAotCompatible || EnableAotAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportAotAnalyzer)
+                    {
                         return ToolPackSupport.UnsupportedForTargetFramework;
+                    }
                 }
                 if (FirstTargetFrameworkVersionToSupportSingleFileAnalyzer != null)
                 {
                     var firstTargetFrameworkVersionToSupportSingleFileAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportSingleFileAnalyzer));
                     if (EnableSingleFileAnalyzer && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportSingleFileAnalyzer)
+                    {
                         return ToolPackSupport.UnsupportedForTargetFramework;
+                    }
                 }
                 if (FirstTargetFrameworkVersionToSupportTrimAnalyzer != null)
                 {
                     var firstTargetFrameworkVersionToSupportTrimAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportTrimAnalyzer));
                     if ((IsTrimmable || EnableTrimAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportTrimAnalyzer)
+                    {
                         return ToolPackSupport.UnsupportedForTargetFramework;
+                    }
                 }
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -366,15 +366,12 @@ namespace Microsoft.NET.Build.Tasks
                         }
                     }
 
-                    if (EffectiveRuntimeIdentifier != null)
-                    {
-                        //  Process primary runtime identifier
-                        ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                            wasReferencedDirectly: frameworkReference != null);
+                    //  Process primary runtime identifier
+                    ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier ?? "any", runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
+                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
+                        wasReferencedDirectly: frameworkReference != null);
 
-                        processedPrimaryRuntimeIdentifier = true;
-                    }
+                    processedPrimaryRuntimeIdentifier = true;
                 }
 
                 if (RuntimeIdentifiers != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Cli;
@@ -21,18 +19,19 @@ namespace Microsoft.NET.Build.Tasks
     /// </summary>
     public class ProcessFrameworkReferences : TaskBase
     {
-        public string TargetFrameworkIdentifier { get; set; }
-
-        public string TargetFrameworkVersion { get; set; }
-
-        public string TargetPlatformIdentifier { get; set; }
-
-        public string TargetPlatformVersion { get; set; }
-
-        public string TargetingPackRoot { get; set; }
+        public string? TargetFrameworkIdentifier { get; set; }
 
         [Required]
-        public string RuntimeGraphPath { get; set; }
+        public string TargetFrameworkVersion { get; set; } = null!;
+
+        public string? TargetPlatformIdentifier { get; set; }
+
+        public string? TargetPlatformVersion { get; set; }
+
+        public string? TargetingPackRoot { get; set; }
+
+        [Required]
+        public string RuntimeGraphPath { get; set; } = null!;
 
         public bool SelfContained { get; set; }
 
@@ -48,39 +47,45 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool SilenceIsAotCompatibleUnsupportedWarning { get; set; }
 
-        public string MinNonEolTargetFrameworkForAot { get; set; }
+        public string? MinNonEolTargetFrameworkForAot { get; set; }
 
         public bool EnableAotAnalyzer { get; set; }
 
-        public string FirstTargetFrameworkVersionToSupportAotAnalyzer { get; set; }
+        public string? FirstTargetFrameworkVersionToSupportAotAnalyzer { get; set; }
 
         public bool PublishTrimmed { get; set; }
 
         public bool IsTrimmable { get; set; }
 
-        public string FirstTargetFrameworkVersionToSupportTrimAnalyzer { get; set; }
+        public string? FirstTargetFrameworkVersionToSupportTrimAnalyzer { get; set; }
 
         public bool SilenceIsTrimmableUnsupportedWarning { get; set; }
 
-        public string MinNonEolTargetFrameworkForTrimming { get; set; }
+        public string? MinNonEolTargetFrameworkForTrimming { get; set; }
 
         public bool EnableTrimAnalyzer { get; set; }
 
         public bool EnableSingleFileAnalyzer { get; set; }
 
-        public string FirstTargetFrameworkVersionToSupportSingleFileAnalyzer { get; set; }
+        public string? FirstTargetFrameworkVersionToSupportSingleFileAnalyzer { get; set; }
 
         public bool SilenceEnableSingleFileAnalyzerUnsupportedWarning { get; set; }
 
-        public string MinNonEolTargetFrameworkForSingleFile { get; set; }
+        public string? MinNonEolTargetFrameworkForSingleFile { get; set; }
 
         public bool AotUseKnownRuntimePackForTarget { get; set; }
 
-        public string RuntimeIdentifier { get; set; }
+        public string? RuntimeIdentifier { get; set; }
 
-        public string[] RuntimeIdentifiers { get; set; }
+        /// <summary>
+        /// Since this Target is mostly focused on managing RID-specific assets, we massage the 'any' RID (which is platform-agnostic) into a 'null'
+        /// value to make processing simpler.
+        /// </summary>
+        public string? EffectiveRuntimeIdentifier => RuntimeIdentifier == "any" ? null : RuntimeIdentifier;
 
-        public string RuntimeFrameworkVersion { get; set; }
+        public string[]? RuntimeIdentifiers { get; set; }
+
+        public string? RuntimeFrameworkVersion { get; set; }
 
         public bool TargetLatestRuntimePatch { get; set; }
 
@@ -115,48 +120,48 @@ namespace Microsoft.NET.Build.Tasks
         public bool RequiresAspNetWebAssets { get; set; }
 
         [Required]
-        public string NETCoreSdkRuntimeIdentifier { get; set; }
+        public string NETCoreSdkRuntimeIdentifier { get; set; } = null!;
 
-        public string NETCoreSdkPortableRuntimeIdentifier { get; set; }
-
-        [Required]
-        public string NetCoreRoot { get; set; }
+        public string? NETCoreSdkPortableRuntimeIdentifier { get; set; }
 
         [Required]
-        public string NETCoreSdkVersion { get; set; }
+        public string NetCoreRoot { get; set; } = null!;
+
+        [Required]
+        public string NETCoreSdkVersion { get; set; } = null!;
 
         [Output]
-        public ITaskItem[] PackagesToDownload { get; set; }
+        public ITaskItem[]? PackagesToDownload { get; set; }
 
         [Output]
-        public ITaskItem[] RuntimeFrameworks { get; set; }
+        public ITaskItem[]? RuntimeFrameworks { get; set; }
 
         [Output]
-        public ITaskItem[] TargetingPacks { get; set; }
+        public ITaskItem[]? TargetingPacks { get; set; }
 
         [Output]
-        public ITaskItem[] RuntimePacks { get; set; }
+        public ITaskItem[]? RuntimePacks { get; set; }
 
         [Output]
-        public ITaskItem[] Crossgen2Packs { get; set; }
+        public ITaskItem[]? Crossgen2Packs { get; set; }
 
         [Output]
-        public ITaskItem[] HostILCompilerPacks { get; set; }
+        public ITaskItem[]? HostILCompilerPacks { get; set; }
 
         [Output]
-        public ITaskItem[] TargetILCompilerPacks { get; set; }
+        public ITaskItem[]? TargetILCompilerPacks { get; set; }
 
         [Output]
-        public ITaskItem[] ImplicitPackageReferences { get; set; }
+        public ITaskItem[]? ImplicitPackageReferences { get; set; }
 
         //  Runtime packs which aren't available for the specified RuntimeIdentifier
         [Output]
-        public ITaskItem[] UnavailableRuntimePacks { get; set; }
+        public ITaskItem[]? UnavailableRuntimePacks { get; set; }
 
         [Output]
-        public string[] KnownRuntimeIdentifierPlatforms { get; set; }
+        public string[]? KnownRuntimeIdentifierPlatforms { get; set; }
 
-        private Version _normalizedTargetFrameworkVersion;
+        private Version? _normalizedTargetFrameworkVersion;
 
         void AddPacksForFrameworkReferences(
             List<ITaskItem> packagesToDownload,
@@ -195,7 +200,7 @@ namespace Microsoft.NET.Build.Tasks
             bool windowsOnlyErrorLogged = false;
             foreach (var knownFrameworkReference in knownFrameworkReferencesForTargetFramework)
             {
-                frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem frameworkReference);
+                frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem? frameworkReference);
 
                 // Handle Windows-only frameworks on non-Windows platforms
                 if (knownFrameworkReference.IsWindowsOnly &&
@@ -240,7 +245,7 @@ namespace Microsoft.NET.Build.Tasks
                 targetingPack.SetMetadata(MetadataKeys.NuGetPackageId, knownFrameworkReference.TargetingPackName);
                 targetingPack.SetMetadata(MetadataKeys.PackageConflictPreferredPackages, string.Join(";", preferredPackages));
 
-                string targetingPackVersion = null;
+                string? targetingPackVersion = null;
                 if (frameworkReference != null)
                 {
                     //  Allow targeting pack version to be overridden via metadata on FrameworkReference
@@ -269,7 +274,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/packs)
-                string targetingPackPath = GetPackPath(knownFrameworkReference.TargetingPackName, targetingPackVersion);
+                string? targetingPackPath = GetPackPath(knownFrameworkReference.TargetingPackName, targetingPackVersion);
                 if (targetingPackPath != null)
                 {
                     // Use targeting pack from packs folder
@@ -295,13 +300,13 @@ namespace Microsoft.NET.Build.Tasks
 
                 Log.LogMessage(MessageImportance.Low, $"Selected targeting pack '{targetingPack.ItemSpec}@{targetingPackVersion}'");
 
-                var runtimeFrameworkVersion = GetRuntimeFrameworkVersion(
+                string runtimeFrameworkVersion = GetRuntimeFrameworkVersion(
                     frameworkReference,
                     knownFrameworkReference,
                     selectedRuntimePack,
                     out string runtimePackVersion);
 
-                string isTrimmable = null;
+                string? isTrimmable = null;
                 if (frameworkReference != null)
                 {
                     // Allow IsTrimmable to be overridden via metadata on FrameworkReference
@@ -314,7 +319,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 bool useRuntimePackAndDownloadIfNecessary;
                 KnownRuntimePack runtimePackForRuntimeIDProcessing;
-                if (knownFrameworkReference.Name.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase))
+                if (knownFrameworkReference.Name.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase) && selectedRuntimePack != null)
                 {
                     //  Only add runtime packs where the framework reference name matches the RuntimeFrameworkName
                     //  Framework references for "profiles" will use the runtime pack from the corresponding non-profile framework
@@ -340,40 +345,39 @@ namespace Microsoft.NET.Build.Tasks
                     selectedRuntimePack != null && selectedRuntimePack.Value.RuntimePackAlwaysCopyLocal;
                 var runtimeRequiredByDeployment
                     = (SelfContained || ReadyToRunEnabled) &&
-                      !string.IsNullOrEmpty(RuntimeIdentifier) &&
-                      RuntimeIdentifier != "any" &&
-                      selectedRuntimePack != null &&
-                      !string.IsNullOrEmpty(selectedRuntimePack.Value.RuntimePackNamePatterns);
+                      !string.IsNullOrEmpty(EffectiveRuntimeIdentifier) &&
+                      !string.IsNullOrEmpty(selectedRuntimePack?.RuntimePackNamePatterns);
 
                 if (hasRuntimePackAlwaysCopyLocal || runtimeRequiredByDeployment)
                 {
                     //  Find other KnownFrameworkReferences that map to the same runtime pack, if any
-                    List<string> additionalFrameworkReferencesForRuntimePack = null;
+                    List<string>? additionalFrameworkReferencesForRuntimePack = null;
                     foreach (var additionalKnownFrameworkReference in knownFrameworkReferencesForTargetFramework)
                     {
                         if (additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase) &&
                             !additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(additionalKnownFrameworkReference.Name, StringComparison.OrdinalIgnoreCase))
                         {
-                            if (additionalFrameworkReferencesForRuntimePack == null)
-                            {
-                                additionalFrameworkReferencesForRuntimePack = new List<string>();
-                            }
+                            additionalFrameworkReferencesForRuntimePack ??= [];
                             additionalFrameworkReferencesForRuntimePack.Add(additionalKnownFrameworkReference.Name);
                         }
                     }
 
-                    ProcessRuntimeIdentifier(RuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                        wasReferencedDirectly: frameworkReference != null);
+                    if (EffectiveRuntimeIdentifier != null)
+                    {
+                        //  Process primary runtime identifier
+                        ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
+                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
+                            wasReferencedDirectly: frameworkReference != null);
 
-                    processedPrimaryRuntimeIdentifier = true;
+                        processedPrimaryRuntimeIdentifier = true;
+                    }
                 }
 
                 if (RuntimeIdentifiers != null)
                 {
                     foreach (var runtimeIdentifier in RuntimeIdentifiers)
                     {
-                        if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == RuntimeIdentifier)
+                        if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == EffectiveRuntimeIdentifier)
                         {
                             //  We've already processed this RID
                             continue;
@@ -410,12 +414,12 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            List<ITaskItem> packagesToDownload = null;
-            List<ITaskItem> runtimeFrameworks = null;
-            List<ITaskItem> targetingPacks = null;
-            List<ITaskItem> runtimePacks = null;
-            List<ITaskItem> unavailableRuntimePacks = null;
-            List<KnownRuntimePack> knownRuntimePacksForTargetFramework = null;
+            List<ITaskItem>? packagesToDownload = null;
+            List<ITaskItem>? runtimeFrameworks = null;
+            List<ITaskItem>? targetingPacks = null;
+            List<ITaskItem>? runtimePacks = null;
+            List<ITaskItem>? unavailableRuntimePacks = null;
+            List<KnownRuntimePack>? knownRuntimePacksForTargetFramework = null;
 
             //  Perf optimization: If there are no FrameworkReference items, then don't do anything
             //  (This means that if you don't have any direct framework references, you won't get any transitive ones either
@@ -461,8 +465,8 @@ namespace Microsoft.NET.Build.Tasks
                     case ToolPackSupport.UnsupportedForHostRuntimeIdentifier:
                         Log.LogError(Strings.AotUnsupportedHostRuntimeIdentifier, NETCoreSdkRuntimeIdentifier);
                         return;
-                    case ToolPackSupport.UnsupportedForTargetRuntimeIdentifier:
-                        Log.LogError(Strings.AotUnsupportedTargetRuntimeIdentifier, RuntimeIdentifier);
+                    case ToolPackSupport.UnsupportedForTargetRuntimeIdentifier when EffectiveRuntimeIdentifier != null:
+                        Log.LogError(Strings.AotUnsupportedTargetRuntimeIdentifier, EffectiveRuntimeIdentifier ?? "<unspecified runtime identifier>");
                         return;
                     case ToolPackSupport.Supported:
                         break;
@@ -484,7 +488,7 @@ namespace Microsoft.NET.Build.Tasks
                     else if (IsAotCompatible || EnableAotAnalyzer)
                     {
                         if (!SilenceIsAotCompatibleUnsupportedWarning)
-                            Log.LogWarning(Strings.IsAotCompatibleUnsupported, MinNonEolTargetFrameworkForAot);
+                            Log.LogWarning(Strings.IsAotCompatibleUnsupported, MinNonEolTargetFrameworkForAot ?? "<missing target framework version>");
                     }
                     else if (PublishTrimmed)
                     {
@@ -493,14 +497,14 @@ namespace Microsoft.NET.Build.Tasks
                     else if (IsTrimmable || EnableTrimAnalyzer)
                     {
                         if (!SilenceIsTrimmableUnsupportedWarning)
-                            Log.LogWarning(Strings.IsTrimmableUnsupported, MinNonEolTargetFrameworkForTrimming);
+                            Log.LogWarning(Strings.IsTrimmableUnsupported, MinNonEolTargetFrameworkForTrimming ?? "<missing target framework version>");
                     }
                     else if (EnableSingleFileAnalyzer)
                     {
                         // There's no IsSingleFileCompatible setting. EnableSingleFileAnalyzer is the
                         // recommended way to ensure single-file compatibility for libraries.
                         if (!SilenceEnableSingleFileAnalyzerUnsupportedWarning)
-                            Log.LogWarning(Strings.EnableSingleFileAnalyzerUnsupported, MinNonEolTargetFrameworkForSingleFile);
+                            Log.LogWarning(Strings.EnableSingleFileAnalyzerUnsupported, MinNonEolTargetFrameworkForSingleFile ?? "<missing target framework version>");
                     }
                     else
                     {
@@ -609,11 +613,11 @@ namespace Microsoft.NET.Build.Tasks
             return true;
         }
 
-        private KnownRuntimePack? SelectRuntimePack(ITaskItem frameworkReference, KnownFrameworkReference knownFrameworkReference, List<KnownRuntimePack> knownRuntimePacks)
+        private KnownRuntimePack? SelectRuntimePack(ITaskItem? frameworkReference, KnownFrameworkReference knownFrameworkReference, List<KnownRuntimePack> knownRuntimePacks)
         {
             var requiredLabelsMetadata = frameworkReference?.GetMetadata(MetadataKeys.RuntimePackLabels) ?? "";
 
-            HashSet<string> requiredRuntimePackLabels = null;
+            HashSet<string>? requiredRuntimePackLabels = null;
             if (frameworkReference != null)
             {
                 requiredRuntimePackLabels = new HashSet<string>(requiredLabelsMetadata.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
@@ -658,24 +662,20 @@ namespace Microsoft.NET.Build.Tasks
             string runtimeIdentifier,
             KnownRuntimePack selectedRuntimePack,
             string runtimePackVersion,
-            List<string> additionalFrameworkReferencesForRuntimePack,
+            List<string>? additionalFrameworkReferencesForRuntimePack,
             HashSet<string> unrecognizedRuntimeIdentifiers,
             List<ITaskItem> unavailableRuntimePacks,
-            List<ITaskItem> runtimePacks,
+            List<ITaskItem>? runtimePacks,
             List<ITaskItem> packagesToDownload,
-            string isTrimmable,
+            string? isTrimmable,
             bool addRuntimePackAndDownloadIfNecessary,
             bool wasReferencedDirectly)
         {
-            if (RuntimeIdentifier == null || RuntimeIdentifier == "any")
-            {
-                return;
-            }
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
             var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
             var knownFrameworkReferenceRuntimePackExcludedRuntimeIdentifiers = selectedRuntimePack.RuntimePackExcludedRuntimeIdentifiers.Split(';');
             Log.LogMessage(MessageImportance.Low, $"Finding best RID match for pack {selectedRuntimePack.Name}@{runtimePackVersion} for target RID '{runtimeIdentifier}' from '{selectedRuntimePack.RuntimePackRuntimeIdentifiers}' excluding '{selectedRuntimePack.RuntimePackExcludedRuntimeIdentifiers}'");
-            string runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRidWithExclusion(
+            string? runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRidWithExclusion(
                     runtimeGraph,
                     runtimeIdentifier,
                     knownFrameworkReferenceRuntimePackExcludedRuntimeIdentifiers,
@@ -711,7 +711,7 @@ namespace Microsoft.NET.Build.Tasks
                     //  Look up runtimePackVersion from workload manifests if necessary
                     string resolvedRuntimePackVersion = GetResolvedPackVersion(runtimePackName, runtimePackVersion);
 
-                    string runtimePackPath = GetPackPath(runtimePackName, resolvedRuntimePackVersion);
+                    string? runtimePackPath = GetPackPath(runtimePackName, resolvedRuntimePackVersion);
 
                     if (runtimePacks != null)
                     {
@@ -809,7 +809,7 @@ namespace Microsoft.NET.Build.Tasks
 
             Log.LogMessage(MessageImportance.Low, $"Found {toolPackType} pack '{knownPack.ItemSpec}@{packVersion}'");
 
-            TaskItem runtimePackToDownload = null;
+            TaskItem? runtimePackToDownload = null;
 
             // Crossgen and ILCompiler have RID-specific bits.
             if (toolPackType is ToolPackType.Crossgen2 or ToolPackType.ILCompiler)
@@ -822,8 +822,8 @@ namespace Microsoft.NET.Build.Tasks
                 // It also enables the non-portable ILCompiler to be packaged separately from the SDK and
                 // only required when publishing for the non-portable SDK RID.
                 string portableSdkRid = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier) ? NETCoreSdkPortableRuntimeIdentifier : NETCoreSdkRuntimeIdentifier;
-                bool targetsNonPortableSdkRid = RuntimeIdentifier == NETCoreSdkRuntimeIdentifier && NETCoreSdkRuntimeIdentifier != portableSdkRid;
-                string hostRuntimeIdentifier = targetsNonPortableSdkRid ? NETCoreSdkRuntimeIdentifier : portableSdkRid;
+                bool targetsNonPortableSdkRid = EffectiveRuntimeIdentifier == NETCoreSdkRuntimeIdentifier && NETCoreSdkRuntimeIdentifier != portableSdkRid;
+                string? hostRuntimeIdentifier = targetsNonPortableSdkRid ? NETCoreSdkRuntimeIdentifier : portableSdkRid;
                 Log.LogMessage(MessageImportance.Low, $"Determining best RID for '{knownPack.ItemSpec}@{packVersion}' for '{hostRuntimeIdentifier}' from among '{knownPack.GetMetadata(packName + "RuntimeIdentifiers")}'");
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
                 var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
@@ -839,7 +839,7 @@ namespace Microsoft.NET.Build.Tasks
                 runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageId, runtimePackName);
                 runtimePackItem.SetMetadata(MetadataKeys.NuGetPackageVersion, packVersion);
 
-                string runtimePackPath = GetPackPath(runtimePackName, packVersion);
+                string? runtimePackPath = GetPackPath(runtimePackName, packVersion);
                 if (runtimePackPath != null)
                 {
                     runtimePackItem.SetMetadata(MetadataKeys.PackageDirectory, runtimePackPath);
@@ -863,10 +863,10 @@ namespace Microsoft.NET.Build.Tasks
                         // ILCompiler supports cross target compilation. If there is a cross-target request,
                         // we need to download that package as well unless we use KnownRuntimePack entries for the target.
                         // We expect RuntimeIdentifier to be defined during publish but can allow during build
-                        if (RuntimeIdentifier != null && !AotUseKnownRuntimePackForTarget)
+                        if (EffectiveRuntimeIdentifier != null && !AotUseKnownRuntimePackForTarget)
                         {
                             Log.LogMessage(MessageImportance.Low, $"Checking for cross-targeting compilation packs");
-                            var targetRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
+                            var targetRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, EffectiveRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph2);
                             if (targetRuntimeIdentifier == null)
                             {
                                 return ToolPackSupport.UnsupportedForTargetRuntimeIdentifier;
@@ -890,7 +890,7 @@ namespace Microsoft.NET.Build.Tasks
                                 TargetILCompilerPacks = new[] { targetIlcPack };
                                 Log.LogMessage(MessageImportance.Low, $"Added {targetIlcPackName}@{packVersion} for cross-targeting compilation");
 
-                                string targetILCompilerPackPath = GetPackPath(targetIlcPackName, packVersion);
+                                string? targetILCompilerPackPath = GetPackPath(targetIlcPackName, packVersion);
                                 if (targetILCompilerPackPath != null)
                                 {
                                     targetIlcPack.SetMetadata(MetadataKeys.PackageDirectory, targetILCompilerPackPath);
@@ -924,15 +924,24 @@ namespace Microsoft.NET.Build.Tasks
                 // The ILLink tool pack is available for some TargetFrameworks where we nonetheless consider
                 // IsTrimmable/IsAotCompatible/EnableSingleFile to be unsupported, because the framework
                 // was not annotated with the attributes.
-                var firstTargetFrameworkVersionToSupportAotAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportAotAnalyzer));
-                if ((IsAotCompatible || EnableAotAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportAotAnalyzer)
-                    return ToolPackSupport.UnsupportedForTargetFramework;
-                var firstTargetFrameworkVersionToSupportSingleFileAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportSingleFileAnalyzer));
-                if (EnableSingleFileAnalyzer && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportSingleFileAnalyzer)
-                    return ToolPackSupport.UnsupportedForTargetFramework;
-                var firstTargetFrameworkVersionToSupportTrimAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportTrimAnalyzer));
-                if ((IsTrimmable || EnableTrimAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportTrimAnalyzer)
-                    return ToolPackSupport.UnsupportedForTargetFramework;
+                if (FirstTargetFrameworkVersionToSupportAotAnalyzer != null)
+                {
+                    var firstTargetFrameworkVersionToSupportAotAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportAotAnalyzer));
+                    if ((IsAotCompatible || EnableAotAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportAotAnalyzer)
+                        return ToolPackSupport.UnsupportedForTargetFramework;
+                }
+                if (FirstTargetFrameworkVersionToSupportSingleFileAnalyzer != null)
+                {
+                    var firstTargetFrameworkVersionToSupportSingleFileAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportSingleFileAnalyzer));
+                    if (EnableSingleFileAnalyzer && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportSingleFileAnalyzer)
+                        return ToolPackSupport.UnsupportedForTargetFramework;
+                }
+                if (FirstTargetFrameworkVersionToSupportTrimAnalyzer != null)
+                {
+                    var firstTargetFrameworkVersionToSupportTrimAnalyzer = NormalizeVersion(new Version(FirstTargetFrameworkVersionToSupportTrimAnalyzer));
+                    if ((IsTrimmable || EnableTrimAnalyzer) && normalizedTargetFrameworkVersion < firstTargetFrameworkVersionToSupportTrimAnalyzer)
+                        return ToolPackSupport.UnsupportedForTargetFramework;
+                }
             }
 
             // Packs with RID-agnostic build packages that contain MSBuild targets.
@@ -963,7 +972,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         private string GetRuntimeFrameworkVersion(
-            ITaskItem frameworkReference,
+            ITaskItem? frameworkReference,
             KnownFrameworkReference knownFrameworkReference,
             KnownRuntimePack? knownRuntimePack,
             out string runtimePackVersion)
@@ -977,7 +986,7 @@ namespace Microsoft.NET.Build.Tasks
             //      - But, if TargetLatestRuntimePatch was defaulted and not overridden by user, then acquire latest runtime pack for future
             //        self-contained deployment (or for crossgen of framework-dependent deployment), while targeting the default version.
 
-            string requestedVersion = GetRequestedRuntimeFrameworkVersion(frameworkReference);
+            string? requestedVersion = GetRequestedRuntimeFrameworkVersion(frameworkReference);
             if (!string.IsNullOrEmpty(requestedVersion))
             {
                 runtimePackVersion = requestedVersion;
@@ -991,10 +1000,10 @@ namespace Microsoft.NET.Build.Tasks
                     return knownFrameworkReference.DefaultRuntimeFrameworkVersion;
 
                 case RuntimePatchRequest.UseLatestVersion:
-                    if (knownRuntimePack != null)
+                    if (knownRuntimePack is KnownRuntimePack knownPack)
                     {
-                        runtimePackVersion = knownRuntimePack?.LatestRuntimeFrameworkVersion;
-                        return knownRuntimePack?.LatestRuntimeFrameworkVersion;
+                        runtimePackVersion = knownPack.LatestRuntimeFrameworkVersion;
+                        return knownPack.LatestRuntimeFrameworkVersion;
                     }
                     else
                     {
@@ -1002,9 +1011,9 @@ namespace Microsoft.NET.Build.Tasks
                         return knownFrameworkReference.DefaultRuntimeFrameworkVersion;
                     }
                 case RuntimePatchRequest.UseDefaultVersionWithLatestRuntimePack:
-                    if (knownRuntimePack != null)
+                    if (knownRuntimePack is KnownRuntimePack knownPack2)
                     {
-                        runtimePackVersion = knownRuntimePack?.LatestRuntimeFrameworkVersion;
+                        runtimePackVersion = knownPack2.LatestRuntimeFrameworkVersion;
                     }
                     else
                     {
@@ -1018,7 +1027,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private string GetPackPath(string packName, string packVersion)
+        private string? GetPackPath(string packName, string packVersion)
         {
             IEnumerable<string> GetPackFolders()
             {
@@ -1058,8 +1067,14 @@ namespace Microsoft.NET.Build.Tasks
             return null;
         }
 
-        SdkDirectoryWorkloadManifestProvider _workloadManifestProvider;
-        WorkloadResolver _workloadResolver;
+        Lazy<WorkloadResolver> _workloadResolver
+        {
+            get
+            {
+                field ??= LazyCreateWorkloadResolver();
+                return field;
+             }
+        }
 
         private string GetResolvedPackVersion(string packID, string packVersion)
         {
@@ -1068,25 +1083,28 @@ namespace Microsoft.NET.Build.Tasks
                 return packVersion;
             }
 
-            if (_workloadManifestProvider == null)
-            {
-                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
-
-                //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
-                //  starting point to search for global.json
-                string globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
-
-                _workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, userProfileDir, globalJsonPath);
-                _workloadResolver = WorkloadResolver.Create(_workloadManifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir);
-            }
-
-            var packInfo = _workloadResolver.TryGetPackInfo(new WorkloadPackId(packID));
+            var packInfo = _workloadResolver.Value.TryGetPackInfo(new WorkloadPackId(packID));
             if (packInfo == null)
             {
                 Log.LogError(Strings.CouldNotGetPackVersionFromWorkloadManifests, packID);
                 return packVersion;
             }
             return packInfo.Version;
+        }
+
+        private Lazy<WorkloadResolver> LazyCreateWorkloadResolver()
+        {
+            return new(() =>
+        {
+                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+
+                //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
+                //  starting point to search for global.json
+                string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
+
+                var manifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, userProfileDir, globalJsonPath);
+                return WorkloadResolver.Create(manifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir);
+        });
         }
 
         private enum RuntimePatchRequest
@@ -1102,7 +1120,7 @@ namespace Microsoft.NET.Build.Tasks
         /// </summary>
         private class PackageToDownloadComparer<T> : IEqualityComparer<T> where T : ITaskItem
         {
-            public bool Equals(T x, T y)
+            public bool Equals(T? x, T? y)
             {
                 if (x is null || y is null)
                 {
@@ -1124,9 +1142,9 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private RuntimePatchRequest GetRuntimePatchRequest(ITaskItem frameworkReference)
+        private RuntimePatchRequest GetRuntimePatchRequest(ITaskItem? frameworkReference)
         {
-            string value = frameworkReference?.GetMetadata("TargetLatestRuntimePatch");
+            string? value = frameworkReference?.GetMetadata("TargetLatestRuntimePatch");
             if (!string.IsNullOrEmpty(value))
             {
                 return MSBuildUtilities.ConvertStringToBool(value, defaultValue: false)
@@ -1144,9 +1162,9 @@ namespace Microsoft.NET.Build.Tasks
                 : RuntimePatchRequest.UseDefaultVersion;
         }
 
-        private string GetRequestedRuntimeFrameworkVersion(ITaskItem frameworkReference)
+        private string? GetRequestedRuntimeFrameworkVersion(ITaskItem? frameworkReference)
         {
-            string requestedVersion = frameworkReference?.GetMetadata("RuntimeFrameworkVersion");
+            string? requestedVersion = frameworkReference?.GetMetadata("RuntimeFrameworkVersion");
 
             if (string.IsNullOrEmpty(requestedVersion))
             {


### PR DESCRIPTION
Fix #50680

This looks like a regression caused by https://github.com/dotnet/sdk/pull/50455 - clearly we have some testing gaps.

If this Target ever executes in a context where no single-RID is specified, some RID-specific assets shouldn't be processed for that single-RID. Instead, processing for any passed-in RIDs should wait until the part of the processing where all of the `RuntimeIdentifiers` are iterated over.

To make this easier to see/check, I enabled nullability for this Target and supporting logic.