### PR TITLE
Fail the RPM build if FPM tool is not present

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -213,7 +213,7 @@ extends:
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
+              osProperties: $(linuxOsPortableProperties) /p:BuildSdkRpm=true
               runTests: false
             - categoryName: Portable
               container: azureLinux30fpm
@@ -222,7 +222,7 @@ extends:
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsPortableProperties) /p:IsRPMBasedDistro=true
+              osProperties: $(linuxOsPortableProperties) /p:BuildSdkRpm=true
               runTests: false
             ### MUSL ###
             - categoryName: Musl

--- a/src/Installer/redist-installer/targets/GenerateRPMs.targets
+++ b/src/Installer/redist-installer/targets/GenerateRPMs.targets
@@ -13,12 +13,12 @@
 
   <Target Name="GenerateRpmsInner"
           DependsOnTargets="TestFPMTool;BuildRpms"
-          Condition=" '$(IsRPMBasedDistro)' == 'True' "
+          Condition=" '$(BuildSdkRpm)' == 'True' "
           Outputs="@(GeneratedInstallers)" />
 
   <Target Name="BuildRpms"
           DependsOnTargets="GenerateSdkRpm"
-          Condition=" '$(IsRPMBasedDistro)' == 'True' and '$(FPMPresent)' == 'True' " />
+          Condition=" '$(BuildSdkRpm)' == 'True' and '$(FPMPresent)' == 'True' " />
 
   <Target Name="GenerateSdkRpm"
           DependsOnTargets="SetupRpmProps">

--- a/src/Installer/redist-installer/targets/GenerateRPMs.targets
+++ b/src/Installer/redist-installer/targets/GenerateRPMs.targets
@@ -301,10 +301,8 @@
       <FPMPresent Condition=" '$(FPMExitCode)' == '0' ">True</FPMPresent>
     </PropertyGroup>
 
-    <!-- Workaround for Jenkins machines that don't have the necessary packages https://github.com/dotnet/core-setup/issues/2260 -->
-    <Message Condition=" '$(FPMPresent)' != 'True' "
-             Text="FPM tool Not found, RPM packages will not be built."
-             Importance="High" />
+    <Error Condition=" '$(FPMPresent)' != 'True' "
+           Text="FPM tool Not found, RPM packages will not be built." />
   </Target>
 
   <!-- Removed the TestSdkRpm task as it would fail when the installed package exactly matched the upgrade package -->

--- a/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
+++ b/src/Installer/redist-installer/targets/GetRuntimeInformation.targets
@@ -28,6 +28,7 @@
       <IsDebianBaseDistro Condition=" $(HostRid.StartsWith('ubuntu')) OR $(HostRid.StartsWith('debian')) ">true</IsDebianBaseDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('centos')) ">true</IsRPMBasedDistro>
+      <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('azurelinux')) ">true</IsRPMBasedDistro>
       <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND !$(Rid.StartsWith('linux-musl'))">true</PublishNativeInstallers>
       <PublishArchives Condition=" '$(IslinuxPortable)' == 'true' OR ('$(IsDebianBaseDistro)' != 'true' AND '$(IsRPMBasedDistro)' != 'true') ">true</PublishArchives>
     </PropertyGroup>


### PR DESCRIPTION
Currently, if the build is supposed to produce RPM packages, but the tooling (i.e. `fpm`) is missing, a message will be logged and the build will skip the RPM package generation. This can result in successful builds that are missing the required artifacts.

Additional changes were needed, as RPM targets were being executed for any build that was running on RPM-based distro due to: https://github.com/dotnet/sdk/blob/c1ff1eb29765fbfc8f0a66ae952f6ed6db6a2473/src/Installer/redist-installer/targets/GenerateRPMs.targets#L14-L16

The use of property `IsRPMBasedDistro` was overloaded to mean both that the distro is RPM-based **and** that we want to build installers.

Property was set here: https://github.com/dotnet/sdk/blob/c1ff1eb29765fbfc8f0a66ae952f6ed6db6a2473/src/Installer/redist-installer/targets/GetRuntimeInformation.targets#L29-L30

For installer build we were passing this same property, which was already being set on rpm-based distros, so this wasn't correct: https://github.com/dotnet/sdk/blob/c1ff1eb29765fbfc8f0a66ae952f6ed6db6a2473/.vsts-ci.yml#L216

I am now setting a different property, `BuildSdkRpm`, in scenarios where RPM packaging is desired. This matches DEB build experience, where we have a similar pair of properties: `BuildSdkDeb` and `IsDebianBaseDistro`.

## Notes

Fix for 9.0.1xx - will be backported to other 9.0.x branches in support. Fix for 8.0 - https://github.com/dotnet/installer/pull/20633

Contributes to https://github.com/dotnet/installer/issues/20561
