### PR TITLE
Make file-based caching opt out work for the basic up-to-date check too

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -289,7 +289,8 @@ The build is performed using MSBuild APIs on in-memory project files.
 If an up-to-date check detects that inputs didn't change in subsequent `dotnet run file.cs` invocations,
 building is skipped (as if `--no-build` option has been passed).
 The up-to-date check is not 100% precise (e.g., files imported through an implicit build file are not considered).
-It is possible to enforce a full build using `--no-cache` flag or `dotnet build file.cs`.
+It is possible to enforce a full build using `--no-cache` flag or `dotnet build file.cs`
+(for a more permanent opt-out, there is MSBuild property `FileBasedProgramCanSkipMSBuild=false`).
 Environment variable [`DOTNET_CLI_CONTEXT_VERBOSE=true`][verbose-env] can be used to get more details about caching decisions made by `dotnet run file.cs`.
 
 There are multiple optimization levels - skipping build altogether, running just the C# compiler, or running full MSBuild.
@@ -297,8 +298,7 @@ We always need to re-run MSBuild if implicit build files like `Directory.Build.p
 from `.cs` files, the only relevant MSBuild inputs are the `#:` directives,
 hence we can first check the `.cs` file timestamps and for those that have changed, compare the sets of `#:` directives.
 If only `.cs` files change, it is enough to invoke `csc.exe` (directly or via a build server)
-re-using command-line arguments that the last MSBuild invocation passed to the compiler
-(you can opt out of this via an MSBuild property `FileBasedProgramCanSkipMSBuild=false`).
+re-using command-line arguments that the last MSBuild invocation passed to the compiler.
 If no inputs change, it is enough to start the target executable without invoking the build at all.
 
 ## Alternatives and future work

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -361,7 +361,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                     }
                     else
                     {
-                        TryCacheCscArguments(cache, buildResult);
+                        CacheCscArguments(cache, buildResult);
 
                         MarkBuildSuccess(cache);
                     }
@@ -451,7 +451,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             return null;
         }
 
-        void TryCacheCscArguments(CacheInfo cache, BuildResult result)
+        void CacheCscArguments(CacheInfo cache, BuildResult result)
         {
             // We cannot reuse CSC arguments from previous run and skip MSBuild if there are project references
             // because we cannot easily detect whether any referenced projects have changed.

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -2842,6 +2842,11 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         Build(testInstance, optOut ? BuildLevel.All : BuildLevel.Csc, expectedOutput: optOut ? "[MyString, UpdatedValue]" : "Resource not found");
 
         Build(testInstance, BuildLevel.All, ["--no-cache"], expectedOutput: "[MyString, UpdatedValue]");
+
+        // Update the C# file.
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), "//v3\n" + code);
+
+        Build(testInstance, optOut ? BuildLevel.All : BuildLevel.Csc, expectedOutput: "[MyString, UpdatedValue]");
     }
 
     /// <summary>


### PR DESCRIPTION
Part of https://github.com/dotnet/sdk/issues/50912.