### PR TITLE
Implicitly set UserSecretsId for file-based apps

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -32,6 +32,8 @@ Additionally, the implicit project file has the following customizations:
 
 - `PublishAot` is set to `true`, see [`dotnet publish file.cs`](#other-commands) for more details.
 
+- `UserSecretsId` is set to a hash of the entry point file path.
+
 - [File-level directives](#directives-for-project-metadata) are applied.
 
 - The following are virtual only, i.e., not preserved after [converting to a project](#grow-up):
@@ -53,8 +55,6 @@ Additionally, the implicit project file has the following customizations:
   - `DisableDefaultItemsInProjectFolder` property is set to `true` which results in `EnableDefaultItems=false` by default
     in case there is a project or solution in the same directory as the file-based app.
     This ensures that items from nested projects and artifacts are not included by the app.
-
-  - `UserSecretsId` is set implicitly to a hash of the entry point file path.
 
 ## Grow up
 

--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -54,6 +54,8 @@ Additionally, the implicit project file has the following customizations:
     in case there is a project or solution in the same directory as the file-based app.
     This ensures that items from nested projects and artifacts are not included by the app.
 
+  - `UserSecretsId` is set implicitly to a hash of the entry point file path.
+
 ## Grow up
 
 When file-based programs reach an inflection point where build customizations in a project file are needed,

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -32,7 +32,6 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         var directives = VirtualProjectBuildingCommand.FindDirectives(sourceFile, reportAllErrors: !_force, DiagnosticBag.ThrowOnFirst());
 
         // Create a project instance for evaluation.
-        string entryPointFileDirectory = PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(file)!);
         var projectCollection = new ProjectCollection();
         var command = new VirtualProjectBuildingCommand(
             entryPointFileFullPath: file,
@@ -123,6 +122,8 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
 
         IEnumerable<(string FullPath, string RelativePath)> FindIncludedItems()
         {
+            string entryPointFileDirectory = PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(file)!);
+
             // Include only items we know are files.
             string[] itemTypes = ["Content", "None", "Compile", "EmbeddedResource"];
             var items = itemTypes.SelectMany(t => projectInstance.GetItems(t));

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -31,6 +31,17 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         var sourceFile = SourceFile.Load(file);
         var directives = VirtualProjectBuildingCommand.FindDirectives(sourceFile, reportAllErrors: !_force, DiagnosticBag.ThrowOnFirst());
 
+        // Create a project instance for evaluation.
+        string entryPointFileDirectory = PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(file)!);
+        var projectCollection = new ProjectCollection();
+        var command = new VirtualProjectBuildingCommand(
+            entryPointFileFullPath: file,
+            msbuildArgs: MSBuildArgs.FromOtherArgs([]))
+        {
+            Directives = directives,
+        };
+        var projectInstance = command.CreateProjectInstance(projectCollection);
+
         // Find other items to copy over, e.g., default Content items like JSON files in Web apps.
         var includeItems = FindIncludedItems().ToList();
 
@@ -61,7 +72,8 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         {
             using var stream = File.Open(projectFile, FileMode.Create, FileAccess.Write);
             using var writer = new StreamWriter(stream, Encoding.UTF8);
-            VirtualProjectBuildingCommand.WriteProjectFile(writer, directives, isVirtualProject: false);
+            VirtualProjectBuildingCommand.WriteProjectFile(writer, directives, isVirtualProject: false,
+                userSecretsId: DetermineUserSecretsId());
         }
 
         // Copy or move over included items.
@@ -111,16 +123,6 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
 
         IEnumerable<(string FullPath, string RelativePath)> FindIncludedItems()
         {
-            string entryPointFileDirectory = PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(file)!);
-            var projectCollection = new ProjectCollection();
-            var command = new VirtualProjectBuildingCommand(
-                entryPointFileFullPath: file,
-                msbuildArgs: MSBuildArgs.FromOtherArgs([]))
-            {
-                Directives = directives,
-            };
-            var projectInstance = command.CreateProjectInstance(projectCollection);
-
             // Include only items we know are files.
             string[] itemTypes = ["Content", "None", "Compile", "EmbeddedResource"];
             var items = itemTypes.SelectMany(t => projectInstance.GetItems(t));
@@ -150,6 +152,13 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
                 string itemRelativePath = Path.GetRelativePath(relativeTo: entryPointFileDirectory, path: itemFullPath);
                 yield return (FullPath: itemFullPath, RelativePath: itemRelativePath);
             }
+        }
+
+        string? DetermineUserSecretsId()
+        {
+            var implicitValue = projectInstance.GetPropertyValue("_ImplicitFileBasedProgramUserSecretsId");
+            var actualValue = projectInstance.GetPropertyValue("UserSecretsId");
+            return implicitValue == actualValue ? actualValue : null;
         }
     }
 

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1138,7 +1138,8 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         bool isVirtualProject,
         string? targetFilePath = null,
         string? artifactsPath = null,
-        bool includeRuntimeConfigInformation = true)
+        bool includeRuntimeConfigInformation = true,
+        string? userSecretsId = null)
     {
         int processedDirectives = 0;
 
@@ -1253,6 +1254,13 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                             <{name}>{EscapeValue(value)}</{name}>
                         """);
                 }
+            }
+
+            if (userSecretsId != null && !customPropertyNames.Contains("UserSecretsId"))
+            {
+                writer.WriteLine($"""
+                        <UserSecretsId>{EscapeValue(userSecretsId)}</UserSecretsId>
+                    """);
             }
 
             // Write virtual-only properties.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -130,7 +130,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors> -->
 
     <!-- Implicitly set UserSecretsId for file-based apps. -->
-    <UserSecretsId Condition="'$(FileBasedProgram)' == 'true' and '$(UserSecretsId)' == ''">$(MSBuildProjectName)-$([MSBuild]::StableStringHash($(MSBuildProjectFullPath.ToLowerInvariant()), 'Sha256'))</UserSecretsId>
+    <_ImplicitFileBasedProgramUserSecretsId Condition="'$(FileBasedProgram)' == 'true'">$(MSBuildProjectName)-$([MSBuild]::StableStringHash($(MSBuildProjectFullPath.ToLowerInvariant()), 'Sha256'))</_ImplicitFileBasedProgramUserSecretsId>
+    <UserSecretsId Condition="'$(FileBasedProgram)' == 'true' and '$(UserSecretsId)' == ''">$(_ImplicitFileBasedProgramUserSecretsId)</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -128,6 +128,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
     <!-- <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors> -->
+
+    <!-- Implicitly set UserSecretsId for file-based apps. -->
+    <UserSecretsId Condition="'$(FileBasedProgram)' == 'true' and '$(UserSecretsId)' == ''">$(MSBuildProjectName)-$([MSBuild]::StableStringHash($(MSBuildProjectFullPath.ToLowerInvariant()), 'Sha256'))</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
@@ -56,9 +57,11 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var dotnetProjectConvertProjectText = File.ReadAllText(dotnetProjectConvertProject);
         var dotnetNewConsoleProjectText = File.ReadAllText(dotnetNewConsoleProject);
 
-        // There are some differences: we add PublishAot=true.
+        // There are some differences: we add PublishAot=true and UserSecretsId.
         var patchedDotnetProjectConvertProjectText = dotnetProjectConvertProjectText
             .Replace("    <PublishAot>true</PublishAot>" + Environment.NewLine, string.Empty);
+        patchedDotnetProjectConvertProjectText = Regex.Replace(patchedDotnetProjectConvertProjectText,
+            """    <UserSecretsId>[^<]*<\/UserSecretsId>""" + Environment.NewLine, string.Empty);
 
         patchedDotnetProjectConvertProjectText.Should().Be(dotnetNewConsoleProjectText)
             .And.StartWith("""<Project Sdk="Microsoft.NET.Sdk">""");
@@ -648,6 +651,92 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .Should().Be("Console.WriteLine();");
 
         File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Match($"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <UserSecretsId>Program-*</UserSecretsId>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Humanizer" Version="2.14.1" />
+                  </ItemGroup>
+
+                </Project>
+
+                """);
+    }
+
+    [Theory, CombinatorialData]
+    public void UserSecretsId_Overridden_ViaDirective(bool hasDirectiveBuildProps)
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #:property UserSecretsId=MyIdFromDirective
+            Console.WriteLine();
+            """);
+
+        if (hasDirectiveBuildProps)
+        {
+            File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <UserSecretsId>MyIdFromDirBuildProps</UserSecretsId>
+                  </PropertyGroup>
+                </Project>
+                """);
+        }
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Be($"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <UserSecretsId>MyIdFromDirective</UserSecretsId>
+                  </PropertyGroup>
+
+                </Project>
+
+                """);
+    }
+
+    [Fact]
+    public void UserSecretsId_Overridden_ViaDirectoryBuildProps()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            Console.WriteLine();
+            """);
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+            <Project>
+              <PropertyGroup>
+                <UserSecretsId>MyIdFromDirBuildProps</UserSecretsId>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
             .Should().Be($"""
                 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -658,10 +747,6 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
                     <Nullable>enable</Nullable>
                     <PublishAot>true</PublishAot>
                   </PropertyGroup>
-
-                  <ItemGroup>
-                    <PackageReference Include="Humanizer" Version="2.14.1" />
-                  </ItemGroup>
 
                 </Project>
 

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -2187,7 +2187,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var testInstance = _testAssetsManager.CreateTestDirectory();
 
         string code = $"""
-            #:package Microsoft.Extensions.Configuration.UserSecrets@*-*
+            #:package Microsoft.Extensions.Configuration.UserSecrets@{CSharpCompilerCommand.RuntimeVersion}
             {(userSecretsId is null ? "" : $"#:property UserSecretsId={userSecretsId}")}
 
             using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/63440.
Limited to file-based apps only to alleviate the concerns raised in https://github.com/dotnet/sdk/pull/50597#discussion_r2318280151.