### PR TITLE
Re-enable telemetry for global.json state - set error writer to swallow expected error messages

### DIFF
--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -240,10 +240,7 @@ public class Program
         if (TelemetryClient.Enabled)
         {
             // Get the global.json state to report in telemetry along with this command invocation.
-            // We don't care about the actual SDK resolution, just the global.json information,
-            // so just pass empty string as executable directory for resolution.
-            // NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory);
-            // globalJsonState = result.GlobalJsonState;
+            globalJsonState = NativeWrapper.NETCoreSdkResolverNativeWrapper.GetGlobalJsonState(Environment.CurrentDirectory);
         }
 
         TelemetryEventEntry.SendFiltered(Tuple.Create(parseResult, performanceData, globalJsonState));

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.NativeWrapper
         }
 
         // MSBuild SDK resolvers are required to be AnyCPU, but we have a native dependency and .NETFramework does not
-        // have a built-in facility for dynamically loading user native dlls for the appropriate platform. We therefore 
+        // have a built-in facility for dynamically loading user native dlls for the appropriate platform. We therefore
         // preload the version with the correct architecture (from a corresponding sub-folder relative to us) on static
         // construction so that subsequent P/Invokes can find it.
         private static void PreloadWindowsLibrary(string dllFileName)
@@ -123,6 +123,12 @@ namespace Microsoft.DotNet.NativeWrapper
             IntPtr reserved,
             hostfxr_get_dotnet_environment_info_result_fn result,
             IntPtr result_context);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void hostfxr_error_writer_fn(IntPtr message);
+
+        [DllImport(Constants.HostFxr, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr hostfxr_set_error_writer(IntPtr error_writer);
 
         public static class Windows
         {

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
@@ -23,6 +23,20 @@ namespace Microsoft.DotNet.NativeWrapper
             return result;
         }
 
+        public static string? GetGlobalJsonState(string globalJsonStartDirectory)
+        {
+            // We don't care about the actual SDK resolution, just the global.json information,
+            // so just pass empty string as executable directory for resolution. This means that
+            // we expect the call to fail to resolve an SDK. Set up the error writer to avoid
+            // output going to stderr. We reset it after the call.
+            var swallowErrors = new Interop.hostfxr_error_writer_fn(message => { });
+            IntPtr errorWriter = Marshal.GetFunctionPointerForDelegate(swallowErrors);
+            IntPtr previousErrorWriter = Interop.hostfxr_set_error_writer(errorWriter);
+            SdkResolutionResult result = ResolveSdk(string.Empty, globalJsonStartDirectory);
+            Interop.hostfxr_set_error_writer(previousErrorWriter);
+            return result.GlobalJsonState;
+        }
+
         private sealed class SdkList
         {
             public string[]? Entries;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
@@ -32,9 +32,15 @@ namespace Microsoft.DotNet.NativeWrapper
             var swallowErrors = new Interop.hostfxr_error_writer_fn(message => { });
             IntPtr errorWriter = Marshal.GetFunctionPointerForDelegate(swallowErrors);
             IntPtr previousErrorWriter = Interop.hostfxr_set_error_writer(errorWriter);
-            SdkResolutionResult result = ResolveSdk(string.Empty, globalJsonStartDirectory);
-            Interop.hostfxr_set_error_writer(previousErrorWriter);
-            return result.GlobalJsonState;
+            try
+            {
+                SdkResolutionResult result = ResolveSdk(string.Empty, globalJsonStartDirectory);
+                return result.GlobalJsonState;
+            }
+            finally
+            {
+                Interop.hostfxr_set_error_writer(previousErrorWriter);
+            }
         }
 
         private sealed class SdkList


### PR DESCRIPTION
When getting the global.json state for telemetry, we avoid the work to actually resolve an SDK. However, this means that the actual SDK resolution (`hostfxr_resolve_sdk2`) fails, resulting in messages printed to stderr by default. This change uses `hostfxr_set_error_writer` to swallow the expected errors for the duration of that call and re-enables sending the telemetry for global.json state

cc @dotnet/appmodel @AaronRobinsonMSFT 

Issue about writing to stderr in original implementation: https://github.com/dotnet/sdk/issues/50632
Issue about adding this telemetry - resolves https://github.com/dotnet/sdk/issues/50058

@dotnet/dotnet-cli I'd also like to get this in 10 if possible. What would be the process and correct branch to target?

## Impact

This telemetry will give us information about the global.json state when an SDK command is invoked. We've gotten feedback over the years about how invalid global.json files shouldn't be ignored. This telemetry will give us a sense of how common this situation is and inform any decision to around changing the behaviour in a future release.

## Regression

- [ ] Yes
- [x] No

## Risk

Low. This is fixing an issue in the original implementation where we'd end up printing extra/undesired messages when getting the information for telemetry. The fix is simply to swallow those messages.
