### PR TITLE
Don't double-load projects when listing references

### DIFF
--- a/src/Cli/dotnet/Commands/Reference/List/ReferenceListCommand.cs
+++ b/src/Cli/dotnet/Commands/Reference/List/ReferenceListCommand.cs
@@ -38,18 +38,7 @@ internal class ReferenceListCommand : CommandBase
             return 0;
         }
 
-        ProjectRootElement projectRootElement;
-        try
-        {
-            projectRootElement = ProjectRootElement.Open(_fileOrDirectory);
-        }
-        catch (InvalidProjectFileException ex)
-        {
-            Reporter.Error.WriteLine(string.Format(CliStrings.InvalidProjectWithExceptionMessage, _fileOrDirectory, ex.Message));
-            return 0;
-        }
-
-        ProjectInstance projectInstance = new(projectRootElement);
+        ProjectInstance projectInstance = new(msbuildProj.ProjectRootElement);
         Reporter.Output.WriteLine($"{CliStrings.ProjectReferenceOneOrMore}");
         Reporter.Output.WriteLine(new string('-', CliStrings.ProjectReferenceOneOrMore.Length));
         foreach (var item in projectInstance.GetItems("ProjectReference"))


### PR DESCRIPTION
Fixes #50830 

The problem was that you shouldn't double-load project files - so in this case we can re-use the ProjectRootElement that MSBuildProject already exposes. When we do this, things work:

```
(dogfood)> dotnet reference list
Invalid project `D:\Code\FsAutoComplete\src\FsAutoComplete`. The project file could not be loaded. Access to the path 'D:\Code\FsAutoComplete\src\FsAutoComplete' is denied.  D:\Code\FsAutoComplete\src\FsAutoComplete.
```

Then make this change, rebuild sdk dogfood, and try again:

```
(dogfood)> dotnet reference list
Project reference(s)
--------------------
..\FsAutoComplete.Core\FsAutoComplete.Core.fsproj
..\FsAutoComplete.BuildServerProtocol\FsAutoComplete.BuildServerProtocol.fsproj
```