### PR TITLE
ensure that all TargetFrameworkEval properties are sent without any m…

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets
@@ -54,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)', 2))</TargetFrameworkVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <_TargetFrameworkVersionWithoutV>$(TargetFrameworkVersion.TrimStart('vV'))</_TargetFrameworkVersionWithoutV>
   </PropertyGroup>
@@ -154,8 +154,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TFTelemetry Include="PublishSelfContained" Value="$(PublishSelfContained)" />
       <TFTelemetry Include="PublishReadyToRun" Value="$(PublishReadyToRun)" />
       <TFTelemetry Include="PublishReadyToRunComposite" Value="$(PublishReadyToRunComposite)" />
-      <TFTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" />    
-      <TFTelemetry Include="Configuration" Value="$(Configuration)" />
+      <TFTelemetry Include="PublishProtocol" Value="$(PublishProtocol)" />
+      <TFTelemetry Include="Configuration" Value="$(Configuration)" Hash="true" />
     </ItemGroup>
     <AllowEmptyTelemetry EventName="targetframeworkeval" EventData="@(TFTelemetry)" />
   </Target>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.NET.Build.Tests
 {
@@ -29,7 +30,7 @@ namespace Microsoft.NET.Build.Tests
             string publishProtocol = "null",
             string configuration = "Debug")
         {
-            return $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{targetFrameworkVersion}\",\"RuntimeIdentifier\":\"{runtimeIdentifier}\",\"SelfContained\":\"{selfContained}\",\"UseApphost\":\"{useApphost}\",\"OutputType\":\"{outputType}\",\"UseArtifactsOutput\":\"{useArtifactsOutput}\",\"ArtifactsPathLocationType\":\"{artifactsPathLocationType}\",\"TargetPlatformIdentifier\":\"{targetPlatformIdentifier}\",\"UseMonoRuntime\":\"{useMonoRuntime}\",\"PublishAot\":\"{publishAot}\",\"PublishTrimmed\":\"{publishTrimmed}\",\"PublishSelfContained\":\"{publishSelfContained}\",\"PublishReadyToRun\":\"{publishReadyToRun}\",\"PublishReadyToRunComposite\":\"{publishReadyToRunComposite}\",\"PublishProtocol\":\"{publishProtocol}\",\"Configuration\":\"{configuration}\"}}";
+            return $"{{\"EventName\":\"targetframeworkeval\",\"Properties\":{{\"TargetFrameworkVersion\":\"{targetFrameworkVersion}\",\"RuntimeIdentifier\":\"{runtimeIdentifier}\",\"SelfContained\":\"{selfContained}\",\"UseApphost\":\"{useApphost}\",\"OutputType\":\"{outputType}\",\"UseArtifactsOutput\":\"{useArtifactsOutput}\",\"ArtifactsPathLocationType\":\"{artifactsPathLocationType}\",\"TargetPlatformIdentifier\":\"{targetPlatformIdentifier}\",\"UseMonoRuntime\":\"{useMonoRuntime}\",\"PublishAot\":\"{publishAot}\",\"PublishTrimmed\":\"{publishTrimmed}\",\"PublishSelfContained\":\"{publishSelfContained}\",\"PublishReadyToRun\":\"{publishReadyToRun}\",\"PublishReadyToRunComposite\":\"{publishReadyToRunComposite}\",\"PublishProtocol\":\"{publishProtocol}\",\"Configuration\":\"{Sha256Hasher.HashWithNormalizedCasing(configuration)}\"}}";
         }
 
         [CoreMSBuildOnlyFact]
@@ -82,7 +83,7 @@ namespace Microsoft.NET.Build.Tests
             result
                 .StdOut.Should()
                 .Contain(CreateTargetFrameworkEvalTelemetryJson(
-                    ".NETFramework,Version=v4.6", 
+                    ".NETFramework,Version=v4.6",
                     targetPlatformIdentifier: "Windows",
                     publishReadyToRunComposite: "null"))
                 .And

--- a/test/dotnet.Tests/CommandTests/MSBuild/FakeTelemetry.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/FakeTelemetry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class FakeTelemetry : ITelemetry
     {
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set; } = true;
 
         public void TrackEvent(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -44,6 +45,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
 
+            fakeTelemetry.LogEntry.Should().NotBeNull();
             fakeTelemetry.LogEntry.EventName.Should().Be(MSBuildLogger.SdkTaskBaseCatchExceptionTelemetryEventName);
             fakeTelemetry.LogEntry.Properties.Keys.Count.Should().Be(2);
             fakeTelemetry.LogEntry.Properties["exceptionType"].Should().Be("System.Exception");
@@ -108,20 +110,13 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                     { "RuntimeIdentifier", "null"},
                     { "SelfContained", "null"},
                     { "UseApphost", "null"},
-                    { "OutputType", "Library"},
+                    { "OutputType", "Library"}
                 }
             };
 
             MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
 
-            fakeTelemetry.LogEntry.Properties.Should().BeEquivalentTo(new Dictionary<string, string>
-                {
-                    { "TargetFrameworkVersion", "9a871d7066260764d4cb5047e4b10570271d04bd1da275681a4b12bce0b27496"},
-                    { "RuntimeIdentifier", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "SelfContained", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "UseApphost", "fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921"},
-                    { "OutputType", "d77982267d9699c2a57bcab5bb975a1935f6427002f52fd4569762fd72db3a94"},
-                });
+            fakeTelemetry.LogEntry.Properties.Should().BeEquivalentTo(telemetryEventArgs.Properties);
         }
     }
 }


### PR DESCRIPTION
In https://github.com/dotnet/sdk/pull/50561 we sent new properties on TargetFrameworkEval, but we didn't allowlist them through the MSBuildLogger so we never saw the new properties.

The allowlisting inside the MSBuildLogger was done before the AllowEmptyTelemetry Task had the `Hash` metadata, so by moving to that we can remove any special handling inside the MSBuildLogger itself and more easily audit the telemetry data configuration.