### PR TITLE
[StaticWebAssets] Fix recursive glob stem truncation for multi‑dot component JS module files and expand pattern coverage

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/StaticWebAssetGlobMatcher.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/StaticWebAssetGlobMatcher.cs
@@ -479,7 +479,10 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
             return MatchStage.Done;
         }
 
-        internal readonly MatchState NextExtension(int extensionIndex) => new(Node, MatchStage.Extension, SegmentIndex, extensionIndex, ComplexSegmentIndex);
+        internal readonly MatchState NextExtension(int extensionIndex) => new(Node, MatchStage.Extension, SegmentIndex, extensionIndex, ComplexSegmentIndex)
+        {
+            StemStartIndex = StemStartIndex
+        };
 
         internal readonly MatchState NextComplex() => new(Node, MatchStage.Complex, SegmentIndex, ExtensionSegmentIndex, ComplexSegmentIndex + 1);
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/Globbing/StaticWebAssetGlobMatcherTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/Globbing/StaticWebAssetGlobMatcherTest.cs
@@ -27,6 +27,29 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks.Test;
 // Recursive wildcard in the middle 'a/**/c'
 public partial class StaticWebAssetGlobMatcherTest
 {
+        [Theory]
+        [InlineData("**/*.razor.js", "Components/Pages/RegularComponent.razor.js", "Components/Pages/RegularComponent.razor.js")]
+        [InlineData("**/*.razor.js", "Components/User.Profile.Details.razor.js", "Components/User.Profile.Details.razor.js")]
+        [InlineData("**/*.razor.js", "Components/Area/Sub/Feature/User.Profile.Details.razor.js", "Components/Area/Sub/Feature/User.Profile.Details.razor.js")]
+        [InlineData("**/*.razor.js", "Components/Area/Sub/Feature/Deep.Component.Name.With.Many.Parts.razor.js", "Components/Area/Sub/Feature/Deep.Component.Name.With.Many.Parts.razor.js")]
+        [InlineData("**/*.cshtml.js", "Pages/Shared/_Host.cshtml.js", "Pages/Shared/_Host.cshtml.js")]
+        [InlineData("**/*.cshtml.js", "Areas/Admin/Pages/Dashboard.cshtml.js", "Areas/Admin/Pages/Dashboard.cshtml.js")]
+        [InlineData("*.lib.module.js", "Widget.lib.module.js", "Widget.lib.module.js")]
+        [InlineData("*.razor.css", "Component.razor.css", "Component.razor.css")]
+        [InlineData("*.cshtml.css", "View.cshtml.css", "View.cshtml.css")]
+        [InlineData("*.modules.json", "app.modules.json", "app.modules.json")]
+        [InlineData("*.lib.module.js", "Rcl.Client.Feature.lib.module.js", "Rcl.Client.Feature.lib.module.js")]
+        public void Can_Match_WellKnownExistingPatterns(string pattern, string path, string expectedStem)
+        {
+            var matcher = new StaticWebAssetGlobMatcherBuilder();
+            matcher.AddIncludePatterns(pattern);
+            var globMatcher = matcher.Build();
+
+            var match = globMatcher.Match(path);
+            Assert.True(match.IsMatch);
+            Assert.Equal(pattern, match.Pattern);
+            Assert.Equal(expectedStem, match.Stem);
+        }
     [Fact]
     public void CanMatchLiterals()
     {


### PR DESCRIPTION
## Description

Recursive glob patterns like `**/*.razor.js` and `**/*.cshtml.js` produced an incorrect relative path for files whose base name contained multiple dots.  

For example, for a pattern like:
Pattern: `**/*.razor.js`  
Path: `Components/User.Profile.Details.razor.js`  
Stem (incorrect): `User.Profile.Details.razor.js` (directory portion lost)

Fixes https://github.com/dotnet/sdk/issues/50840

## Customer Impact

Without this fix, any file with multiple extensions that is filtered during build time processing receives incorrect relative paths which translates in harder to debug issues later during build or at runtime. For example, the file will be served from the wrong file path during runtime.

## Regression?

- [x] Yes
- [] No

9.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Justification: Change is localized to preserving a single integer
(`StemStartIndex`) across extension matching. No algorithmic branching
added; existing broad test suite plus new targeted cases all pass.

## Verification

- [ ] Manual
- [x] Automated

Added tests for the problematic cases and additional tests for variations of the pattern.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A