### PR TITLE
[dotnet-watch] Auto-restart project on runtime rude edit

### DIFF
--- a/src/BuiltInTools/DotNetDeltaApplier/PipeListener.cs
+++ b/src/BuiltInTools/DotNetDeltaApplier/PipeListener.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -9,6 +10,16 @@ namespace Microsoft.DotNet.HotReload;
 
 internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Action<string> log, int connectionTimeoutMS = 5000)
 {
+    /// <summary>
+    /// Messages to the client sent after the initial <see cref="ClientInitializationResponse"/> is sent
+    /// need to be sent while holding this lock in order to synchronize
+    /// 1) responses to requests received from the client (e.g. <see cref="UpdateResponse"/>) or
+    /// 2) notifications sent to the client that may be triggered at arbitrary times (e.g. <see cref="HotReloadExceptionCreatedNotification"/>).
+    /// </summary>
+    private readonly SemaphoreSlim _messageToClientLock = new(initialCount: 1);
+
+    private NamedPipeClientStream? _pipeClient;
+
     public Task Listen(CancellationToken cancellationToken)
     {
         // Connect to the pipe synchronously.
@@ -21,23 +32,23 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
 
         log($"Connecting to hot-reload server via pipe {pipeName}");
 
-        var pipeClient = new NamedPipeClientStream(serverName: ".", pipeName, PipeDirection.InOut, PipeOptions.CurrentUserOnly | PipeOptions.Asynchronous);
+        _pipeClient = new NamedPipeClientStream(serverName: ".", pipeName, PipeDirection.InOut, PipeOptions.CurrentUserOnly | PipeOptions.Asynchronous);
         try
         {
-            pipeClient.Connect(connectionTimeoutMS);
+            _pipeClient.Connect(connectionTimeoutMS);
             log("Connected.");
         }
         catch (TimeoutException)
         {
             log($"Failed to connect in {connectionTimeoutMS}ms.");
-            pipeClient.Dispose();
+            _pipeClient.Dispose();
             return Task.CompletedTask;
         }
 
         try
         {
             // block execution of the app until initial updates are applied:
-            InitializeAsync(pipeClient, cancellationToken).GetAwaiter().GetResult();
+            InitializeAsync(cancellationToken).GetAwaiter().GetResult();
         }
         catch (Exception e)
         {
@@ -46,7 +57,8 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
                 log(e.Message);
             }
 
-            pipeClient.Dispose();
+            _pipeClient.Dispose();
+            _pipeClient = null;
             agent.Dispose();
 
             return Task.CompletedTask;
@@ -56,7 +68,7 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
         {
             try
             {
-                await ReceiveAndApplyUpdatesAsync(pipeClient, initialUpdates: false, cancellationToken);
+                await ReceiveAndApplyUpdatesAsync(initialUpdates: false, cancellationToken);
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
@@ -64,40 +76,45 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
             }
             finally
             {
-                pipeClient.Dispose();
+                _pipeClient.Dispose();
+                _pipeClient = null;
                 agent.Dispose();
             }
         }, cancellationToken);
     }
 
-    private async Task InitializeAsync(NamedPipeClientStream pipeClient, CancellationToken cancellationToken)
+    private async Task InitializeAsync(CancellationToken cancellationToken)
     {
+        Debug.Assert(_pipeClient != null);
+
         agent.Reporter.Report("Writing capabilities: " + agent.Capabilities, AgentMessageSeverity.Verbose);
 
         var initPayload = new ClientInitializationResponse(agent.Capabilities);
-        await initPayload.WriteAsync(pipeClient, cancellationToken);
+        await initPayload.WriteAsync(_pipeClient, cancellationToken);
 
         // Apply updates made before this process was launched to avoid executing unupdated versions of the affected modules.
 
         // We should only receive ManagedCodeUpdate when when the debugger isn't attached,
         // otherwise the initialization should send InitialUpdatesCompleted immediately.
         // The debugger itself applies these updates when launching process with the debugger attached.
-        await ReceiveAndApplyUpdatesAsync(pipeClient, initialUpdates: true, cancellationToken);
+        await ReceiveAndApplyUpdatesAsync(initialUpdates: true, cancellationToken);
     }
 
-    private async Task ReceiveAndApplyUpdatesAsync(NamedPipeClientStream pipeClient, bool initialUpdates, CancellationToken cancellationToken)
+    private async Task ReceiveAndApplyUpdatesAsync(bool initialUpdates, CancellationToken cancellationToken)
     {
-        while (pipeClient.IsConnected)
+        Debug.Assert(_pipeClient != null);
+
+        while (_pipeClient.IsConnected)
         {
-            var payloadType = (RequestType)await pipeClient.ReadByteAsync(cancellationToken);
+            var payloadType = (RequestType)await _pipeClient.ReadByteAsync(cancellationToken);
             switch (payloadType)
             {
                 case RequestType.ManagedCodeUpdate:
-                    await ReadAndApplyManagedCodeUpdateAsync(pipeClient, cancellationToken);
+                    await ReadAndApplyManagedCodeUpdateAsync(cancellationToken);
                     break;
 
                 case RequestType.StaticAssetUpdate:
-                    await ReadAndApplyStaticAssetUpdateAsync(pipeClient, cancellationToken);
+                    await ReadAndApplyStaticAssetUpdateAsync(cancellationToken);
                     break;
 
                 case RequestType.InitialUpdatesCompleted when initialUpdates:
@@ -110,11 +127,11 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
         }
     }
 
-    private async ValueTask ReadAndApplyManagedCodeUpdateAsync(
-        NamedPipeClientStream pipeClient,
-        CancellationToken cancellationToken)
+    private async ValueTask ReadAndApplyManagedCodeUpdateAsync(CancellationToken cancellationToken)
     {
-        var request = await ManagedCodeUpdateRequest.ReadAsync(pipeClient, cancellationToken);
+        Debug.Assert(_pipeClient != null);
+
+        var request = await ManagedCodeUpdateRequest.ReadAsync(_pipeClient, cancellationToken);
 
         bool success;
         try
@@ -131,15 +148,14 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
 
         var logEntries = agent.Reporter.GetAndClearLogEntries(request.ResponseLoggingLevel);
 
-        var response = new UpdateResponse(logEntries, success);
-        await response.WriteAsync(pipeClient, cancellationToken);
+        await SendResponseAsync(new UpdateResponse(logEntries, success), cancellationToken);
     }
 
-    private async ValueTask ReadAndApplyStaticAssetUpdateAsync(
-        NamedPipeClientStream pipeClient,
-        CancellationToken cancellationToken)
+    private async ValueTask ReadAndApplyStaticAssetUpdateAsync(CancellationToken cancellationToken)
     {
-        var request = await StaticAssetUpdateRequest.ReadAsync(pipeClient, cancellationToken);
+        Debug.Assert(_pipeClient != null);
+
+        var request = await StaticAssetUpdateRequest.ReadAsync(_pipeClient, cancellationToken);
 
         try
         {
@@ -155,8 +171,22 @@ internal sealed class PipeListener(string pipeName, IHotReloadAgent agent, Actio
         // Updating static asset only invokes ContentUpdate metadata update handlers.
         // Failures of these handlers are reported to the log and ignored.
         // Therefore, this request always succeeds.
-        var response = new UpdateResponse(logEntries, success: true);
+        await SendResponseAsync(new UpdateResponse(logEntries, success: true), cancellationToken);
+    }
 
-        await response.WriteAsync(pipeClient, cancellationToken);
+    internal async ValueTask SendResponseAsync<T>(T response, CancellationToken cancellationToken)
+        where T : IResponse
+    {
+        Debug.Assert(_pipeClient != null);
+        try
+        {
+            _messageToClientLock.Wait(cancellationToken);
+            await _pipeClient.WriteAsync((byte)response.Type, cancellationToken);
+            await response.WriteAsync(_pipeClient, cancellationToken);
+        }
+        finally
+        {
+            _messageToClientLock.Release();
+        }
     }
 }

--- a/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/WebAssemblyHotReload.cs
+++ b/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/WebAssemblyHotReload.cs
@@ -71,7 +71,8 @@ internal static partial class WebAssemblyHotReload
         {
             s_initialized = true;
 
-            var agent = new HotReloadAgent(assemblyResolvingHandler: null);
+            // TODO: Implement hotReloadExceptionCreateHandler: https://github.com/dotnet/sdk/issues/51056
+            var agent = new HotReloadAgent(assemblyResolvingHandler: null, hotReloadExceptionCreateHandler: null);
 
             var existingAgent = Interlocked.CompareExchange(ref s_hotReloadAgent, agent, null);
             if (existingAgent != null)

--- a/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
+++ b/src/BuiltInTools/HotReloadAgent/MetadataUpdateHandlerInvoker.cs
@@ -110,7 +110,7 @@ internal sealed class MetadataUpdateHandlerInvoker(AgentReporter reporter)
     }
 
     /// <summary>
-    /// Invokes all registered mtadata update handlers.
+    /// Invokes all registered metadata update handlers.
     /// </summary>
     internal void MetadataUpdated(Type[] updatedTypes)
     {

--- a/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
@@ -32,6 +32,11 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     private readonly object _pendingUpdatesGate = new();
     private Task _pendingUpdates = Task.CompletedTask;
 
+    /// <summary>
+    /// Invoked when a rude edit is detected at runtime.
+    /// </summary>
+    public event Action<int, string>? OnRuntimeRudeEdit;
+
     // for testing
     internal Task PendingUpdates
         => _pendingUpdates;
@@ -78,6 +83,9 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     /// Disposes the client. Can occur unexpectedly whenever the process exits.
     /// </summary>
     public abstract void Dispose();
+
+    protected void RuntimeRudeEditDetected(int errorCode, string message)
+        => OnRuntimeRudeEdit?.Invoke(errorCode, message);
 
     public static void ReportLogEntry(ILogger logger, string message, AgentMessageSeverity severity)
     {

--- a/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Aspire/AspireServiceFactory.cs
@@ -208,7 +208,7 @@ internal class AspireServiceFactory : IRuntimeProcessLauncherFactory
         {
             _logger.LogDebug("Stop session #{SessionId}", session.Id);
 
-            await session.RunningProject.TerminateAsync(isRestarting: false);
+            await session.RunningProject.TerminateAsync();
 
             // process termination should cancel output reader task:
             await session.OutputReader;

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Watch
                         rootProcessTerminationSource,
                         onOutput: null,
                         onExit: null,
-                        restartOperation: new RestartOperation(_ => throw new InvalidOperationException("Root project shouldn't be restarted")),
+                        restartOperation: new RestartOperation(_ => default), // the process will automatically restart
                         iterationCancellationToken);
 
                     if (rootRunningProject == null)
@@ -531,7 +531,7 @@ namespace Microsoft.DotNet.Watch
 
                     if (rootRunningProject != null)
                     {
-                        await rootRunningProject.TerminateAsync(isRestarting: false);
+                        await rootRunningProject.TerminateAsync();
                     }
 
                     if (runtimeProcessLauncher != null)
@@ -541,7 +541,8 @@ namespace Microsoft.DotNet.Watch
 
                     if (waitForFileChangeBeforeRestarting &&
                         !shutdownCancellationToken.IsCancellationRequested &&
-                        !forceRestartCancellationSource.IsCancellationRequested)
+                        !forceRestartCancellationSource.IsCancellationRequested &&
+                        rootRunningProject?.IsRestarting != true)
                     {
                         using var shutdownOrForcedRestartSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellationToken, forceRestartCancellationSource.Token);
                         await WaitForFileChangeBeforeRestarting(fileWatcher, evaluationResult, shutdownOrForcedRestartSource.Token);

--- a/src/BuiltInTools/dotnet-watch/Process/RunningProject.cs
+++ b/src/BuiltInTools/dotnet-watch/Process/RunningProject.cs
@@ -85,14 +85,14 @@ namespace Microsoft.DotNet.Watch
         /// <summary>
         /// Terminates the process if it hasn't terminated yet.
         /// </summary>
-        public async Task TerminateAsync()
+        public Task TerminateAsync()
         {
             if (!_isDisposed)
             {
                 processTerminationSource.Cancel();
             }
 
-            _ = await RunningProcess;
+            return RunningProcess;
         }
 
         /// <summary>
@@ -106,10 +106,10 @@ namespace Microsoft.DotNet.Watch
         /// <summary>
         /// Terminates the process in preparation for a restart.
         /// </summary>
-        public async Task TerminateForRestartAsync()
+        public Task TerminateForRestartAsync()
         {
             InitiateRestart();
-            await TerminateAsync();
+            return TerminateAsync();
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/Process/RunningProject.cs
+++ b/src/BuiltInTools/dotnet-watch/Process/RunningProject.cs
@@ -41,8 +41,9 @@ namespace Microsoft.DotNet.Watch
         /// Set to true when the process termination is being requested so that it can be restarted within
         /// the Hot Reload session (i.e. without restarting the root project).
         /// </summary>
-        public bool IsRestarting { get; private set; }
+        public bool IsRestarting => _isRestarting != 0;
 
+        private volatile int _isRestarting;
         private volatile bool _isDisposed;
 
         /// <summary>
@@ -81,16 +82,34 @@ namespace Microsoft.DotNet.Watch
             }
         }
 
-        public async Task<int> TerminateAsync(bool isRestarting)
+        /// <summary>
+        /// Terminates the process if it hasn't terminated yet.
+        /// </summary>
+        public async Task TerminateAsync()
         {
-            IsRestarting = isRestarting;
-
             if (!_isDisposed)
             {
                 processTerminationSource.Cancel();
             }
 
-            return await RunningProcess;
+            _ = await RunningProcess;
+        }
+
+        /// <summary>
+        /// Marks the <see cref="RunningProject"/> as restarting.
+        /// Subsequent process termination will be treated as a restart.
+        /// </summary>
+        /// <returns>True if the project hasn't been int restarting state prior the call.</returns>
+        public bool InitiateRestart()
+            => Interlocked.Exchange(ref _isRestarting, 1) == 0;
+
+        /// <summary>
+        /// Terminates the process in preparation for a restart.
+        /// </summary>
+        public async Task TerminateForRestartAsync()
+        {
+            InitiateRestart();
+            await TerminateAsync();
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
@@ -215,6 +215,7 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor RefreshServerRunningAt = Create(LogEvents.RefreshServerRunningAt, Emoji.Default);
         public static readonly MessageDescriptor ConnectedToRefreshServer = Create(LogEvents.ConnectedToRefreshServer, Emoji.Default);
         public static readonly MessageDescriptor RestartingApplicationToApplyChanges = Create("Restarting application to apply changes ...", Emoji.Default, MessageSeverity.Output);
+        public static readonly MessageDescriptor RestartingApplication = Create("Restarting application ...", Emoji.Default, MessageSeverity.Output);
         public static readonly MessageDescriptor IgnoringChangeInHiddenDirectory = Create("Ignoring change in hidden directory '{0}': {1} '{2}'", Emoji.Watch, MessageSeverity.Verbose);
         public static readonly MessageDescriptor IgnoringChangeInOutputDirectory = Create("Ignoring change in output directory: {0} '{1}'", Emoji.Watch, MessageSeverity.Verbose);
         public static readonly MessageDescriptor IgnoringChangeInExcludedFile = Create("Ignoring change in excluded file '{0}': {1}. Path matches {2} glob '{3}' set in '{4}'.", Emoji.Watch, MessageSeverity.Verbose);

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -526,7 +526,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
         // Terminate the process:
         Log($"Terminating process {runningProject.ProjectNode.GetDisplayName()} ...");
-        await runningProject.TerminateAsync(isRestarting: false);
+        await runningProject.TerminateAsync();
 
         // rude edit in A (changing assembly level attribute):
         UpdateSourceFile(serviceSourceA2, """

--- a/test/dotnet-watch.Tests/TestUtilities/AssertEx.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/AssertEx.cs
@@ -249,9 +249,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var message = new StringBuilder();
 
-
             message.AppendLine(expectedPresent
-                ? "Expected text found in the output:"
+                ? "Expected text not found in the output:"
                 : "Text not expected to be found in the output:");
 
             message.AppendLine(expected);


### PR DESCRIPTION
## Description

Implements support for auto-restart when runtime rude edit is encountered.
Fixes https://github.com/dotnet/sdk/issues/48515

### Background

Certain Hot Reload edits are applied speculatively - the compiler emits two code paths gated by a runtime check. If the expected code path is executed the edit works as the user intended (the executed code matches the source code) and the application continues executing flawlessly. The other code path throws `HotReloadException` with message that explains why the edit failed.

Examples of such edits include renaming a method, changing method signature, changing lambda signature, changing lambda closure, etc. In these cases a new method or lambda is emitted that matches the code, but the application may still hold onto a delegate to the previous version of the method. If such no longer valid delegate is invoked the `HotReloadException` is thrown.

### Change

In this change, the Hot Reload agent loaded into the application process hooks into the `HotReloadException` constructor via a hook added by https://github.com/dotnet/roslyn/pull/79790 when the `HotReloadException` is emitted into the delta. The exception construction is intercepted, a notification is sent to the host (dotnet-watch/VS/VS Code) and the current thread is suspended (to avoid throwing the exception). When the host receives the notification it triggers auto-restarts of the process.

The change refactors the pipe communication to allow for sending the rude edit notification at arbitrary time. Previously the pipe expected serialized sequence of request - response messages. Instead, we now asynchronously read incoming messages in a loop and trigger the corresponding action based on the response type received.

### Before

![RRE_Before](https://github.com/user-attachments/assets/dd683697-e53b-4a66-b416-f2c826f13508)

### After

![RRE_After](https://github.com/user-attachments/assets/7df68eec-ccf3-44e2-8c67-8ec0bcbe80bb)

## Customer Impact

Impacts Hot Reload scenarios for all types of projects but especially Aspire and web app scenarios.

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [x] Medium
- [ ] Low  

Justification: The impact is limited to dotnet-watch.

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  
