### PR TITLE
[Hot Reload] Do not refresh browser until changes are applied

### DIFF
--- a/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -299,14 +299,7 @@ internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPa
     public ValueTask ReportCompilationErrorsInBrowserAsync(ImmutableArray<string> compilationErrors, CancellationToken cancellationToken)
     {
         logger.Log(LogEvents.UpdatingDiagnostics);
-        if (compilationErrors.IsEmpty)
-        {
-            return SendJsonMessageAsync(new AspNetCoreHotReloadApplied(), cancellationToken);
-        }
-        else
-        {
-            return SendJsonMessageAsync(new HotReloadDiagnostics { Diagnostics = compilationErrors }, cancellationToken);
-        }
+        return SendJsonMessageAsync(new HotReloadDiagnostics { Diagnostics = compilationErrors }, cancellationToken);
     }
 
     public async ValueTask UpdateStaticAssetsAsync(IEnumerable<string> relativeUrls, CancellationToken cancellationToken)

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -79,7 +79,12 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             🧪 Received: Reload
             """);
 
+        // no other browser message sent:
+        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
+
         await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
+
+        App.Process.ClearOutput();
 
         // another rude edit:
         UpdateSourceFile(homePagePath, src => src.Replace("public virtual int F() => 1;", "/* member placeholder */"));
@@ -98,13 +103,25 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             🧪 Received: Reload
             """);
 
+        // no other browser message sent:
+        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
+
+        App.Process.ClearOutput();
+
         // valid edit:
         UpdateSourceFile(homePagePath, src => src.Replace("/* member placeholder */", "public int F() => 1;"));
 
         await App.WaitForOutputLineContaining(MessageDescriptor.HotReloadSucceeded);
 
         await App.WaitUntilOutputContains($$"""
+            🧪 Received: {"type":"HotReloadDiagnosticsv1","diagnostics":[]}
+            """);
+
+        await App.WaitUntilOutputContains($$"""
             🧪 Received: {"type":"AspNetCoreHotReloadApplied"}
             """);
+
+        // no other browser message sent:
+        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
     }
 }


### PR DESCRIPTION
## Description

Browser sometimes does not display changed content after applying changes.

We send browser refresh message too early. The browser actually refreshed but sometimes it happened before the changes were applied on the server and thus the server responded with the old content.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3086, https://github.com/dotnet/sdk/issues/51107

## Customer Impact

Impacts Hot Reload scenarios for web app scenarios, including Aspire. 
Customer may perceive Hot Reload as unreliable as the browser does not display applied changes.

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: The impact is limited to sending Hot Reload messages to browser and the change is trivial.

## Verification

- [x] Manual (required)  
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  