### PR TITLE
More LLM detections for other CLI agents + alter TL behavior in the presence of LLMs

### DIFF
--- a/documentation/project-docs/telemetry.md
+++ b/documentation/project-docs/telemetry.md
@@ -61,7 +61,7 @@ Every telemetry event automatically includes these common properties:
 | **Telemetry Profile** | Custom telemetry profile (if set via env var) | Custom value or null |
 | **Docker Container** | Whether running in Docker container | `True` or `False` |
 | **CI** | Whether running in CI environment | `True` or `False` |
-| **LLM** | Detected LLM/assistant environment identifiers (comma-separated) | `claude` or `cursor` |
+| **LLM** | Detected LLM/assistant environment identifiers (comma-separated) | `claude`, `cursor`, `gemini`, `copilot`, `generic_agent` |
 | **Current Path Hash** | SHA256 hash of current directory path | Hashed value |
 | **Machine ID** | SHA256 hash of machine MAC address (or GUID if unavailable) | Hashed value |
 | **Machine ID Old** | Legacy machine ID for compatibility | Hashed value |

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -35,6 +35,14 @@ public static class Constants
     public const string Identity = nameof(Identity);
     public const string FullPath = nameof(FullPath);
 
+    // MSBuild CLI flags
+
+    /// <summary>
+    /// Disables the live-updating node display in the terminal logger, which is useful for LLM/agentic environments.
+    /// </summary>
+    public const string TerminalLogger_DisableNodeDisplay = "-tlp:DISABLENODEDISPLAY";
+
+
     public static readonly string ProjectArgumentName = "<PROJECT>";
     public static readonly string SolutionArgumentName = "<SLN_FILE>";
     public static readonly string ToolPackageArgumentName = "<PACKAGE_ID>";

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -56,7 +56,6 @@ internal sealed class MSBuildForwardingAppWithoutLogging
             msbuildArgs.OtherMSBuildArgs.Add("-nologo");
         }
         string? tlpDefault = TerminalLoggerDefault;
-        // new for .NET 9 - default TL to auto (aka enable in non-CI scenarios)
         if (string.IsNullOrWhiteSpace(tlpDefault))
         {
             tlpDefault = "auto";

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -18,8 +18,6 @@ public class MSBuildForwardingApp : CommandBase
     /// <summary>
     /// Adds the CLI's telemetry logger to the MSBuild arguments if telemetry is enabled.
     /// </summary>
-    /// <param name="msbuildArgs"></param>
-    /// <returns></returns>
     private static MSBuildArgs ConcatTelemetryLogger(MSBuildArgs msbuildArgs)
     {
         if (Telemetry.Telemetry.CurrentSessionId != null)
@@ -39,7 +37,6 @@ public class MSBuildForwardingApp : CommandBase
         }
         return msbuildArgs;
     }
-
 
     /// <summary>
     /// Mostly intended for quick/one-shot usage - most 'core' SDK commands should do more hands-on parsing.

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -27,19 +27,28 @@ internal static class CommonRunHelpers
     public static string GetFlatLaunchSettingsPath(string directoryPath, string projectNameWithoutExtension)
         => Path.Join(directoryPath, $"{projectNameWithoutExtension}.run.json");
 
+
+    /// <summary>
+    /// Applies adjustments to MSBuild arguments to better suit LLM/agentic environments, if such an environment is detected.
+    /// </summary>
+    public static MSBuildArgs AdjustMSBuildForLLMs(MSBuildArgs msbuildArgs)
+    {
+        if (new Telemetry.LLMEnvironmentDetectorForTelemetry().IsLLMEnvironment())
+        {
+            // disable the live-update display of the TerminalLogger, which wastes tokens
+            return msbuildArgs.CloneWithAdditionalArgs(Constants.TerminalLogger_DisableNodeDisplay);
+        }
+        else
+        {
+            return msbuildArgs;
+        }
+    }
+
     /// <summary>
     /// Creates a TerminalLogger or ConsoleLogger based on the provided MSBuild arguments.
     /// If the environment is detected to be an LLM environment, the logger is adjusted to
     /// better suit that environment.
     /// </summary>
-    /// <param name="msbuildArgs"></param>
-    /// <returns></returns>
-    public static Microsoft.Build.Framework.ILogger GetConsoleLogger(params ReadOnlySpan<string> msbuildArgs)
-    {
-        if (new Telemetry.LLMEnvironmentDetectorForTelemetry().GetLLMEnvironment() is string llmEnv)
-        {
-            msbuildArgs = [.. msbuildArgs, "-tlp:DISABLENODEDISPLAY"];
-        }
-        return Microsoft.Build.Logging.TerminalLogger.CreateTerminalOrConsoleLogger([.. msbuildArgs]);
-    }
+    public static Microsoft.Build.Framework.ILogger GetConsoleLogger(MSBuildArgs args) =>
+        Microsoft.Build.Logging.TerminalLogger.CreateTerminalOrConsoleLogger([.. AdjustMSBuildForLLMs(args).OtherMSBuildArgs]);
 }

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -26,4 +26,20 @@ internal static class CommonRunHelpers
 
     public static string GetFlatLaunchSettingsPath(string directoryPath, string projectNameWithoutExtension)
         => Path.Join(directoryPath, $"{projectNameWithoutExtension}.run.json");
+
+    /// <summary>
+    /// Creates a TerminalLogger or ConsoleLogger based on the provided MSBuild arguments.
+    /// If the environment is detected to be an LLM environment, the logger is adjusted to
+    /// better suit that environment.
+    /// </summary>
+    /// <param name="msbuildArgs"></param>
+    /// <returns></returns>
+    public static Microsoft.Build.Framework.ILogger GetConsoleLogger(params ReadOnlySpan<string> msbuildArgs)
+    {
+        if (new Telemetry.LLMEnvironmentDetectorForTelemetry().GetLLMEnvironment() is string llmEnv)
+        {
+            msbuildArgs = [.. msbuildArgs, "-tlp:DISABLENODEDISPLAY"];
+        }
+        return Microsoft.Build.Logging.TerminalLogger.CreateTerminalOrConsoleLogger([.. msbuildArgs]);
+    }
 }

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -483,7 +483,7 @@ public class RunCommand
         static void InvokeRunArgumentsTarget(ProjectInstance project, bool noBuild, FacadeLogger? binaryLogger, MSBuildArgs buildArgs)
         {
             List<ILogger> loggersForBuild = [
-                TerminalLogger.CreateTerminalOrConsoleLogger([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", ..buildArgs.OtherMSBuildArgs])
+                CommonRunHelpers.GetConsoleLogger([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", ..buildArgs.OtherMSBuildArgs])
             ];
             if (binaryLogger is not null)
             {

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -483,7 +483,9 @@ public class RunCommand
         static void InvokeRunArgumentsTarget(ProjectInstance project, bool noBuild, FacadeLogger? binaryLogger, MSBuildArgs buildArgs)
         {
             List<ILogger> loggersForBuild = [
-                CommonRunHelpers.GetConsoleLogger([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", ..buildArgs.OtherMSBuildArgs])
+                CommonRunHelpers.GetConsoleLogger(
+                    buildArgs.CloneWithExplicitArgs([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", ..buildArgs.OtherMSBuildArgs])
+                )
             ];
             if (binaryLogger is not null)
             {

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -190,7 +190,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         var verbosity = MSBuildArgs.Verbosity ?? MSBuildForwardingAppWithoutLogging.DefaultVerbosity;
         var consoleLogger = minimizeStdOut
             ? new SimpleErrorLogger()
-            : CommonRunHelpers.GetConsoleLogger([$"--verbosity:{verbosity}", .. MSBuildArgs.OtherMSBuildArgs]);
+            : CommonRunHelpers.GetConsoleLogger(MSBuildArgs.CloneWithExplicitArgs([$"--verbosity:{verbosity}", .. MSBuildArgs.OtherMSBuildArgs]));
         var binaryLogger = GetBinaryLogger(MSBuildArgs.OtherMSBuildArgs);
 
         CacheInfo? cache = null;

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -190,7 +190,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         var verbosity = MSBuildArgs.Verbosity ?? MSBuildForwardingAppWithoutLogging.DefaultVerbosity;
         var consoleLogger = minimizeStdOut
             ? new SimpleErrorLogger()
-            : TerminalLogger.CreateTerminalOrConsoleLogger([$"--verbosity:{verbosity}", .. MSBuildArgs.OtherMSBuildArgs]);
+            : CommonRunHelpers.GetConsoleLogger([$"--verbosity:{verbosity}", .. MSBuildArgs.OtherMSBuildArgs]);
         var binaryLogger = GetBinaryLogger(MSBuildArgs.OtherMSBuildArgs);
 
         CacheInfo? cache = null;

--- a/src/Cli/dotnet/Telemetry/EnvironmentDetectionRule.cs
+++ b/src/Cli/dotnet/Telemetry/EnvironmentDetectionRule.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
@@ -33,8 +34,7 @@ internal class BooleanEnvironmentRule : EnvironmentDetectionRule
 
     public override bool IsMatch()
     {
-        return _variables.Any(variable => 
-            bool.TryParse(Environment.GetEnvironmentVariable(variable), out bool value) && value);
+        return _variables.Any(variable => Env.GetEnvironmentVariableAsBool(variable));
     }
 }
 
@@ -81,12 +81,12 @@ internal class AnyPresentEnvironmentRule : EnvironmentDetectionRule
 /// <typeparam name="T">The type of the result value.</typeparam>
 internal class EnvironmentDetectionRuleWithResult<T> where T : class
 {
-    private readonly string[] _variables;
+    private readonly EnvironmentDetectionRule _rule;
     private readonly T _result;
 
-    public EnvironmentDetectionRuleWithResult(T result, params string[] variables)
+    public EnvironmentDetectionRuleWithResult(T result, EnvironmentDetectionRule rule)
     {
-        _variables = variables ?? throw new ArgumentNullException(nameof(variables));
+        _rule = rule ?? throw new ArgumentNullException(nameof(rule));
         _result = result ?? throw new ArgumentNullException(nameof(result));
     }
 
@@ -96,8 +96,8 @@ internal class EnvironmentDetectionRuleWithResult<T> where T : class
     /// <returns>The result value if the rule matches; otherwise, null.</returns>
     public T? GetResult()
     {
-        return _variables.Any(variable => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable))) 
-            ? _result 
+        return _rule.IsMatch()
+            ? _result
             : null;
     }
 }

--- a/src/Cli/dotnet/Telemetry/ILLMEnvironmentDetector.cs
+++ b/src/Cli/dotnet/Telemetry/ILLMEnvironmentDetector.cs
@@ -5,5 +5,13 @@ namespace Microsoft.DotNet.Cli.Telemetry;
 
 internal interface ILLMEnvironmentDetector
 {
+    /// <summary>
+    /// Checks the current environment for known indicators of LLM usage and returns a string identifying the LLM environment if detected.
+    /// </summary>
     string? GetLLMEnvironment();
+
+    /// <summary>
+    /// Returns true if the current environment is detected to be an LLM/agentic environment, false otherwise.
+    /// </summary>
+    bool IsLLMEnvironment();
 }

--- a/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
-
 namespace Microsoft.DotNet.Cli.Telemetry;
 
 internal class LLMEnvironmentDetectorForTelemetry : ILLMEnvironmentDetector
@@ -21,9 +18,13 @@ internal class LLMEnvironmentDetectorForTelemetry : ILLMEnvironmentDetector
         new EnvironmentDetectionRuleWithResult<string>("generic_agent", new BooleanEnvironmentRule("AGENT_CLI")),
     ];
 
+    /// <inheritdoc/>
     public string? GetLLMEnvironment()
     {
         var results = _detectionRules.Select(r => r.GetResult()).Where(r => r != null).ToArray();
         return results.Length > 0 ? string.Join(", ", results) : null;
     }
+
+    /// <inheritdoc/>
+    public bool IsLLMEnvironment() => !string.IsNullOrEmpty(GetLLMEnvironment());
 }

--- a/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
@@ -10,9 +10,15 @@ internal class LLMEnvironmentDetectorForTelemetry : ILLMEnvironmentDetector
 {
     private static readonly EnvironmentDetectionRuleWithResult<string>[] _detectionRules = [
         // Claude Code
-        new EnvironmentDetectionRuleWithResult<string>("claude", "CLAUDECODE"),
+        new EnvironmentDetectionRuleWithResult<string>("claude", new AnyPresentEnvironmentRule("CLAUDECODE")),
         // Cursor AI
-        new EnvironmentDetectionRuleWithResult<string>("cursor", "CURSOR_EDITOR")
+        new EnvironmentDetectionRuleWithResult<string>("cursor", new AnyPresentEnvironmentRule("CURSOR_EDITOR")),
+        // Gemini
+        new EnvironmentDetectionRuleWithResult<string>("gemini", new BooleanEnvironmentRule("GEMINI_CLI")),
+        // GitHub Copilot
+        new EnvironmentDetectionRuleWithResult<string>("copilot", new BooleanEnvironmentRule("GITHUB_COPILOT_CLI_MODE")),
+        // (proposed) generic flag for Agentic usage
+        new EnvironmentDetectionRuleWithResult<string>("generic_agent", new BooleanEnvironmentRule("AGENT_CLI")),
     ];
 
     public string? GetLLMEnvironment()

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -228,7 +228,16 @@ namespace Microsoft.DotNet.Tests
         public static IEnumerable<object[]> LLMTelemetryTestCases => new List<object[]>{
             new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" } }, "claude" },
             new object[] { new Dictionary<string, string> { { "CURSOR_EDITOR", "1" } }, "cursor" },
+            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "true" } }, "gemini" },
+            new object[] { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
+            new object[] { new Dictionary<string, string> { { "AGENT_CLI", "true" } }, "generic_agent" },
             new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" } }, "claude, cursor" },
+            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" } }, "gemini, copilot" },
+            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "GEMINI_CLI", "true" }, { "AGENT_CLI", "true" } }, "claude, gemini, generic_agent" },
+            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" }, { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" }, { "AGENT_CLI", "true" } }, "claude, cursor, gemini, copilot, generic_agent" },
+            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "false" } }, null },
+            new object[] { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "false" } }, null },
+            new object[] { new Dictionary<string, string> { { "AGENT_CLI", "false" } }, null },
             new object[] { new Dictionary<string, string>(), null },
         };
 

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Configurer;
 
@@ -193,29 +191,34 @@ namespace Microsoft.DotNet.Tests
 
         [Theory]
         [MemberData(nameof(LLMTelemetryTestCases))]
-        public void CanDetectLLMStatusForEnvVars(Dictionary<string, string> envVars, string expected)
+        public void CanDetectLLMStatusForEnvVars(Dictionary<string, string>? envVars, string? expected)
         {
             try
             {
-                foreach (var (key, value) in envVars)
-                {
-                    Environment.SetEnvironmentVariable(key, value);
+                if (envVars is not null){
+                    foreach (var (key, value) in envVars)
+                    {
+                        Environment.SetEnvironmentVariable(key, value);
+                    }
                 }
                 new LLMEnvironmentDetectorForTelemetry().GetLLMEnvironment().Should().Be(expected);
             }
             finally
             {
-                foreach (var (key, value) in envVars)
+                if (envVars is not null)
                 {
-                    Environment.SetEnvironmentVariable(key, null);
+                    foreach (var (key, value) in envVars)
+                    {
+                        Environment.SetEnvironmentVariable(key, null);
+                    }
                 }
             }
         }
-        
+
         [Theory]
         [InlineData("dummySessionId")]
         [InlineData(null)]
-        public void TelemetryCommonPropertiesShouldContainSessionId(string sessionId)
+        public void TelemetryCommonPropertiesShouldContainSessionId(string? sessionId)
         {
             var unitUnderTest = new TelemetryCommonProperties(userLevelCacheWriter: new NothingCache());
             var commonProperties = unitUnderTest.GetTelemetryCommonProperties(sessionId);
@@ -225,43 +228,42 @@ namespace Microsoft.DotNet.Tests
         }
 
 
-        public static IEnumerable<object[]> LLMTelemetryTestCases => new List<object[]>{
-            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" } }, "claude" },
-            new object[] { new Dictionary<string, string> { { "CURSOR_EDITOR", "1" } }, "cursor" },
-            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "true" } }, "gemini" },
-            new object[] { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
-            new object[] { new Dictionary<string, string> { { "AGENT_CLI", "true" } }, "generic_agent" },
-            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" } }, "claude, cursor" },
-            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" } }, "gemini, copilot" },
-            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "GEMINI_CLI", "true" }, { "AGENT_CLI", "true" } }, "claude, gemini, generic_agent" },
-            new object[] { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" }, { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" }, { "AGENT_CLI", "true" } }, "claude, cursor, gemini, copilot, generic_agent" },
-            new object[] { new Dictionary<string, string> { { "GEMINI_CLI", "false" } }, null },
-            new object[] { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "false" } }, null },
-            new object[] { new Dictionary<string, string> { { "AGENT_CLI", "false" } }, null },
-            new object[] { new Dictionary<string, string>(), null },
+        public static TheoryData<Dictionary<string, string>?, string?> LLMTelemetryTestCases => new()
+        {
+            { new Dictionary<string, string> { {"CLAUDECODE", "1" } }, "claude" },
+            { new Dictionary<string, string> { { "CURSOR_EDITOR", "1" } }, "cursor" },
+            { new Dictionary<string, string> { { "GEMINI_CLI", "true" } }, "gemini" },
+            { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
+            { new Dictionary<string, string> { { "AGENT_CLI", "true" } }, "generic_agent" },
+            { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" } }, "claude, cursor" },
+            { new Dictionary<string, string> { { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" } }, "gemini, copilot" },
+            { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "GEMINI_CLI", "true" }, { "AGENT_CLI", "true" } }, "claude, gemini, generic_agent" },
+            { new Dictionary<string, string> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" }, { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" }, { "AGENT_CLI", "true" } }, "claude, cursor, gemini, copilot, generic_agent" },
+            { new Dictionary<string, string> { { "GEMINI_CLI", "false" } }, null },
+            { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "false" } }, null },
+            { new Dictionary<string, string> { { "AGENT_CLI", "false" } }, null },
+            { new Dictionary<string, string>(), null },
         };
 
-        public static IEnumerable<object[]> CITelemetryTestCases => new List<object[]>{
-            new object[] { new Dictionary<string, string> { { "TF_BUILD", "true" } }, true },
-            new object[] { new Dictionary<string, string> { { "GITHUB_ACTIONS", "true" } }, true },
-            new object[] { new Dictionary<string, string> { { "APPVEYOR", "true"} }, true },
-            new object[] { new Dictionary<string, string> { { "CI", "true"} }, true },
-            new object[] { new Dictionary<string, string> { { "TRAVIS", "true"} }, true },
-            new object[] { new Dictionary<string, string> { { "CIRCLECI", "true"} }, true },
-
-            new object[] { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" }, { "AWS_REGION", "hi" } }, true },
-            new object[] { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" } }, false },
-            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "BUILD_URL", "hi" } }, true },
-            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
-            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "PROJECT_ID", "hi" } }, true },
-            new object[] { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
-
-            new object[] { new Dictionary<string, string> { { "TEAMCITY_VERSION", "hi" } }, true },
-            new object[] { new Dictionary<string, string> { { "TEAMCITY_VERSION", "" } }, false },
-            new object[] { new Dictionary<string, string> { { "JB_SPACE_API_URL", "hi" } }, true },
-            new object[] { new Dictionary<string, string> { { "JB_SPACE_API_URL", "" } }, false },
-
-            new object[] { new Dictionary<string, string> { { "SomethingElse", "hi" } }, false },
+        public static TheoryData<Dictionary<string, string>, bool> CITelemetryTestCases => new()
+        {
+            { new Dictionary<string, string> { { "TF_BUILD", "true" } }, true },
+            { new Dictionary<string, string> { { "GITHUB_ACTIONS", "true" } }, true },
+            { new Dictionary<string, string> { { "APPVEYOR", "true"} }, true },
+            { new Dictionary<string, string> { { "CI", "true"} }, true },
+            { new Dictionary<string, string> { { "TRAVIS", "true"} }, true },
+            { new Dictionary<string, string> { { "CIRCLECI", "true"} }, true },
+{ new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" }, { "AWS_REGION", "hi" } }, true },
+            { new Dictionary<string, string> { { "CODEBUILD_BUILD_ID", "hi" } }, false },
+            { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "BUILD_URL", "hi" } }, true },
+            { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
+            { new Dictionary<string, string> { { "BUILD_ID", "hi" }, { "PROJECT_ID", "hi" } }, true },
+            { new Dictionary<string, string> { { "BUILD_ID", "hi" } }, false },
+{ new Dictionary<string, string> { { "TEAMCITY_VERSION", "hi" } }, true },
+            { new Dictionary<string, string> { { "TEAMCITY_VERSION", "" } }, false },
+            { new Dictionary<string, string> { { "JB_SPACE_API_URL", "hi" } }, true },
+            { new Dictionary<string, string> { { "JB_SPACE_API_URL", "" } }, false },
+{ new Dictionary<string, string> { { "SomethingElse", "hi" } }, false },
         };
 
         private class NothingCache : IUserLevelCacheWriter


### PR DESCRIPTION
## Impact

Add two new known LLM agentic CLIs, and a proposed 'generic' option to drive discussion across other tools/products.

We want to try and use this detection to change the behavior of the product in a way that is more useful to LLMs - specifically enabling terminal logger and _disabling_ it's live-update portion. This change, plus https://github.com/dotnet/msbuild/pull/12581 from MSBuild, will let us do the first example of that behavioral change.

Once we detect an LLM is present, we tell the MSBuild Terminal Logger to disable its live-update feature, which is token-inefficient.

## Risk

**Low** for this change - it's additional detection + telemetry plus a flag that has zero impact if TL is not used on a particular build.