### PR TITLE
Discovery indicator fixes

### DIFF
--- a/sdk.slnx
+++ b/sdk.slnx
@@ -54,6 +54,8 @@
     <Project Path="src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj" />
     <Project Path="src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj" />
     <Project Path="src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.shproj" />
+    <Project Path="src/BuiltInTools/HotReloadClient/Microsoft.DotNet.HotReload.Client.Package.csproj" />
+    <Project Path="src/BuiltInTools/HotReloadClient/Microsoft.DotNet.HotReload.Client.shproj" Id="a78ff92a-d715-4249-9e3d-40d9997a098f" />
   </Folder>
   <Folder Name="/src/Cli/">
     <Project Path="src/Cli/dotnet/dotnet.csproj" />
@@ -316,6 +318,7 @@
     <Project Path="test/HelixTasks/HelixTasks.csproj" />
     <Project Path="test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj" />
+    <Project Path="test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj" />

--- a/sdk.slnx
+++ b/sdk.slnx
@@ -54,8 +54,6 @@
     <Project Path="src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj" />
     <Project Path="src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.Package.csproj" />
     <Project Path="src/BuiltInTools/HotReloadAgent/Microsoft.DotNet.HotReload.Agent.shproj" />
-    <Project Path="src/BuiltInTools/HotReloadClient/Microsoft.DotNet.HotReload.Client.Package.csproj" />
-    <Project Path="src/BuiltInTools/HotReloadClient/Microsoft.DotNet.HotReload.Client.shproj" Id="a78ff92a-d715-4249-9e3d-40d9997a098f" />
   </Folder>
   <Folder Name="/src/Cli/">
     <Project Path="src/Cli/dotnet/dotnet.csproj" />
@@ -318,7 +316,6 @@
     <Project Path="test/HelixTasks/HelixTasks.csproj" />
     <Project Path="test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj" />
-    <Project Path="test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj" />
     <Project Path="test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj" />

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -26,59 +26,77 @@ internal sealed class AnsiTerminalTestProgressFrame(int width, int height)
 
         int nonReservedWidth = Width - (durationString.Length + 2);
 
+        int discovered = progress.DiscoveredTests;
         int passed = progress.PassedTests;
         int failed = progress.FailedTests;
         int skipped = progress.SkippedTests;
         int retried = progress.RetriedFailedTests;
         int charsTaken = 0;
 
-        terminal.Append('[');
-        charsTaken++;
-        terminal.SetColor(TerminalColor.DarkGreen);
-        terminal.Append('✓');
-        charsTaken++;
-        string passedText = passed.ToString(CultureInfo.CurrentCulture);
-        terminal.Append(passedText);
-        charsTaken += passedText.Length;
-        terminal.ResetColor();
-
-        terminal.Append('/');
-        charsTaken++;
-
-        terminal.SetColor(TerminalColor.DarkRed);
-        terminal.Append('x');
-        charsTaken++;
-        string failedText = failed.ToString(CultureInfo.CurrentCulture);
-        terminal.Append(failedText);
-        charsTaken += failedText.Length;
-        terminal.ResetColor();
-
-        terminal.Append('/');
-        charsTaken++;
-
-        terminal.SetColor(TerminalColor.DarkYellow);
-        terminal.Append('↓');
-        charsTaken++;
-        string skippedText = skipped.ToString(CultureInfo.CurrentCulture);
-        terminal.Append(skippedText);
-        charsTaken += skippedText.Length;
-        terminal.ResetColor();
-
-        if (retried > 0)
+        if (!progress.IsDiscovery)
         {
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkGreen);
+            terminal.Append('✓');
+            charsTaken++;
+            string passedText = passed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(passedText);
+            charsTaken += passedText.Length;
+            terminal.ResetColor();
+
             terminal.Append('/');
             charsTaken++;
-            terminal.SetColor(TerminalColor.Gray);
-            terminal.Append('r');
-            charsTaken++;
-            string retriedText = retried.ToString(CultureInfo.CurrentCulture);
-            terminal.Append(retriedText);
-            charsTaken += retriedText.Length;
-            terminal.ResetColor();
-        }
 
-        terminal.Append(']');
-        charsTaken++;
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append('x');
+            charsTaken++;
+            string failedText = failed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(failedText);
+            charsTaken += failedText.Length;
+            terminal.ResetColor();
+
+            terminal.Append('/');
+            charsTaken++;
+
+            terminal.SetColor(TerminalColor.DarkYellow);
+            terminal.Append('↓');
+            charsTaken++;
+            string skippedText = skipped.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(skippedText);
+            charsTaken += skippedText.Length;
+            terminal.ResetColor();
+
+            if (retried > 0)
+            {
+                terminal.Append('/');
+                charsTaken++;
+                terminal.SetColor(TerminalColor.Gray);
+                terminal.Append('r');
+                charsTaken++;
+                string retriedText = retried.ToString(CultureInfo.CurrentCulture);
+                terminal.Append(retriedText);
+                charsTaken += retriedText.Length;
+                terminal.ResetColor();
+            }
+
+            terminal.Append(']');
+            charsTaken++;
+        }
+        else
+        {
+            string discoveredText = progress.DiscoveredTests.ToString(CultureInfo.CurrentCulture);
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkMagenta);
+            terminal.Append('+');
+            charsTaken++;
+            terminal.Append(discoveredText);
+            charsTaken += discoveredText.Length;
+            terminal.ResetColor();
+            terminal.Append(']');
+            charsTaken++;
+        }
 
         terminal.Append(' ');
         charsTaken++;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
@@ -67,32 +67,49 @@ internal abstract class SimpleTerminal : ITerminal
 
             string durationString = HumanReadableDurationFormatter.Render(p.Stopwatch.Elapsed);
 
+            int discovered = p.DiscoveredTests;
             int passed = p.PassedTests;
             int failed = p.FailedTests;
             int skipped = p.SkippedTests;
 
-            // Use just ascii here, so we don't put too many restrictions on fonts needing to
-            // properly show unicode, or logs being saved in particular encoding.
-            Append('[');
-            SetColor(TerminalColor.DarkGreen);
-            Append('+');
-            Append(passed.ToString(CultureInfo.CurrentCulture));
-            ResetColor();
+            if (!p.IsDiscovery)
+            {
+                // Use just ascii here, so we don't put too many restrictions on fonts needing to
+                // properly show unicode, or logs being saved in particular encoding.
+                Append('[');
+                SetColor(TerminalColor.DarkGreen);
+                Append('+');
+                Append(passed.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
 
-            Append('/');
+                Append('/');
 
-            SetColor(TerminalColor.DarkRed);
-            Append('x');
-            Append(failed.ToString(CultureInfo.CurrentCulture));
-            ResetColor();
+                SetColor(TerminalColor.DarkRed);
+                Append('x');
+                Append(failed.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
 
-            Append('/');
+                Append('/');
 
-            SetColor(TerminalColor.DarkYellow);
-            Append('?');
-            Append(skipped.ToString(CultureInfo.CurrentCulture));
-            ResetColor();
-            Append(']');
+                SetColor(TerminalColor.DarkYellow);
+                Append('?');
+                Append(skipped.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append(']');
+            }
+            else
+            {
+                // Use just ascii here, so we don't put too many restrictions on fonts needing to
+                // properly show unicode, or logs being saved in particular encoding.
+                Append('[');
+                SetColor(TerminalColor.DarkMagenta);
+                Append('+');
+                Append(discovered.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append(']');
+            }
 
             Append(' ');
             Append(p.AssemblyName);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -6,7 +6,7 @@ using TestNodeInfoEntry = (int Passed, int Skipped, int Failed, int LastAttemptN
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 
-internal sealed class TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch)
+internal sealed class TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch, bool isDiscovery)
 {
     private readonly Dictionary<string, TestNodeInfoEntry> _testUidToResults = new();
 
@@ -24,13 +24,15 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     public IStopwatch Stopwatch { get; } = stopwatch;
 
+    public int DiscoveredTests { get; private set; }
+
     public int FailedTests { get; private set; }
 
     public int PassedTests { get; private set; }
 
     public int SkippedTests { get; private set; }
 
-    public int TotalTests => PassedTests + SkippedTests + FailedTests;
+    public int TotalTests => IsDiscovery ? DiscoveredTests : PassedTests + SkippedTests + FailedTests;
 
     public int RetriedFailedTests { get; private set; }
 
@@ -42,9 +44,11 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     public long Version { get; internal set; }
 
-    public List<(string? DisplayName, string? UID)> DiscoveredTests { get; internal set; } = [];
+    public List<(string? DisplayName, string? UID)> DiscoveredTestNames { get; internal set; } = [];
 
     public bool Success { get; internal set; }
+
+    public bool IsDiscovery = isDiscovery;
 
     public int TryCount { get; private set; }
 
@@ -122,8 +126,8 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     public void DiscoverTest(string? displayName, string? uid)
     {
-        PassedTests++;
-        DiscoveredTests.Add(new(displayName, uid));
+        DiscoveredTests++;
+        DiscoveredTestNames.Add(new(displayName, uid));
     }
 
     internal void NotifyHandshake(string instanceId)

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -154,6 +154,7 @@ public class TestProgressStateTests
         state.SkippedTests.Should().Be(1);
         state.RetriedFailedTests.Should().Be(3);
     }
+
     /// <summary>
     /// Tests that DiscoverTest increments PassedTests and adds the displayName and uid to DiscoveredTests.
     /// </summary>
@@ -178,7 +179,7 @@ public class TestProgressStateTests
 
         state.DiscoverTest(displayName, uid);
 
-        state.PassedTests.Should().Be(1);
+        state.DiscoveredTests.Should().Be(1);
         state.DiscoveredTestNames.Count.Should().Be(1);
         state.DiscoveredTestNames[0].DisplayName.Should().Be(displayName);
         state.DiscoveredTestNames[0].UID.Should().Be(uid);

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -18,7 +18,7 @@ public class TestProgressStateTests
     public void ReportSkippedTest_MultipleCalls_DifferentInstanceId()
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         string testUid = "test1";
         string instanceA = "instanceA";
         string instanceB = "instanceB";
@@ -48,7 +48,7 @@ public class TestProgressStateTests
     public void ReportSkippedTest_RepeatedInstanceAfterRetry_ThrowsInvalidOperationException()
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         string testUid = "test1";
         string instanceA = "instanceA";
         string instanceB = "instanceB";
@@ -75,7 +75,7 @@ public class TestProgressStateTests
     public void ReportFailedTest_RepeatedCalls_IncrementsFailedTests(int callCount)
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("instance1");
         for (int i = 0; i < callCount; i++)
         {
@@ -95,7 +95,7 @@ public class TestProgressStateTests
     public void ReportFailedTest_DifferentInstanceId_RetriesFailureAndResetsCount()
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
         state.ReportFailedTest("testUid", "id1");
         state.ReportFailedTest("testUid", "id1");
@@ -114,7 +114,7 @@ public class TestProgressStateTests
     public void ReportFailedTest_ReusingOldInstanceId_ThrowsInvalidOperationException()
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
         state.ReportFailedTest("testUid", "id1");
         state.NotifyHandshake("id2");
@@ -134,7 +134,7 @@ public class TestProgressStateTests
     public void ReportTest_WithNewInstanceId_ClearsOldReports()
     {
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
         state.ReportFailedTest("testUid", "id1");
         state.ReportFailedTest("testUid", "id1");
@@ -173,14 +173,15 @@ public class TestProgressStateTests
             assembly: "assembly.dll",
             targetFramework: null,
             architecture: null,
-            stopwatch: stopwatchMock.Object);
+            stopwatch: stopwatchMock.Object,
+            isDiscovery: true);
 
         state.DiscoverTest(displayName, uid);
 
         state.PassedTests.Should().Be(1);
-        state.DiscoveredTests.Count.Should().Be(1);
-        state.DiscoveredTests[0].DisplayName.Should().Be(displayName);
-        state.DiscoveredTests[0].UID.Should().Be(uid);
+        state.DiscoveredTestNames.Count.Should().Be(1);
+        state.DiscoveredTestNames[0].DisplayName.Should().Be(displayName);
+        state.DiscoveredTestNames[0].UID.Should().Be(uid);
     }
 
     [Fact]
@@ -188,7 +189,7 @@ public class TestProgressStateTests
     {
         // Tests are retried, total test count stays 3 to give use comparable counts, no matter how many times we retry.
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
 
         // First run
         state.NotifyHandshake("run1");
@@ -227,7 +228,7 @@ public class TestProgressStateTests
     {
         // This is special test for dynamic tests where we don't know how many tests will be produced in the second run.
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
 
         // First run
         state.NotifyHandshake("run1");
@@ -259,7 +260,7 @@ public class TestProgressStateTests
     {
         // This is special test for dynamic tests where we cannot avoid re-running even non-failing tests from dynamic tests.
         var stopwatchMock = new Mock<IStopwatch>();
-        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object);
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
 
         // First run
         state.NotifyHandshake("run1");


### PR DESCRIPTION
Change progress bar color to neutral color on discovery
<img width="485" height="123" alt="image" src="https://github.com/user-attachments/assets/af55197a-9908-49e9-b437-bbfa5600f3f0" />

Show red message when 0 tests are discovered. E.g. when we do `--list-tests --unknown-option`, to align with exit code 1.

Related to https://github.com/dotnet/sdk/issues/45927
fix https://github.com/dotnet/sdk/issues/50786