### PR TITLE
CLI --self-contained description is wrong

### DIFF
--- a/src/Cli/dotnet/CliStrings.resx
+++ b/src/Cli/dotnet/CliStrings.resx
@@ -541,8 +541,7 @@ Examples:
     <value>Incorrectly formatted environment variables: {0}</value>
   </data>
   <data name="SelfContainedOptionDescription" xml:space="preserve">
-    <value>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</value>
+    <value>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</value>
   </data>
   <data name="FrameworkDependentOptionDescription" xml:space="preserve">
     <value>Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application.</value>

--- a/src/Cli/dotnet/xlf/CliStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.cs.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Publikujte se svou aplikací modul runtime pro .NET, aby ho nebylo nutné instalovat na cílovém počítači.
-Výchozí hodnota je false. Pokud však cílíte na .NET 7 nebo nižší a je zadán identifikátor modulu runtime, výchozí hodnota je true.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Publikujte se svou aplikací modul runtime pro .NET, aby ho nebylo nutné instalovat na cílovém počítači.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.de.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Hiermit wird die .NET-Runtime mit Ihrer Anwendung veröffentlicht, sodass die Runtime nicht auf dem Zielcomputer installiert werden muss.
-Der Standardwert lautet FALSE. Wenn sie jedoch auf .NET 7 oder niedriger abzielen, lautet der Standardwert TRUE, wenn ein Laufzeitbezeichner angegeben wird.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Hiermit wird die .NET-Runtime mit Ihrer Anwendung veröffentlicht, sodass die Runtime nicht auf dem Zielcomputer installiert werden muss.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.es.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Publique el entorno de ejecución de .NET con la aplicación para que no sea necesario instalarlo en el equipo de destino.
-El valor predeterminado es "false." Sin embargo, cuando el destino es .NET 7 o inferior, el valor predeterminado es "true" si se especifica un identificador en tiempo de ejecución.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Publique el entorno de ejecución de .NET con la aplicación para que no sea necesario instalarlo en el equipo de destino.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.fr.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Publiez le runtime .NET avec votre application afin que le runtime n’ait pas besoin d’être installé sur l’ordinateur cible.
-La valeur par défaut est « false ». Toutefois, lorsque vous ciblez .NET 7 ou une version antérieure, la valeur par défaut est « true » si un identificateur d’exécution est spécifié.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Publiez le runtime .NET avec votre application afin que le runtime n’ait pas besoin d’être installé sur l’ordinateur cible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.it.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Pubblicare il runtime .NET con l'applicazione in modo che non sia necessario installare il runtime nel computer di destinazione.
-Il valore predefinito è 'false'. Tuttavia, quando la destinazione è .NET 7 o una versione inferiore, il valore predefinito è 'true' se viene specificato un identificatore di runtime.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Pubblicare il runtime .NET con l'applicazione in modo che non sia necessario installare il runtime nel computer di destinazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ja.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">アプリケーションと一緒に .NET ランタイムを発行して、ランタイムをターゲット マシンにインストールする必要がないようにします。
-既定値は 'false' です。しかし、.NET 7 以前が対象の場合、ランタイム識別子が指定されていれば、既定値は 'true' です。</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">アプリケーションと一緒に .NET ランタイムを発行して、ランタイムをターゲット マシンにインストールする必要がないようにします。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ko.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">대상 컴퓨터에 런타임을 설치할 필요가 없도록 애플리케이션과 함께 .NET 런타임을 게시합니다.
-기본값은 'false'입니다. 그러나 .NET 7 이하를 대상으로 하고 런타임 식별자를 지정하는 경우 기본값은 'true'입니다.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">대상 컴퓨터에 런타임을 설치할 필요가 없도록 애플리케이션과 함께 .NET 런타임을 게시합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pl.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Opublikuj środowisko uruchomieniowe platformy .NET z aplikacją, aby nie trzeba było instalować środowiska uruchomieniowego na maszynie docelowej.
-Wartość domyślna to „false”. Jednak w przypadku określania wartości docelowej platformy .NET 7 lub niższej wartość domyślna to „true”, jeśli określono identyfikator środowiska uruchomieniowego.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Opublikuj środowisko uruchomieniowe platformy .NET z aplikacją, aby nie trzeba było instalować środowiska uruchomieniowego na maszynie docelowej.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Publique o tempo de execução do .NET junto com sua aplicação para que o tempo de execução não precise ser instalado na máquina de destino.
-O padrão é 'false.' No entanto, ao direcionar para .NET 7 ou inferior, o padrão é 'true' se um identificador de tempo de execução for especificado.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Publique o tempo de execução do .NET junto com sua aplicação para que o tempo de execução não precise ser instalado na máquina de destino.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ru.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Публикация среды выполнения .NET вместе с вашим приложением, чтобы ее не пришлось устанавливать на целевом компьютере.
-Значение по умолчанию — "false". Однако для .NET 7 или более ранней версии значение по умолчанию — "true", если указан идентификатор среды выполнения.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Публикация среды выполнения .NET вместе с вашим приложением, чтобы ее не пришлось устанавливать на целевом компьютере.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.tr.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">Uygulamanızla birlikte .NET çalışma zamanını yayımladığınızda hedef makinede çalışma zamanının yüklü olması gerekmez.
-Varsayılan değer 'false.' Ancak çalışma zamanı tanımlayıcısı belirtildiyse .NET 7 veya altı projeler hedeflenirken varsayılan değer 'true' olur.</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">Uygulamanızla birlikte .NET çalışma zamanını yayımladığınızda hedef makinede çalışma zamanının yüklü olması gerekmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">将 .NET 运行时与应用程序一起发布，从而无需在目标计算机上安装运行时。
-默认值为 ‘false’。但目标为 .NET 7 或更低版本时，如果指定了运行时标识符，则默认值为 ‘true’。</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">将 .NET 运行时与应用程序一起发布，从而无需在目标计算机上安装运行时。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
@@ -987,10 +987,8 @@ setx PATH "%PATH%;{0}"
         <note>{Locked="--self-contained"}{Locked="--no-self-contained"}</note>
       </trans-unit>
       <trans-unit id="SelfContainedOptionDescription">
-        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
-The default is 'false.' However, when targeting .NET 7 or lower, the default is 'true' if a runtime identifier is specified.</source>
-        <target state="translated">將 .NET 執行階段隨著您的應用程式發佈，以便您不需在目標電腦上安裝執行階段。
-預設值為 'false'。不過，當目標為 .NET 7 或更低版本時，如有指定執行階段識別碼，則預設值為 'true'。</target>
+        <source>Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.</source>
+        <target state="translated">將 .NET 執行階段隨著您的應用程式發佈，以便您不需在目標電腦上安裝執行階段。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">


### PR DESCRIPTION
It looks like https://github.com/dotnet/sdk/pull/32656 updated the `--self-contained` description incorrectly. The code change that triggered the old PR was actually related to the --runtime parameter no longer enforcing self-contained=true. It had nothing to do with the --self-contained option itself.

--self-contained is an option argument type and defaults to true when passed.

@baronfel 