### PR TITLE
Revert Merge branch 'release/9.0.3xx' into darc-release/9.0.3xx-dd349698-0d4f-47dc-984b-9b4cdb884111

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -23,8 +23,6 @@
     <!--  End: Package sources from dotnet-deployment-tools -->
     <!--  Begin: Package sources from dotnet-aspire -->
     <!--  End: Package sources from dotnet-aspire -->
-    <!--  Begin: Package sources from dotnet-emsdk -->
-    <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-emsdk -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,16 +3,16 @@
   <ProductDependencies>
     <Dependency Name="Microsoft.TemplateEngine.Abstractions" Version="9.0.307">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>96bad0d3e0e43c50bdb3e93efc9520724677b22a</Sha>
+      <Sha>f630f0370e54f47e47dff4a6997a016db9528ab2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Mocks" Version="9.0.307-servicing.25510.14">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>96bad0d3e0e43c50bdb3e93efc9520724677b22a</Sha>
+      <Sha>cb70723777d3bc60bd98214eee7c12c4c5882943</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.templating" Version="9.0.112-servicing.25510.16">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.templating" Version="9.0.300-preview.25209.5">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>59a3db5bc1c15050d0327ede05b10738c27e25f8</Sha>
+      <Sha>b73682307aa0128c5edbec94c2e6a070d13ae6bb</Sha>
       <SourceBuild RepoName="templating" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.9">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="Repo version information">
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionFeature>12</VersionFeature>
+    <VersionSDKMinor>3</VersionSDKMinor>
+    <VersionFeature>07</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any
          preview version components or anything else. E.g. 8.0.100, 9.0.300, etc. -->


### PR DESCRIPTION
Reverts a commit that changed the templating dependencies to 9.0.1xx and branding