### PR TITLE
Fix dotnet test detection for dlls

### DIFF
--- a/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
@@ -46,7 +46,7 @@ public class TestCommand(
 
         // Fix for https://github.com/Microsoft/vstest/issues/1453
         // Run dll/exe directly using the VSTestForwardingApp
-        if (ContainsBuiltTestSources(args))
+        if (ContainsBuiltTestSources(parseResult))
         {
             return ForwardToVSTestConsole(parseResult, args, settings, testSessionCorrelationId);
         }
@@ -295,18 +295,14 @@ public class TestCommand(
         }
     }
 
-    private static bool ContainsBuiltTestSources(string[] args)
+    private static bool ContainsBuiltTestSources(ParseResult parseResult)
     {
-        for (int i = 0; i < args.Length; i++)
+        for (int i = 0; i < parseResult.UnmatchedTokens.Count; i++)
         {
-            string arg = args[i];
-            if (arg.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || arg.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            string arg = parseResult.UnmatchedTokens[i];
+            if (!arg.StartsWith("-") &&
+                (arg.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || arg.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)))
             {
-                var previousArg = i > 0 ? args[i - 1] : null;
-                if (previousArg != null &&  CommonOptions.PropertiesOption.Aliases.Contains(previousArg))
-                {
-                    return false;
-                }
                 return true;
             }
         }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -836,6 +836,28 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(1);
         }
 
+        [Fact]
+        public void DistributedLoggerEndingWithDotDllShouldBePassedToMSBuild()
+        {
+            var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp([]);
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
+                                        .WithWorkingDirectory(testProjectDirectory)
+                                        .Execute(ConsoleLoggerOutputNormal.Concat(["-dl:my.dll"]));
+
+            if (!TestContext.IsLocalized())
+            {
+                // This ensures that this was passed to MSBuild and not vstest.console.
+                result.StdOut.Should().Contain("error MSB1021: Cannot create an instance of the logger my.dll.");
+            }
+            else
+            {
+                result.StdOut.Should().Contain("MSB1021");
+            }
+
+            result.ExitCode.Should().Be(1);
+        }
+
         private string CopyAndRestoreVSTestDotNetCoreTestApp(object[] parameters, [CallerMemberName] string callingMethod = "")
         {
             // Copy VSTestCore project in output directory of project dotnet-vstest.Tests


### PR DESCRIPTION
Fixes #51249
Fixes #50923

Before the fix, the added test will fail:

```
    Expected result.StdOut "VSTest version 18.0.0 (x64)" to contain "error MSB1021: Cannot create an instance of the logger my.dll.".
```

In case of failure, StdErr will also contain:

```
The argument --property:VsTestUseMSBuildOutput=false is invalid. Please use the /help option to check the list of valid arguments.
```

This fixes a regression from https://github.com/dotnet/sdk/pull/50926

---

### Description

This fixes a regression in .NET 10 GA for parsing `dotnet test` command for VSTest and deciding whether we should forward to MSBuild and VSTest. If an MSBuild distributed logger is used where the value ends with `.dll`, we incorrectly considered that the given dll is an assembly we want to run tests for, and we offloaded the work to VSTest instead of MSBuild

### Customer impact

Issue was reported by customer in https://github.com/dotnet/sdk/issues/51249. There is some CI scenario that runs the following:

> /Users/builder/azdo/_work/2/s/.dotnet/dotnet test "/Users/builder/azdo/_work/2/s/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj" --logger "trx;LogFileName=Graphics.Tests-Debug.trx" --logger "console;verbosity=normal" --configuration Debug --results-directory "/Users/builder/azdo/_work/2/a/test-results" -dl:CentralLogger,"/Users/builder/azdo/_work/2/s/artifacts/msbuildlogger/Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"*ForwardingLogger,"/Users/builder/azdo/_work/2/s/artifacts/msbuildlogger/Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll" /bl:/Users/builder/azdo/_work/2/a/logs/Graphics.Tests-Debug.binlog /p:VStestUseMSBuildOutput=false

The `-dl` part that ended with `.dll` was causing issues due to incorrect parsing.

### Regression

Yes

### Testing

Added automated test.

### Risk

Low
