### PR TITLE
Stop building source-build in non-1xx branches

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,12 +115,6 @@ extends:
               value: real
             - name: _Test
               value: ''
-      - template: /eng/common/templates-official/job/source-build.yml@self
-        parameters:
-          enableInternalSources: true
-          platform:
-            name: 'Managed'
-            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/build.yml@self
           parameters:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -85,12 +85,6 @@ stages:
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: real
               _Test: ''
-  - template: /eng/common/templates/job/source-build.yml
-    parameters:
-      enableInternalSources: true
-      platform:
-        name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/build-pr.yml
       parameters:


### PR DESCRIPTION
There is no need to build source-build legs in any feature band except 8.0.1xx. We often see issues related to this leg that require unnecessary work - i.e. https://github.com/dotnet/sdk/pull/50847#issuecomment-3303550283

This will need to be backported to 8.0.3xx.

**NOTE** - merge only after https://github.com/dotnet/installer/pull/20614 is merged