### PR TITLE
Add exit code telemetry and add session id

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -275,6 +275,13 @@ public class Program
                     PerformanceLogEventSource.Log.ExtensibleCommandStop();
 
                     exitCode = result.ExitCode;
+
+                    TelemetryClient.TrackEvent("command/finish", properties: new Dictionary<string, string>
+                    {
+                        { "command", commandName },
+                        { "exitCode", exitCode.ToString() }
+                    },
+                    measurements: new Dictionary<string, double>());
                 }
             }
             catch (CommandUnknownException e)

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -287,7 +287,6 @@ public class Program
 
         TelemetryClient.TrackEvent("command/finish", properties: new Dictionary<string, string>
                     {
-                        { "command", string.Join(" ", args) },
                         { "exitCode", exitCode.ToString() }
                     },
             measurements: new Dictionary<string, double>());

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -275,13 +275,6 @@ public class Program
                     PerformanceLogEventSource.Log.ExtensibleCommandStop();
 
                     exitCode = result.ExitCode;
-
-                    TelemetryClient.TrackEvent("command/finish", properties: new Dictionary<string, string>
-                    {
-                        { "command", commandName },
-                        { "exitCode", exitCode.ToString() }
-                    },
-                    measurements: new Dictionary<string, double>());
                 }
             }
             catch (CommandUnknownException e)
@@ -291,6 +284,13 @@ public class Program
                 exitCode = 1;
             }
         }
+
+        TelemetryClient.TrackEvent("command/finish", properties: new Dictionary<string, string>
+                    {
+                        { "command", parseResult.ToString() },
+                        { "exitCode", exitCode.ToString() }
+                    },
+            measurements: new Dictionary<string, double>());
 
         PerformanceLogEventSource.Log.TelemetryClientFlushStart();
         TelemetryClient.Flush();

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -287,7 +287,7 @@ public class Program
 
         TelemetryClient.TrackEvent("command/finish", properties: new Dictionary<string, string>
                     {
-                        { "command", parseResult.ToString() },
+                        { "command", string.Join(" ", args) },
                         { "exitCode", exitCode.ToString() }
                     },
             measurements: new Dictionary<string, double>());

--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -154,7 +154,7 @@ public class Telemetry : ITelemetry
             _client.Context.Session.Id = CurrentSessionId;
             _client.Context.Device.OperatingSystem = CLIRuntimeEnvironment.OperatingSystem;
 
-            _commonProperties = new TelemetryCommonProperties().GetTelemetryCommonProperties();
+            _commonProperties = new TelemetryCommonProperties().GetTelemetryCommonProperties(CurrentSessionId);
             _commonMeasurements = FrozenDictionary<string, double>.Empty;
         }
         catch (Exception e)

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -44,6 +44,7 @@ internal class TelemetryCommonProperties(
     private const string ProductType = "Product Type";
     private const string LibcRelease = "Libc Release";
     private const string LibcVersion = "Libc Version";
+    private const string SessionId = "SessionId";
 
     private const string CI = "Continuous Integration";
 
@@ -53,7 +54,7 @@ internal class TelemetryCommonProperties(
     private const string MachineIdCacheKey = "MachineId";
     private const string IsDockerContainerCacheKey = "IsDockerContainer";
 
-    public FrozenDictionary<string, string> GetTelemetryCommonProperties()
+    public FrozenDictionary<string, string> GetTelemetryCommonProperties(string currentSessionId)
     {
         return new Dictionary<string, string>
         {
@@ -82,7 +83,8 @@ internal class TelemetryCommonProperties(
             {InstallationType, ExternalTelemetryProperties.GetInstallationType()},
             {ProductType, ExternalTelemetryProperties.GetProductType()},
             {LibcRelease, ExternalTelemetryProperties.GetLibcRelease()},
-            {LibcVersion, ExternalTelemetryProperties.GetLibcVersion()}
+            {LibcVersion, ExternalTelemetryProperties.GetLibcVersion()},
+            {SessionId, currentSessionId}
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -184,14 +184,16 @@ namespace Microsoft.DotNet.Tests
             }
         }
 
-        [Fact]
-        public void TelemetryCommonPropertiesShouldContainSessionId()
+        [Theory]
+        [InlineData("dummySessionId")]
+        [InlineData(null)]
+        public void TelemetryCommonPropertiesShouldContainSessionId(string sessionId)
         {
             var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
-            var commonProperties = unitUnderTest.GetTelemetryCommonProperties("dummySessionId");
+            var commonProperties = unitUnderTest.GetTelemetryCommonProperties(sessionId);
 
             commonProperties.Should().ContainKey("SessionId");
-            commonProperties["SessionId"].Should().Be("dummySessionId");
+            commonProperties["SessionId"].Should().Be(sessionId);
         }
 
         public static IEnumerable<object[]> CITelemetryTestCases => new List<object[]>{

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -18,35 +18,35 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldContainIfItIsInDockerOrNot()
         {
             var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties().Should().ContainKey("Docker Container");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId").Should().ContainKey("Docker Container");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnHashedPath()
         {
             var unitUnderTest = new TelemetryCommonProperties(() => "ADirectory", userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Current Path Hash"].Should().NotBe("ADirectory");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Current Path Hash"].Should().NotBe("ADirectory");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnHashedMachineId()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => "plaintext", userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Machine ID"].Should().NotBe("plaintext");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Machine ID"].Should().NotBe("plaintext");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnDevDeviceId()
         {
             var unitUnderTest = new TelemetryCommonProperties(getDeviceId: () => "plaintext", userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"].Should().Be("plaintext");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["devdeviceid"].Should().Be("plaintext");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotGetMacAddress()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Machine ID"];
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Machine ID"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
         }
@@ -55,10 +55,10 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldEnsureDevDeviceIDIsCached()
         {
             var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
-            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"];
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["devdeviceid"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
-            var secondAssignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["devdeviceid"];
+            var secondAssignedMachineId = unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["devdeviceid"];
 
             Guid.TryParse(secondAssignedMachineId, out var _).Should().BeTrue("it should be a guid");
             secondAssignedMachineId.Should().Be(assignedMachineId, "it should match the previously assigned guid");
@@ -68,14 +68,14 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldReturnHashedMachineIdOld()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => "plaintext", userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Machine ID Old"].Should().NotBe("plaintext");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Machine ID Old"].Should().NotBe("plaintext");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnNewGuidWhenCannotGetMacAddressOld()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Machine ID Old"];
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Machine ID Old"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
         }
@@ -84,72 +84,72 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldReturnIsOutputRedirected()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Output Redirected"].Should().BeOneOf("True", "False");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Output Redirected"].Should().BeOneOf("True", "False");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldReturnIsCIDetection()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Continuous Integration"].Should().BeOneOf("True", "False");
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Continuous Integration"].Should().BeOneOf("True", "False");
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldContainKernelVersion()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
         }
 
         [Fact]
         public void TelemetryCommonPropertiesShouldContainArchitectureInformation()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["OS Architecture"].Should().Be(RuntimeInformation.OSArchitecture.ToString());
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["OS Architecture"].Should().Be(RuntimeInformation.OSArchitecture.ToString());
         }
 
         [WindowsOnlyFact]
         public void TelemetryCommonPropertiesShouldContainWindowsInstallType()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Installation Type"].Should().NotBeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Installation Type"].Should().NotBeEmpty();
         }
 
         [UnixOnlyFact]
         public void TelemetryCommonPropertiesShouldContainEmptyWindowsInstallType()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Installation Type"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Installation Type"].Should().BeEmpty();
         }
 
         [WindowsOnlyFact]
         public void TelemetryCommonPropertiesShouldContainWindowsProductType()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Product Type"].Should().NotBeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Product Type"].Should().NotBeEmpty();
         }
 
         [UnixOnlyFact]
         public void TelemetryCommonPropertiesShouldContainEmptyWindowsProductType()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Product Type"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Product Type"].Should().BeEmpty();
         }
 
         [WindowsOnlyFact]
         public void TelemetryCommonPropertiesShouldContainEmptyLibcReleaseAndVersion()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Libc Release"].Should().BeEmpty();
-            unitUnderTest.GetTelemetryCommonProperties()["Libc Version"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Release"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Version"].Should().BeEmpty();
         }
 
         [MacOsOnlyFact]
         public void TelemetryCommonPropertiesShouldContainEmptyLibcReleaseAndVersion2()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties()["Libc Release"].Should().BeEmpty();
-            unitUnderTest.GetTelemetryCommonProperties()["Libc Version"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Release"].Should().BeEmpty();
+            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Version"].Should().BeEmpty();
         }
 
         [LinuxOnlyFact]
@@ -158,8 +158,8 @@ namespace Microsoft.DotNet.Tests
             if (!RuntimeInformation.RuntimeIdentifier.Contains("alpine", StringComparison.OrdinalIgnoreCase))
             {
                 var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-                unitUnderTest.GetTelemetryCommonProperties()["Libc Release"].Should().NotBeEmpty();
-                unitUnderTest.GetTelemetryCommonProperties()["Libc Version"].Should().NotBeEmpty();
+                unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Release"].Should().NotBeEmpty();
+                unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["Libc Version"].Should().NotBeEmpty();
             }
         }
 
@@ -182,6 +182,16 @@ namespace Microsoft.DotNet.Tests
                     Environment.SetEnvironmentVariable(key, null);
                 }
             }
+        }
+
+        [Fact]
+        public void TelemetryCommonPropertiesShouldContainSessionId()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
+            var commonProperties = unitUnderTest.GetTelemetryCommonProperties("dummySessionId");
+
+            commonProperties.Should().ContainKey("SessionId");
+            commonProperties["SessionId"].Should().Be("dummySessionId");
         }
 
         public static IEnumerable<object[]> CITelemetryTestCases => new List<object[]>{


### PR DESCRIPTION
Added the session id to the common properties. 

Add an exit event:

EventName: `command/finish` - @baronfel's idea, and I think it's a great one.
Props: 
exitCode - exit code. 

This will probably lead to more telemetry at a later point, but this is what we need today.