### PR TITLE
Have copilot handle formatting better

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,8 @@ Coding Style and Changes:
 - When generating code, run `dotnet format` to ensure uniform formatting.
 - Prefer using file-based namespaces for new code.
 - Do not allow unused `using` directives to be committed.
+- commit your changes, and then format them.
+- add the format commit SHA to the .git-blame-ignore-revs file so that the commit doesn't dirty git blame in the future
 
 Testing:
 - Large changes should always include test changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,8 +5,8 @@ Coding Style and Changes:
 - When generating code, run `dotnet format` to ensure uniform formatting.
 - Prefer using file-based namespaces for new code.
 - Do not allow unused `using` directives to be committed.
-- commit your changes, and then format them.
-- add the format commit SHA to the .git-blame-ignore-revs file so that the commit doesn't dirty git blame in the future
+- Commit your changes, and then format them.
+- Add the format commit SHA to the .git-blame-ignore-revs file so that the commit doesn't dirty git blame in the future
 
 Testing:
 - Large changes should always include test changes.


### PR DESCRIPTION
Updated guidelines for committing changes and testing. dotnet format doesn't allow for formatting a single file. If copilot tries to format, it'll try the file, then the solution, and then the project resulting in lots of formatting. This will enable us to fix formatting but not mess up the diffs.