### PR TITLE
Fix phantom text being read by Narrator

### DIFF
--- a/src/Layout/pkg/windows/bundles/sdk/bundle.thm
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.thm
@@ -116,6 +116,7 @@
       </Button>
     </Page>
     <Page Name="Failure">
+      <!-- Reserve two lines of space to accommodate localized content. -->
       <Label Name="FailureRestartText" X="148" Y="-48" Width="-12" Height="32" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
       <Label Name="FailureHeader" X="148" Y="80" Width="-12" Height="32" HexStyle="00000000" FontId="PageHeaderFont" TabStop="yes">
         <Text>#(loc.FailureHeader)</Text>
@@ -133,9 +134,6 @@
 
       <!-- This element is updated by the bootstrapper application. Reserve 3 lines of space. -->
       <Hypertext HexStyle="000000" Name="FailureMessageText" X="148" Y="172" Width="-12" Height="48" FontId="ErrorFont" TabStop="yes" HideWhenDisabled="yes" />
-
-      <!-- Reserve two lines of space to accommodate localized content. -->
-
 
       <Button Name="FailureRestartButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
       <Button Name="FailureCloseButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">

--- a/src/Layout/pkg/windows/bundles/sdk/bundle.thm
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.thm
@@ -101,7 +101,7 @@
       <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" TabStop="yes" Name="ReleaseNotesLinkText" X="148" Y="300" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.ReleaseNotesLinkText)</Hypertext>
       <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" TabStop="yes" Name="TutorialsLinkText" X="148" Y="316" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.TutorialsLinkText)</Hypertext>
 
-      <Label X="148" Y="-48" Width="-12" Height="34" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
+      <Label Name="SuccessRestartText" X="148" Y="-48" Width="-12" Height="34" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
         <Text>#(loc.SuccessRestartText)</Text>
         <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>
       </Label>
@@ -116,6 +116,7 @@
       </Button>
     </Page>
     <Page Name="Failure">
+      <Label Name="FailureRestartText" X="148" Y="-48" Width="-12" Height="32" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
       <Label Name="FailureHeader" X="148" Y="80" Width="-12" Height="32" HexStyle="00000000" FontId="PageHeaderFont" TabStop="yes">
         <Text>#(loc.FailureHeader)</Text>
         <Text Condition="WixBundleAction = 2">#(loc.FailureLayoutHeader)</Text>
@@ -134,7 +135,8 @@
       <Hypertext HexStyle="000000" Name="FailureMessageText" X="148" Y="172" Width="-12" Height="48" FontId="ErrorFont" TabStop="yes" HideWhenDisabled="yes" />
 
       <!-- Reserve two lines of space to accommodate localized content. -->
-      <Label X="148" Y="-48" Width="-12" Height="32" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
+
+
       <Button Name="FailureRestartButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
       <Button Name="FailureCloseButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
         <Text>#(loc.FailureCloseButton)</Text>


### PR DESCRIPTION
## Description

When the `FailureRestartText` label appears at the end of the Window, the ordering appears to impact how accessibility data is retrieved. The failure text ends up being assigned to the logo image, which results in Narrator announcing non-visible text. The announcement instructs users to uninstall and restart their machines, even though the user completed a successful install. This is confusing for users that rely on audible responses.

The RCA is not complete, but initial investigations hint at ordering impacts what `IAccessible` may be returning

Below is a screenshot from AI and the failure page text being assigned to the logo on the Success page

### Before
<img width="1439" height="502" alt="image" src="https://github.com/user-attachments/assets/de3dde96-6c8e-4539-9402-f923d9bca3b8" />

### After
<img width="1535" height="527" alt="image" src="https://github.com/user-attachments/assets/c5a0fc99-2227-4c00-86a3-7219a92baa49" />


## Layout fixes

The PR also contains corrections for two labels (including the failure text) that incorrectly set the height to 34 instead of 32.