### PR TITLE
Remove dnx.ps1

### DIFF
--- a/src/Layout/redist/dnx.ps1
+++ b/src/Layout/redist/dnx.ps1
@@ -1,8 +1,0 @@
-# Licensed to the .NET Foundation under one or more agreements.
-# The .NET Foundation licenses this file to you under the MIT license.
-
-# PowerShell script to launch dotnet.exe with 'dnx' and all passed arguments
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$dotnet = Join-Path $scriptDir 'dotnet.exe'
-& $dotnet dnx @Args
-exit $LASTEXITCODE

--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -67,7 +67,6 @@
   <Target Name="LayoutDnxShim">
     <ItemGroup>
       <DnxShimSource Condition="$([MSBuild]::IsOSPlatform('Windows'))" Include="dnx.cmd" />
-      <DnxShimSource Condition="$([MSBuild]::IsOSPlatform('Windows'))" Include="dnx.ps1" />
       <DnxShimSource Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))" Include="dnx" />
     </ItemGroup>
     <Copy SourceFiles="@(DnxShimSource)" DestinationFolder="$(RedistInstallerLayoutPath)" />


### PR DESCRIPTION
See #51067.  The .ps1 script prevents the CLI from correctly processing `--`.  So we'll remove the script, This will regress to the "terminate batch job" behavior described in #49623, but that's better than incorrectly processing command line arguments.

### Description

Removes dnx.ps1 helper script.

### Customer impact

Fixes processing of `--` when calling dnx from PowerShell.
Brings back "Terminate Batch Job" prompt when CTRL+C is pressed, but this is preferrable to incorrectly processing the command line.

### Regression

`dnx` is new in .NET 10.  This was a regression from a previous preview release.

### Risk

Low