### PR TITLE
Fix SWID tag

### DIFF
--- a/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
@@ -27,7 +27,13 @@
       <Payload Name="dotnet.ico" Compressed="yes" SourceFile="..\..\dotnet.ico" />
     </BootstrapperApplication>
 
-    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles6432Folder]dotnet" />
+    <!-- Do not use ProgramFiles6432Folder. It defaults to CSIDL_PROGRAM_FILES and will write
+         the tag to Program Files when installing the x86 SDK on 64-bit OS. -->
+    <?if $(TargetArchitecture)~=x86?>
+    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFilesFolder]dotnet" />
+    <?else?>
+    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet]" />
+    <?endif?>
 
     <!-- Search references for upgrade policy keys -->
     <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>

--- a/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
@@ -32,7 +32,7 @@
     <?if $(TargetArchitecture)~=x86?>
     <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFilesFolder]dotnet" />
     <?else?>
-    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet]" />
+    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
     <?endif?>
 
     <!-- Search references for upgrade policy keys -->


### PR DESCRIPTION
# Description

This is a regression from migrating to WiX v5. Using the new `ProgramFiles6432Folder` variable causes non-native installations to always write the SWID tag to `CSIDL_PROGRAM_FILES`. When installing the x86 SDK on 64-bit Windows, the tag ends up under `Program Files` instead of `Program Files (x86)`.

# Testing

Manual test