### PR TITLE
Follow-up to dotnet test parsing

### DIFF
--- a/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
@@ -46,7 +46,10 @@ public class TestCommand(
 
         // Fix for https://github.com/Microsoft/vstest/issues/1453
         // Run dll/exe directly using the VSTestForwardingApp
-        if (ContainsBuiltTestSources(parseResult))
+        // Note: ContainsBuiltTestSources need to know how many settings are there, to skip those from unmatched tokens
+        // When we don't have settings, we pass 0.
+        // When we have settings, we want to exclude the '--' as it doesn't end up in unmatched tokens, so we pass settings.Length - 1
+        if (ContainsBuiltTestSources(parseResult, settings.Length == 0 ? 0 : settings.Length - 1))
         {
             return ForwardToVSTestConsole(parseResult, args, settings, testSessionCorrelationId);
         }
@@ -295,9 +298,9 @@ public class TestCommand(
         }
     }
 
-    private static bool ContainsBuiltTestSources(ParseResult parseResult)
+    private static bool ContainsBuiltTestSources(ParseResult parseResult, int settingsLength)
     {
-        for (int i = 0; i < parseResult.UnmatchedTokens.Count; i++)
+        for (int i = 0; i < parseResult.UnmatchedTokens.Count - settingsLength; i++)
         {
             string arg = parseResult.UnmatchedTokens[i];
             if (!arg.StartsWith("-") &&

--- a/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
@@ -39,22 +40,39 @@ public class TestCommand(
             VSTestTrace.SafeWriteTrace(() => $"Argument list: '{commandLineParameters}'");
         }
 
-        // settings parameters are after -- (including --), these should not be considered by the parser
-        string[] settings = [.. args.SkipWhile(a => a != "--")];
-        // all parameters before --
-        args = [.. args.TakeWhile(a => a != "--")];
+        (args, string[] settings) = SeparateSettingsFromArgs(args);
 
         // Fix for https://github.com/Microsoft/vstest/issues/1453
         // Run dll/exe directly using the VSTestForwardingApp
         // Note: ContainsBuiltTestSources need to know how many settings are there, to skip those from unmatched tokens
         // When we don't have settings, we pass 0.
         // When we have settings, we want to exclude the '--' as it doesn't end up in unmatched tokens, so we pass settings.Length - 1
-        if (ContainsBuiltTestSources(parseResult, settings.Length == 0 ? 0 : settings.Length - 1))
+        if (ContainsBuiltTestSources(parseResult, GetSettingsCount(settings)))
         {
             return ForwardToVSTestConsole(parseResult, args, settings, testSessionCorrelationId);
         }
 
         return ForwardToMsbuild(parseResult, settings, testSessionCorrelationId);
+    }
+
+    internal /*internal for testing*/ static (string[] Args, string[] Settings) SeparateSettingsFromArgs(string[] args)
+    {
+        // settings parameters are after -- (including --), these should not be considered by the parser
+        string[] settings = [.. args.SkipWhile(a => a != "--")];
+        // all parameters before --
+        args = [.. args.TakeWhile(a => a != "--")];
+        return (args, settings);
+    }
+
+    internal /*internal for testing*/ static int GetSettingsCount(string[] settings)
+    {
+        if (settings.Length == 0)
+        {
+            return 0;
+        }
+
+        Debug.Assert(settings[0] == "--", "Settings should start with --");
+        return settings.Length - 1;
     }
 
     private static int ForwardToMsbuild(ParseResult parseResult, string[] settings, string testSessionCorrelationId)
@@ -298,7 +316,7 @@ public class TestCommand(
         }
     }
 
-    private static bool ContainsBuiltTestSources(ParseResult parseResult, int settingsLength)
+    internal /*internal for testing*/ static bool ContainsBuiltTestSources(ParseResult parseResult, int settingsLength)
     {
         for (int i = 0; i < parseResult.UnmatchedTokens.Count - settingsLength; i++)
         {

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -89,9 +89,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Equal("--", settings[0]);
             Assert.Equal(settings.Length, settingsCount + 1);
-            for (int i = 0; i < settingsCount; i++)
+            for (int i = 1; i <= settingsCount; i++)
             {
-                Assert.Equal(settings[i + 1], parseResult.UnmatchedTokens[i]);
+                Assert.Equal(settings[^i], parseResult.UnmatchedTokens[^i]);
             }
 
             TestCommand.ContainsBuiltTestSources(parseResult, settingsCount).Should().Be(false);
@@ -112,9 +112,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Assert.Equal("--", settings[0]);
             Assert.Equal(settings.Length, settingsCount + 1);
-            for (int i = 0; i < settingsCount; i++)
+            for (int i = 1; i <= settingsCount; i++)
             {
-                Assert.Equal(settings[i + 1], parseResult.UnmatchedTokens[i]);
+                Assert.Equal(settings[^i], parseResult.UnmatchedTokens[^i]);
             }
 
             TestCommand.ContainsBuiltTestSources(parseResult, settingsCount).Should().Be(true);

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -83,9 +83,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             (args, string[] settings) = TestCommand.SeparateSettingsFromArgs(args);
             int settingsCount = TestCommand.GetSettingsCount(settings);
             settingsCount.Should().Be(4);
+
+            // Our unmatched tokens for this test case are only the settings (after the `--`).
+            Assert.Equal(settingsCount, parseResult.UnmatchedTokens.Count);
+
             Assert.Equal("--", settings[0]);
             Assert.Equal(settings.Length, settingsCount + 1);
-            Assert.Equal(settingsCount, parseResult.UnmatchedTokens.Count);
             for (int i = 0; i < settingsCount; i++)
             {
                 Assert.Equal(settings[i + 1], parseResult.UnmatchedTokens[i]);
@@ -103,9 +106,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             (args, string[] settings) = TestCommand.SeparateSettingsFromArgs(args);
             int settingsCount = TestCommand.GetSettingsCount(settings);
             settingsCount.Should().Be(1);
+
+            // Our unmatched tokens here are all the settings, plus the abd.dll before the `--`.
+            Assert.Equal(settingsCount + 1, parseResult.UnmatchedTokens.Count);
+
             Assert.Equal("--", settings[0]);
             Assert.Equal(settings.Length, settingsCount + 1);
-            Assert.Equal(settingsCount, parseResult.UnmatchedTokens.Count);
             for (int i = 0; i < settingsCount; i++)
             {
                 Assert.Equal(settings[i + 1], parseResult.UnmatchedTokens[i]);


### PR DESCRIPTION
I forgot to draft https://github.com/dotnet/sdk/pull/51309 after discussion with @nohwnd about more potential issues with the current implementation. So following-up in a new PR as the original PR got merged accidentally.

`ContainsBuiltTestSources` should return true if and only if:

- There is an unmatched token that ends with `.dll`
- That unmatched token isn't coming after `--` which specifies runsettings inline.
- That unmatched token doesn't start with `-` (e.g, `-dl` which is passed down to MSBuild)

For example:

- If we have `dotnet test <options> -- <settings>`, the existence of .dll in the `<settings>` part should have no impact on the choice of vstest.console vs MSBuild.
- However, if `<options>` has something that ends with `.dll` and doesn't start with `-`, we consider that as a "source" to test.

In other words:

Dotnet test detects if dlls were provided, and it offloads to VSTest.Console directly in that case.  In other cases it finds closest csproj or sln, and offloads that to msbuild.
 
`dotnet test my.dll` should offload the run to vstest.console.
 
dotnet test -p:a=my.dll -dl:myDistributedLogger.dll -- MySetting=My.dll  should offload to msbuild, even though we use parameter that is known to dotnet test (-p), parameter that is unknown to dotnet test (-dl), but has to propagate to msbuild. And test specific inline runsettings after the --.
 
NONE of these cases should trigger the offloading to vstest.console.