### PR TITLE
 Improve progress output, rebuild projects serially

### DIFF
--- a/src/BuiltInTools/dotnet-watch/Build/BuildReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/Build/BuildReporter.cs
@@ -102,7 +102,7 @@ internal sealed class BuildReporter(ILogger logger, GlobalOptions options, Envir
         public void ReportOutput()
         {
             _logger.LogInformation("MSBuild output:");
-            BuildOutput.ReportBuildOutput(_logger, Messages, success: false, projectDisplay: null);
+            BuildOutput.ReportBuildOutput(_logger, Messages, success: false);
         }
     }
 }

--- a/src/BuiltInTools/dotnet-watch/CommandLine/EnvironmentOptions.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/EnvironmentOptions.cs
@@ -13,20 +13,15 @@ namespace Microsoft.DotNet.Watch
         MockBrowser = 1 << 1,
 
         /// <summary>
-        /// Elevates the severity of <see cref="MessageDescriptor.WaitingForChanges"/> from <see cref="MessageSeverity.Output"/>.
-        /// </summary>
-        ElevateWaitingForChangesMessageSeverity = 1 << 2,
-
-        /// <summary>
         /// Instead of using <see cref="Console.ReadKey()"/> to watch for Ctrl+C, Ctlr+R, and other keys, read from standard input.
         /// This allows tests to trigger key based events.
         /// </summary>
-        ReadKeyFromStdin = 1 << 3,
+        ReadKeyFromStdin = 1 << 2,
 
         /// <summary>
         /// Redirects the output of the launched browser process to watch output.
         /// </summary>
-        RedirectBrowserOutput = 1 << 4,
+        RedirectBrowserOutput = 1 << 3,
     }
 
     internal sealed record EnvironmentOptions(

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.Watch
                                 try
                                 {
                                     // Build projects sequentially to avoid failed attempts to overwrite dependent project outputs.
-                                    // TODO: Ideally, dotnet build would be able to build multiple projects.
+                                    // TODO: Ideally, dotnet build would be able to build multiple projects. https://github.com/dotnet/sdk/issues/51311
                                     var success = true;
                                     foreach (var projectPath in projectsToRebuild)
                                     {

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "--verbose -bl",
-      "workingDirectory": "C:\\bugs\\9756\\aspire-watch-start-issue\\Aspire.AppHost",
+      "commandLineArgs": "",
+      "workingDirectory": "C:\\temp\\Razor",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)",
         "DCP_IDE_REQUEST_TIMEOUT_SECONDS": "100000",

--- a/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
+++ b/src/BuiltInTools/dotnet-watch/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-watch": {
       "commandName": "Project",
-      "commandLineArgs": "",
-      "workingDirectory": "C:\\temp\\Razor",
+      "commandLineArgs": "--verbose -bl",
+      "workingDirectory": "C:\\bugs\\9756\\aspire-watch-start-issue\\Aspire.AppHost",
       "environmentVariables": {
         "DOTNET_WATCH_DEBUG_SDK_DIRECTORY": "$(RepoRoot)artifacts\\bin\\redist\\$(Configuration)\\dotnet\\sdk\\$(Version)",
         "DCP_IDE_REQUEST_TIMEOUT_SECONDS": "100000",

--- a/src/BuiltInTools/dotnet-watch/UI/BuildOutput.cs
+++ b/src/BuiltInTools/dotnet-watch/UI/BuildOutput.cs
@@ -13,20 +13,8 @@ internal static partial class BuildOutput
     [GeneratedRegex(@"[^:]+: (error|warning) [A-Za-z]+[0-9]+: .+")]
     private static partial Regex GetBuildDiagnosticRegex();
 
-    public static void ReportBuildOutput(ILogger logger, IEnumerable<OutputLine> buildOutput, bool success, string? projectDisplay)
+    public static void ReportBuildOutput(ILogger logger, IEnumerable<OutputLine> buildOutput, bool success)
     {
-        if (projectDisplay != null)
-        {
-            if (success)
-            {
-                logger.Log(MessageDescriptor.BuildSucceeded, projectDisplay);
-            }
-            else
-            {
-                logger.Log(MessageDescriptor.BuildFailed, projectDisplay);
-            }
-        }
-
         foreach (var (line, isError) in buildOutput)
         {
             if (isError)

--- a/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
+++ b/src/BuiltInTools/dotnet-watch/UI/IReporter.cs
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor ProjectsRestarted = Create("Projects restarted ({0})", Emoji.HotReload, MessageSeverity.Verbose);
         public static readonly MessageDescriptor ProjectDependenciesDeployed = Create("Project dependencies deployed ({0})", Emoji.HotReload, MessageSeverity.Verbose);
         public static readonly MessageDescriptor FixBuildError = Create("Fix the error to continue or press Ctrl+C to exit.", Emoji.Watch, MessageSeverity.Warning);
-        public static readonly MessageDescriptor WaitingForChanges = Create("Waiting for changes", Emoji.Watch, MessageSeverity.Verbose);
+        public static readonly MessageDescriptor WaitingForChanges = Create("Waiting for changes", Emoji.Watch, MessageSeverity.Output);
         public static readonly MessageDescriptor LaunchedProcess = Create("Launched '{0}' with arguments '{1}': process id {2}", Emoji.Launch, MessageSeverity.Verbose);
         public static readonly MessageDescriptor HotReloadChangeHandled = Create("Hot reload change handled in {0}ms.", Emoji.HotReload, MessageSeverity.Verbose);
         public static readonly MessageDescriptor HotReloadSucceeded = Create(LogEvents.HotReloadSucceeded, Emoji.HotReload);

--- a/src/BuiltInTools/dotnet-watch/Watch/MsBuildFileSetFactory.cs
+++ b/src/BuiltInTools/dotnet-watch/Watch/MsBuildFileSetFactory.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Watch
                     Logger.LogInformation("MSBuild output from target '{TargetName}':", TargetName);
                 }
 
-                BuildOutput.ReportBuildOutput(Logger, capturedOutput, success, projectDisplay: null);
+                BuildOutput.ReportBuildOutput(Logger, capturedOutput, success);
                 if (!success)
                 {
                     return null;

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -755,7 +755,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 App.DotnetWatchArgs.Clear();
             }
 
-            App.Start(testAsset, [], testFlags: TestFlags.ElevateWaitingForChangesMessageSeverity);
+            App.Start(testAsset, []);
 
             await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
 


### PR DESCRIPTION
Only capture output of `dotnet build` when running in a test environment. In production, let `dotnet build` show build progress.

Output messages that inform of project evaluation start and end, and project load start and end, and include elapsed time.
Output "Waiting for changes" even when `--verbose` is not specified, so that it's clear when dotnet-watch starts to listen for changes. 

When projects need to be rebuilt due to rude edits, rebuild them serially to avoid potential write access issues of dependent project outputs.

<img width="947" height="462" alt="image" src="https://github.com/user-attachments/assets/02e1437c-5abf-4544-b75e-6edddf3f72c1" />
