### PR TITLE
Avoid exceptions when parsing _NormalizedWindowsSdkSupportedTargetPlatformVersion

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -26,9 +26,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- Normalize the last part of TFM to .0 when ending with .1 as that indicates the use of the CsWinRT 3.0 verison. -->
       <_NormalizedWindowsSdkSupportedTargetPlatformVersion Include="@(WindowsSdkSupportedTargetPlatformVersion)">
         <NormalizedSupportedTargetPlatformVersion
-            Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').Length) == 4 And
-                         $([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(3)) == '1'"
-              >$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(0)).$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(1)).$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(2)).0</NormalizedSupportedTargetPlatformVersion>
+            Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(Identity), '^((\d+\.){3})1$'))"
+              >$([System.Text.RegularExpressions.Regex]::Replace(%(Identity), '^((\d+\.){3})1$', '${1}0'))</NormalizedSupportedTargetPlatformVersion>
       </_NormalizedWindowsSdkSupportedTargetPlatformVersion>
       <SdkSupportedTargetPlatformVersion Include="@(_NormalizedWindowsSdkSupportedTargetPlatformVersion)" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props
@@ -24,10 +24,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Windows'">
         <!-- Normalize the last part of TFM to .0 when ending with .1 as that indicates the use of the CsWinRT 3.0 verison. -->
-        <_NormalizedWindowsSdkSupportedTargetPlatformVersion Include="@(WindowsSdkSupportedTargetPlatformVersion)">
-            <NormalizedSupportedTargetPlatformVersion 
-                Condition="$([System.Version]::Parse('%(Identity)').Revision) == 1">$([System.Version]::Parse('%(Identity)').Major).$([System.Version]::Parse('%(Identity)').Minor).$([System.Version]::Parse('%(Identity)').Build).0</NormalizedSupportedTargetPlatformVersion>
-        </_NormalizedWindowsSdkSupportedTargetPlatformVersion>
-        <SdkSupportedTargetPlatformVersion Include="@(_NormalizedWindowsSdkSupportedTargetPlatformVersion)" />
+      <_NormalizedWindowsSdkSupportedTargetPlatformVersion Include="@(WindowsSdkSupportedTargetPlatformVersion)">
+        <NormalizedSupportedTargetPlatformVersion
+            Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').Length) == 4 And
+                         $([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(3)) == '1'"
+              >$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(0)).$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(1)).$([MSBuild]::ValueOrDefault('%(Identity)', '').Split('.').GetValue(2)).0</NormalizedSupportedTargetPlatformVersion>
+      </_NormalizedWindowsSdkSupportedTargetPlatformVersion>
+      <SdkSupportedTargetPlatformVersion Include="@(_NormalizedWindowsSdkSupportedTargetPlatformVersion)" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
For "funky" reasons related to https://github.com/dotnet/msbuild/issues/3460, the version normalization that we added in https://github.com/dotnet/sdk/pull/50264 is causing exceptions to be thrown.  This isn't a functional issue, the fact that the exceptions are thrown and then caught are part of how MSBuild works.

However, the additional exceptions are showing up on VS perf tests as a regression in the total number of exceptions thrown.

This PR rewrites the logic to avoid calling Version.Parse on the `%(Identity)`, which should avoid the exceptions.

### Description

Replace Version.Parse in MSBuild evaluation with regular expression to avoid first-chance exceptions in weird MSBuild evaluation modes.

### Customer impact

This should not cause any visible customer impact, but it should reduce the count of exceptions thrown.

### Regression

This was an exception perf counter regression over .NET 9.

### Testing

Manual testing that first-chance exceptions were no longer thrown.

### Risk

Low