### PR TITLE
Support env variables for dotnet test (MTP)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
@@ -41,7 +42,10 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         ValidationUtility.ValidateSolutionOrProjectOrDirectoryOrModulesArePassedCorrectly(parseResult);
 
         int degreeOfParallelism = GetDegreeOfParallelism(parseResult);
-        var testOptions = new TestOptions(IsHelp: isHelp, IsDiscovery: parseResult.HasOption(MicrosoftTestingPlatformOptions.ListTestsOption));
+        var testOptions = new TestOptions(
+            IsHelp: isHelp,
+            IsDiscovery: parseResult.HasOption(MicrosoftTestingPlatformOptions.ListTestsOption),
+            EnvironmentVariables: parseResult.GetValue(CommonOptions.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
 
         InitializeOutput(degreeOfParallelism, parseResult, testOptions);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal record TestOptions(bool IsHelp, bool IsDiscovery);
+internal record TestOptions(bool IsHelp, bool IsDiscovery, IReadOnlyDictionary<string, string> EnvironmentVariables);
 
 internal record PathOptions(string? ProjectPath, string? SolutionPath, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -140,6 +140,12 @@ internal sealed class TestApplication(
                 processStartInfo.Environment[entry.Key] = value;
             }
 
+            // Env variables specified on command line override those specified in launch profile:
+            foreach (var (name, value) in TestOptions.EnvironmentVariables)
+            {
+                processStartInfo.Environment[name] = value;
+            }
+
             if (!_buildOptions.NoLaunchProfileArguments &&
                 !string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {

--- a/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandParser.cs
@@ -246,6 +246,7 @@ internal static class TestCommandParser
         command.Options.Add(MicrosoftTestingPlatformOptions.MaxParallelTestModulesOption);
         command.Options.Add(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption);
         command.Options.Add(CommonOptions.ArchitectureOption);
+        command.Options.Add(CommonOptions.EnvOption);
         command.Options.Add(CommonOptions.PropertiesOption);
         command.Options.Add(MicrosoftTestingPlatformOptions.ConfigurationOption);
         command.Options.Add(MicrosoftTestingPlatformOptions.FrameworkOption);

--- a/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/Program.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		var envVariableValue = Environment.GetEnvironmentVariable("DUMMY_TEST_ENV_VAR") ?? "NOT SET";
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test1",
+			DisplayName = "Test1",
+			Properties = new PropertyBag(new FailedTestNodeStateProperty($"DUMMY_TEST_ENV_VAR is '{envVariableValue}'")),
+		}));
+		
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/Properties/launchSettings.json
+++ b/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "ConsoleApp25": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DUMMY_TEST_ENV_VAR": "FROM_LAUNCHSETTINGS"
+      }
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/TestProjectShowingEnvVariable.csproj
+++ b/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/TestProjectShowingEnvVariable.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+		<RunArguments>--from-run-arguments</RunArguments>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/TestProjectShowingEnvVariable.csproj
+++ b/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/TestProjectShowingEnvVariable.csproj
@@ -10,7 +10,6 @@
 
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
-		<RunArguments>--from-run-arguments</RunArguments>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/global.json
+++ b/test/TestAssets/TestProjects/TestProjectShowingEnvVariable/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -504,7 +504,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("DUMMY_TEST_ENV_VAR is 'ENV_VAR_CMD_LINE'");
             }
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -476,5 +476,35 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut.Contains("Test run completed with non-success exit code: 1 (see: https://aka.ms/testingplatform/exitcodes)");
             }
         }
+
+        [Theory]
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        public void RunTestProjectWithEnvVariable(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("TestProjectShowingEnvVariable", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(
+                                        MicrosoftTestingPlatformOptions.ConfigurationOption.Name, configuration,
+                                        CommonOptions.EnvOption.Name, "DUMMY_TEST_ENV_VAR=ENV_VAR_CMD_LINE");
+
+            if (!TestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Using launch settings from")
+                    .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...")
+                    .And.Contain("Test run summary: Failed!")
+                    .And.Contain("total: 1")
+                    .And.Contain("succeeded: 0")
+                    .And.Contain("failed: 1")
+                    .And.Contain("skipped: 0")
+                    .And.Contain("DUMMY_TEST_ENV_VAR is 'ENV_VAR_CMD_LINE'");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
     }
 }


### PR DESCRIPTION
Related to #45927
Fixes #50806