### PR TITLE
force containers tasks to net taskhost

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.MSBuild;
@@ -61,6 +62,22 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         RegistryMode sourceRegistryMode = BaseRegistry.Equals(OutputRegistry, StringComparison.InvariantCultureIgnoreCase) ? RegistryMode.PullFromOutput : RegistryMode.Pull;
         Registry? sourceRegistry = IsLocalPull ? null : new Registry(BaseRegistry, logger, sourceRegistryMode);
         SourceImageReference sourceImageReference = new(sourceRegistry, BaseImageName, BaseImageTag, BaseImageDigest);
+
+        // easy debugging to see if host object is present in a .NET Task-host-using world.
+        Debugger.Launch();
+
+        if (HostObject is System.Collections.Generic.IEnumerable<ITaskItem> items)
+        {
+            Log.LogMessage(MessageImportance.Low, "HostObject is present");
+            foreach (var item in items)
+            {
+                Log.LogMessage(MessageImportance.Low, $"HostObject item: {item.ItemSpec} with metadata:");
+                foreach (string name in item.MetadataNames)
+                {
+                    Log.LogMessage(MessageImportance.Low, $"  {name} = {item.GetMetadata(name)}");
+                }
+            }
+        }
 
         DestinationImageReference destinationImageReference = DestinationImageReference.CreateFromSettings(
             Repository,

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
@@ -3,19 +3,18 @@
          <!-- A flag representing this package existing in a project.  -->
         <SDKContainerSupportEnabled>true</SDKContainerSupportEnabled>
         <ContainerTaskFolderName>tasks</ContainerTaskFolderName>
-        <ContainerTaskFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">net10.0</ContainerTaskFramework>
-        <ContainerTaskFramework Condition="'$(MSBuildRuntimeType)' == 'Full'">net472</ContainerTaskFramework>
         <ContainerizeFolderName>containerize</ContainerizeFolderName>
         <!--The folder where the custom task will be present. It points to inside the nuget package. -->
-        <ContainerCustomTasksFolder>$(MSBuildThisFileDirectory)..\$(ContainerTaskFolderName)\$(ContainerTaskFramework)\</ContainerCustomTasksFolder>
+        <ContainerCustomTasksFolder>$(MSBuildThisFileDirectory)..\$(ContainerTaskFolderName)\</ContainerCustomTasksFolder>
         <ContainerizeFolder>$(MSBuildThisFileDirectory)..\$(ContainerizeFolderName)\</ContainerizeFolder>
         <!--Reference to the assembly which contains the MSBuild Task-->
-        <ContainerCustomTasksAssembly Condition="'$(ContainerCustomTasksAssembly)' == ''">$(ContainerCustomTasksFolder)$(MSBuildThisFileName).dll</ContainerCustomTasksAssembly>
+        <ContainerCustomTasksAssemblyFramework Condition="'$(ContainerCustomTasksAssembly)' == ''">$(ContainerCustomTasksFolder)net472\$(MSBuildThisFileName).dll</ContainerCustomTasksAssemblyFramework>
+        <ContainerCustomTasksAssemblyNet Condition="'$(ContainerCustomTasksAssembly)' == ''">$(ContainerCustomTasksFolder)net10.0\$(MSBuildThisFileName).dll</ContainerCustomTasksAssemblyNet>
     </PropertyGroup>
 
     <!--Register our custom task-->
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateImageIndex" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ComputeDotnetBaseImageAndTag" AssemblyFile="$(ContainerCustomTasksAssembly)"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateImageIndex" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" />
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ComputeDotnetBaseImageAndTag" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
 </Project>

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.props
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <!--Register our custom task-->
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateImageIndex" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" />
-    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ComputeDotnetBaseImageAndTag" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET"/>
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateNewImage" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" TaskFactory="TaskHostFactory" />
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.CreateImageIndex" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" TaskFactory="TaskHostFactory" />
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ParseContainerProperties" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" TaskFactory="TaskHostFactory" />
+    <UsingTask TaskName="$(MSBuildThisFileName).Tasks.ComputeDotnetBaseImageAndTag" AssemblyFile="$(ContainerCustomTasksAssemblyNet)" Runtime="NET" TaskFactory="TaskHostFactory" />
 </Project>


### PR DESCRIPTION
This is a quick test of the .NET TaskHost feature in MSBuild, not intended for actual merge.

To test this:
* install dev18
* build this branch
* launch the VS dev command prompt
* run `eng/dogfood.ps1` from this repo
* clone `baronfel/sdk-container-demo` repo
* make sure you have docker running
* delete the global.json from that cloned repo
* do a container publish from dotnet: `dotnet publish -t:PublishContainer` - should work
* do a container publish from msbuild.exe: `dotnet /t:Publish /t:PublishContainer` - should work too! 
* Take a binlog and verify the .NET Task is used.
