### PR TITLE
Improve target graph handling in log messages

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolvePackageDependenciesTask.cs
@@ -141,11 +141,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Fact]
-        public void ItAssignsDiagnosticLevel()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ItAssignsDiagnosticLevel(bool useAlias)
         {
             const string target1 = ".NETCoreApp,Version=v1.0";
             const string target2 = ".NETCoreApp,Version=v2.0";
+
+            string alias1 = useAlias ? "netcoreapp1.0" : target1;
+            string alias2 = useAlias ? "netcoreapp2.0" : target2;
 
             string lockFileContent = CreateLockFileSnippet(
                 targets: new string[] {
@@ -157,15 +162,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 logs: new[]
                 {
                     // LibA
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibA", targetGraphs: new[] { target1 }),
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibA", targetGraphs: new[] { target1 }),
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Error,       "", libraryId: "LibA", targetGraphs: new[] { target1 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibA", targetGraphs: new[] { alias1 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibA", targetGraphs: new[] { alias1 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Error,       "", libraryId: "LibA", targetGraphs: new[] { alias1 }),
                     // LibB
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibB", targetGraphs: new[] { target1, target2 }),
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibB", targetGraphs: new[] { target1, target2 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibB", targetGraphs: new[] { alias1, alias2 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibB", targetGraphs: new[] { alias1, alias2 }),
                     // LibC (wrong target)
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibB", targetGraphs: new[] { target2 }),
-                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibB", targetGraphs: new[] { target2 })
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Information, "", libraryId: "LibB", targetGraphs: new[] { alias2 }),
+                    CreateLog(NuGetLogCode.NU1000, LogLevel.Warning,     "", libraryId: "LibB", targetGraphs: new[] { alias2 })
                 }
             );
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -352,9 +352,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ItShouldOnlyReturnTopLevelPackages(bool useAlias)
+        [InlineData("latestNet")]
+        [InlineData("net6.0")]
+        public void ItShouldOnlyReturnTopLevelPackages(string alias)
         {
             var testRoot = _testAssetsManager.CreateTestDirectory().Path;
             Log.WriteLine("Test root: " + testRoot);
@@ -362,11 +362,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             string projectAssetsJsonPath = Path.Combine(testRoot, "project.assets.json");
             string projectCacheAssetsJsonPath = Path.Combine(testRoot, "projectassets.cache");
             // project.assets.json
-            File.WriteAllText(projectAssetsJsonPath, CreateBasicProjectAssetsFile(testRoot, useAlias: useAlias));
+            File.WriteAllText(projectAssetsJsonPath, CreateBasicProjectAssetsFile(testRoot, alias: alias));
             var task = InitializeTask(testRoot, out _);
             task.ProjectAssetsFile = projectAssetsJsonPath;
             task.ProjectAssetsCacheFile = projectCacheAssetsJsonPath;
-            task.TargetFramework = "net6.0";
+            task.TargetFramework = alias;
             task.Execute();
 
             // Verify all top packages are listed here
@@ -406,7 +406,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         /// </c>
         /// dependent.package2 has an error message, and dependent.package3 has a warning.
         /// </remarks>
-        private string CreateBasicProjectAssetsFile(string testRoot, string package2Type = "package", string package3Type = "package", bool useAlias = false)
+        private string CreateBasicProjectAssetsFile(string testRoot, string package2Type = "package", string package3Type = "package", string alias = "net6.0")
         {
             var json =
 """
@@ -638,7 +638,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
   ]
 }
 """;
-            var alias = useAlias ? "latestNet" : "net6.0";
             return json.Replace("PACKAGE2_TYPE", package2Type)
                        .Replace("PACKAGE3_TYPE", package3Type)
                        .Replace("TFM_ALIAS", alias)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -1575,10 +1575,19 @@ namespace Microsoft.NET.Build.Tasks
                     bool ForCurrentTargetFramework(string targetFramework)
                     {
                         var parts = targetFramework.Split(LockFile.DirectorySeparatorChar);
-                        var parsedTargetGraph = NuGetFramework.Parse(parts[0]);
-                        var alias = _lockFile.PackageSpec.TargetFrameworks
-                            .FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)
-                            ?.TargetAlias ?? targetFramework;
+                        string alias = parts[0];
+                        if (alias == _task.TargetFramework)
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            var parsedTargetGraph = NuGetFramework.Parse(alias);
+                            alias = _lockFile.PackageSpec.TargetFrameworks
+                                .FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)
+                                ?.TargetAlias ?? targetFramework;
+                        }
+
                         return alias == _task.TargetFramework;
                     }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -259,7 +259,7 @@ namespace Microsoft.NET.Build.Tasks
                             var parsedTargetGraph = NuGetFramework.Parse(tg);
                             var alias = _lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)?.TargetAlias;
 
-                            if (tg == target)
+                            if (alias == target)
                             {
                                 if (logLevel == null || message.Level > logLevel)
                                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -241,15 +241,15 @@ namespace Microsoft.NET.Build.Tasks
 
                 LogLevel? logLevel = null;
 
-                foreach(var message in LockFile.LogMessages)
+                foreach (var message in LockFile.LogMessages)
                 {
                     if (message.LibraryId == package.Name)
                     {
-                        foreach(var tg in message.TargetGraphs)
+                        foreach (var tg in message.TargetGraphs)
                         {
-                            if(tg == target)
+                            if (tg == target)
                             {
-                                if(logLevel == null || message.Level > logLevel)
+                                if (logLevel == null || message.Level > logLevel)
                                 {
                                     logLevel = message.Level;
                                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -249,7 +249,7 @@ namespace Microsoft.NET.Build.Tasks
                         {
                             string effectiveTargetGraphName = targetGraph;
                             // If the target graph is not in the map, then very likely aliases are being used.
-                            if (!_targetNameToAliasMap.ContainsKey(targetGraph))
+                            if (_targetNameToAliasMap.ContainsKey(targetGraph))
                             {
                                 var parsedTargetGraph = NuGetFramework.Parse(targetGraph);
                                 effectiveTargetGraphName = _lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)?.TargetAlias;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -245,21 +245,17 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     if (message.LibraryId == package.Name)
                     {
-                        foreach (var tg in message.TargetGraphs)
+                        foreach (var targetGraph in message.TargetGraphs)
                         {
-                            if (tg == target)
+                            string effectiveTargetGraphName = targetGraph;
+                            // If the target graph is not in the map, then very likely aliases are being used.
+                            if (!_targetNameToAliasMap.ContainsKey(targetGraph))
                             {
-                                if (logLevel == null || message.Level > logLevel)
-                                {
-                                    logLevel = message.Level;
-                                }
-                                break;
+                                var parsedTargetGraph = NuGetFramework.Parse(targetGraph);
+                                effectiveTargetGraphName = _lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)?.TargetAlias;
                             }
 
-                            var parsedTargetGraph = NuGetFramework.Parse(tg);
-                            var alias = _lockFile.PackageSpec.TargetFrameworks.FirstOrDefault(tf => tf.FrameworkName == parsedTargetGraph)?.TargetAlias;
-
-                            if (alias == target)
+                            if (effectiveTargetGraphName == target)
                             {
                                 if (logLevel == null || message.Level > logLevel)
                                 {


### PR DESCRIPTION
With target framework aliasing, NuGet will change the target graph name within the log message from tfm/rid to alias/rid.

Since the NuGet & SDK version combinations will vary in the wild due to global.json and VS shipping it's own version of NuGet, the SDK will be need to be able to handle both iterations. 

Long term, NuGet will only use the aliasing, so the implementation will have better perf with aliasing.

By getting this change in in 10.0, it will allow more seamless round tripping and allow to minimize the potential for bugs by rolling out the changes in smaller chunks instead of one mega switch.

Progress towards: https://github.com/NuGet/Home/issues/14528

