### PR TITLE
Manual backport of 48874 to release 9.0.3xx

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -208,7 +208,8 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (string installArg in args.TemplatePackages)
             {
-                string[] split = installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries).SelectMany(arg => arg.Split('@', StringSplitOptions.RemoveEmptyEntries)).ToArray();
+                bool isPath = File.Exists(installArg) || Directory.Exists(installArg);
+                string[] split = isPath ? new[] { installArg } : installArg.Split(["::"], StringSplitOptions.RemoveEmptyEntries).SelectMany(arg => arg.Split('@', StringSplitOptions.RemoveEmptyEntries)).ToArray();
                 string identifier = split[0];
                 string? version = split.Length > 1 ? split[1] : null;
                 foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(identifier, _engineEnvironmentSettings))

--- a/test/dotnet-new.Tests/DotnetNewInstallTests.cs
+++ b/test/dotnet-new.Tests/DotnetNewInstallTests.cs
@@ -85,6 +85,23 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             Assert.Equal(command1.StdOut, command3Out);
         }
 
+        [Fact]
+        public void CanInstallToPathWithAt()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "repro@4");
+            try
+            {
+                Directory.CreateDirectory(path);
+                new DotnetCommand(_log, "new", "console", "-o", path, "-n", "myconsole").Execute().Should().Pass();
+                new DotnetCommand(_log, "add", "package", "--project", Path.Combine(path, "myconsole.csproj"), "Microsoft.Azure.Functions.Worker.ProjectTemplates", "-v", "4.0.5086", "--package-directory", path).Execute().Should().Pass();
+                new DotnetCommand(_log, "new", "install", Path.Combine(path, "microsoft.azure.functions.worker.projecttemplates/4.0.5086/microsoft.azure.functions.worker.projecttemplates.4.0.5086.nupkg")).Execute().Should().Pass();
+            }
+            finally
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+
         [Theory]
         [InlineData("-i")]
         [InlineData("install")]


### PR DESCRIPTION
## Customer Impact

Users that invoke a template directly from a local NuGet package (i.e. `dotnet new install <path to file>`) can't install that package if the path contains `::` or `@` characters. This is a blocker for Azure Functions experiences in VSCode on macOS.

To fix this, we detect if the user is requesting to install a versioned NuGet template from their feeds, or a specific local file. We only attempt our PackageId/Version splitting logic on the former kind of input.

## Risk

**Low** - this code has been working in .NET 10 since this past spring.

## Testing

New automated tests for this scenario work, and we've got evidence of it working for end users running 10.x