### PR TITLE
Mark SDK bundle as shipping

### DIFF
--- a/src/Layout/pkg/windows/bundles/sdk/bundle.wixproj
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.wixproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <!-- OutputType determines the extension, .msi, .wixlib, .exe, etc. -->
     <OutputType>Bundle</OutputType>
+    <IsShippingPackage>true</IsShippingPackage>
 
     <!-- Globbing will automatically find any .wxl relative to the project file. Since we're simshipping localized content for
          the bundle UI, we either need to exclude the .wxl files or place them in a directory outside of the project. For simshipping


### PR DESCRIPTION
## Description

Fixes #51234 by marking the bundle as shipping. Based on various binlogs, when the final build is marked as release, the bundle is still considered non-shipping, resulting in the full prerelease values included in the version information passed to the bundle.

## Testing

Verified a local, official build

<img width="1130" height="856" alt="image" src="https://github.com/user-attachments/assets/15b8c804-6e76-4066-a101-de18b4a10d6e" />
