### PR TITLE
[dotnet-watch] Notify DCP of terminated session when process exits on its own

### DIFF
--- a/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
+++ b/src/BuiltInTools/AspireService/Models/SessionChangeNotification.cs
@@ -56,6 +56,9 @@ internal sealed class SessionTerminatedNotification : SessionNotification
     [Required]
     [JsonPropertyName("exit_code")]
     public required int? ExitCode { get; init; }
+
+    public override string ToString()
+        => $"pid={Pid}, exit_code={ExitCode}";
 }
 
 /// <summary>
@@ -70,6 +73,9 @@ internal sealed class ProcessRestartedNotification : SessionNotification
     [Required]
     [JsonPropertyName("pid")]
     public required int PID { get; init; }
+
+    public override string ToString()
+        => $"pid={PID}";
 }
 
 /// <summary>
@@ -91,4 +97,7 @@ internal sealed class ServiceLogsNotification : SessionNotification
     [Required]
     [JsonPropertyName("log_message")]
     public required string LogMessage { get; init; }
+
+    public override string ToString()
+        => $"log_message='{LogMessage}', is_std_err={IsStdErr}";
 }

--- a/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
@@ -41,23 +41,42 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     /// <summary>
     /// Initiates connection with the agent in the target process.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract void InitiateConnection(CancellationToken cancellationToken);
 
     /// <summary>
     /// Waits until the connection with the agent is established.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract Task WaitForConnectionEstablishedAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns update capabilities of the target process.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Applies managed code updates to the target process.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract Task<ApplyStatus> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, bool isProcessSuspended, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Applies static asset updates to the target process.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract Task<ApplyStatus> ApplyStaticAssetUpdatesAsync(ImmutableArray<HotReloadStaticAssetUpdate> updates, bool isProcessSuspended, CancellationToken cancellationToken);
 
     /// <summary>
     /// Notifies the agent that the initial set of updates has been applied and the user code in the process can start executing.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public abstract Task InitialUpdatesAppliedAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Disposes the client. Can occur unexpectedly whenever the process exits.
+    /// </summary>
     public abstract void Dispose();
 
     public static void ReportLogEntry(ILogger logger, string message, AgentMessageSeverity severity)
@@ -72,7 +91,7 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
         logger.Log(level, message);
     }
 
-    public async Task<IReadOnlyList<HotReloadManagedCodeUpdate>> FilterApplicableUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken cancellationToken)
+    protected async Task<IReadOnlyList<HotReloadManagedCodeUpdate>> FilterApplicableUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken cancellationToken)
     {
         var availableCapabilities = await GetUpdateCapabilitiesAsync(cancellationToken);
         var applicableUpdates = new List<HotReloadManagedCodeUpdate>();

--- a/src/BuiltInTools/HotReloadClient/HotReloadClients.cs
+++ b/src/BuiltInTools/HotReloadClient/HotReloadClients.cs
@@ -23,6 +23,9 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
     {
     }
 
+    /// <summary>
+    /// Disposes all clients. Can occur unexpectedly whenever the process exits.
+    /// </summary>
     public void Dispose()
     {
         foreach (var (client, _) in clients)
@@ -56,6 +59,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         browserRefreshServer?.ConfigureLaunchEnvironment(environmentBuilder, enableHotReload: true);
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     internal void InitiateConnection(CancellationToken cancellationToken)
     {
         foreach (var (client, _) in clients)
@@ -64,11 +68,13 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         }
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     internal async ValueTask WaitForConnectionEstablishedAsync(CancellationToken cancellationToken)
     {
         await Task.WhenAll(clients.Select(c => c.client.WaitForConnectionEstablishedAsync(cancellationToken)));
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public async ValueTask<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
     {
         if (clients is [var (singleClient, _)])
@@ -83,6 +89,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         return [.. results.SelectMany(r => r).Distinct(StringComparer.Ordinal).OrderBy(c => c)];
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public async ValueTask ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, bool isProcessSuspended, CancellationToken cancellationToken)
     {
         var anyFailure = false;
@@ -139,6 +146,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         }
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public async ValueTask InitialUpdatesAppliedAsync(CancellationToken cancellationToken)
     {
         if (clients is [var (singleClient, _)])
@@ -151,6 +159,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         }
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public async Task ApplyStaticAssetUpdatesAsync(IEnumerable<(string filePath, string relativeUrl, string assemblyName, bool isApplicationProject)> assets, CancellationToken cancellationToken)
     {
         if (browserRefreshServer != null)
@@ -190,6 +199,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         }
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public async ValueTask ApplyStaticAssetUpdatesAsync(ImmutableArray<HotReloadStaticAssetUpdate> updates, bool isProcessSuspended, CancellationToken cancellationToken)
     {
         if (clients is [var (singleClient, _)])
@@ -202,6 +212,7 @@ internal sealed class HotReloadClients(ImmutableArray<(HotReloadClient client, s
         }
     }
 
+    /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public ValueTask ReportCompilationErrorsInApplicationAsync(ImmutableArray<string> compilationErrors, CancellationToken cancellationToken)
         => browserRefreshServer?.ReportCompilationErrorsInBrowserAsync(compilationErrors, cancellationToken) ?? ValueTask.CompletedTask;
 }

--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -43,6 +43,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
 
         private readonly Dictionary<string, Session> _sessions = [];
         private int _sessionIdDispenser;
+
         private volatile bool _isDisposed;
 
         public SessionManager(ProjectLauncher projectLauncher, ProjectOptions hostProjectOptions)
@@ -82,10 +83,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                 _sessions.Clear();
             }
 
-            foreach (var session in sessions)
-            {
-                await TerminateSessionAsync(session, cancellationToken);
-            }
+            await Task.WhenAll(sessions.Select(TerminateSessionAsync)).WaitAsync(cancellationToken);
         }
 
         public IEnumerable<(string name, string value)> GetEnvironmentVariables()
@@ -113,13 +111,30 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
             var processTerminationSource = new CancellationTokenSource();
             var outputChannel = Channel.CreateUnbounded<OutputLine>(s_outputChannelOptions);
 
-            var runningProject = await _projectLauncher.TryLaunchProcessAsync(
+            RunningProject? runningProject = null;
+
+            runningProject = await _projectLauncher.TryLaunchProcessAsync(
                 projectOptions,
                 processTerminationSource,
                 onOutput: line =>
                 {
                     var writeResult = outputChannel.Writer.TryWrite(line);
                     Debug.Assert(writeResult);
+                },
+                onExit: async (processId, exitCode) =>
+                {
+                    // Project can be null if the process exists while it's being initialized.
+                    if (runningProject?.IsRestarting == false)
+                    {
+                        try
+                        {
+                            await _service.NotifySessionEndedAsync(dcpId, sessionId, processId, exitCode, cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // canceled on shutdown, ignore
+                        }
+                    }
                 },
                 restartOperation: cancellationToken =>
                     StartProjectAsync(dcpId, sessionId, projectOptions, isRestart: true, cancellationToken),
@@ -134,7 +149,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
             await _service.NotifySessionStartedAsync(dcpId, sessionId, runningProject.ProcessId, cancellationToken);
 
             // cancel reading output when the process terminates:
-            var outputReader = StartChannelReader(processTerminationSource.Token);
+            var outputReader = StartChannelReader(runningProject.ProcessExitedCancellationToken);
 
             lock (_guard)
             {
@@ -159,7 +174,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                 }
                 catch (Exception e)
                 {
-                    if (e is not OperationCanceledException)
+                    if (!cancellationToken.IsCancellationRequested)
                     {
                         _logger.LogError("Unexpected error reading output of session '{SessionId}': {Exception}", sessionId, e);
                     }
@@ -185,18 +200,15 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
                 _sessions.Remove(sessionId);
             }
 
-            await TerminateSessionAsync(session, cancellationToken);
+            await TerminateSessionAsync(session);
             return true;
         }
 
-        private async ValueTask TerminateSessionAsync(Session session, CancellationToken cancellationToken)
+        private async Task TerminateSessionAsync(Session session)
         {
             _logger.LogDebug("Stop session #{SessionId}", session.Id);
 
-            var exitCode = await _projectLauncher.TerminateProcessAsync(session.RunningProject, cancellationToken);
-
-            // Wait until the started notification has been sent so that we don't send out of order notifications:
-            await _service.NotifySessionEndedAsync(session.DcpId, session.Id, session.RunningProject.ProcessId, exitCode, cancellationToken);
+            await session.RunningProject.TerminateAsync(isRestarting: false);
 
             // process termination should cancel output reader task:
             await session.OutputReader;

--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.Watch
     internal sealed class CompilationHandler : IDisposable
     {
         public readonly IncrementalMSBuildWorkspace Workspace;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
         private readonly WatchHotReloadService _hotReloadService;
         private readonly ProcessRunner _processRunner;
@@ -40,9 +39,8 @@ namespace Microsoft.DotNet.Watch
 
         private bool _isDisposed;
 
-        public CompilationHandler(ILoggerFactory loggerFactory, ILogger logger, ProcessRunner processRunner)
+        public CompilationHandler(ILogger logger, ProcessRunner processRunner)
         {
-            _loggerFactory = loggerFactory;
             _logger = logger;
             _processRunner = processRunner;
             Workspace = new IncrementalMSBuildWorkspace(logger);
@@ -57,15 +55,8 @@ namespace Microsoft.DotNet.Watch
 
         public async ValueTask TerminateNonRootProcessesAndDispose(CancellationToken cancellationToken)
         {
-            _logger.LogDebug("Disposing remaining child processes.");
-
-            var projectsToDispose = await TerminateNonRootProcessesAsync(projectPaths: null, cancellationToken);
-
-            foreach (var project in projectsToDispose)
-            {
-                project.Dispose();
-            }
-
+            _logger.LogDebug("Terminating remaining child processes.");
+            await TerminateNonRootProcessesAsync(projectPaths: null, cancellationToken);
             Dispose();
         }
 
@@ -101,19 +92,35 @@ namespace Microsoft.DotNet.Watch
             CancellationToken cancellationToken)
         {
             var processExitedSource = new CancellationTokenSource();
-            var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(processExitedSource.Token, cancellationToken);
+
+            // Cancel process communication as soon as process termination is requested, shutdown is requested, or the process exits (whichever comes first).
+            // If we only cancel after we process exit event handler is triggered the pipe might have already been closed and may fail unexpectedly.
+            using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(processTerminationSource.Token, processExitedSource.Token, cancellationToken);
+            var processCommunicationCancellationToken = processCommunicationCancellationSource.Token;
 
             // Dispose these objects on failure:
-            using var disposables = new Disposables([clients, processExitedSource, processCommunicationCancellationSource]);
+            using var disposables = new Disposables([clients, processExitedSource]);
 
             // It is important to first create the named pipe connection (Hot Reload client is the named pipe server)
             // and then start the process (named pipe client). Otherwise, the connection would fail.
-            clients.InitiateConnection(processCommunicationCancellationSource.Token);
+            clients.InitiateConnection(processCommunicationCancellationToken);
 
-            processSpec.OnExit += (_, _) =>
+            RunningProject? publishedRunningProject = null;
+
+            var previousOnExit = processSpec.OnExit;
+            processSpec.OnExit = async (processId, exitCode) =>
             {
-                processExitedSource.Cancel();
-                return ValueTask.CompletedTask;
+                // Await the previous action so that we only clean up after all requested "on exit" actions have been completed.
+                if (previousOnExit != null)
+                {
+                    await previousOnExit(processId, exitCode);
+                }
+
+                // Remove the running project if it has been published to _runningProjects (if it hasn't exited during initialization):
+                if (publishedRunningProject != null && RemoveRunningProject(publishedRunningProject))
+                {
+                    publishedRunningProject.Dispose();
+                }
             };
 
             var launchResult = new ProcessLaunchResult();
@@ -124,79 +131,88 @@ namespace Microsoft.DotNet.Watch
                 return null;
             }
 
-            // Wait for agent to create the name pipe and send capabilities over.
-            // the agent blocks the app execution until initial updates are applied (if any).
-            var capabilities = await clients.GetUpdateCapabilitiesAsync(processCommunicationCancellationSource.Token);
-
-            var runningProject = new RunningProject(
-                projectNode,
-                projectOptions,
-                clients,
-                runningProcess,
-                launchResult.ProcessId.Value,
-                processExitedSource: processExitedSource,
-                processTerminationSource: processTerminationSource,
-                restartOperation: restartOperation,
-                disposables: [processCommunicationCancellationSource],
-                capabilities);
-
             var projectPath = projectNode.ProjectInstance.FullPath;
 
-            // ownership transferred to running project:
-            disposables.Items.Clear();
-            disposables.Items.Add(runningProject);
-
-            var appliedUpdateCount = 0;
-            while (true)
+            try
             {
-                // Observe updates that need to be applied to the new process
-                // and apply them before adding it to running processes.
-                // Do not block on udpates being made to other processes to avoid delaying the new process being up-to-date.
-                var updatesToApply = _previousUpdates.Skip(appliedUpdateCount).ToImmutableArray();
-                if (updatesToApply.Any())
+                // Wait for agent to create the name pipe and send capabilities over.
+                // the agent blocks the app execution until initial updates are applied (if any).
+                var capabilities = await clients.GetUpdateCapabilitiesAsync(processCommunicationCancellationToken);
+
+                var runningProject = new RunningProject(
+                    projectNode,
+                    projectOptions,
+                    clients,
+                    runningProcess,
+                    launchResult.ProcessId.Value,
+                    processExitedSource: processExitedSource,
+                    processTerminationSource: processTerminationSource,
+                    restartOperation: restartOperation,
+                    capabilities);
+
+                // ownership transferred to running project:
+                disposables.Items.Clear();
+                disposables.Items.Add(runningProject);
+
+                var appliedUpdateCount = 0;
+                while (true)
                 {
-                    await clients.ApplyManagedCodeUpdatesAsync(ToManagedCodeUpdates(updatesToApply), isProcessSuspended: false, processCommunicationCancellationSource.Token);
-                }
-
-                appliedUpdateCount += updatesToApply.Length;
-
-                lock (_runningProjectsAndUpdatesGuard)
-                {
-                    ObjectDisposedException.ThrowIf(_isDisposed, this);
-
-                    // More updates might have come in while we have been applying updates.
-                    // If so, continue updating.
-                    if (_previousUpdates.Count > appliedUpdateCount)
+                    // Observe updates that need to be applied to the new process
+                    // and apply them before adding it to running processes.
+                    // Do not block on udpates being made to other processes to avoid delaying the new process being up-to-date.
+                    var updatesToApply = _previousUpdates.Skip(appliedUpdateCount).ToImmutableArray();
+                    if (updatesToApply.Any())
                     {
-                        continue;
+                        await clients.ApplyManagedCodeUpdatesAsync(ToManagedCodeUpdates(updatesToApply), isProcessSuspended: false, processCommunicationCancellationToken);
                     }
 
-                    // Only add the running process after it has been up-to-date.
-                    // This will prevent new updates being applied before we have applied all the previous updates.
-                    if (!_runningProjects.TryGetValue(projectPath, out var projectInstances))
+                    appliedUpdateCount += updatesToApply.Length;
+
+                    lock (_runningProjectsAndUpdatesGuard)
                     {
-                        projectInstances = [];
+                        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+                        // More updates might have come in while we have been applying updates.
+                        // If so, continue updating.
+                        if (_previousUpdates.Count > appliedUpdateCount)
+                        {
+                            continue;
+                        }
+
+                        // Only add the running process after it has been up-to-date.
+                        // This will prevent new updates being applied before we have applied all the previous updates.
+                        if (!_runningProjects.TryGetValue(projectPath, out var projectInstances))
+                        {
+                            projectInstances = [];
+                        }
+
+                        _runningProjects = _runningProjects.SetItem(projectPath, projectInstances.Add(runningProject));
+
+                        // ownership transferred to _runningProjects
+                        publishedRunningProject = runningProject;
+                        disposables.Items.Clear();
+                        break;
                     }
-
-                    _runningProjects = _runningProjects.SetItem(projectPath, projectInstances.Add(runningProject));
-
-                    // ownership transferred to _runningProjects
-                    disposables.Items.Clear();
-                    break;
                 }
+
+                // Notifies the agent that it can unblock the execution of the process:
+                await clients.InitialUpdatesAppliedAsync(processCommunicationCancellationToken);
+
+                // If non-empty solution is loaded into the workspace (a Hot Reload session is active):
+                if (Workspace.CurrentSolution is { ProjectIds: not [] } currentSolution)
+                {
+                    // Preparing the compilation is a perf optimization. We can skip it if the session hasn't been started yet. 
+                    PrepareCompilations(currentSolution, projectPath, cancellationToken);
+                }
+
+                return runningProject;
             }
-
-            // Notifies the agent that it can unblock the execution of the process:
-            await clients.InitialUpdatesAppliedAsync(cancellationToken);
-
-            // If non-empty solution is loaded into the workspace (a Hot Reload session is active):
-            if (Workspace.CurrentSolution is { ProjectIds: not [] } currentSolution)
+            catch (OperationCanceledException) when (processExitedSource.IsCancellationRequested)
             {
-                // Preparing the compilation is a perf optimization. We can skip it if the session hasn't been started yet. 
-                PrepareCompilations(currentSolution, projectPath, cancellationToken);
+                // Process exited during initialization. This should not happen since we control the process during this time.
+                _logger.LogError("Failed to launch '{ProjectPath}'. Process {PID} exited during initialization.", projectPath, launchResult.ProcessId);
+                return null;
             }
-
-            return runningProject;
         }
 
         private ImmutableArray<string> GetAggregateCapabilities()
@@ -229,7 +245,7 @@ namespace Microsoft.DotNet.Watch
                 ImmutableArray<WatchHotReloadService.Update> projectUpdates,
                 ImmutableArray<string> projectsToRebuild,
                 ImmutableArray<string> projectsToRedeploy,
-                ImmutableArray<RunningProject> terminatedProjects)> HandleManagedCodeChangesAsync(
+                ImmutableArray<RunningProject> projectsToRestart)> HandleManagedCodeChangesAsync(
             bool autoRestart,
             Func<IEnumerable<string>, CancellationToken, Task<bool>> restartPrompt,
             CancellationToken cancellationToken)
@@ -284,11 +300,11 @@ namespace Microsoft.DotNet.Watch
 
             // Terminate all tracked processes that need to be restarted,
             // except for the root process, which will terminate later on.
-            var terminatedProjects = updates.ProjectsToRestart.IsEmpty
+            var projectsToRestart = updates.ProjectsToRestart.IsEmpty
                 ? []
                 : await TerminateNonRootProcessesAsync(updates.ProjectsToRestart.Select(e => currentSolution.GetProject(e.Key)!.FilePath!), cancellationToken);
 
-            return (updates.ProjectUpdates, projectsToRebuild, projectsToRedeploy, terminatedProjects);
+            return (updates.ProjectUpdates, projectsToRebuild, projectsToRedeploy, projectsToRestart);
         }
 
         public async ValueTask ApplyUpdatesAsync(ImmutableArray<WatchHotReloadService.Update> updates, CancellationToken cancellationToken)
@@ -312,10 +328,10 @@ namespace Microsoft.DotNet.Watch
             {
                 try
                 {
-                    using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(runningProject.ProcessExitedSource.Token, cancellationToken);
+                    using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(runningProject.ProcessExitedCancellationToken, cancellationToken);
                     await runningProject.Clients.ApplyManagedCodeUpdatesAsync(ToManagedCodeUpdates(updates), isProcessSuspended: false, processCommunicationCancellationSource.Token);
                 }
-                catch (OperationCanceledException) when (runningProject.ProcessExitedSource.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (runningProject.ProcessExitedCancellationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     runningProject.Clients.ClientLogger.Log(MessageDescriptor.HotReloadCanceledProcessExited);
                 }
@@ -532,7 +548,8 @@ namespace Microsoft.DotNet.Watch
             var tasks = updates.Select(async entry =>
             {
                 var (runningProject, assets) = entry;
-                await runningProject.Clients.ApplyStaticAssetUpdatesAsync(assets, cancellationToken);
+                using var processCommunicationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(runningProject.ProcessExitedCancellationToken, cancellationToken);
+                await runningProject.Clients.ApplyStaticAssetUpdatesAsync(assets, processCommunicationCancellationSource.Token);
             });
 
             await Task.WhenAll(tasks).WaitAsync(cancellationToken);
@@ -543,76 +560,64 @@ namespace Microsoft.DotNet.Watch
         }
 
         /// <summary>
-        /// Terminates all processes launched for projects with <paramref name="projectPaths"/>,
+        /// Terminates all processes launched for non-root projects with <paramref name="projectPaths"/>,
         /// or all running non-root project processes if <paramref name="projectPaths"/> is null.
         /// 
         /// Removes corresponding entries from <see cref="_runningProjects"/>.
         /// 
         /// Does not terminate the root project.
         /// </summary>
+        /// <returns>All processes (including root) to be restarted.</returns>
         internal async ValueTask<ImmutableArray<RunningProject>> TerminateNonRootProcessesAsync(
             IEnumerable<string>? projectPaths, CancellationToken cancellationToken)
         {
             ImmutableArray<RunningProject> projectsToRestart = [];
 
-            UpdateRunningProjects(runningProjectsByPath =>
+            lock (_runningProjectsAndUpdatesGuard)
             {
-                if (projectPaths == null)
-                {
-                    projectsToRestart = _runningProjects.SelectMany(entry => entry.Value).Where(p => !p.Options.IsRootProject).ToImmutableArray();
-                    return _runningProjects.Clear();
-                }
-
-                projectsToRestart = projectPaths.SelectMany(path => _runningProjects.TryGetValue(path, out var array) ? array : []).ToImmutableArray();
-                return runningProjectsByPath.RemoveRange(projectPaths);
-            });
+                projectsToRestart = projectPaths == null
+                    ? [.. _runningProjects.SelectMany(entry => entry.Value)]
+                    : [.. projectPaths.SelectMany(path => _runningProjects.TryGetValue(path, out var array) ? array : [])];
+            }
 
             // Do not terminate root process at this time - it would signal the cancellation token we are currently using.
             // The process will be restarted later on.
-            var projectsToTerminate = projectsToRestart.Where(p => !p.Options.IsRootProject);
-
-            // wait for all processes to exit to release their resources, so we can rebuild:
-            _ = await TerminateRunningProjects(projectsToTerminate, cancellationToken);
+            // Wait for all processes to exit to release their resources, so we can rebuild.
+            await Task.WhenAll(projectsToRestart.Where(p => !p.Options.IsRootProject).Select(p => p.TerminateAsync(isRestarting: true))).WaitAsync(cancellationToken);
 
             return projectsToRestart;
         }
 
-        /// <summary>
-        /// Terminates process of the given <paramref name="project"/>.
-        /// Removes corresponding entries from <see cref="_runningProjects"/>.
-        ///
-        /// Should not be called with the root project.
-        /// </summary>
-        /// <returns>Exit code of the terminated process.</returns>
-        internal async ValueTask<int> TerminateNonRootProcessAsync(RunningProject project, CancellationToken cancellationToken)
+        private bool RemoveRunningProject(RunningProject project)
         {
-            Debug.Assert(!project.Options.IsRootProject);
-
             var projectPath = project.ProjectNode.ProjectInstance.FullPath;
 
-            UpdateRunningProjects(runningProjectsByPath =>
+            return UpdateRunningProjects(runningProjectsByPath =>
             {
-                if (!runningProjectsByPath.TryGetValue(projectPath, out var runningProjects) ||
-                    runningProjects.Remove(project) is var updatedRunningProjects && runningProjects == updatedRunningProjects)
+                if (!runningProjectsByPath.TryGetValue(projectPath, out var runningInstances))
                 {
-                    _logger.LogDebug("Ignoring an attempt to terminate process {ProcessId} of project '{Path}' that has no associated running processes.", project.ProcessId, projectPath);
                     return runningProjectsByPath;
                 }
 
+                var updatedRunningProjects = runningInstances.Remove(project);
                 return updatedRunningProjects is []
                     ? runningProjectsByPath.Remove(projectPath)
                     : runningProjectsByPath.SetItem(projectPath, updatedRunningProjects);
             });
-
-            // wait for all processes to exit to release their resources:
-            return (await TerminateRunningProjects([project], cancellationToken)).Single();
         }
 
-        private void UpdateRunningProjects(Func<ImmutableDictionary<string, ImmutableArray<RunningProject>>, ImmutableDictionary<string, ImmutableArray<RunningProject>>> updater)
+        private bool UpdateRunningProjects(Func<ImmutableDictionary<string, ImmutableArray<RunningProject>>, ImmutableDictionary<string, ImmutableArray<RunningProject>>> updater)
         {
             lock (_runningProjectsAndUpdatesGuard)
             {
-                _runningProjects = updater(_runningProjects);
+                var newRunningProjects = updater(_runningProjects);
+                if (newRunningProjects != _runningProjects)
+                {
+                    _runningProjects = newRunningProjects;
+                    return true;
+                }
+
+                return false;
             }
         }
 
@@ -622,12 +627,6 @@ namespace Microsoft.DotNet.Watch
             {
                 return _runningProjects.TryGetValue(projectPath, out projects);
             }
-        }
-
-        private async ValueTask<IReadOnlyList<int>> TerminateRunningProjects(IEnumerable<RunningProject> projects, CancellationToken cancellationToken)
-        {
-            // wait for all tasks to complete:
-            return await Task.WhenAll(projects.Select(p => p.TerminateAsync().AsTask())).WaitAsync(cancellationToken);
         }
 
         private static Task ForEachProjectAsync(ImmutableDictionary<string, ImmutableArray<RunningProject>> projects, Func<RunningProject, CancellationToken, Task> action, CancellationToken cancellationToken)

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "dotnet-watch": {
       "commandName": "Project",
       "commandLineArgs": "--verbose -bl",
-      "workingDirectory": "$(RepoRoot)src\\Assets\\TestProjects\\BlazorWasmWithLibrary\\blazorwasm",
+      "workingDirectory": "C:\\bugs\\9756\\aspire-watch-start-issue\\Aspire.AppHost",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)",
         "DCP_IDE_REQUEST_TIMEOUT_SECONDS": "100000",

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.ApiService/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.ApiService/Program.cs
@@ -37,7 +37,7 @@ app.MapDefaultEndpoints();
 
 app.Run();
 
-internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+internal record WeatherForecast(DateOnly Date, int TemperatureC, string Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/Program.cs
@@ -1,8 +1,13 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var apiService = builder.AddProject<Projects.WatchAspire_ApiService>("apiservice");
+var migration = builder.AddProject<Projects.WatchAspire_MigrationService>("migrationservice");
+
+var apiService = builder
+    .AddProject<Projects.WatchAspire_ApiService>("apiservice")
+    .WaitForCompletion(migration);
 
 builder.AddProject<Projects.WatchAspire_Web>("webfrontend")
+    .WaitForCompletion(migration)
     .WithExternalHttpEndpoints()
     .WithReference(apiService)
     .WaitFor(apiService);

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/WatchAspire.AppHost.csproj
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.AppHost/WatchAspire.AppHost.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WatchAspire.ApiService\WatchAspire.ApiService.csproj" Watch="true" />
-    <ProjectReference Include="..\WatchAspire.Web\WatchAspire.Web.csproj" Watch="true" />
-    <ProjectReference Include="..\WatchAspire.Wasm\WatchAspire.Wasm.csproj" Watch="true" />
+    <ProjectReference Include="..\WatchAspire.ApiService\WatchAspire.ApiService.csproj" />
+    <ProjectReference Include="..\WatchAspire.Web\WatchAspire.Web.csproj" />
+    <ProjectReference Include="..\WatchAspire.Wasm\WatchAspire.Wasm.csproj" />
+    <ProjectReference Include="..\WatchAspire.MigrationService\WatchAspire.MigrationService.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Program.cs
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Program.cs
@@ -1,0 +1,10 @@
+using MigrationService;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+host.Run();

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Properties/launchSettings.json
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "MigrationService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/WatchAspire.MigrationService.csproj
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/WatchAspire.MigrationService.csproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WatchAspire.ServiceDefaults\WatchAspire.ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Worker.cs
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/Worker.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+
+namespace MigrationService;
+
+public class Worker(IHostApplicationLifetime hostApplicationLifetime, ILogger<Worker> logger) : BackgroundService
+{
+    private static readonly ActivitySource s_activitySource = new("Migrations");
+
+    protected override Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        using var activity = s_activitySource.StartActivity(
+            "Migrating database",
+            ActivityKind.Client
+        );
+
+        logger.LogInformation("Migration complete");
+
+        hostApplicationLifetime.StopApplication();
+
+        return Task.CompletedTask;
+    }
+}

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/appsettings.Development.json
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/appsettings.Development.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/appsettings.json
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.MigrationService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.Wasm/App.razor
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.Wasm/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData"/>
     </Found>

--- a/test/TestAssets/TestProjects/WatchAspire/WatchAspire.slnx
+++ b/test/TestAssets/TestProjects/WatchAspire/WatchAspire.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Project Path="WatchAspire.ApiService/WatchAspire.ApiService.csproj" />
+  <Project Path="WatchAspire.AppHost/WatchAspire.AppHost.csproj" />
+  <Project Path="WatchAspire.MigrationService/WatchAspire.MigrationService.csproj" />
+  <Project Path="WatchAspire.ServiceDefaults/WatchAspire.ServiceDefaults.csproj" />
+  <Project Path="WatchAspire.Wasm/WatchAspire.Wasm.csproj" />
+  <Project Path="WatchAspire.Web/WatchAspire.Web.csproj" />
+</Solution>

--- a/test/dotnet-watch.Tests/Build/EvaluationTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationTests.cs
@@ -236,8 +236,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var project1 = new TestProject("Project1")
             {
+                IsExe = true,
                 TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework};net462",
                 ReferencedProjects = { project2 },
+                SourceFiles =
+                {
+                    { "Project1.cs", s_emptyProgram },
+                },
             };
 
             var testAsset = _testAssets.CreateTestProject(project1);
@@ -271,8 +276,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var project1 = new TestProject("Project1")
             {
+                IsExe = true,
                 TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework};net462",
                 ReferencedProjects = { project2 },
+                SourceFiles =
+                {
+                    { "Project1.cs", s_emptyProgram },
+                },
             };
 
             var testAsset = _testAssets.CreateTestProject(project1);
@@ -305,8 +315,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var project1 = new TestProject("Project1")
             {
+                IsExe = true,
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 ReferencedProjects = { project2 },
+                SourceFiles =
+                {
+                    { "Project1.cs", s_emptyProgram },
+                },
             };
 
             var testAsset = _testAssets.CreateTestProject(project1, identifier: specifyTargetFramework.ToString());
@@ -479,8 +494,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var project1 = new TestProject("Project1")
             {
+                IsExe = true,
                 TargetFrameworks = "net462",
                 ReferencedProjects = { project2 },
+                SourceFiles =
+                {
+                    { "Program.cs", s_emptyProgram },
+                },
             };
 
             var testAsset = _testAssets.CreateTestProject(project1);
@@ -495,9 +515,9 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Null(result);
 
             // note: msbuild prints errors to stdout, we match the pattern and report as error:
-            AssertEx.Equal(
+            Assert.Contains(
                 $"[Error] {project1Path} : error NU1201: Project Project2 is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Project2 supports: netstandard2.1 (.NETStandard,Version=v2.1)",
-                _logger.GetAndClearMessages().Single(m => m.Contains("error NU1201")));
+                _logger.GetAndClearMessages());
         }
 
         private readonly struct ExpectedFile(string path, string? staticAssetUrl = null, bool targetsOnly = false, bool graphOnly = false)

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -25,7 +25,7 @@ public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTest
         var loggerFactory = new LoggerFactory(reporter);
         var logger = loggerFactory.CreateLogger("Test");
         var projectGraph = ProjectGraphUtilities.TryLoadProjectGraph(options.ProjectPath, globalOptions: [], logger, projectGraphRequired: false, CancellationToken.None);
-        var handler = new CompilationHandler(loggerFactory, logger, processRunner);
+        var handler = new CompilationHandler(logger, processRunner);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);
 

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -78,6 +78,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
                 projectOptions,
                 new CancellationTokenSource(),
                 onOutput: null,
+                onExit: null,
                 restartOperation: startOp!,
                 cancellationToken);
 
@@ -525,7 +526,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
         // Terminate the process:
         Log($"Terminating process {runningProject.ProjectNode.GetDisplayName()} ...");
-        await w.Service.ProjectLauncher.TerminateProcessAsync(runningProject, CancellationToken.None);
+        await runningProject.TerminateAsync(isRestarting: false);
 
         // rude edit in A (changing assembly level attribute):
         UpdateSourceFile(serviceSourceA2, """

--- a/test/dotnet-watch.Tests/TestUtilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/AssertEx.cs
@@ -248,7 +248,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             }
 
             var message = new StringBuilder();
-            message.AppendLine($"Expected output {(expectedPresent ? "not found" : "found")}:");
+
+
+            message.AppendLine(expectedPresent
+                ? "Expected text found in the output:"
+                : "Text not expected to be found in the output:");
+
             message.AppendLine(expected);
             message.AppendLine();
             message.AppendLine("Actual output:");
@@ -275,7 +280,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
             }
 
             var message = new StringBuilder();
-            message.AppendLine($"Expected pattern {(expectedPresent ? "not found" : "found")} in the output:");
+
+            message.AppendLine(expectedPresent
+                ? "Expected pattern found in the output:"
+                : "Pattern not expected to be found in the output:");
+
             message.AppendLine(pattern.ToString());
             message.AppendLine();
             message.AppendLine("Actual output:");


### PR DESCRIPTION
## Description

Previously we only notified DCP when dotnet-watch terminated the process.

Fixes cancellation handling in a few places to avoid reporting errors that are caused by expected process termination/shutdown and pass correct cancellation tokens.
Fixes process output redirection for Aspire child processes.

Fixes https://github.com/dotnet/sdk/issues/50952
Fixes https://github.com/dotnet/aspire/issues/9756

## Customer Impact

Impacts Aspire customers.

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: Only impacts dotnet-watch and Aspire CLI.

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  



