### PR TITLE
[dotnet-watch] Remove excess logging that slows down Hot Reload

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -77,7 +77,23 @@ namespace Microsoft.DotNet.Watch
         {
             _logger.Log(MessageDescriptor.HotReloadSessionStarting);
 
-            await _hotReloadService.StartSessionAsync(Workspace.CurrentSolution, cancellationToken);
+            var solution = Workspace.CurrentSolution;
+
+            await _hotReloadService.StartSessionAsync(solution, cancellationToken);
+
+            // TODO: StartSessionAsync should do this: https://github.com/dotnet/roslyn/issues/80687
+            foreach (var project in solution.Projects)
+            {
+                foreach (var document in project.AdditionalDocuments)
+                {
+                    await document.GetTextAsync(cancellationToken);
+                }
+
+                foreach (var document in project.AnalyzerConfigDocuments)
+                {
+                    await document.GetTextAsync(cancellationToken);
+                }
+            }
 
             _logger.Log(MessageDescriptor.HotReloadSessionStarted);
         }

--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -219,6 +219,7 @@ internal sealed class IncrementalMSBuildWorkspace : Workspace
 
     public async Task ReportSolutionFilesAsync(Solution solution, CancellationToken cancellationToken)
     {
+#if DEBUG
         _logger.LogDebug("Solution: {Path}", solution.FilePath);
         foreach (var project in solution.Projects)
         {
@@ -245,5 +246,8 @@ internal sealed class IncrementalMSBuildWorkspace : Workspace
             var text = await document.GetTextAsync(cancellationToken);
             _logger.LogDebug("    {Kind}: {FilePath} [{Checksum}]", kind, document.FilePath, Convert.ToBase64String(text.GetChecksum().ToArray()));
         }
+#else
+        await Task.CompletedTask;
+#endif
     }
 }


### PR DESCRIPTION
## Description

Remove logging of solution content in Release builds. This logging used to be valuable for diagnostics in past, but we haven't seen issues that need this information in a while. 
The logging slows down project loading. 

## Customer Impact

Significantly improves dotnet-watch initialization, especially on large solutions.
On a solution with 4,500 files the project load time is reduced by 75s (46%): from 164s to 89s.

## Regression?

- [x] Yes
- [ ] No  

Regression compared to 8.0. The logging was added in 9.0.

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: The impact is limited to sending Hot Reload messages to browser and the change is trivial.

## Verification

- [x] Manual (required)  
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  