### PR TITLE
Improve where file-level directives are added

### DIFF
--- a/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
+++ b/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
@@ -86,7 +86,8 @@ internal sealed class FileBasedAppSourceEditor
     {
         // Find one that has the same kind and name.
         // If found, we will replace it with the new directive.
-        if (directive is CSharpDirective.Named named &&
+        var named = directive as CSharpDirective.Named;
+        if (named != null &&
             Directives.OfType<CSharpDirective.Named>().FirstOrDefault(d => NamedDirectiveComparer.Instance.Equals(d, named)) is { } toReplace)
         {
             return new TextChange(toReplace.Info.Span, newText: directive.ToString() + NewLine);
@@ -99,6 +100,14 @@ internal sealed class FileBasedAppSourceEditor
         {
             if (existingDirective.GetType() == directive.GetType())
             {
+                // Add named directives in sorted order.
+                if (named != null &&
+                    existingDirective is CSharpDirective.Named existingNamed &&
+                    string.CompareOrdinal(existingNamed.Name, named.Name) > 0)
+                {
+                    break;
+                }
+
                 addAfter = existingDirective;
             }
             else if (addAfter != null)

--- a/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
+++ b/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
@@ -120,7 +120,7 @@ internal sealed class FileBasedAppSourceEditor
         var result = tokenizer.ParseNextToken();
         var leadingTrivia = result.Token.LeadingTrivia;
 
-        // If there is a comment at the top of the file, we add the directive after it
+        // If there is a comment or #! at the top of the file, we add the directive after it
         // (the comment might be a license which should always stay at the top).
         int insertAfterIndex = -1;
         int trailingNewLines = 0;
@@ -159,6 +159,11 @@ internal sealed class FileBasedAppSourceEditor
                         trailingNewLines = 1;
                         insertAfterIndex = i;
                     }
+                    break;
+
+                case SyntaxKind.ShebangDirectiveTrivia:
+                    trailingNewLines = 1; // shebang trivia has one newline embedded in its structure
+                    insertAfterIndex = i;
                     break;
 
                 case SyntaxKind.EndOfLineTrivia:

--- a/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
@@ -371,6 +371,33 @@ public sealed class FileBasedAppSourceEditorTests(ITestOutputHelper log) : SdkTe
             """));
     }
 
+    /// <summary>
+    /// Shebang directive should always stay first.
+    /// </summary>
+    [Fact]
+    public void Shebang()
+    {
+        Verify(
+            """
+            #!/test
+            Console.WriteLine();
+            """,
+            (static editor => editor.Add(new CSharpDirective.Package(default) { Name = "MyPackage", Version = "1.0.0" }),
+            """
+            #!/test
+
+            #:package MyPackage@1.0.0
+
+            Console.WriteLine();
+            """),
+            (static editor => editor.Remove(editor.Directives[1]),
+            """
+            #!/test
+
+            Console.WriteLine();
+            """));
+    }
+
     [Fact]
     public void AfterTokens()
     {

--- a/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
@@ -347,6 +347,45 @@ public sealed class FileBasedAppSourceEditorTests(ITestOutputHelper log) : SdkTe
             """));
     }
 
+    /// <summary>
+    /// New package directive should be sorted into the correct location in the package group.
+    /// </summary>
+    [Fact]
+    public void Sort()
+    {
+        Verify(
+            """
+            #:property X=Y
+            #:package B@C
+            #:package X@Y
+            #:project D
+            #:package E
+
+            Console.WriteLine();
+            """,
+            (static editor => editor.Add(new CSharpDirective.Package(default) { Name = "Test", Version = "1.0.0" }),
+            """
+            #:property X=Y
+            #:package B@C
+            #:package Test@1.0.0
+            #:package X@Y
+            #:project D
+            #:package E
+
+            Console.WriteLine();
+            """),
+            (static editor => editor.Remove(editor.Directives[2]),
+            """
+            #:property X=Y
+            #:package B@C
+            #:package X@Y
+            #:project D
+            #:package E
+
+            Console.WriteLine();
+            """));
+    }
+
     [Fact]
     public void OtherDirectives()
     {


### PR DESCRIPTION
### Description

`dotnet add app.cs package` will now insert `#:package` directives:

- After `#!` directives (first commit) because `#!` needs to always be first in the file.
- Sorted (second commit) to match the behavior of `dotnet add project.csproj package`.

### Customer impact

This was discovered by me while dogfooding the feature.

### Regression

No.

### Risk

Low. This is just a tooling update, scoped to the new feature (file-based apps). Unit tests verify the behavior.