### PR TITLE
Don't strip default items from build-related Targets when building runnable apps

### DIFF
--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -17,7 +17,6 @@ internal static class CommonRunHelpers
     public static Dictionary<string, string> GetGlobalPropertiesFromArgs(MSBuildArgs msbuildArgs)
     {
         var globalProperties = msbuildArgs.GlobalProperties?.ToDictionary() ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        globalProperties[Constants.EnableDefaultItems] = "false"; // Disable default item globbing to improve performance
         globalProperties[Constants.MSBuildExtensionsPath] = AppContext.BaseDirectory;
         return globalProperties;
     }

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -824,11 +824,11 @@ public class RunCommand
     {
         Debug.Assert(ProjectFileFullPath != null);
         var projectIdentifier = RunTelemetry.GetProjectBasedIdentifier(ProjectFileFullPath, GetRepositoryRoot(), Sha256Hasher.Hash);
-        
+
         // Get package and project reference counts for project-based apps
         int packageReferenceCount = 0;
         int projectReferenceCount = 0;
-        
+
         // Try to get project information for telemetry if we built the project
         if (ShouldBuild)
         {
@@ -837,10 +837,10 @@ public class RunCommand
                 var globalProperties = MSBuildArgs.GlobalProperties?.ToDictionary() ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 globalProperties[Constants.EnableDefaultItems] = "false";
                 globalProperties[Constants.MSBuildExtensionsPath] = AppContext.BaseDirectory;
-                
+
                 using var collection = new ProjectCollection(globalProperties: globalProperties);
                 var project = collection.LoadProject(ProjectFileFullPath).CreateProjectInstance();
-                
+
                 packageReferenceCount = RunTelemetry.CountPackageReferences(project);
                 projectReferenceCount = RunTelemetry.CountProjectReferences(project);
             }
@@ -869,10 +869,10 @@ public class RunCommand
     {
         try
         {
-            var currentDir = ProjectFileFullPath != null 
+            var currentDir = ProjectFileFullPath != null
                 ? Path.GetDirectoryName(ProjectFileFullPath)
                 : Directory.GetCurrentDirectory();
-                
+
             while (currentDir != null)
             {
                 if (Directory.Exists(Path.Combine(currentDir, ".git")))
@@ -886,7 +886,7 @@ public class RunCommand
         {
             // Ignore errors when trying to find repo root
         }
-        
+
         return null;
     }
 }


### PR DESCRIPTION
Potential fix for https://github.com/dotnet/android/issues/10500.

Historically we've included `EnableDefaultItems=false` in purely-evaluation or Restore scenarios as a free performance bump, since doing MSBuild glob expansion is a performance hit that isn't generally necessary in those cases.

However, we were including this flag even when running run-related Targets that in android's case involve actual building, so this assumption no longer holds. Due to this, we remove the optimization.