### PR TITLE
Use stderr for watch output

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -89,7 +89,7 @@ internal sealed class StartupHook
         if (!string.IsNullOrEmpty(prefix))
         {
             Console.ForegroundColor = ConsoleColor.DarkGray;
-            Console.WriteLine($"{prefix} {message}");
+            Console.Error.WriteLine($"{prefix} {message}");
             Console.ResetColor();
         }
     }

--- a/src/BuiltInTools/dotnet-watch/UI/ConsoleReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/UI/ConsoleReporter.cs
@@ -56,24 +56,24 @@ namespace Microsoft.DotNet.Watch
             {
                 case MessageSeverity.Error:
                     // Use stdout for error messages to preserve ordering with respect to other output.
-                    WriteLine(console.Out, message, ConsoleColor.Red, emoji);
+                    WriteLine(console.Error, message, ConsoleColor.Red, emoji);
                     break;
 
                 case MessageSeverity.Warning:
-                    WriteLine(console.Out, message, ConsoleColor.Yellow, emoji);
+                    WriteLine(console.Error, message, ConsoleColor.Yellow, emoji);
                     break;
 
                 case MessageSeverity.Output:
                     if (!IsQuiet)
                     {
-                        WriteLine(console.Out, message, color: null, emoji);
+                        WriteLine(console.Error, message, color: null, emoji);
                     }
                     break;
 
                 case MessageSeverity.Verbose:
                     if (IsVerbose)
                     {
-                        WriteLine(console.Out, message, ConsoleColor.DarkGray, emoji);
+                        WriteLine(console.Error, message, ConsoleColor.DarkGray, emoji);
                     }
                     break;
             }

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -18,19 +18,19 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var reporter = new ConsoleReporter(testConsole, verbose: true, quiet: false, suppressEmojis: suppressEmojis);
 
             reporter.Report(id: default, Emoji.Watch, MessageSeverity.Verbose, "verbose {0}");
-            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⌚")} verbose {{0}}" + EOL, testConsole.GetOutput());
+            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⌚")} verbose {{0}}" + EOL, testConsole.GetError());
             testConsole.Clear();
 
             reporter.Report(id: default, Emoji.Watch, MessageSeverity.Output, "out");
-            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⌚")} out" + EOL, testConsole.GetOutput());
+            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⌚")} out" + EOL, testConsole.GetError());
             testConsole.Clear();
 
             reporter.Report(id: default, Emoji.Warning, MessageSeverity.Warning, "warn");
-            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⚠")} warn" + EOL, testConsole.GetOutput());
+            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "⚠")} warn" + EOL, testConsole.GetError());
             testConsole.Clear();
 
             reporter.Report(id: default, Emoji.Error, MessageSeverity.Error, "error");
-            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetOutput());
+            Assert.Equal($"dotnet watch {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetError());
             testConsole.Clear();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/50768

TODO:
- Currently tests merge both stdout and stderr into a single stream of lines. Updating all tests to distinguish between app output and watch output is desirable but a lot of effort. Will leave that for later: https://github.com/dotnet/sdk/issues/50873