### PR TITLE
Fix dotnet test perf for MTP

### DIFF
--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -14,26 +14,11 @@ internal static class CommonRunHelpers
     /// specifically Compile, None, and EmbeddedResource items are not globbed by default.
     /// See <see cref="Commands.Restore.RestoringCommand.RestoreOptimizationProperties"/> for more details.
     /// </summary>
-    public static Dictionary<string, string> GetGlobalPropertiesFromArgs(string[] args)
+    public static Dictionary<string, string> GetGlobalPropertiesFromArgs(MSBuildArgs msbuildArgs)
     {
-        var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            // This property disables default item globbing to improve performance
-            // This should be safe because we are not evaluating items, only properties
-            { Constants.EnableDefaultItems,  "false" },
-            { Constants.MSBuildExtensionsPath, AppContext.BaseDirectory }
-        };
-
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(args, CommonOptions.PropertiesOption, CommonOptions.RestorePropertiesOption, CommonOptions.MSBuildTargetOption(), CommonOptions.VerbosityOption());
-        if (msbuildArgs.GlobalProperties is null)
-        {
-            return globalProperties;
-        }
-        foreach (var kv in msbuildArgs.GlobalProperties)
-        {
-            // If the property is already set, we don't override it
-            globalProperties[kv.Key] = kv.Value;
-        }
+        var globalProperties = msbuildArgs.GlobalProperties?.ToDictionary() ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        globalProperties[Constants.EnableDefaultItems] = "false"; // Disable default item globbing to improve performance
+        globalProperties[Constants.MSBuildExtensionsPath] = AppContext.BaseDirectory;
         return globalProperties;
     }
 

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -409,9 +409,7 @@ public class RunCommand
         {
             Debug.Assert(projectFilePath is not null || projectFactory is not null);
 
-            var globalProperties = msbuildArgs.GlobalProperties?.ToDictionary() ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            globalProperties[Constants.EnableDefaultItems] = "false"; // Disable default item globbing to improve performance
-            globalProperties[Constants.MSBuildExtensionsPath] = AppContext.BaseDirectory;
+            var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
 
             var collection = new ProjectCollection(globalProperties: globalProperties, loggers: binaryLogger is null ? null : [binaryLogger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
@@ -7,10 +7,9 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationActionQueue actionQueue, TerminalTestReporter output)
+internal sealed class MSBuildHandler(BuildOptions buildOptions, TerminalTestReporter output)
 {
     private readonly BuildOptions _buildOptions = buildOptions;
-    private readonly TestApplicationActionQueue _actionQueue = actionQueue;
     private readonly TerminalTestReporter _output = output;
 
     private readonly ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> _testApplications = [];
@@ -128,7 +127,7 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationA
         }
     }
 
-    public bool EnqueueTestApplications()
+    public bool EnqueueTestApplications(TestApplicationActionQueue queue)
     {
         if (!_areTestingPlatformApplications)
         {
@@ -137,7 +136,7 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, TestApplicationA
 
         foreach (var testApp in _testApplications)
         {
-            _actionQueue.Enqueue(testApp);
+            queue.Enqueue(testApp);
         }
         return true;
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -33,10 +33,11 @@ internal static class MSBuildUtility
                 SolutionAndProjectUtility.GetRootDirectory(solutionFilePath);
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
-        var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
         ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = GetProjectsProperties(collection, solutionModel.SolutionProjects.Select(p => Path.Combine(rootDirectory, p.FilePath)), buildOptions);
         logger?.ReallyShutdown();
+        collection.UnloadAllProjects();
 
         return (projects, isBuiltOrRestored);
     }
@@ -51,11 +52,11 @@ internal static class MSBuildUtility
         }
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
-        var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
         IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, buildOptions);
         logger?.ReallyShutdown();
-
+        collection.UnloadAllProjects();
         return (projects, isBuiltOrRestored);
     }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -33,7 +33,10 @@ internal static class MSBuildUtility
                 SolutionAndProjectUtility.GetRootDirectory(solutionFilePath);
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
-        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(buildOptions.MSBuildArgs, CommonOptions.PropertiesOption, CommonOptions.RestorePropertiesOption, CommonOptions.MSBuildTargetOption(), CommonOptions.VerbosityOption());
+
+        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs), loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
         ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = GetProjectsProperties(collection, solutionModel.SolutionProjects.Select(p => Path.Combine(rootDirectory, p.FilePath)), buildOptions);
         logger?.ReallyShutdown();
@@ -52,7 +55,10 @@ internal static class MSBuildUtility
         }
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], dotnetTestVerb);
-        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs([.. buildOptions.MSBuildArgs]), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(buildOptions.MSBuildArgs, CommonOptions.PropertiesOption, CommonOptions.RestorePropertiesOption, CommonOptions.MSBuildTargetOption(), CommonOptions.VerbosityOption());
+
+        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
 
         IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, buildOptions);
         logger?.ReallyShutdown();

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -71,6 +71,7 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
             // NOTE: Don't create TestApplicationActionQueue before RunMSBuild.
             // The constructor will do Task.Run calls matching the degree of parallelism, and if we did that before the build, that can
             // be slowing us down unnecessarily.
+            // Alternatively, if we can enqueue right after every project evaluation without waiting all evaluations to be done, we can enqueue early.
             actionQueue = new TestApplicationActionQueue(degreeOfParallelism, buildOptions, testOptions, _output, OnHelpRequested);
             if (!msBuildHandler.EnqueueTestApplications(actionQueue))
             {

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal static class SolutionAndProjectUtility
 {
-    private static readonly string[] s_computeRunArgumentsTarget = ["ComputeRunArguments"];
+    private static readonly string[] s_computeRunArgumentsTarget = [Constants.ComputeRunArguments];
     private static readonly Lock s_buildLock = new();
     private static readonly EvaluationContext s_evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -18,6 +18,7 @@ internal static class SolutionAndProjectUtility
 {
     private static readonly string s_computeRunArgumentsTarget = "ComputeRunArguments";
     private static readonly Lock s_buildLock = new();
+    private static readonly EvaluationContext s_evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 
     public static (bool SolutionOrProjectFileFound, string Message) TryGetProjectOrSolutionFilePath(string directory, out string projectOrSolutionFilePath, out bool isSolution)
     {
@@ -182,7 +183,6 @@ internal static class SolutionAndProjectUtility
     {
         Debug.Assert(projectFilePath is not null);
 
-        var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
         Dictionary<string, string>? globalProperties = null;
         if (tfm is not null)
         {
@@ -195,7 +195,7 @@ internal static class SolutionAndProjectUtility
         return ProjectInstance.FromFile(projectFilePath, new ProjectOptions
         {
             GlobalProperties = globalProperties,
-            EvaluationContext = evaluationContext,
+            EvaluationContext = s_evaluationContext,
             ProjectCollection = collection,
         });
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 using Microsoft.DotNet.Cli.Utils;
@@ -16,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal static class SolutionAndProjectUtility
 {
-    private static readonly string s_computeRunArgumentsTarget = "ComputeRunArguments";
+    private static readonly string[] s_computeRunArgumentsTarget = ["ComputeRunArguments"];
     private static readonly Lock s_buildLock = new();
     private static readonly EvaluationContext s_evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 
@@ -357,7 +356,7 @@ internal static class SolutionAndProjectUtility
             {
                 if (!project.Build(s_computeRunArgumentsTarget, loggers: null))
                 {
-                    throw new GracefulException(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, s_computeRunArgumentsTarget);
+                    throw new GracefulException(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, s_computeRunArgumentsTarget[0]);
                 }
             }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -209,7 +209,7 @@ internal static class SolutionAndProjectUtility
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
-            if (GetModuleFromProject(projectInstance, projectCollection.Loggers, buildOptions) is { } module)
+            if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
             {
                 projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
             }
@@ -237,7 +237,7 @@ internal static class SolutionAndProjectUtility
                     projectInstance = EvaluateProject(projectCollection, projectFilePath, framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
-                    if (GetModuleFromProject(projectInstance, projectCollection.Loggers, buildOptions) is { } module)
+                    if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
                         projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
                     }
@@ -251,7 +251,7 @@ internal static class SolutionAndProjectUtility
                     projectInstance = EvaluateProject(projectCollection, projectFilePath, framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
-                    if (GetModuleFromProject(projectInstance, projectCollection.Loggers, buildOptions) is { } module)
+                    if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
                         innerModules ??= new List<TestModule>();
                         innerModules.Add(module);
@@ -268,7 +268,7 @@ internal static class SolutionAndProjectUtility
         return projects;
     }
 
-    private static TestModule? GetModuleFromProject(ProjectInstance project, ICollection<ILogger>? loggers, BuildOptions buildOptions)
+    private static TestModule? GetModuleFromProject(ProjectInstance project, BuildOptions buildOptions)
     {
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestProject), out bool isTestProject);
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
@@ -286,7 +286,7 @@ internal static class SolutionAndProjectUtility
         RunProperties runProperties;
         if (isTestingPlatformApplication)
         {
-            runProperties = GetRunProperties(project, loggers);
+            runProperties = GetRunProperties(project);
 
             // dotnet run throws the same if RunCommand is null or empty.
             // In dotnet test, we are additionally checking that RunCommand is not dll.
@@ -326,7 +326,7 @@ internal static class SolutionAndProjectUtility
 
         return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, isTestingPlatformApplication, launchSettings, project.GetPropertyValue(ProjectProperties.TargetPath), rootVariableName);
 
-        static RunProperties GetRunProperties(ProjectInstance project, ICollection<ILogger>? loggers)
+        static RunProperties GetRunProperties(ProjectInstance project)
         {
             // Build API cannot be called in parallel, even if the projects are different.
             // Otherwise, BuildManager in MSBuild will fail:

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -192,6 +192,17 @@ internal static class SolutionAndProjectUtility
             };
         }
 
+        // Merge the global properties from the project collection.
+        // It's unclear why MSBuild isn't considering the global properties defined in the ProjectCollection when
+        // the collection is passed in ProjectOptions below.
+        foreach (var property in collection.GlobalProperties)
+        {
+            if (!(globalProperties ??= new Dictionary<string, string>()).ContainsKey(property.Key))
+            {
+                globalProperties.Add(property.Key, property.Value);
+            }
+        }
+
         return ProjectInstance.FromFile(projectFilePath, new ProjectOptions
         {
             GlobalProperties = globalProperties,

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -276,19 +276,10 @@ internal sealed class TestApplication(
         Logger.LogTrace($"Starting test process with command '{processStartInfo.FileName}' and arguments '{processStartInfo.Arguments}'.");
 
         using var process = Process.Start(processStartInfo)!;
+        var outputAndError = await Task.WhenAll(process.StandardOutput.ReadToEndAsync(), process.StandardError.ReadToEndAsync());
         await process.WaitForExitAsync();
 
-        string outputData = string.Empty;
-        string errorData = string.Empty;
-        if (process.ExitCode != 0)
-        {
-            // NOTE: outputData and errorData are only used by TerminalTestReporter when the process exit code is non-zero.
-            // So, we avoid reading them unnecessarily.
-            outputData = await process.StandardOutput.ReadToEndAsync();
-            errorData = await process.StandardError.ReadToEndAsync();
-        }
-
-        _handler.OnTestProcessExited(process.ExitCode, outputData, errorData);
+        _handler.OnTestProcessExited(process.ExitCode, outputAndError[0], outputAndError[1]);
 
         return process.ExitCode;
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -237,20 +237,18 @@ internal sealed class TestApplicationHandler
         return false;
     }
 
-    internal void OnTestProcessExited(int exitCode, List<string> outputData, List<string> errorData)
+    internal void OnTestProcessExited(int exitCode, string outputData, string errorData)
     {
-        string outputDataString = string.Join(Environment.NewLine, outputData);
-        string errorDataString = string.Join(Environment.NewLine, errorData);
         if (_handshakeInfo.HasValue)
         {
-            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputDataString, errorDataString);
+            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
         }
         else
         {
-            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputDataString, errorDataString);
+            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
         }
 
-        LogTestProcessExit(exitCode, outputDataString, errorDataString);
+        LogTestProcessExit(exitCode, outputData, errorData);
     }
 
     private static TestOutcome ToOutcome(byte? testState) => testState switch

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/OtherTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/OtherTestProject/Program.cs
@@ -3,6 +3,12 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 
+for (int i = 0; i < 3; i++)
+{
+	Console.WriteLine(new string('a', 10000));
+	Console.Error.WriteLine(new string('e', 10000));
+}
+
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProject/Program.cs
@@ -3,6 +3,12 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 
+for (int i = 0; i < 3; i++)
+{
+	Console.WriteLine(new string('a', 10000));
+	Console.Error.WriteLine(new string('e', 10000));
+}
+
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());


### PR DESCRIPTION
Scenario measured: Running discovery with `--no-build` on dotnet/aspire.

Before:

<img width="2129" height="226" alt="image" src="https://github.com/user-attachments/assets/347ff8f9-73c7-403a-9a30-cd52c50b5062" />

After:

<img width="2092" height="229" alt="image" src="https://github.com/user-attachments/assets/f7ddd34a-8391-4781-aa52-1c5802395626" />

We had two issues:

First, evaluation time. Previously, we used to use `ProjectCollection.LoadProject`. We parallelized the call for the projects in the solution, but MSBuild ends up just allowing a single thread to do the work. So we paid the cost of parallelizing without actually doing anything in parallel.

Second, running the test apps. Previously, we had symptoms of thread pool starvation, with many threadpool threads ends up being doing blocking synchronous I/O, preventing fast progress on the actual communication with the child processes. This went away just by moving away from `Process.BeginOutputReadLine`, but it's not immediately clear why and might need more investigation if we want to understand the reasons.