### PR TITLE
Include instructions for multi-targeting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@ Coding Style and Changes:
 - When generating code, run `dotnet format` to ensure uniform formatting.
 - Prefer using file-based namespaces for new code.
 - Do not allow unused `using` directives to be committed.
+- Use `#if NET` blocks for .NET Core specific code, and `#if NETFRAMEWORK` for .NET Framework specific code.
 
 Testing:
 - Large changes should always include test changes.


### PR DESCRIPTION
Using Copilot CLI locally to make speculative changes to the sdk. The CLI was able to detect when multi-targeting was needed to access new .NET Core APIs but it defaulted to emitting `#if NET6_0_OR_GREATER`. Looking at the build files our minimum TFM is, likely, `net9.0` hence this is unnecessary.

Considered for a bit adding an instruction that told copilot what the minimum TFM was but in the end decided that the preference would almost always be `#if NET` anyways hence just default to that.

Tested before / after locally this change resulted a better experience.