### PR TITLE
Allow empty file-level directive values

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1723,8 +1723,8 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
 
     private static (string, string?)? ParseOptionalTwoParts(in ParseContext context, char separator)
     {
-        var i = context.DirectiveText.IndexOf(separator, StringComparison.Ordinal);
-        var firstPart = (i < 0 ? context.DirectiveText : context.DirectiveText.AsSpan(..i)).TrimEnd();
+        var separatorIndex = context.DirectiveText.IndexOf(separator, StringComparison.Ordinal);
+        var firstPart = (separatorIndex < 0 ? context.DirectiveText : context.DirectiveText.AsSpan(..separatorIndex)).TrimEnd();
 
         string directiveKind = context.DirectiveKind;
         if (firstPart.IsWhiteSpace())
@@ -1738,12 +1738,12 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
             return context.Diagnostics.AddError<(string, string?)?>(context.SourceFile, context.Info.Span, string.Format(CliCommandStrings.InvalidDirectiveName, directiveKind, separator));
         }
 
-        if (i < 0)
+        if (separatorIndex < 0)
         {
             return (firstPart.ToString(), null);
         }
 
-        var secondPart = context.DirectiveText.AsSpan((i + 1)..).TrimStart();
+        var secondPart = context.DirectiveText.AsSpan((separatorIndex + 1)..).TrimStart();
         if (secondPart.IsWhiteSpace())
         {
             Debug.Assert(secondPart.Length == 0,

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1738,10 +1738,18 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
             return context.Diagnostics.AddError<(string, string?)?>(context.SourceFile, context.Info.Span, string.Format(CliCommandStrings.InvalidDirectiveName, directiveKind, separator));
         }
 
-        var secondPart = i < 0 ? [] : context.DirectiveText.AsSpan((i + 1)..).TrimStart();
-        if (i < 0 || secondPart.IsWhiteSpace())
+        if (i < 0)
         {
             return (firstPart.ToString(), null);
+        }
+
+        var secondPart = context.DirectiveText.AsSpan((i + 1)..).TrimStart();
+        if (secondPart.IsWhiteSpace())
+        {
+            Debug.Assert(secondPart.Length == 0,
+                "We have trimmed the second part, so if it's white space, it should be actually empty.");
+
+            return (firstPart.ToString(), string.Empty);
         }
 
         return (firstPart.ToString(), secondPart.ToString());

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -889,6 +889,50 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             expectedWildcardPattern: RunFileTests.DirectiveError("/app/Program.cs", 1, CliCommandStrings.MissingDirectiveName, directive));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Directives_EmptyValue(string value)
+    {
+        VerifyConversion(
+            inputCSharp: $"""
+                #:property TargetFramework={value}
+                #:property Prop1={value}
+                #:sdk First@{value}
+                #:sdk Second@{value}
+                #:package P1@{value}
+                """,
+            expectedProject: """
+                <Project Sdk="First/">
+
+                  <Sdk Name="Second" Version="" />
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                    <TargetFramework></TargetFramework>
+                    <Prop1></Prop1>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="P1" Version="" />
+                  </ItemGroup>
+
+                </Project>
+
+                """,
+            expectedCSharp: "");
+
+        VerifyConversionThrows(
+            inputCSharp: $"""
+                #:project{value}
+                """,
+            expectedWildcardPattern: RunFileTests.DirectiveError("/app/Program.cs", 1, CliCommandStrings.MissingDirectiveName, "project"));
+    }
+
     [Fact]
     public void Directives_MissingPropertyValue()
     {


### PR DESCRIPTION
### Description and customer impact

Fixes https://github.com/dotnet/sdk/issues/51077.

Empty property values specified via the `#:property` directive were incorrectly disallowed even though the spec says they should be allowed. This is useful in some scenarios like clearing the default `TargetFramework` when I want to specify `TargetFrameworks` (plural) which is how I discovered this.

### Regression

No, I think this was always broken.

### Risk

Low, a simple change, allowing a scenario that was previously an error.