### PR TITLE
Ensure file-based apps' csc uses correct dotnet

### DIFF
--- a/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
@@ -72,6 +72,9 @@ internal sealed partial class CSharpCompilerCommand
         // Write .rsp file and other intermediate build outputs.
         PrepareAuxiliaryFiles(out string rspPath);
 
+        // Ensure the compiler is launched with the correct dotnet.
+        Environment.SetEnvironmentVariable("DOTNET_HOST_PATH", new Muxer().MuxerPath);
+
         // Create a request for the compiler server
         // (this is much faster than starting a csc.dll process, especially on Windows).
         var buildRequest = BuildServerConnection.CreateBuildRequest(


### PR DESCRIPTION
Discovered while dogfooding a locally built SDK - when `dotnet exec VBCSCompiler` uses wrong `dotnet.exe` (e.g., the globally installed one instead of the locally built one), the compiler server launch fails (which means a 20 second timeout and fallback to MSBuild).