### PR TITLE
[clr-ios] Support targeting Apple mobile platforms with CoreCLR

### DIFF
--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -255,10 +255,8 @@
       <Net110RuntimePackRids Include="
         @(Net100RuntimePackRids);
         ios-arm64;
-        ios-arm;
         iossimulator-arm64;
         iossimulator-x64;
-        iossimulator-x86;
         tvos-arm64;
         tvossimulator-arm64;
         tvossimulator-x64;

--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -252,9 +252,23 @@
         android-x64;
         " />
 
+      <Net110RuntimePackRids Include="
+        @(Net100RuntimePackRids);
+        ios-arm64;
+        ios-arm;
+        iossimulator-arm64;
+        iossimulator-x64;
+        iossimulator-x86;
+        tvos-arm64;
+        tvossimulator-arm64;
+        tvossimulator-x64;
+        maccatalyst-x64;
+        maccatalyst-arm64;
+        " />
+
       <NetCoreAppHostRids Include="@(Net90AppHostRids)" />
 
-      <NetCoreRuntimePackRids Include="@(Net100RuntimePackRids)" />
+      <NetCoreRuntimePackRids Include="@(Net110RuntimePackRids)" />
 
       <!--
         In source-only builds, we build the current RID from source, which may be
@@ -692,7 +706,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.NETCore.App.Ref"
                               TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
+                              RuntimePackRuntimeIdentifiers="@(Net100RuntimePackRids, '%3B')"
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"


### PR DESCRIPTION
## Description

This PR adds Apple mobile rids to the `NetCoreRuntimePackRids` to support targeting CoreCLR.