### PR TITLE
Set Microsoft_CodeAnalysis_BuildHost_SkipRuntimeVersionCheck

### DIFF
--- a/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/CompilationHandler.cs
@@ -40,12 +40,12 @@ namespace Microsoft.DotNet.Watch
 
         private bool _isDisposed;
 
-        public CompilationHandler(ILoggerFactory loggerFactory, ILogger logger, ProcessRunner processRunner)
+        public CompilationHandler(ILoggerFactory loggerFactory, ILogger logger, ProcessRunner processRunner, EnvironmentOptions environmentOptions)
         {
             _loggerFactory = loggerFactory;
             _logger = logger;
             _processRunner = processRunner;
-            Workspace = new IncrementalMSBuildWorkspace(logger);
+            Workspace = new IncrementalMSBuildWorkspace(logger, environmentOptions);
             _hotReloadService = new WatchHotReloadService(Workspace.CurrentSolution.Services, () => ValueTask.FromResult(GetAggregateCapabilities()));
         }
 

--- a/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/HotReloadDotNetWatcher.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Watch
                     }
 
                     var projectMap = new ProjectNodeMap(evaluationResult.ProjectGraph, _context.Logger);
-                    compilationHandler = new CompilationHandler(_context.LoggerFactory, _context.Logger, _context.ProcessRunner);
+                    compilationHandler = new CompilationHandler(_context.LoggerFactory, _context.Logger, _context.ProcessRunner, _context.EnvironmentOptions);
                     var scopedCssFileHandler = new ScopedCssFileHandler(_context.Logger, _context.BuildLogger, projectMap, _context.BrowserRefreshServerFactory, _context.Options, _context.EnvironmentOptions);
                     var projectLauncher = new ProjectLauncher(_context, projectMap, compilationHandler, iteration);
                     evaluationResult.ItemExclusions.Report(_context.Logger);

--- a/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
+++ b/src/BuiltInTools/dotnet-watch/HotReload/IncrementalMSBuildWorkspace.cs
@@ -16,9 +16,16 @@ internal sealed class IncrementalMSBuildWorkspace : Workspace
 {
     private readonly ILogger _logger;
 
-    public IncrementalMSBuildWorkspace(ILogger logger)
+    public IncrementalMSBuildWorkspace(ILogger logger, EnvironmentOptions environmentOptions)
         : base(MSBuildMefHostServices.DefaultServices, WorkspaceKind.MSBuild)
     {
+        // Allows us to run tests in SDK repo during transition from version N to version N+1.
+        // During this time the version of the runtime may still be N while version of the SDK is on N+1.
+        if (environmentOptions.TestFlags.HasFlag(TestFlags.RunningAsTest))
+        {
+            Environment.SetEnvironmentVariable("Microsoft_CodeAnalysis_BuildHost_SkipRuntimeVersionCheck", "1");
+        }
+
 #pragma warning disable CS0618 // https://github.com/dotnet/sdk/issues/49725
         WorkspaceFailed += (_sender, diag) =>
         {

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -25,7 +25,7 @@ public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTest
         var loggerFactory = new LoggerFactory(reporter);
         var logger = loggerFactory.CreateLogger("Test");
         var projectGraph = ProjectGraphUtilities.TryLoadProjectGraph(options.ProjectPath, globalOptions: [], logger, projectGraphRequired: false, CancellationToken.None);
-        var handler = new CompilationHandler(loggerFactory, logger, processRunner);
+        var handler = new CompilationHandler(loggerFactory, logger, processRunner, environmentOptions);
 
         await handler.Workspace.UpdateProjectConeAsync(hostProject, CancellationToken.None);
 


### PR DESCRIPTION
Allows mismatch between the version of the runtime and the SDK for testing purposes.

See https://github.com/dotnet/roslyn/pull/80767