### PR TITLE
[Blazor] Remove unnecessary update to the Blazor webassembly js file

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -88,11 +88,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ResolvePublishRelatedStaticWebAssetsDependsOn>
       $(ResolvePublishRelatedStaticWebAssetsDependsOn);
-      _ReplaceFingerprintedBlazorJsForPublish
     </ResolvePublishRelatedStaticWebAssetsDependsOn>
     <ResolveCompressedFilesForPublishDependsOn>
       $(ResolveCompressedFilesForPublishDependsOn);
-      _ReplaceFingerprintedBlazorJsForPublish
     </ResolveCompressedFilesForPublishDependsOn>
 
     <GeneratePublishWasmBootJsonDependsOn>
@@ -156,65 +154,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <StaticWebAsset Include="@(_BlazorJSStaticWebAsset)" />
       <StaticWebAssetEndpoint Include="@(_BlazorStaticWebAssetEndpoint)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_ReplaceFingerprintedBlazorJsForPublish" DependsOnTargets="ProcessPublishFilesForWasm" Condition="'$(WasmBuildingForNestedPublish)' != 'true' and '$(BlazorFingerprintBlazorJs)' == 'true'">
-    <PropertyGroup>
-      <_BlazorJSFileNames>;@(_BlazorJSFile->'%(FileName)');</_BlazorJSFileNames>
-    </PropertyGroup>
-    <ItemGroup>
-      <_BlazorJSJSStaticWebAsset Include="@(StaticWebAsset)" Condition="$(_BlazorJSFileNames.Contains(';%(FileName);')) and '%(Extension)' == '.js'" />
-      <_BlazorJSPublishCandidate Include="%(_BlazorJSJSStaticWebAsset.RelativeDir)%(_BlazorJSJSStaticWebAsset.FileName).%(_BlazorJSJSStaticWebAsset.Fingerprint)%(_BlazorJSJSStaticWebAsset.Extension)" />
-      <_BlazorJSPublishCandidate Remove="@(_BlazorJSPublishCandidate)" Condition="'%(Extension)' == '.map'" />
-      <_BlazorJSPublishCandidate>
-        <RelativePath>_framework/$([System.IO.Path]::GetFileNameWithoutExtension('%(Filename)'))%(Extension)</RelativePath>
-      </_BlazorJSPublishCandidate>
-    </ItemGroup>
-
-    <DefineStaticWebAssets
-      CandidateAssets="@(_BlazorJSPublishCandidate)"
-      FingerprintCandidates="true"
-      FingerprintPatterns="@(_BlazorJSFingerprintPattern)"
-      SourceId="$(PackageId)"
-      SourceType="Computed"
-      AssetKind="All"
-      AssetMergeSource="$(StaticWebAssetMergeTarget)"
-      AssetRole="Primary"
-      AssetTraitName="WasmResource"
-      AssetTraitValue="boot"
-      CopyToOutputDirectory="Never"
-      CopyToPublishDirectory="PreserveNewest"
-      ContentRoot="%(_BlazorJSJSStaticWebAsset.ContentRoot)"
-      BasePath="%(_BlazorJSJSStaticWebAsset.BasePath)"
-    >
-      <Output TaskParameter="Assets" ItemName="_BlazorJSJSPublishStaticWebAssets" />
-    </DefineStaticWebAssets>
-    <DefineStaticWebAssetEndpoints
-      CandidateAssets="@(_BlazorJSJSPublishStaticWebAssets)"
-      ExistingEndpoints="@(StaticWebAssetEndpoint)"
-      ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
-    >
-      <Output TaskParameter="Endpoints" ItemName="_BlazorJSJSPublishStaticWebAssetsEndpoint" />
-    </DefineStaticWebAssetEndpoints>
-    <PropertyGroup>
-      <_BlazorJSJSStaticWebAssetFullPath>@(_BlazorJSJSStaticWebAsset->'%(FullPath)')</_BlazorJSJSStaticWebAssetFullPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <_BlazorJSJSStaticWebAsset Include="@(StaticWebAsset)" Condition="'%(AssetTraitName)' == 'Content-Encoding' and '%(RelatedAsset)' == '$(_BlazorJSJSStaticWebAssetFullPath)'" />
-    </ItemGroup>
-    <FilterStaticWebAssetEndpoints Condition="'@(_BlazorJSJSStaticWebAsset)' != ''"
-      Endpoints="@(StaticWebAssetEndpoint)"
-      Assets="@(_BlazorJSJSStaticWebAsset)"
-      Filters=""
-    >
-      <Output TaskParameter="FilteredEndpoints" ItemName="_BlazorJSEndpointsToRemove" />
-    </FilterStaticWebAssetEndpoints>
-    <ItemGroup>
-      <StaticWebAsset Remove="@(_BlazorJSJSStaticWebAsset)" />
-      <StaticWebAsset Include="@(_BlazorJSJSPublishStaticWebAssets)" />
-      <StaticWebAssetEndpoint Remove="@(_BlazorJSEndpointsToRemove)" />
-      <StaticWebAssetEndpoint Include="@(_BlazorJSJSPublishStaticWebAssetsEndpoint)" />
     </ItemGroup>
   </Target>
 

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetPathPattern.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetPathPattern.cs
@@ -505,4 +505,71 @@ public sealed class StaticWebAssetPathPattern : IEquatable<StaticWebAssetPathPat
     private static bool IsLiteralSegment(StaticWebAssetPathSegment segment) => segment.Parts.Count == 1 && segment.Parts[0].IsLiteral;
 
     internal static string PathWithoutTokens(string path) => Parse(path).ComputePatternLabel();
+
+    internal static string ExpandIdentityFileNameForFingerprint(string fileNamePattern, string fingerprint)
+    {
+        var pattern = Parse(fileNamePattern);
+        var sb = new StringBuilder();
+        foreach (var segment in pattern.Segments)
+        {
+            var isLiteral = segment.Parts.Count == 1 && segment.Parts[0].IsLiteral;
+            if (isLiteral)
+            {
+                sb.Append(segment.Parts[0].Name);
+                continue;
+            }
+
+            if (segment.IsOptional && !segment.IsPreferred)
+            {
+                continue; // skip non-preferred optional segments
+            }
+
+            bool missingRequired = false;
+            foreach (var part in segment.Parts)
+            {
+                if (!part.IsLiteral && part.Value.IsEmpty)
+                {
+                    var tokenName = part.Name.ToString();
+                    if (string.Equals(tokenName, "fingerprint", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(fingerprint))
+                    {
+                        missingRequired = true;
+                        break;
+                    }
+                }
+            }
+            if (missingRequired)
+            {
+                if (!segment.IsOptional)
+                {
+                    throw new InvalidOperationException($"Token 'fingerprint' not provided for '{fileNamePattern}'.");
+                }
+                continue;
+            }
+
+            foreach (var part in segment.Parts)
+            {
+                if (part.IsLiteral)
+                {
+                    sb.Append(part.Name);
+                }
+                else if (!part.Value.IsEmpty)
+                {
+                    sb.Append(part.Value);
+                }
+                else
+                {
+                    var tokenName = part.Name.ToString();
+                    if (string.Equals(tokenName, "fingerprint", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append(fingerprint);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Unsupported token '{tokenName}' in '{fileNamePattern}'.");
+                    }
+                }
+            }
+        }
+        return sb.ToString();
+    }
 }

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -254,6 +254,17 @@ public partial class DefineStaticWebAssets : Task
 
                     if (computed)
                     {
+                        // If we synthesized identity and there is a fingerprint placeholder pattern in the file name
+                        // expand it to the concrete fingerprinted file name while keeping RelativePath pattern form.
+                        if (FingerprintCandidates && !string.IsNullOrEmpty(fingerprint))
+                        {
+                            var fileNamePattern = Path.GetFileName(identity);
+                            if (fileNamePattern.Contains("#["))
+                            {
+                                var expanded = StaticWebAssetPathPattern.ExpandIdentityFileNameForFingerprint(fileNamePattern, fingerprint);
+                                identity = Path.Combine(Path.GetDirectoryName(identity) ?? string.Empty, expanded);
+                            }
+                        }
                         assetsCache.AppendCopyCandidate(hash, candidate.ItemSpec, identity);
                     }
                 }
@@ -384,7 +395,7 @@ public partial class DefineStaticWebAssets : Task
             }
         }
     }
-
+    
     private string ComputePropertyValue(ITaskItem element, string metadataName, string propertyValue, bool isRequired = true)
     {
         if (_overrides.Contains(metadataName))

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -395,7 +395,7 @@ public partial class DefineStaticWebAssets : Task
             }
         }
     }
-    
+
     private string ComputePropertyValue(ITaskItem element, string metadataName, string propertyValue, bool isRequired = true)
     {
         if (_overrides.Contains(metadataName))
@@ -512,7 +512,7 @@ public partial class DefineStaticWebAssets : Task
                 {
                     case (StaticWebAsset.AssetCopyOptions.Never, StaticWebAsset.AssetCopyOptions.Never):
                     case (not StaticWebAsset.AssetCopyOptions.Never, not StaticWebAsset.AssetCopyOptions.Never):
-                        var errorMessage = "Two assets found targeting the same path with incompatible asset kinds: " + Environment.NewLine +
+                        var errorMessage = "Two assets found targeting the same path with incompatible asset kinds:" + Environment.NewLine +
                             "'{0}' with kind '{1}'" + Environment.NewLine +
                             "'{2}' with kind '{3}'" + Environment.NewLine +
                             "for path '{4}'";

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs
@@ -1612,6 +1612,16 @@ public class TestReference
             fileInWwwroot.Should().Exist();
         }
 
+        [RequiresMSBuildVersionTheory("17.12", Reason = "Needs System.Text.Json 8.0.5")]
+        [InlineData("")]
+        [InlineData("/p:BlazorFingerprintBlazorJs=false")]
+        public void Publish_BlazorWasmReferencedByAspNetCoreServer(string publishArg)
+        {
+            var testInstance = CreateAspNetSdkTestAsset("BlazorWasmReferencedByAspNetCoreServer");
+            var publishCommand = CreatePublishCommand(testInstance, "Server");
+            ExecuteCommand(publishCommand, publishArg).Should().Pass();
+        }
+
         private void VerifyTypeGranularTrimming(string blazorPublishDirectory)
         {
             VerifyAssemblyHasTypes(Path.Combine(blazorPublishDirectory, "_framework", "Microsoft.AspNetCore.Components.wasm"), new[] {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -270,11 +270,13 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
             task.Assets.Length.Should().Be(1);
             var asset = task.Assets[0];
 
-            // RelativePath should contain the hard fingerprint pattern per existing behavior
+            // RelativePath should still contain the hard fingerprint pattern placeholder (not expanded yet)
             asset.GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("_framework/blazor.webassembly#[.{fingerprint}]!.js");
 
-            // Identity (ItemSpec) MUST now incorporate the fingerprint pattern file name (regression expectation)
-            var expectedIdentity = Path.GetFullPath(Path.Combine(contentRoot, "_framework", "blazor.webassembly#[.{fingerprint}]!.js"));
+            // Identity must contain the ACTUAL fingerprint value in the file name (placeholder expanded)
+            var actualFingerprint = asset.GetMetadata(nameof(StaticWebAsset.Fingerprint));
+            actualFingerprint.Should().NotBeNullOrEmpty();
+            var expectedIdentity = Path.GetFullPath(Path.Combine(contentRoot, "_framework", $"blazor.webassembly.{actualFingerprint}.js"));
             asset.ItemSpec.Should().Be(expectedIdentity);
         }
 

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/BlazorWasmReferencedByAspNetCoreServer.slnx
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/BlazorWasmReferencedByAspNetCoreServer.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Client/Client.csproj" />
+  <Project Path="Server/Server.csproj" Id="edd5dc5a-a093-4efa-88a1-f4df05c2da44" />
+</Solution>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/App.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Client.csproj
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Client.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0-rc.1.25451.107" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Program.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/Program.cs
@@ -1,0 +1,11 @@
+using Client;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+await builder.Build().RunAsync();

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/_Imports.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using Client

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/css/app.css
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/css/app.css
@@ -1,0 +1,2 @@
+/* minimal css */
+body { font-family: sans-serif; }

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/index.html
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Client</title>
+  <base href="/" />
+  <link rel="preload" id="webassembly" />
+  <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="css/app.css" />
+  <link rel="icon" type="image/png" href="favicon.png" />
+  <link href="Client.styles.css" rel="stylesheet" />
+  <link href="manifest.webmanifest" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+  <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
+  <script type="importmap"></script>
+</head>
+<body>
+  <div id="app">
+    <svg class="loading-progress">
+      <circle r="40%" cx="50%" cy="50%" />
+      <circle r="40%" cx="50%" cy="50%" />
+    </svg>
+    <div class="loading-progress-text"></div>
+  </div>
+  <div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="." class="reload">Reload</a>
+    <span class="dismiss">🗙</span>
+  </div>
+  <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+</html>

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/manifest.webmanifest
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "Client",
+  "short_name": "Client",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Test Blazor WASM referenced by ASP.NET Core Server"
+}

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/service-worker.js
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/service-worker.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => clients.claim());

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/service-worker.published.js
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Client/wwwroot/service-worker.published.js
@@ -1,0 +1,3 @@
+// Published service worker placeholder
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => clients.claim());

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Program.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Program.cs
@@ -1,0 +1,16 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseWebAssemblyDebugging();
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+app.MapStaticAssets();
+app.MapFallbackToFile("index.html");
+app.Run();

--- a/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Server.csproj
+++ b/test/TestAssets/TestProjects/BlazorWasmReferencedByAspNetCoreServer/Server/Server.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Client\Client.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
# [Blazor] Remove unnecessary update to the Blazor webassembly js file

Remove redundant blazor.webassembly.js update that broke publish

## Description

Hosted webassembly apps failed to publish due to a bug in how we were trying to update the `blazor.webassembly.js` asset definition. We realized that we did not have to do so, but that there was a bug precluding us from finding the asset during the publish process.

The fix corrects the identity of the blazor.webassembly.js to account for the fingerprint for the file we introduced in 10.0, which wasn't being taken into account.
 
Fixes #119886

## Customer Impact

Customers with a hosted Blazor WebAssembly + Web API (Server) solution failed to publish. There is no straightforward user workaround short of editing writing a significant amount of MSBuild to work around the issue.

## Regression?

- [x] Yes
- [ ] No  

Regressed from .NET 8 (publishing the same project type succeeded in 8.x).

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: The change only removes an unnecessary build step and fixes a case that was exclusively related to Blazor webassembly. It does not alter the contents of the delivered script, pipeline ordering, or introduce new logic— it simply stops creating an anomalous asset entry. Existing publish & static web asset tests still apply. Low surface area and isolated to Blazor WASM publish scenario.

## Verification

- [x] Manual (required)  
  - Reproduced failure with unpatched SDK (publish fails).
  - Applied change; publish succeeds
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  