### PR TITLE
Cleanup dotnet test [MTP]

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2694,4 +2694,8 @@ Proceed?</value>
   <data name="UnexpectedMessageWithoutHandshake" xml:space="preserve">
     <value>A message of type '{0}' was received before we got any handshakes, which is unexpected.</value>
   </data>
+  <data name="DotnetTestMismatchingExecutionId" xml:space="preserve">
+    <value>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</value>
+    <comment>{Locked="ExecutionId"}</comment>
+  </data>
 </root>

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -13,7 +13,6 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHelp, ICommandDocument
 {
     private TerminalTestReporter? _output;
-    private byte _cancelled;
 
     public MicrosoftTestingPlatformTestCommand(string name, string? description = null) : base(name, description)
     {
@@ -32,7 +31,7 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         }
         finally
         {
-            CompleteRun(exitCode);
+            _output?.TestExecutionCompleted(DateTimeOffset.Now, exitCode);
         }
     }
 
@@ -47,16 +46,14 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
             IsDiscovery: parseResult.HasOption(MicrosoftTestingPlatformOptions.ListTestsOption),
             EnvironmentVariables: parseResult.GetValue(CommonOptions.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
 
-        InitializeOutput(degreeOfParallelism, parseResult, testOptions);
-
-        SetupCancelKeyPressHandler();
-
         BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
 
         bool filterModeEnabled = parseResult.HasOption(MicrosoftTestingPlatformOptions.TestModulesFilterOption);
         TestApplicationActionQueue actionQueue;
         if (filterModeEnabled)
         {
+            InitializeOutput(degreeOfParallelism, parseResult, testOptions);
+
             actionQueue = new TestApplicationActionQueue(degreeOfParallelism, buildOptions, testOptions, _output, OnHelpRequested);
             var testModulesFilterHandler = new TestModulesFilterHandler(actionQueue, _output);
             if (!testModulesFilterHandler.RunWithTestModulesFilter(parseResult))
@@ -66,11 +63,13 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         }
         else
         {
-            var msBuildHandler = new MSBuildHandler(buildOptions, _output);
+            var msBuildHandler = new MSBuildHandler(buildOptions);
             if (!msBuildHandler.RunMSBuild())
             {
                 return ExitCode.GenericFailure;
             }
+
+            InitializeOutput(degreeOfParallelism, parseResult, testOptions);
 
             // NOTE: Don't create TestApplicationActionQueue before RunMSBuild.
             // The constructor will do Task.Run calls matching the degree of parallelism, and if we did that before the build, that can
@@ -98,16 +97,6 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         return exitCode;
     }
 
-    private void SetupCancelKeyPressHandler()
-    {
-        Console.CancelKeyPress += (s, e) =>
-        {
-            _output?.StartCancelling();
-            // We are not sure what the exit code will be, there might be an exception.
-            CompleteRun(exitCode: null);
-        };
-    }
-
     [MemberNotNull(nameof(_output))]
     private void InitializeOutput(int degreeOfParallelism, ParseResult parseResult, TestOptions testOptions)
     {
@@ -130,6 +119,11 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
             MinimumExpectedTests = parseResult.GetValue(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption),
         });
 
+        Console.CancelKeyPress += (s, e) =>
+        {
+            _output.StartCancelling();
+        };
+
         // This is ugly, and we need to replace it by passing out some info from testing platform to inform us that some process level retry plugin is active.
         var isRetry = parseResult.GetArguments().Contains("--retry-failed-tests");
 
@@ -142,13 +136,5 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         if (degreeOfParallelism <= 0)
             degreeOfParallelism = Environment.ProcessorCount;
         return degreeOfParallelism;
-    }
-
-    private void CompleteRun(int? exitCode)
-    {
-        if (Interlocked.CompareExchange(ref _cancelled, 1, 0) == 0)
-        {
-            _output?.TestExecutionCompleted(DateTimeOffset.Now, exitCode);
-        }
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -57,7 +57,6 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private static partial Regex GetFrameRegex();
 
     private int _counter;
-    private bool _disableTestRunSummary;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminalTestReporter"/> class with custom terminal and manual refresh for testing.
@@ -148,17 +147,12 @@ internal sealed partial class TerminalTestReporter : IDisposable
         });
     }
 
-    public void DisableTestRunSummary()
-    {
-        _disableTestRunSummary = true;
-    }
-
     public void TestExecutionCompleted(DateTimeOffset endTime, int? exitCode)
     {
         _testExecutionEndTime = endTime;
         _terminalWithProgress.StopShowingProgress();
 
-        if (!_isHelp && !_disableTestRunSummary)
+        if (!_isHelp)
         {
             if (_isDiscovery)
             {
@@ -844,6 +838,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
     /// </summary>
     public void StartCancelling()
     {
+        if (_wasCancelled)
+        {
+            return;
+        }
+
         _wasCancelled = true;
         _terminalWithProgress.WriteToTerminal(terminal =>
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -100,6 +100,12 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(DiscoveredTestMessages)));
         }
 
+        if (discoveredTestMessages.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        {
+            // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, discoveredTestMessages.ExecutionId, nameof(DiscoveredTestMessages), _handshakeInfo.Value.ExecutionId));
+        }
+
         foreach (var test in discoveredTestMessages.DiscoveredMessages)
         {
             _output.TestDiscovered(_handshakeInfo.Value.ExecutionId,
@@ -120,6 +126,12 @@ internal sealed class TestApplicationHandler
         if (!_handshakeInfo.HasValue)
         {
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(TestResultMessages)));
+        }
+
+        if (testResultMessage.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        {
+            // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, testResultMessage.ExecutionId, nameof(TestResultMessages), _handshakeInfo.Value.ExecutionId));
         }
 
         var handshakeInfo = _handshakeInfo.Value;
@@ -169,6 +181,12 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(FileArtifactMessages)));
         }
 
+        if (fileArtifactMessages.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        {
+            // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, fileArtifactMessages.ExecutionId, nameof(FileArtifactMessages), _handshakeInfo.Value.ExecutionId));
+        }
+
         var handshakeInfo = _handshakeInfo.Value;
         foreach (var artifact in fileArtifactMessages.FileArtifacts)
         {
@@ -191,6 +209,12 @@ internal sealed class TestApplicationHandler
             if (!_handshakeInfo.HasValue)
             {
                 throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(DiscoveredTestMessages)));
+            }
+
+            if (sessionEvent.ExecutionId != _handshakeInfo.Value.ExecutionId)
+            {
+                // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
+                throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, sessionEvent.ExecutionId, nameof(TestSessionEvent), _handshakeInfo.Value.ExecutionId));
             }
 
             if (sessionEvent.SessionType == SessionEventTypes.TestSessionStart)

--- a/src/Cli/dotnet/Commands/Test/MTP/ValidationUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ValidationUtility.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -49,18 +48,18 @@ internal static class ValidationUtility
         }
     }
 
-    public static bool ValidateBuildPathOptions(BuildOptions buildPathOptions, TerminalTestReporter output)
+    public static bool ValidateBuildPathOptions(BuildOptions buildPathOptions)
     {
         PathOptions pathOptions = buildPathOptions.PathOptions;
 
         if (!string.IsNullOrEmpty(pathOptions.ProjectPath))
         {
-            return ValidateProjectPath(pathOptions.ProjectPath, output);
+            return ValidateProjectPath(pathOptions.ProjectPath);
         }
 
         if (!string.IsNullOrEmpty(pathOptions.SolutionPath))
         {
-            return ValidateSolutionPath(pathOptions.SolutionPath, output);
+            return ValidateSolutionPath(pathOptions.SolutionPath);
         }
 
         return true;
@@ -107,7 +106,7 @@ internal static class ValidationUtility
         }
     }
 
-    private static bool ValidateSolutionPath(string path, TerminalTestReporter output)
+    private static bool ValidateSolutionPath(string path)
     {
         // If it's a directory, just check if it exists
         if (Directory.Exists(path))
@@ -118,14 +117,14 @@ internal static class ValidationUtility
         // If it's not a directory, validate as a file path
         if (!CliConstants.SolutionExtensions.Contains(Path.GetExtension(path)))
         {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, path));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, path));
             return false;
         }
 
-        return ValidateFilePathExists(path, output);
+        return ValidateFilePathExists(path);
     }
 
-    private static bool ValidateProjectPath(string path, TerminalTestReporter output)
+    private static bool ValidateProjectPath(string path)
     {
         // If it's a directory, just check if it exists
         if (Directory.Exists(path))
@@ -136,18 +135,18 @@ internal static class ValidationUtility
         // If it's not a directory, validate as a file path
         if (!Path.GetExtension(path).EndsWith("proj", StringComparison.OrdinalIgnoreCase))
         {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, path));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, path));
             return false;
         }
 
-        return ValidateFilePathExists(path, output);
+        return ValidateFilePathExists(path);
     }
 
-    private static bool ValidateFilePathExists(string filePath, TerminalTestReporter output)
+    private static bool ValidateFilePathExists(string filePath)
     {
         if (!File.Exists(filePath))
         {
-            output.WriteMessage(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, Path.GetFullPath(filePath)));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, Path.GetFullPath(filePath)));
             return false;
         }
 

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -1172,6 +1172,11 @@ See https://aka.ms/dotnet-test/mtp for more information.</target>
         <target state="new">Supported protocol versions sent by Microsoft.Testing.Platform are '{0}'. The SDK supports '{1}', which is incompatible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMismatchingExecutionId">
+        <source>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</source>
+        <target state="new">Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</target>
+        <note>{Locked="ExecutionId"}</note>
+      </trans-unit>
       <trans-unit id="DotnetTestPipeFailureHasHandshake">
         <source>Error disposing 'NamedPipeServer' corresponding to handshake:</source>
         <target state="new">Error disposing 'NamedPipeServer' corresponding to handshake:</target>

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
+                result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
+                result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
+                result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
@@ -298,7 +298,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
+                result.StdErr.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
@@ -318,7 +318,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!TestContext.IsLocalized())
             {
-                result.StdOut.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
+                result.StdErr.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(MicrosoftTestingPlatformOptions.ProjectOption.Name, invalidProjectPath,
                                              MicrosoftTestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, invalidProjectPath));
+            result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdInvalidProjectFileExtensionErrorDescription, invalidProjectPath));
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute(MicrosoftTestingPlatformOptions.SolutionOption.Name, invalidSolutionPath,
                                              MicrosoftTestingPlatformOptions.ConfigurationOption.Name, configuration);
 
-            result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, invalidSolutionPath));
+            result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdInvalidSolutionFileExtensionErrorDescription, invalidSolutionPath));
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     MicrosoftTestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             string fullProjectPath = $"{testInstance.TestRoot}{Path.DirectorySeparatorChar}{testProjectPath}";
-            result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, fullProjectPath));
+            result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, fullProjectPath));
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                              MicrosoftTestingPlatformOptions.ConfigurationOption.Name, configuration);
 
             string fullSolutionPath = $"{testInstance.TestRoot}{Path.DirectorySeparatorChar}{solutionPath}";
-            result.StdOut.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, fullSolutionPath));
+            result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdNonExistentFileErrorDescription, fullSolutionPath));
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
         }
@@ -480,22 +480,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             /*
                 error NETSDK1005: Assets file 'path\to\OtherTestProject\obj\project.assets.json' doesn't have a target for 'net9.0'. Ensure that restore has run and that you have included 'net9.0' in the TargetFrameworks for your project.
                 Get projects properties with MSBuild didn't execute properly with exit code: 1.
-
-                Test run summary: Zero tests ran
-                  total: 0
-                  failed: 0
-                  succeeded: 0
-                  skipped: 0
-                  duration: 33s 867ms
             */
             if (!TestContext.IsLocalized())
             {
                 result.StdOut
-                 .Should().Contain("Test run summary: Zero tests ran")
-                 .And.Contain("total: 0")
-                 .And.Contain("succeeded: 0")
-                 .And.Contain("failed: 0")
-                 .And.Contain("skipped: 0")
+                 .Should().NotContain("Test run summary")
                  .And.Contain("NETSDK1005");
             }
 


### PR DESCRIPTION
- Makes our assumptions stronger about ExecutionId expectations.
- Moves TerminalTestReporter out of MSBuildHandler. We should initialize TerminalTestReporter only when we are about to execute tests. We shouldn't have it during build step at all.
- On receiving Ctrl+C, we shouldn't print the test summary. We end up printing it but tests are still running. We should wait until all child processes are able to exit.
