### PR TITLE
Fix the VS warning to state 18.0 is required for net10.0 targeting

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedTargetFrameworks.props
@@ -33,7 +33,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
         <!-- This is for a better error experience when using an older VS (with an older SDK) to target a newer TFM. The value should be the min VS version for N+1 version-->
         <UnsupportedTargetFrameworkVersion>10.0</UnsupportedTargetFrameworkVersion>
-        <MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>17.16</MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>
+        <MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>18.0</MinimumVisualStudioVersionForUnsupportedTargetFrameworkVersion>
     </PropertyGroup>
 
     <!-- .NET Standard -->


### PR DESCRIPTION
## Description

There's a customer warning message when a customer tries to target a newer runtime than is supported in the SDK they are using and they are building in VS. The scenario for this is using VS 2022 17.14 to target net10 and having a 9.0 SDK.

The message was hardcoded to 17.16 back when net9 first released as we didn't know what the VS version number would be. Now that that's been announced, we should fix this.

## Customer impact
VS will tell customers to use 18.0 if trying to target net10.0 within VS 17.14 or below

## Regression?
No

## Risk
Low
