### PR TITLE
Avoid error when building file-based libraries

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
@@ -497,6 +498,7 @@ public class RunCommand
         }
     }
 
+    [DoesNotReturn]
     internal static void ThrowUnableToRunError(ProjectInstance project)
     {
         string targetFrameworks = project.GetPropertyValue("TargetFrameworks");

--- a/src/Cli/dotnet/Commands/Run/RunProperties.cs
+++ b/src/Cli/dotnet/Commands/Run/RunProperties.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -19,7 +20,7 @@ internal sealed record RunProperties(
     {
     }
 
-    internal static bool TryFromProject(ProjectInstance project, out RunProperties result)
+    internal static bool TryFromProject(ProjectInstance project, [NotNullWhen(returnValue: true)] out RunProperties? result)
     {
         result = new RunProperties(
             Command: project.GetPropertyValue("RunCommand"),
@@ -29,7 +30,13 @@ internal sealed record RunProperties(
             DefaultAppHostRuntimeIdentifier: project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"),
             TargetFrameworkVersion: project.GetPropertyValue("TargetFrameworkVersion"));
 
-        return !string.IsNullOrEmpty(result.Command);
+        if (string.IsNullOrEmpty(result.Command))
+        {
+            result = null;
+            return false;
+        }
+
+        return true;
     }
 
     internal static RunProperties FromProject(ProjectInstance project)

--- a/src/Cli/dotnet/Commands/Run/RunProperties.cs
+++ b/src/Cli/dotnet/Commands/Run/RunProperties.cs
@@ -19,9 +19,9 @@ internal sealed record RunProperties(
     {
     }
 
-    internal static RunProperties FromProject(ProjectInstance project)
+    internal static bool TryFromProject(ProjectInstance project, out RunProperties result)
     {
-        var result = new RunProperties(
+        result = new RunProperties(
             Command: project.GetPropertyValue("RunCommand"),
             Arguments: project.GetPropertyValue("RunArguments"),
             WorkingDirectory: project.GetPropertyValue("RunWorkingDirectory"),
@@ -29,7 +29,12 @@ internal sealed record RunProperties(
             DefaultAppHostRuntimeIdentifier: project.GetPropertyValue("DefaultAppHostRuntimeIdentifier"),
             TargetFrameworkVersion: project.GetPropertyValue("TargetFrameworkVersion"));
 
-        if (string.IsNullOrEmpty(result.Command))
+        return !string.IsNullOrEmpty(result.Command);
+    }
+
+    internal static RunProperties FromProject(ProjectInstance project)
+    {
+        if (!TryFromProject(project, out var result))
         {
             RunCommand.ThrowUnableToRunError(project);
         }

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -353,7 +353,9 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                     Debug.Assert(buildRequest.ProjectInstance != null);
 
                     // Cache run info (to avoid re-evaluating the project instance).
-                    cache.CurrentEntry.Run = RunProperties.FromProject(buildRequest.ProjectInstance);
+                    cache.CurrentEntry.Run = RunProperties.TryFromProject(buildRequest.ProjectInstance, out var runProperties)
+                        ? runProperties
+                        : null;
 
                     TryCacheCscArguments(cache, buildResult, buildRequest.ProjectInstance);
 
@@ -897,7 +899,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
     {
         if (!NeedsToBuild(out cache))
         {
-            Reporter.Verbose.WriteLine("No need to build, the output is up to date.");
+            Reporter.Verbose.WriteLine("No need to build, the output is up to date. Cache: " + ArtifactsPath);
             return BuildLevel.None;
         }
 

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1512,6 +1512,150 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
     }
 
     [Fact]
+    public void Build_Library_MultiTarget()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programFile = Path.Join(testInstance.Path, "lib.cs");
+        File.WriteAllText(programFile, $"""
+            #:property OutputType=Library
+            #:property PublishAot=false
+            #:property LangVersion=preview
+            #:property TargetFrameworks=netstandard2.0;{ToolsetInfo.CurrentTargetFramework}
+            class C;
+            """);
+
+        // https://github.com/dotnet/sdk/issues/51077: cannot set this via `#:property` directive.
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework></TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        new DotnetCommand(Log, "build", "lib.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run", "lib.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErr(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework"));
+    }
+
+    [Fact]
+    public void Build_Module()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programFile = Path.Join(testInstance.Path, "module.cs");
+        File.WriteAllText(programFile, """
+            #:property OutputType=Module
+            #:property ProduceReferenceAssembly=false
+            class C;
+            """);
+
+        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        new DotnetCommand(Log, "build", "module.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run", "module.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErr(string.Format(CliCommandStrings.RunCommandExceptionUnableToRun,
+                Path.ChangeExtension(programFile, ".csproj"),
+                ToolsetInfo.CurrentTargetFrameworkVersion,
+                "Module"));
+    }
+
+    [Fact]
+    public void Build_WinExe()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programFile = Path.Join(testInstance.Path, "winexe.cs");
+        File.WriteAllText(programFile, """
+            #:property OutputType=WinExe
+            Console.WriteLine("Hello WinExe");
+            """);
+
+        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        new DotnetCommand(Log, "build", "winexe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run", "winexe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello WinExe");
+    }
+
+    [Fact]
+    public void Build_Exe()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programFile = Path.Join(testInstance.Path, "exe.cs");
+        File.WriteAllText(programFile, """
+            #:property OutputType=Exe
+            Console.WriteLine("Hello Exe");
+            """);
+
+        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        new DotnetCommand(Log, "build", "exe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run", "exe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello Exe");
+    }
+
+    [Fact]
+    public void Build_AppContainerExe()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programFile = Path.Join(testInstance.Path, "appcontainerexe.cs");
+        File.WriteAllText(programFile, """
+            #:property OutputType=AppContainerExe
+            Console.WriteLine("Hello AppContainerExe");
+            """);
+
+        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        new DotnetCommand(Log, "build", "appcontainerexe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run", "appcontainerexe.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErr(string.Format(CliCommandStrings.RunCommandExceptionUnableToRun,
+                Path.ChangeExtension(programFile, ".csproj"),
+                ToolsetInfo.CurrentTargetFrameworkVersion,
+                "AppContainerExe"));
+    }
+
+    [Fact]
     public void Publish()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();


### PR DESCRIPTION
### Description and customer impact

Fixes https://github.com/dotnet/sdk/issues/51064.

This fixes a regression which broke file-based libraries (that's not a mainline scenario for file-based apps, but it's commonly used for example when testing out compiler features or creating minimal bug repros - that's also how I discovered the issue).

### Regression

Yes, worked in prior .NET 10 previews.

### Risk

Low, this is a small change, with lots of unit testing (pre-existing tests for the mainline `dotnet run app.cs` behavior and new tests for the library behavior which regressed).