### PR TITLE
[Blazor] Compute `_BlazorJSFile` for `_ReplaceFingerprintedBlazorJsForPublish`

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -86,6 +86,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       GenerateBuildBlazorBootExtensionJson;
     </GenerateBuildWasmBootJsonDependsOn>
 
+    <ResolveHtmlAssetPlaceholdersPublishConfigurationDependsOn>
+      $(ResolveHtmlAssetPlaceholdersPublishConfigurationDependsOn);
+      _ReplaceFingerprintedBlazorJsForPublish
+    </ResolveHtmlAssetPlaceholdersPublishConfigurationDependsOn>
     <ResolvePublishRelatedStaticWebAssetsDependsOn>
       $(ResolvePublishRelatedStaticWebAssetsDependsOn);
       _ReplaceFingerprintedBlazorJsForPublish

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -128,13 +128,17 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_ResolveBlazorWasmOutputs" DependsOnTargets="_ResolveBlazorJSFile" BeforeTargets="_RazorPrepareForRun">
+    <PropertyGroup>
+      <_BlazorJSFileAssetKindBuild>All</_BlazorJSFileAssetKindBuild>
+      <_BlazorJSFileAssetKindBuild Condition="'$(BlazorFingerprintBlazorJs)' == 'true'">Build</_BlazorJSFileAssetKindBuild>
+    </PropertyGroup>
     <DefineStaticWebAssets
       CandidateAssets="@(_BlazorJSFile)"
       FingerprintCandidates="$(BlazorFingerprintBlazorJs)"
       FingerprintPatterns="@(_BlazorJSFingerprintPattern)"
       SourceId="$(PackageId)"
       SourceType="Computed"
-      AssetKind="All"
+      AssetKind="$(_BlazorJSFileAssetKindBuild)"
       AssetMergeSource="$(StaticWebAssetMergeTarget)"
       AssetRole="Primary"
       AssetTraitName="WasmResource"
@@ -180,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       FingerprintPatterns="@(_BlazorJSFingerprintPattern)"
       SourceId="$(PackageId)"
       SourceType="Computed"
-      AssetKind="All"
+      AssetKind="Publish"
       AssetMergeSource="$(StaticWebAssetMergeTarget)"
       AssetRole="Primary"
       AssetTraitName="WasmResource"
@@ -199,23 +203,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     >
       <Output TaskParameter="Endpoints" ItemName="_BlazorJSJSPublishStaticWebAssetsEndpoint" />
     </DefineStaticWebAssetEndpoints>
-    <PropertyGroup>
-      <_BlazorJSJSStaticWebAssetFullPath>@(_BlazorJSJSStaticWebAsset->'%(FullPath)')</_BlazorJSJSStaticWebAssetFullPath>
-    </PropertyGroup>
+    
     <ItemGroup>
-      <_BlazorJSJSStaticWebAsset Include="@(StaticWebAsset)" Condition="'%(AssetTraitName)' == 'Content-Encoding' and '%(RelatedAsset)' == '$(_BlazorJSJSStaticWebAssetFullPath)'" />
-    </ItemGroup>
-    <FilterStaticWebAssetEndpoints Condition="'@(_BlazorJSJSStaticWebAsset)' != ''"
-      Endpoints="@(StaticWebAssetEndpoint)"
-      Assets="@(_BlazorJSJSStaticWebAsset)"
-      Filters=""
-    >
-      <Output TaskParameter="FilteredEndpoints" ItemName="_BlazorJSEndpointsToRemove" />
-    </FilterStaticWebAssetEndpoints>
-    <ItemGroup>
-      <StaticWebAsset Remove="@(_BlazorJSJSStaticWebAsset)" />
       <StaticWebAsset Include="@(_BlazorJSJSPublishStaticWebAssets)" />
-      <StaticWebAssetEndpoint Remove="@(_BlazorJSEndpointsToRemove)" />
       <StaticWebAssetEndpoint Include="@(_BlazorJSJSPublishStaticWebAssetsEndpoint)" />
     </ItemGroup>
   </Target>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -109,7 +109,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveBlazorWasmOutputs" DependsOnTargets="ResolveWasmOutputs;ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_BlazorWasmNativeForBuild" BeforeTargets="_RazorPrepareForRun">
+  <Target Name="_ResolveBlazorJSFile" DependsOnTargets="ResolveWasmOutputs;ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_BlazorWasmNativeForBuild">
     <ItemGroup>
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSPath)" />
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSMapPath)" Condition="Exists('$(BlazorWebAssemblyJSMapPath)')" />
@@ -125,7 +125,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         Code="RAZORSDK1007"
         Condition="'@(_BlazorJSFile->Count())' == '0'" />
     </ItemGroup>
+  </Target>
 
+  <Target Name="_ResolveBlazorWasmOutputs" DependsOnTargets="_ResolveBlazorJSFile" BeforeTargets="_RazorPrepareForRun">
     <DefineStaticWebAssets
       CandidateAssets="@(_BlazorJSFile)"
       FingerprintCandidates="$(BlazorFingerprintBlazorJs)"
@@ -159,7 +161,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ReplaceFingerprintedBlazorJsForPublish" DependsOnTargets="ProcessPublishFilesForWasm" Condition="'$(WasmBuildingForNestedPublish)' != 'true' and '$(BlazorFingerprintBlazorJs)' == 'true'">
+  <Target Name="_ReplaceFingerprintedBlazorJsForPublish" DependsOnTargets="ProcessPublishFilesForWasm;_ResolveBlazorJSFile" Condition="'$(WasmBuildingForNestedPublish)' != 'true' and '$(BlazorFingerprintBlazorJs)' == 'true'">
     <PropertyGroup>
       <_BlazorJSFileNames>;@(_BlazorJSFile->'%(FileName)');</_BlazorJSFileNames>
     </PropertyGroup>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.HtmlAssetPlaceholders.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.HtmlAssetPlaceholders.targets
@@ -145,7 +145,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   
   <!-- Publish -->
 
-  <Target Name="ResolveHtmlAssetPlaceholdersPublishConfiguration">
+  <Target Name="ResolveHtmlAssetPlaceholdersPublishConfiguration" DependsOnTargets="$(ResolveHtmlAssetPlaceholdersPublishConfigurationDependsOn)">
     <PropertyGroup>
       <_PublishHtmlAssetPlaceholdersPath>$([MSBuild]::NormalizeDirectory($(_StaticWebAssetsIntermediateOutputPath), 'htmlassetplaceholders', 'publish'))</_PublishHtmlAssetPlaceholdersPath>
     </PropertyGroup>

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -1612,6 +1612,14 @@ public class TestReference
             fileInWwwroot.Should().Exist();
         }
 
+        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
+        public void Publish_BlazorWasmReferencedByAspNetCoreServer()
+        {
+            var testInstance = CreateAspNetSdkTestAsset("BlazorWasmReferencedByAspNetCoreServer");
+            var publishCommand = CreatePublishCommand(testInstance, "Server");
+            ExecuteCommand(publishCommand).Should().Pass();
+        }
+
         private void VerifyTypeGranularTrimming(string blazorPublishDirectory)
         {
             VerifyAssemblyHasTypes(Path.Combine(blazorPublishDirectory, "_framework", "Microsoft.AspNetCore.Components.wasm"), new[] {

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -1612,12 +1612,14 @@ public class TestReference
             fileInWwwroot.Should().Exist();
         }
 
-        [RequiresMSBuildVersionFact("17.12", Reason = "Needs System.Text.Json 8.0.5")]
-        public void Publish_BlazorWasmReferencedByAspNetCoreServer()
+        [RequiresMSBuildVersionTheory("17.12", Reason = "Needs System.Text.Json 8.0.5")]
+        [InlineData("")]
+        [InlineData("/p:BlazorFingerprintBlazorJs=false")]
+        public void Publish_BlazorWasmReferencedByAspNetCoreServer(string publishArg)
         {
             var testInstance = CreateAspNetSdkTestAsset("BlazorWasmReferencedByAspNetCoreServer");
             var publishCommand = CreatePublishCommand(testInstance, "Server");
-            ExecuteCommand(publishCommand).Should().Pass();
+            ExecuteCommand(publishCommand, publishArg).Should().Pass();
         }
 
         private void VerifyTypeGranularTrimming(string blazorPublishDirectory)

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/BlazorWasmReferencedByAspNetCoreServer.slnx
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/BlazorWasmReferencedByAspNetCoreServer.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Client/Client.csproj" />
+  <Project Path="Server/Server.csproj" Id="edd5dc5a-a093-4efa-88a1-f4df05c2da44" />
+</Solution>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
@@ -1,0 +1,6 @@
+﻿<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
@@ -1,6 +1,6 @@
 ﻿<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+        <RouteView RouteData="@routeData" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
 </Router>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Client.csproj
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Client.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0-rc.1.25451.107" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Program.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Program.cs
@@ -1,0 +1,11 @@
+using Client;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+await builder.Build().RunAsync();

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/_Imports.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/_Imports.razor
@@ -1,0 +1,9 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using Client

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/index.html
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Client</title>
+    <base href="/" />
+    <link rel="preload" id="webassembly" />
+    <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <link href="Client.styles.css" rel="stylesheet" />
+    <link href="manifest.webmanifest" rel="manifest" />
+    <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
+    <script type="importmap"></script>
+</head>
+
+<body>
+    <div id="app">
+        <svg class="loading-progress">
+            <circle r="40%" cx="50%" cy="50%" />
+            <circle r="40%" cx="50%" cy="50%" />
+        </svg>
+        <div class="loading-progress-text"></div>
+    </div>
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
+    </div>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+
+</html>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Program.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Program.cs
@@ -1,0 +1,18 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseWebAssemblyDebugging();
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.MapStaticAssets();
+app.MapFallbackToFile("index.html");
+
+app.Run();

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Server.csproj
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Server.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Client\Client.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
When Blazor Wasm project is referenced from an AspNetCore server project, we need to compute `_BlazorJSFile` to correctly replace StaticWebAssets `_ReplaceFingerprintedBlazorJsForPublish`.

To mitigate that the Server project already contains assets for blazor.js from build (and removing them inside of the nested build isn't enough), we define the SWA for blazor.js AssetKind=Build and AssetKind=Publish if fingerprinting is enabled.

This needs to be backported to .NET 10.

Fixes https://github.com/dotnet/runtime/issues/119886