### PR TITLE
Misc Json PostAction fixes

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1440,6 +1440,17 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The result of parsing the following JSON was &apos;null&apos;:
+        ///
+        ///{0}.
+        /// </summary>
+        internal static string PostAction_ModifyJson_Error_NullJson {
+            get {
+                return ResourceManager.GetString("PostAction_ModifyJson_Error_NullJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parent property path &apos;{0}&apos; could not be traversed..
         /// </summary>
         internal static string PostAction_ModifyJson_Error_ParentPropertyPathInvalid {

--- a/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -953,4 +953,10 @@ The header is followed by the list of parameters and their errors (might be seve
   <data name="PostAction_ModifyJson_Verbose_AttemptingToFindJsonFile" xml:space="preserve">
     <value>Attempting to find json file '{0}' in '{1}'</value>
   </data>
+  <data name="PostAction_ModifyJson_Error_NullJson" xml:space="preserve">
+    <value>The result of parsing the following JSON was 'null':
+
+{0}</value>
+    <comment>{0} is the JSON that is being parsed.</comment>
+  </data>
 </root>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
@@ -111,7 +111,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 environment.Host.FileSystem,
                 outputBasePath,
                 jsonFileName,
-                includeAllDirectories ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories,
+                includeAllDirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly,
                 includeAllParentDirectories ? int.MaxValue : 1);
 
             if (jsonFiles.Count == 0)

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
         private const string ParentPropertyPathArgument = "parentPropertyPath";
         private const string NewJsonPropertyNameArgument = "newJsonPropertyName";
         private const string NewJsonPropertyValueArgument = "newJsonPropertyValue";
-        private const string DetectRepoRootForFileCreation = "detectRepositoryRootForFileCreation";
+        private const string DetectRepoRoot = "detectRepositoryRoot";
         private const string IncludeAllDirectoriesInSearch = "includeAllDirectoriesInSearch";
         private const string IncludeAllParentDirectoriesInSearch = "includeAllParentDirectoriesInSearch";
 
@@ -89,9 +89,9 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 return false;
             }
 
-            if (!bool.TryParse(action.Args.GetValueOrDefault(DetectRepoRootForFileCreation, "false"), out bool detectRepoRoot))
+            if (!bool.TryParse(action.Args.GetValueOrDefault(DetectRepoRoot, "false"), out bool detectRepoRoot))
             {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostAction_ModifyJson_Error_ArgumentNotBoolean, DetectRepoRootForFileCreation));
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostAction_ModifyJson_Error_ArgumentNotBoolean, DetectRepoRoot));
                 return false;
             }
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddJsonPropertyPostActionProcessor.cs
@@ -169,17 +169,19 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         private static JsonNode? AddElementToJson(IPhysicalFileSystem fileSystem, string targetJsonFile, string? propertyPath, string propertyPathSeparator, string newJsonPropertyName, string newJsonPropertyValue, IPostAction action)
         {
-            JsonNode? jsonContent = JsonNode.Parse(fileSystem.ReadAllText(targetJsonFile), nodeOptions: null, documentOptions: DeserializerOptions);
+            var fileContent = fileSystem.ReadAllText(targetJsonFile);
+            JsonNode? jsonContent = JsonNode.Parse(fileContent, nodeOptions: null, documentOptions: DeserializerOptions);
 
             if (jsonContent == null)
             {
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostAction_ModifyJson_Error_NullJson, fileContent));
                 return null;
             }
 
             if (!bool.TryParse(action.Args.GetValueOrDefault(AllowPathCreationArgument, "false"), out bool createPath))
             {
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostAction_ModifyJson_Error_ArgumentNotBoolean, AllowPathCreationArgument));
-                return false;
+                return null;
             }
 
             JsonNode? parentProperty = FindJsonNode(jsonContent, propertyPath, propertyPathSeparator, createPath);

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">V řešení se nepovedlo najít soubor JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Cestu k nadřazené vlastnosti „{0}“ nelze projít.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Die JSON-Datei wurde in der Projektmappe nicht gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Der übergeordnete Eigenschaftenpfad "{0}" konnte nicht durchlaufen werden.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">No se encuentra el archivo JSON en la solución</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">No se pudo atravesar la ruta de acceso de la propiedad primaria '{0}'.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Impossible de trouver le fichier json dans la solution</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Le chemin de la propriété parente '{0}' n'a pas pu être traversé.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Non è possibile trovare il file JSON nella soluzione</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Impossibile attraversare il percorso della proprietà padre '{0}'.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">ソリューションで JSON ファイルが見つかりません</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">親プロパティのパス '{0}' を走査できませんでした。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">솔루션에서 json 파일을 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">'{0}' 부모 속성 경로를 트래버스할 수 없습니다.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Nie można odnaleźć pliku JSON w rozwiązaniu</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Nie można przejść przez ścieżkę właściwości nadrzędnej „{0}”.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Não é possível encontrar o arquivo json na solução</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">O caminho da propriedade pai '{0}' não pôde ser percorrido.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Не удалось найти файл JSON в решении</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Не удалось просмотреть путь к родительскому свойству "{0}".</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Çözümde json dosyası bulunamıyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">Üst özellik '{0}' yolu geçirilemedi.</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">在解决方案中找不到 json 文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">无法遍历父属性路径“{0}”。</target>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -850,6 +850,15 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">在解決方案中找不到 JSON 檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="PostAction_ModifyJson_Error_NullJson">
+        <source>The result of parsing the following JSON was 'null':
+
+{0}</source>
+        <target state="new">The result of parsing the following JSON was 'null':
+
+{0}</target>
+        <note>{0} is the JSON that is being parsed.</note>
+      </trans-unit>
       <trans-unit id="PostAction_ModifyJson_Error_ParentPropertyPathInvalid">
         <source>Parent property path '{0}' could not be traversed.</source>
         <target state="translated">無法周遊父屬性路徑 '{0}'。</target>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-CSharp/.template.config/template.json
@@ -240,7 +240,9 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true
+        "detectRepositoryRoot": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
       },
       "continueOnError": true
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/template.json
@@ -240,7 +240,7 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true,
+        "detectRepositoryRoot": true,
         "includeAllDirectoriesInSearch": false,
         "includeAllParentDirectoriesInSearch": true
       },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-FSharp/.template.config/template.json
@@ -240,7 +240,9 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true
+        "detectRepositoryRootForFileCreation": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
       },
       "continueOnError": true
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -240,7 +240,7 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true,
+        "detectRepositoryRoot": true,
         "includeAllDirectoriesInSearch": false,
         "includeAllParentDirectoriesInSearch": true
       },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -240,7 +240,9 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true
+        "detectRepositoryRootForFileCreation": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
       },
       "continueOnError": true
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -260,7 +260,9 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true
+        "detectRepositoryRootForFileCreation": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
       },
       "continueOnError": true
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -260,7 +260,7 @@
         "parentPropertyPath": "test",
         "newJsonPropertyName": "runner",
         "newJsonPropertyValue": "Microsoft.Testing.Platform",
-        "detectRepositoryRootForFileCreation": true,
+        "detectRepositoryRoot": true,
         "includeAllDirectoriesInSearch": false,
         "includeAllParentDirectoriesInSearch": true
       },


### PR DESCRIPTION
The current logic has few unfortunate pieces:

- All directories down are searched for the requested json file. This doesn't make sense for our usages in test templates that needs to update/create global.json. To preserve compatibility, a flag is added instead of breaking the existing behavior. This is controlled now by `includeAllDirectoriesInSearch`.
- Only one level up is currently searched. This is again an unfortunate behavior. This is controlled now by `includeAllParentDirectoriesInSearch`.
- The logic that goes "up" in the directories is updated to not go further than the detected repo root (when detect repo root option is enabled, thus, the option is renamed. Note that the option is already new in .NET 10 RC2 so the rename isn't problematic)

Additionally:

- A code path where the post action fails doesn't log any errors. Added `PostAction_ModifyJson_Error_NullJson` for this case.
- Fix a small bug if `allowPathCreationArgument` isn't parse-able as boolean.

The test templates for MSTest are now updated to use the logic that we think is correct regarding how to search the directories for `global.json`.

Notes:

1. We still keep the original behavior as the "default" behavior to avoid risking breaking people relying on the original behavior.
2. One additional pain point of the original behavior (which is still kept) is when enumerating all sub directories, then nothing is found, then we look up one level up again and enumerate all sub directories, this is duplicate work for enumerating.
3. As for test templates, we don't need to look down into sub-directories at all. The idea of this PR is to add template options so that it becomes generic enough for various needs. If a configuration file needs to be looked **down**, this is available (and remains the default), but otherwise (e.g, for looking global.json), templates can choose to only look in parent directories. etc.

Doc PR: https://github.com/dotnet/templating/pull/9375