### PR TITLE
Update the list of supported portable RIDs for the tool packs in our tests

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -546,7 +546,8 @@ namespace Microsoft.NET.Publish.Tests
             project.Root.Add(new XElement(ns + "ItemGroup",
                 new XElement(ns + "KnownILCompilerPack",
                     new XAttribute("Update", "@(KnownILCompilerPack)"),
-                    new XElement(ns + "ILCompilerRuntimeIdentifiers", runtimeIdentifiers))));
+                    new XElement(ns + "ILCompilerRuntimeIdentifiers", runtimeIdentifiers),
+                    new XElement(ns + "ILCompilerPortableRuntimeIdentifiers", runtimeIdentifiers))));
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]


### PR DESCRIPTION
Fixes test failures found in https://github.com/dotnet/sdk/pull/50999.

# Customer Impact

None, this is a test-only change

# Risk

None, test only change