### PR TITLE
Don't fall back to .NET Standard package pruning for .NET Framework

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -235,12 +235,6 @@ namespace Microsoft.NET.Build.Tasks
         {
             var nugetFramework = new NuGetFramework(targetFrameworkIdentifier, Version.Parse(targetFrameworkVersion));
 
-            //  FrameworkPackages just has data for .NET Framework 4.6.1, so turn on fallback for anything greater than that so it will resolve to the .NET Framework 4.6.1 data
-            if (!acceptNearestMatch && nugetFramework.IsDesktop() && nugetFramework.Version > new Version(4,6,1))
-            {
-                acceptNearestMatch = true;
-            }
-
             var frameworkPackages = FrameworkPackages.GetFrameworkPackages(nugetFramework, [frameworkReference], acceptNearestMatch)
                 .SelectMany(packages => packages)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
@@ -82,6 +82,7 @@ namespace Microsoft.NET.Build.Tests
                 "1.exe",
                 "1.pdb",
                 "1.exe.config",
+                "System.Diagnostics.DiagnosticSource.dll",
             };
 
             foreach (var targetFramework in targetFrameworks)

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -329,8 +329,8 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netstandard1.1", false)]
         [InlineData("netstandard1.0", false)]
         [InlineData("net451", false)]
-        [InlineData("net462")]
-        [InlineData("net481")]
+        [InlineData("net462", false)]
+        [InlineData("net481", false)]
         //  These target frameworks shouldn't prune packages unless explicitly enabled
         [InlineData("net9.0", false, "")]
         [InlineData("netstandard2.1", false, "")]


### PR DESCRIPTION
Fix #51265

### Description

Prevent package pruning from occurring  for .NET Framework.  This was supposed to have occurred with #50816, but we missed that the prune package data logic would fall back to compatible frameworks for .NET Framework, so it ended up falling back to and using the .NET Standard pruning data.

### Customer impact

This will fix various problems when compiling for .NET Framework, such as

- Not being able to use ValueTuple when targeting .NET 4.6.1
- xUnit crashing with "Catastrophic Failure" due to not being able to load System.ValueTuple - https://github.com/xunit/xunit/issues/3413#issuecomment-3404243187

### Regression

Yes

### Testing

Added automated test

Have not yet been able to validate this fixes the xUnit crash

### Risk

Low
