### PR TITLE
Only run the test templates on x64

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -105,8 +105,9 @@ jobs:
           BuildConfig: $(buildConfiguration)
           TestFullMSBuild: ${{ parameters.testFullMSBuild }}
 
-      - powershell: build/RunTestTemplateTests.ps1
-        displayName: 🟣 Run Test Templates Tests
+      - ${{ if eq(parameters.targetArchitecture, 'x64') }}:
+        - powershell: build/RunTestTemplateTests.ps1
+          displayName: 🟣 Run Test Templates Tests
 
     - ${{ else }}:
       - script: |


### PR DESCRIPTION
This test step was added to ensure we scanned the packages pulled down in the test templates so it specifically had to run in the context of the CI machine rather than on helix. This causes issues when cross compiling on windows.

Since we only care about version, it should be fine to only run on x64.