### PR TITLE
[dotnet test MTP] Separate evaluation parallelization level from running test apps

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -47,7 +47,7 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
 
         SetupCancelKeyPressHandler();
 
-        BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult, degreeOfParallelism);
+        BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
 
         bool filterModeEnabled = parseResult.HasOption(MicrosoftTestingPlatformOptions.TestModulesFilterOption);
         TestApplicationActionQueue actionQueue;

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -14,6 +14,5 @@ internal record BuildOptions(
     Utils.VerbosityOptions? Verbosity,
     bool NoLaunchProfile,
     bool NoLaunchProfileArguments,
-    int DegreeOfParallelism,
     List<string> UnmatchedTokens,
     IEnumerable<string> MSBuildArgs);


### PR DESCRIPTION
Today, `--max-parallel-test-modules` value is used in two places:

1. Control how many test modules are run in parallel (its original purpose following its naming)
2. Control the degree of parallelism when doing MSBuild evaluations.

Using this value for "2" doesn't sound reasonable. If user wants to limit the number of running test apps (e.g, user might decide to set `--max-parallel-test-modules` to 1 because the tests compete on common resources like file system, database, etc), we shouldn't punish the user and slow down the evaluation unnecessarily.

Related to #45927