### PR TITLE
Fix clearing and reading env variables in startup hook

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/StartupHook.cs
@@ -32,7 +32,7 @@ internal sealed class StartupHook
 
         HotReloadAgent.ClearHotReloadEnvironmentVariables(typeof(StartupHook));
 
-        if (s_namedPipeName == null)
+        if (string.IsNullOrEmpty(s_namedPipeName))
         {
             Log($"Environment variable {AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName} has no value");
             return;
@@ -86,7 +86,7 @@ internal sealed class StartupHook
     private static void Log(string message)
     {
         var prefix = s_standardOutputLogPrefix;
-        if (prefix != null)
+        if (!string.IsNullOrEmpty(prefix))
         {
             Console.ForegroundColor = ConsoleColor.DarkGray;
             Console.WriteLine($"{prefix} {message}");

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -237,8 +237,8 @@ internal sealed class HotReloadAgent : IDisposable, IHotReloadAgent
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks,
             RemoveCurrentAssembly(startupHookType, Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks)!));
 
-        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName, "");
-        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages, "");
+        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName, null);
+        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages, null);
     }
 
     // internal for testing


### PR DESCRIPTION
Set variables to `null` to remove them.
Chech both null and empty when reading them.