### PR TITLE
Add `.slnx` to default `.editorconfig` template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 indent_size = 2
 
 # Xml project files
-[*.{csproj,fsproj,vbproj,proj}]
+[*.{csproj,fsproj,vbproj,proj,slnx}]
 indent_size = 2
 
 # Xml config files

--- a/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
+++ b/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#EditorConfig-file#-n#item.verified/EditorConfig-file/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 indent_size = 2
 
 # Xml project files
-[*.{csproj,fsproj,vbproj,proj}]
+[*.{csproj,fsproj,vbproj,proj,slnx}]
 indent_size = 2
 
 # Xml config files


### PR DESCRIPTION
`.slnx` files should match the same indentation settings as `.csproj` and other XML-based project files. This PR adds `.slnx` to the default `.editorconfig` template that's used by `dotnet new editorconfig`.

/cc @baronfel 