### PR TITLE
[Hot Reload] Only enable ASP.NET debug logging if logging level is Trace

### DIFF
--- a/src/BuiltInTools/HotReloadClient/Logging/LogEvents.cs
+++ b/src/BuiltInTools/HotReloadClient/Logging/LogEvents.cs
@@ -25,6 +25,7 @@ internal static class LogEvents
     public static readonly LogEvent HotReloadSucceeded = Create(LogLevel.Information, "Hot reload succeeded.");
     public static readonly LogEvent RefreshingBrowser = Create(LogLevel.Debug, "Refreshing browser.");
     public static readonly LogEvent ReloadingBrowser = Create(LogLevel.Debug, "Reloading browser.");
+    public static readonly LogEvent SendingWaitMessage = Create(LogLevel.Debug, "Sending wait message.");
     public static readonly LogEvent NoBrowserConnected = Create(LogLevel.Debug, "No browser is connected.");
     public static readonly LogEvent FailedToReceiveResponseFromConnectedBrowser = Create(LogLevel.Debug, "Failed to receive response from a connected browser.");
     public static readonly LogEvent UpdatingDiagnostics = Create(LogLevel.Debug, "Updating diagnostics.");

--- a/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -101,7 +101,7 @@ internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPa
             builder[MiddlewareEnvironmentVariables.DotNetModifiableAssemblies] = "debug";
         }
 
-        if (logger.IsEnabled(LogLevel.Debug))
+        if (logger.IsEnabled(LogLevel.Trace))
         {
             // enable debug logging from middleware:
             builder[MiddlewareEnvironmentVariables.LoggingLevel] = "Debug";
@@ -237,8 +237,12 @@ internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPa
     }
 
     public ValueTask SendWaitMessageAsync(CancellationToken cancellationToken)
-        => SendAsync(s_waitMessage, cancellationToken);
+    {
+        logger.Log(LogEvents.SendingWaitMessage);
+        return SendAsync(s_waitMessage, cancellationToken);
+    }
 
+    // obsolete: to be removed
     public ValueTask SendPingMessageAsync(CancellationToken cancellationToken)
         => SendAsync(s_pingMessage, cancellationToken);
 

--- a/src/BuiltInTools/dotnet-watch/Process/ProjectLauncher.cs
+++ b/src/BuiltInTools/dotnet-watch/Process/ProjectLauncher.cs
@@ -91,7 +91,7 @@ internal sealed class ProjectLauncher(
         environmentBuilder[EnvironmentVariables.Names.DotnetWatch] = "1";
         environmentBuilder[EnvironmentVariables.Names.DotnetWatchIteration] = (Iteration + 1).ToString(CultureInfo.InvariantCulture);
 
-        if (Logger.IsEnabled(LogLevel.Debug))
+        if (Logger.IsEnabled(LogLevel.Trace))
         {
             environmentBuilder[EnvironmentVariables.Names.HotReloadDeltaClientLogMessages] =
                 (EnvironmentOptions.SuppressEmojis ? Emoji.Default : Emoji.Agent).GetLogMessagePrefix() + $"[{projectDisplayName}]";

--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.HotReload;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class BrowserRefreshServerTests
+{
+    class TestListener : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task ConfigureLaunchEnvironmentAsync(LogLevel logLevel, bool enableHotReload) 
+    {
+        var middlewarePath = Path.GetTempPath();
+        var middlewareFileName = Path.GetFileNameWithoutExtension(middlewarePath);
+
+        var server = new TestBrowserRefreshServer(middlewarePath)
+        {
+            CreateAndStartHostImpl = () => new WebServerHost(new TestListener(), ["http://test.endpoint"], virtualDirectory: "/test/virt/dir")
+        };
+
+        ((TestLogger)server.Logger).IsEnabledImpl = level => level == logLevel;
+
+        await server.StartAsync(CancellationToken.None);
+
+        var envBuilder = new Dictionary<string, string>();
+        server.ConfigureLaunchEnvironment(envBuilder, enableHotReload);
+
+        Assert.True(envBuilder.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
+
+        var expected = new List<string>()
+        {
+            "ASPNETCORE_AUTO_RELOAD_VDIR=/test/virt/dir",
+            "ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT=http://test.endpoint",
+            "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=" + middlewareFileName,
+            "DOTNET_STARTUP_HOOKS=" + middlewarePath,
+        };
+
+        if (enableHotReload)
+        {
+            expected.Add("DOTNET_MODIFIABLE_ASSEMBLIES=debug");
+        }
+
+        if (logLevel == LogLevel.Trace)
+        {
+            expected.Add("Logging__LogLevel__Microsoft.AspNetCore.Watch=Debug");
+        }
+
+        AssertEx.SequenceEqual(expected.Order(), envBuilder.OrderBy(e => e.Key).Select(e => $"{e.Key}={e.Value}"));
+    }
+}

--- a/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.HotReload;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+internal class TestBrowserRefreshServer(string middlewareAssemblyPath)
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath, new TestLogger(), new TestLoggerFactory())
+{
+    public Func<WebServerHost>? CreateAndStartHostImpl;
+
+    protected override ValueTask<WebServerHost> CreateAndStartHostAsync(CancellationToken cancellationToken)
+        => ValueTask.FromResult((CreateAndStartHostImpl ?? throw new NotImplementedException())());
+
+    protected override bool SuppressTimeouts => true;
+}

--- a/test/dotnet-watch.Tests/TestUtilities/TestLogger.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestLogger.cs
@@ -11,6 +11,8 @@ internal class TestLogger(ITestOutputHelper? output = null) : ILogger
     public readonly Lock Guard = new();
     private readonly List<string> _messages = [];
 
+    public Func<LogLevel, bool>? IsEnabledImpl;
+
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         var message = $"[{logLevel}] {formatter(state, exception)}";
@@ -36,5 +38,5 @@ internal class TestLogger(ITestOutputHelper? output = null) : ILogger
         where TState : notnull => throw new NotImplementedException();
 
     public bool IsEnabled(LogLevel logLevel)
-        => true;
+        => IsEnabledImpl?.Invoke(logLevel) ?? true;
 }

--- a/test/dotnet-watch.Tests/TestUtilities/TestLoggerFactory.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestLoggerFactory.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+internal class TestLoggerFactory(ITestOutputHelper? output = null) : ILoggerFactory
+{
+    public Func<string, ILogger>? CreateLoggerImpl;
+
+    public ILogger CreateLogger(string categoryName)
+        => CreateLoggerImpl?.Invoke(categoryName) ?? new TestLogger(output);
+
+    public void AddProvider(ILoggerProvider provider) {}
+    public void Dispose() { }
+}


### PR DESCRIPTION
Use LogLevel.Trace for all logging that affects application output.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2582944

## Customer Impact

Impacts VS and VS Code (the implementation is now shared with dotnet-watch) but does not change behavior of dotnet-watch since we report both Debug and Trace level messages in `--verbose` mode. 

## Regression?

- [x] Yes
- [ ] No  

Regression of VS behavior.

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: Only affects logging.

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  
