### PR TITLE
Remove condition from NuGet.Localization package reference

### DIFF
--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
     <PackageReference Include="Microsoft.TestPlatform.CLI" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.TestPlatform.Build" />
-    <PackageReference Condition=" '$(DotNetBuildSourceOnly)' != 'true' " Include="NuGet.Localization" />
+    <PackageReference Include="NuGet.Localization" />
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" ExcludeAssets="All" GeneratePathProperty="true" />


### PR DESCRIPTION
A regression occurred with the changes in https://github.com/dotnet/dotnet/pull/2128 that caused localized resource DLLs for NuGet to be missing from a source-built SDK.