### PR TITLE
Handle Ctrl+R in non-interactive mode

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
@@ -46,25 +46,18 @@ namespace Microsoft.DotNet.Watch
         {
             CancellationTokenSource? forceRestartCancellationSource = null;
 
-            if (!_context.Options.NonInteractive)
-            {
-                _context.Logger.Log(MessageDescriptor.HotReloadEnabled);
-                _context.Logger.Log(MessageDescriptor.PressCtrlRToRestart);
+            _context.Logger.Log(MessageDescriptor.HotReloadEnabled);
+            _context.Logger.Log(MessageDescriptor.PressCtrlRToRestart);
 
-                _console.KeyPressed += (key) =>
-                {
-                    if (key.Modifiers.HasFlag(ConsoleModifiers.Control) && key.Key == ConsoleKey.R && forceRestartCancellationSource is { } source)
-                    {
-                        // provide immediate feedback to the user:
-                        _context.Logger.Log(source.IsCancellationRequested ? MessageDescriptor.RestartInProgress : MessageDescriptor.RestartRequested);
-                        source.Cancel();
-                    }
-                };
-            }
-            else
+            _console.KeyPressed += (key) =>
             {
-                _context.Logger.Log(MessageDescriptor.HotReloadEnabled with { Severity = MessageSeverity.Verbose });
-            }
+                if (key.Modifiers.HasFlag(ConsoleModifiers.Control) && key.Key == ConsoleKey.R && forceRestartCancellationSource is { } source)
+                {
+                    // provide immediate feedback to the user:
+                    _context.Logger.Log(source.IsCancellationRequested ? MessageDescriptor.RestartInProgress : MessageDescriptor.RestartRequested);
+                    source.Cancel();
+                }
+            };
 
             using var fileWatcher = new FileWatcher(_context.Logger, _context.EnvironmentOptions);
 

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -838,12 +838,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 .WithSource();
 
             var port = TestOptions.GetTestPort();
-            App.Start(testAsset, ["--urls", "http://localhost:" + port], testFlags: TestFlags.ReadKeyFromStdin | TestFlags.MockBrowser);
+            App.Start(testAsset, ["--urls", "http://localhost:" + port, "--non-interactive"], testFlags: TestFlags.ReadKeyFromStdin | TestFlags.MockBrowser);
 
             await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
 
             App.AssertOutputContains(MessageDescriptor.ConfiguredToUseBrowserRefresh);
             App.AssertOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
+            App.AssertOutputContains(MessageDescriptor.PressCtrlRToRestart);
 
             // Browser is launched based on blazor-devserver output "Now listening on: ...".
             await App.WaitUntilOutputContains($"dotnet watch ⌚ Launching browser: http://localhost:{port}");


### PR DESCRIPTION
Non-interactive mode should disable prompting user for input, but it should allow the user to trigger restart (`Ctlr+R`) and termination (`Ctrl+C`). The latter was enabled while the former was blocked.