### PR TITLE
Remove source-build job dependency

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -290,7 +290,6 @@ extends:
             publishAssetsImmediately: true
             dependsOn:
               - Windows_NT
-              - Source_Build_Managed
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -171,7 +171,6 @@ stages:
         publishAssetsImmediately: true
         dependsOn:
           - Windows_NT
-          - Source_Build_Managed
         pool:
           name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64


### PR DESCRIPTION
Follow up on https://github.com/dotnet/sdk/pull/50888

Publishing job had a dependency on source-build job that was removed. Simple fix - verified with [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2816347&view=results).