### PR TITLE
Allow hot reload refresh script injection for 404 status code

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs
@@ -233,10 +233,16 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 $"This may have been caused by the response's {HeaderNames.ContentEncoding}: '{{encoding}}'. " +
                 "Consider disabling response compression.");
 
+            private static readonly Action<ILogger, int, string?, Exception?> _scriptInjectionSkipped = LoggerMessage.Define<int, string?>(
+                LogLevel.Debug,
+                new EventId(6, "ScriptInjectionSkipped"),
+                "Browser refresh script injection skipped. Status code: {StatusCode}, Content type: {ContentType}");
+
             public static void SetupResponseForBrowserRefresh(ILogger logger) => _setupResponseForBrowserRefresh(logger, null);
             public static void BrowserConfiguredForRefreshes(ILogger logger) => _browserConfiguredForRefreshes(logger, null);
             public static void FailedToConfiguredForRefreshes(ILogger logger) => _failedToConfigureForRefreshes(logger, null);
             public static void ResponseCompressionDetected(ILogger logger, StringValues encoding) => _responseCompressionDetected(logger, encoding, null);
+            public static void ScriptInjectionSkipped(ILogger logger, int statusCode, string? contentType) => _scriptInjectionSkipped(logger, statusCode, contentType, null);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/63831.

Tested locally on the issue's reproduction. The change fixes hot reload actions after the re-execution with `UseStatusCodePagesWithReExecute` heppened.

Changes:
- In case injection of the refresh script was skipped, log a message, 

before:
<img width="479" height="47" alt="image" src="https://github.com/user-attachments/assets/6cdd235e-4a96-4c77-a3f0-e83d0554c073" />

after (404 does not log it after the fix, it's only to show how logging would be visible to the user):
<img width="762" height="59" alt="image" src="https://github.com/user-attachments/assets/47d3427f-3de7-46a8-aeab-5c2e9bcdc3e2" />


- Allow refresh script injection for 404 status codes. This PR's goal is to fix the reported issue. I do not fully understand the filtering mechanism and it's possible that it requires more changes than just adding 404 code. [Dan's question](https://github.com/dotnet/aspnetcore/issues/63831#issuecomment-3339060369) is valid here and further changes might be discussed and submitted later.

- Cover the filtering mechanism with corresponding unit tests. We used to test only 200 case. I replaced this test with injection OK / injection not OK tests.