### PR TITLE
Add flag to silence sdk resolution warning

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -237,7 +237,7 @@ public class Program
             // Get the global.json state to report in telemetry along with this command invocation.
             // We don't care about the actual SDK resolution, just the global.json information,
             // so just pass empty string as executable directory for resolution.
-            NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory);
+            NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory, doNotPrintErrors: true);
             globalJsonState = result.GlobalJsonState;
         }
 

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.NativeWrapper
         }
 
         // MSBuild SDK resolvers are required to be AnyCPU, but we have a native dependency and .NETFramework does not
-        // have a built-in facility for dynamically loading user native dlls for the appropriate platform. We therefore 
+        // have a built-in facility for dynamically loading user native dlls for the appropriate platform. We therefore
         // preload the version with the correct architecture (from a corresponding sub-folder relative to us) on static
         // construction so that subsequent P/Invokes can find it.
         private static void PreloadWindowsLibrary(string dllFileName)
@@ -73,6 +73,7 @@ namespace Microsoft.DotNet.NativeWrapper
         internal enum hostfxr_resolve_sdk2_flags_t : int
         {
             disallow_prerelease = 0x1,
+            do_not_print_errors = 0x2,
         }
 
         internal enum hostfxr_resolve_sdk2_result_key_t : int

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
@@ -10,10 +10,12 @@ namespace Microsoft.DotNet.NativeWrapper
         public static SdkResolutionResult ResolveSdk(
             string? dotnetExeDirectory,
             string? globalJsonStartDirectory,
-            bool disallowPrerelease = false)
+            bool disallowPrerelease = false,
+            bool doNotPrintErrors = false)
         {
             var result = new SdkResolutionResult();
             var flags = disallowPrerelease ? Interop.hostfxr_resolve_sdk2_flags_t.disallow_prerelease : 0;
+            flags |= doNotPrintErrors ?  Interop.hostfxr_resolve_sdk2_flags_t.do_not_print_errors : 0;
 
             int errorCode = Interop.RunningOnWindows
                 ? Interop.Windows.hostfxr_resolve_sdk2(dotnetExeDirectory, globalJsonStartDirectory, flags, result.Initialize)


### PR DESCRIPTION
Updates the usage of `hostfxr_resolve_sdk2` to use the doNotPrintErrors flag introduced in https://github.com/dotnet/runtime/pull/119729. Does not have any effect until that runtime commit flows to sdk. I haven't yet managed to create a test where `TelemetryClient.Enabled == true` to reproduce https://github.com/dotnet/sdk/issues/50632 to verify that this change does actually fix the issue.