### PR TITLE
Clean up browser communication protocol

### DIFF
--- a/src/BuiltInTools/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.HotReload
                 var anyFailure = false;
 
                 await browserRefreshServer.SendAndReceiveAsync(
-                    request: sharedSecret => new JsonApplyHotReloadDeltasRequest
+                    request: sharedSecret => new JsonApplyManagedCodeUpdatesRequest
                     {
                         SharedSecret = sharedSecret,
                         UpdateId = batchId,
@@ -178,9 +178,9 @@ namespace Microsoft.DotNet.HotReload
         public override Task InitialUpdatesAppliedAsync(CancellationToken cancellationToken)
             => Task.CompletedTask;
 
-        private readonly struct JsonApplyHotReloadDeltasRequest
+        private readonly struct JsonApplyManagedCodeUpdatesRequest
         {
-            public string Type => "BlazorHotReloadDeltav3";
+            public string Type => "ApplyManagedCodeUpdates";
             public string? SharedSecret { get; init; }
 
             public int UpdateId { get; init; }
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.HotReload
 
         private readonly struct JsonGetApplyUpdateCapabilitiesRequest
         {
-            public string Type => "BlazorRequestApplyUpdateCapabilities2";
+            public string Type => "GetApplyUpdateCapabilities";
         }
     }
 }

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -76,7 +76,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
 
         // browser page was reloaded after the app restarted:
         await App.WaitUntilOutputContains("""
-            🧪 Received: Reload
+            🧪 Received: {"type":"Reload"}
             """);
 
         // no other browser message sent:
@@ -100,7 +100,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
 
         // browser page was reloaded after the app restarted:
         await App.WaitUntilOutputContains("""
-            🧪 Received: Reload
+            🧪 Received: {"type":"Reload"}
             """);
 
         // no other browser message sent:

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -65,7 +65,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         await App.WaitForOutputLineContaining("Do you want to restart your app?");
 
         await App.WaitUntilOutputContains($$"""
-            🧪 Received: {"type":"HotReloadDiagnosticsv1","diagnostics":[{{jsonErrorMessage}}]}
+            🧪 Received: {"type":"ReportDiagnostics","diagnostics":[{{jsonErrorMessage}}]}
             """);
 
         // auto restart next time:
@@ -93,7 +93,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         await App.WaitForOutputLineContaining("[auto-restart] " + errorMessage);
 
         await App.WaitUntilOutputContains($$"""
-            🧪 Received: {"type":"HotReloadDiagnosticsv1","diagnostics":["Restarting application to apply changes ..."]}
+            🧪 Received: {"type":"ReportDiagnostics","diagnostics":["Restarting application to apply changes ..."]}
             """);
 
         await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
@@ -114,11 +114,11 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         await App.WaitForOutputLineContaining(MessageDescriptor.HotReloadSucceeded);
 
         await App.WaitUntilOutputContains($$"""
-            🧪 Received: {"type":"HotReloadDiagnosticsv1","diagnostics":[]}
+            🧪 Received: {"type":"ReportDiagnostics","diagnostics":[]}
             """);
 
         await App.WaitUntilOutputContains($$"""
-            🧪 Received: {"type":"AspNetCoreHotReloadApplied"}
+            🧪 Received: {"type":"RefreshBrowser"}
             """);
 
         // no other browser message sent:


### PR DESCRIPTION
Since we now deploy middleware and Hot Reload client together we can remove support for previous versions of the protocol between these to components.
We still need to support multiple versions of WASM runtime for projects that reference older versions.

Removes "ping" message. The implementation was incorrect and is no longer needed.

See also https://devdiv.visualstudio.com/DevDiv/_git/WebTools/pullrequest/679114 and 