### PR TITLE
Add vulnerable option to telemetry

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -62,6 +62,7 @@ internal class TelemetryFilter(Func<string, string> hash) : ITelemetryFilter
                 ));
 
                 LogVerbosityForAllTopLevelCommand(result, parseResult, topLevelCommandName, measurements);
+                LogVulnerableOptionForPackageUpdateCommand(result, parseResult, topLevelCommandName, measurements);
 
                 foreach (IParseResultLogRule rule in ParseResultLogRules)
                 {
@@ -137,6 +138,27 @@ internal class TelemetryFilter(Func<string, string> hash) : ITelemetryFilter
         ),
         new AllowListToSendVerbSecondVerbFirstArgument(["workload", "tool", "new"]),
     ];
+
+    private static void LogVulnerableOptionForPackageUpdateCommand(
+        ICollection<ApplicationInsightsEntryFormat> result,
+        ParseResult parseResult,
+        string topLevelCommandName,
+        Dictionary<string, double> measurements = null)
+    {
+        if (topLevelCommandName == "package" && parseResult.CommandResult.Command != null && parseResult.CommandResult.Command.Name == "update")
+        {
+            var hasVulnerableOption = parseResult.HasOption("--vulnerable");
+
+            result.Add(new ApplicationInsightsEntryFormat(
+                "sublevelparser/command",
+                new Dictionary<string, string>()
+                {
+                    { "verb", topLevelCommandName + " update" },
+                    { "vulnerable", hasVulnerableOption.ToString()}
+                },
+                measurements));
+        }
+    }
 
     private static void LogVerbosityForAllTopLevelCommand(
         ICollection<ApplicationInsightsEntryFormat> result,

--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -153,7 +153,7 @@ internal class TelemetryFilter(Func<string, string> hash) : ITelemetryFilter
                 "sublevelparser/command",
                 new Dictionary<string, string>()
                 {
-                    { "verb", topLevelCommandName + " update" },
+                    { "verb", "package update" },
                     { "vulnerable", hasVulnerableOption.ToString()}
                 },
                 measurements));

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -358,6 +358,20 @@ namespace Microsoft.DotNet.Tests
                               e.Properties["verb"] == Sha256Hasher.Hash("CLEAN"));
         }
 
+        [Fact]
+        public void DotnetUpdatePackageVulnerableOptionShouldBeSentToTelemetry()
+        {
+            const string optionKey = "vulnerable";
+            string[] args = { "package", "update", "--vulnerable" };
+            Cli.Program.ProcessArgs(args);
+            _fakeTelemetry
+                .LogEntries.Should()
+                .Contain(e => e.EventName == "sublevelparser/command" &&
+                              e.Properties.ContainsKey(optionKey) &&
+                              e.Properties.ContainsKey("verb") &&
+                              e.Properties["verb"] == Sha256Hasher.Hash("PACKAGE UPDATE"));
+        }
+
         [WindowsOnlyFact]
         public void InternalreportinstallsuccessCommandCollectExeNameWithEventname()
         {


### PR DESCRIPTION
I'm largely following instructions from @zivkan relayed to him by @baronfel :D 

The gist is that we want to know when customers run the update command, whether they used the `--vulnerable` flag.
