### PR TITLE
Disable Roslyn new rulesets

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -66,6 +66,9 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    featureFlags:
+      autoEnablePREfastWithNewRuleset: false
+      autoEnableRoslynWithNewRuleset: false
     containers:
       azureLinux30Amd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64


### PR DESCRIPTION
There's a bug in the new rulesets per an internal teams chat that they'll fix in a future release. For now, they suggested disabling the ruleset