### PR TITLE
[dotnet-cli] prompt for target framework using `Spectre.Console`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,6 +113,7 @@
     <PackageVersion Include="runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
+    <PackageVersion Include="Spectre.Console" Version="0.52.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersPackageVersion)" />
     <PackageVersion Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1790,6 +1790,18 @@ The current OutputType is '{2}'.</value>
     <value>Unable to run your project
 Your project targets multiple frameworks. Specify which framework to run using '{0}'.</value>
   </data>
+  <data name="RunCommandSelectTargetFrameworkPrompt" xml:space="preserve">
+    <value>Select the target framework to run:</value>
+  </data>
+  <data name="RunCommandMoreFrameworksText" xml:space="preserve">
+    <value>Move up and down to reveal more frameworks</value>
+  </data>
+  <data name="RunCommandAvailableTargetFrameworks" xml:space="preserve">
+    <value>Available target frameworks:</value>
+  </data>
+  <data name="RunCommandExampleText" xml:space="preserve">
+    <value>Example</value>
+  </data>
   <data name="RunCommandProjectAbbreviationDeprecated" xml:space="preserve">
     <value>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</value>
     <comment>{Locked="--project"}</comment>

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -197,14 +197,10 @@ public class RunCommand
         Debug.Assert(ProjectFileFullPath is not null);
 
         var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(MSBuildArgs);
-        
-        // Check if we're in an interactive terminal
-        bool isInteractive = !Console.IsInputRedirected && !Console.IsOutputRedirected;
-
         if (TargetFrameworkSelector.TrySelectTargetFramework(
             ProjectFileFullPath,
             globalProperties,
-            isInteractive,
+            Interactive,
             out string? selectedFramework))
         {
             // If a framework was selected, add it to MSBuildArgs

--- a/src/Cli/dotnet/Commands/Run/TargetFrameworkSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/TargetFrameworkSelector.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
 using Microsoft.DotNet.Cli.Utils;
 using Spectre.Console;
 
@@ -33,8 +34,17 @@ internal static class TargetFrameworkSelector
         }
 
         // Evaluate the project to get TargetFrameworks
-        using var collection = new ProjectCollection(globalProperties: globalProperties);
-        var project = collection.LoadProject(projectFilePath);
+        Microsoft.Build.Evaluation.Project project;
+        try
+        {
+            using var collection = new ProjectCollection(globalProperties: globalProperties);
+            project = collection.LoadProject(projectFilePath);
+        }
+        catch (InvalidProjectFileException)
+        {
+            // Invalid project file, return true to continue for normal error handling
+            return true;
+        }
 
         string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
 

--- a/src/Cli/dotnet/Commands/Run/TargetFrameworkSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/TargetFrameworkSelector.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli.Utils;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Cli.Commands.Run;
+
+internal static class TargetFrameworkSelector
+{
+    /// <summary>
+    /// Evaluates the project to determine if target framework selection is needed.
+    /// If the project has multiple target frameworks and none was specified, prompts the user to select one.
+    /// </summary>
+    /// <param name="projectFilePath">Path to the project file</param>
+    /// <param name="globalProperties">Global properties for MSBuild evaluation</param>
+    /// <param name="isInteractive">Whether we're running in interactive mode (can prompt user)</param>
+    /// <param name="selectedFramework">The selected target framework, or null if not needed</param>
+    /// <returns>True if we should continue, false if we should exit with error</returns>
+    public static bool TrySelectTargetFramework(
+        string projectFilePath,
+        Dictionary<string, string> globalProperties,
+        bool isInteractive,
+        out string? selectedFramework)
+    {
+        selectedFramework = null;
+
+        // If a framework is already specified, no need to prompt
+        if (globalProperties.TryGetValue("TargetFramework", out var existingFramework) && !string.IsNullOrWhiteSpace(existingFramework))
+        {
+            return true;
+        }
+
+        // Evaluate the project to get TargetFrameworks
+        using var collection = new ProjectCollection(globalProperties: globalProperties);
+        var project = collection.LoadProject(projectFilePath);
+
+        string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
+
+        // If there's no TargetFrameworks property or only one framework, no selection needed
+        if (string.IsNullOrWhiteSpace(targetFrameworks))
+        {
+            return true;
+        }
+
+        var frameworks = targetFrameworks.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+        // If there's only one framework, no selection needed
+        if (frameworks.Length <= 1)
+        {
+            return true;
+        }
+
+        if (isInteractive)
+        {
+            selectedFramework = PromptForTargetFramework(frameworks);
+            return selectedFramework != null;
+        }
+        else
+        {
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework"));
+            Reporter.Error.WriteLine();
+            Reporter.Error.WriteLine(CliCommandStrings.RunCommandAvailableTargetFrameworks);
+            Reporter.Error.WriteLine();
+            
+            for (int i = 0; i < frameworks.Length; i++)
+            {
+                Reporter.Error.WriteLine($"  {i + 1}. {frameworks[i]}");
+            }
+            
+            Reporter.Error.WriteLine();
+            Reporter.Error.WriteLine($"{CliCommandStrings.RunCommandExampleText}: dotnet run --framework {frameworks[0]}");
+            Reporter.Error.WriteLine();
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Prompts the user to select a target framework from the available options using Spectre.Console.
+    /// </summary>
+    private static string? PromptForTargetFramework(string[] frameworks)
+    {
+        try
+        {
+            var prompt = new SelectionPrompt<string>()
+                .Title($"[cyan]{Markup.Escape(CliCommandStrings.RunCommandSelectTargetFrameworkPrompt)}[/]")
+                .PageSize(10)
+                .MoreChoicesText($"[grey]({Markup.Escape(CliCommandStrings.RunCommandMoreFrameworksText)})[/]")
+                .AddChoices(frameworks);
+            
+            return Spectre.Console.AnsiConsole.Prompt(prompt);
+        }
+        catch (Exception)
+        {
+            // If Spectre.Console fails (e.g., terminal doesn't support it), return null
+            return null;
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2702,6 +2702,11 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <target state="translated">Příkaz rozhraní .NET pro spuštění</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Sestavování...</target>
@@ -2711,6 +2716,11 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Spuštění cíle {0} ke zjištění příkazů spuštění pro tento projekt se nezdařilo. Opravte chyby a upozornění a spusťte je znovu.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Cílem projektu je více architektur. Pomocí parametru {0} určete, která architektura se má spustit.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Upozornění NETSDK1174: Zkratka -p pro --project je zastaralá. Použijte prosím --project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2702,6 +2702,11 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <target state="translated">.NET-Befehl "Run"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Buildvorgang wird ausgeführt...</target>
@@ -2711,6 +2716,11 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Das {0} Ziel ausführen, um zu ermitteln, dass ein Fehler bei den Ausführungsbefehlen für dieses Projekt aufgetreten ist. Beheben Sie die Fehler und Warnungen, und führen Sie dies erneut aus.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches Framework ausgeführt werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Warnung NETSDK1174: Die Abkürzung von „-p“ für „--project“ ist veraltet. Verwenden Sie „--project“.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2702,6 +2702,11 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <target state="translated">Ejecutar comando de .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Compilando...</target>
@@ -2711,6 +2716,11 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Error al ejecutar el destino {0} para detectar comandos de ejecución para este proyecto. Corrija los errores y advertencias y vuelva a ejecutarlo.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Su proyecto tiene como destino varias plataformas. Especifique la que quiere usar mediante "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Advertencia NETSDK1174: La abreviatura de -p para --project está en desuso. Use --project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2702,6 +2702,11 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <target state="translated">Commande d'exécution .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Génération...</target>
@@ -2711,6 +2716,11 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">L’exécution de la {0} cible pour découvrir les commandes d’exécution a échoué pour ce projet. Corrigez les erreurs et les avertissements, puis réexécutez.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à l'aide de '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">AVERTISSEMENT NETSDK1174 : l’abréviation de-p pour--project est déconseillée. Veuillez utiliser--project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2702,6 +2702,11 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <target state="translated">Comando esecuzione .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Compilazione...</target>
@@ -2711,6 +2716,11 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">L'esecuzione della destinazione {0} per individuare i comandi di esecuzione non è riuscita per questo progetto. Correggere gli errori e gli avvisi ed eseguire di nuovo.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Il progetto è destinato a più framework. Specificare il framework da eseguire con '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Avviso NETSDK1174: l'abbreviazione di -p per --project è deprecata. Usare --project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2702,6 +2702,11 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">.NET Run コマンド</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">ビルドしています...</target>
@@ -2711,6 +2716,11 @@ The default is to publish a framework-dependent application.</source>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">このプロジェクトで実行コマンドを検出するための {0} ターゲットの実行に失敗しました。エラーと警告を修正して、もう一度実行してください。</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 プロジェクトは複数のフレームワークを対象としています。'{0}' を使用して、実行するフレームワークを指定してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: --project の省略形である -p は推奨されていません。--project を使用してください。</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2702,6 +2702,11 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">.NET 실행 명령</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">빌드하는 중...</target>
@@ -2711,6 +2716,11 @@ The default is to publish a framework-dependent application.</source>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">이 프로젝트에 대해 실행 명령을 검색하기 위해 {0} 대상을 실행하지 못했습니다. 오류 및 경고를 수정하고 다시 실행합니다.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 프로젝트에서 여러 프레임워크를 대상으로 합니다. '{0}'을(를) 사용하여 실행할 프레임워크를 지정하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">경고 NETSDK1174: --project에 대한 약어 -p는 더 이상 사용되지 않습니다. --project를 사용하세요.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2702,6 +2702,11 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <target state="translated">Uruchamianie polecenia platformy .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Trwa kompilowanie...</target>
@@ -2711,6 +2716,11 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Uruchomienie obiektu docelowego {0} w celu odnalezienia poleceń przebiegu dla tego projektu nie powiodło się. Usuń błędy i ostrzeżenia, a następnie uruchom ponownie.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy użyciu elementu „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Ostrzeżenie NETSDK1174: Skrót -p dla polecenia --project jest przestarzały. Użyj polecenia --project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2702,6 +2702,11 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <target state="translated">Comando Run do .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Compilando...</target>
@@ -2711,6 +2716,11 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Falha na execução do destino {0} para descobrir comandos de execução para este projeto. Corrija os erros e avisos e execute novamente.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Ele tem diversas estruturas como destino. Especifique que estrutura executar usando '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Aviso NETSDK1174: a abreviação de-p para--project é preterida. Use --project.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2702,6 +2702,11 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">Команда .NET Run</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Сборка…</target>
@@ -2711,6 +2716,11 @@ The default is to publish a framework-dependent application.</source>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Не удалось запустить цель {0} для обнаружения команд выполнения для этого проекта. Исправьте ошибки и предупреждения и повторите попытку.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Проект предназначен для нескольких платформ. Укажите платформу, для которой следует запустить проект, с помощью "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Предупреждение NETSDK1174: сокращение "-p" для "--project" не рекомендуется. Используйте "--project".</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2702,6 +2702,11 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <target state="translated">.NET Run Komutu</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">Derleniyor...</target>
@@ -2711,6 +2716,11 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">Çalıştırma komutlarını bulmak için {0} hedefini çalıştırma bu proje için başarısız oldu. Hataları ve uyarıları düzeltip yeniden çalıştırın.</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'ün çalıştırılacağını belirtin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">Uyarı NETSDK1174: --project için -p kısaltması kullanımdan kaldırıldı. Lütfen --project kullanın.</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2702,6 +2702,11 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">.NET 运行命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">正在生成...</target>
@@ -2711,6 +2716,11 @@ The default is to publish a framework-dependent application.</source>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">为此项目运行 {0} 目标以发现运行命令失败。请修复错误和警告，然后再次运行。</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 你的项目面向多个框架。请指定要使用“{0}”运行的框架。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: 已弃用使用缩写“-p”来代表“--project”。请使用“--project”。</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2702,6 +2702,11 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">.NET 執行命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandAvailableTargetFrameworks">
+        <source>Available target frameworks:</source>
+        <target state="new">Available target frameworks:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandBuilding">
         <source>Building...</source>
         <target state="translated">正在建置...</target>
@@ -2711,6 +2716,11 @@ The default is to publish a framework-dependent application.</source>
         <source>Running the {0} target to discover run commands failed for this project. Fix the errors and warnings and run again.</source>
         <target state="translated">執行 {0} 目標以探索對此專案的執行命令失敗。修正錯誤和警告，然後重新執行。</target>
         <note>{0} is the name of an MSBuild target</note>
+      </trans-unit>
+      <trans-unit id="RunCommandExampleText">
+        <source>Example</source>
+        <target state="new">Example</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandException">
         <source>The build failed. Fix the build errors and run again.</source>
@@ -2759,10 +2769,20 @@ Your project targets multiple frameworks. Specify which framework to run using '
 您的專案以多重架構為目標。請使用 '{0}' 指定要執行的架構。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunCommandMoreFrameworksText">
+        <source>Move up and down to reveal more frameworks</source>
+        <target state="new">Move up and down to reveal more frameworks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunCommandProjectAbbreviationDeprecated">
         <source>Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.</source>
         <target state="translated">警告 NETSDK1174: --project 已取代縮寫 -p。請使用 --project。</target>
         <note>{Locked="--project"}</note>
+      </trans-unit>
+      <trans-unit id="RunCommandSelectTargetFrameworkPrompt">
+        <source>Select the target framework to run:</source>
+        <target state="new">Select the target framework to run:</target>
+        <note />
       </trans-unit>
       <trans-unit id="RunCommandSpecifiedFileIsNotAValidProject">
         <source>'{0}' is not a valid project file.</source>

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.NET.HostModel" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" />
+    <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />

--- a/test/TestAssets/TestProjects/DotnetRunMultiTarget/DotnetRunMultiTarget.csproj
+++ b/test/TestAssets/TestProjects/DotnetRunMultiTarget/DotnetRunMultiTarget.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net9.0;$(CurrentTargetFramework)</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/test/TestAssets/TestProjects/DotnetRunMultiTarget/Program.cs
+++ b/test/TestAssets/TestProjects/DotnetRunMultiTarget/Program.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace DotNetRunMultiTarget
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from multi-targeted app!");
+            Console.WriteLine($"Target Framework: {AppContext.TargetFrameworkName}");
+            Console.WriteLine($"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -104,7 +104,7 @@ public class GivenDotnetRunSelectsTargetFramework : SdkTest
                 "--framework", ToolsetInfo.CurrentTargetFramework,
                 "-p:TargetFramework=net8.0")
             .Should().Pass()
-            .And.HaveStdOutContaining("Hello from multi-targeted app!");
+            .And.HaveStdOutContaining($"Target Framework: {ToolsetInfo.CurrentTargetFrameworkMoniker}");
     }
 
     [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -93,22 +93,18 @@ public class GivenDotnetRunSelectsTargetFramework : SdkTest
     [Fact]
     public void ItPrefersExplicitFrameworkOptionOverProperty()
     {
-        var testInstance = _testAssetsManager.CopyTestAsset(
-                "NETFrameworkReferenceNETStandard20",
-                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+        var testInstance = _testAssetsManager.CopyTestAsset("DotnetRunMultiTarget")
             .WithSource();
-
-        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
 
         // Pass both --framework and -p:TargetFramework
         // The --framework option should take precedence
         new DotnetCommand(Log, "run")
-            .WithWorkingDirectory(projectDirectory)
+            .WithWorkingDirectory(testInstance.Path)
             .Execute(
                 "--framework", ToolsetInfo.CurrentTargetFramework,
-                "-p:TargetFramework=net462")
+                "-p:TargetFramework=net8.0")
             .Should().Pass()
-            .And.HaveStdOutContaining("This string came from the test library!");
+            .And.HaveStdOutContaining("Hello from multi-targeted app!");
     }
 
     [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Cli.Utils;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Cli.Run.Tests;
 
@@ -165,6 +165,13 @@ public class GivenDotnetRunSelectsTargetFramework : SdkTest
     [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkMoniker)]
     public void ItRunsDifferentFrameworksInMultiTargetedApp(string targetFramework, string expectedMoniker)
     {
+        // Skip net8.0 and net9.0 on arm64 as they may not be available on CI
+        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 &&
+            (targetFramework == "net8.0" || targetFramework == "net9.0"))
+        {
+            return;
+        }
+
         var testInstance = _testAssetsManager.CopyTestAsset("DotnetRunMultiTarget")
             .WithSource();
 

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -176,33 +176,6 @@ public class GivenDotnetRunSelectsTargetFramework : SdkTest
     }
 
     [Fact]
-    public void ItRunsSingleTFMProjectWithoutFrameworkSpecification()
-    {
-        var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld")
-            .WithSource();
-
-        new DotnetCommand(Log, "run")
-            .WithWorkingDirectory(testInstance.Path)
-            .Execute()
-            .Should().Pass()
-            .And.HaveStdOutContaining("Hello World!");
-    }
-
-    [Fact]
-    public void ItRunsProjectWithOnlyTargetFrameworkProperty()
-    {
-        // Projects with only TargetFramework (not TargetFrameworks) should run without needing --framework
-        var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")
-            .WithSource();
-
-        new DotnetCommand(Log, "run")
-            .WithWorkingDirectory(testInstance.Path)
-            .Execute()
-            .Should().Pass()
-            .And.HaveStdOutContaining("Hello World!");
-    }
-
-    [Fact]
     public void ItTreatsEmptyFrameworkSpecificationAsNotSpecified()
     {
         var testInstance = _testAssetsManager.CopyTestAsset(

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Run.Tests;
+
+/// <summary>
+/// Integration tests for target framework selection in dotnet run
+/// </summary>
+public class GivenDotnetRunSelectsTargetFramework : SdkTest
+{
+    public GivenDotnetRunSelectsTargetFramework(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    [Fact]
+    public void ItRunsMultiTFMProjectWhenFrameworkIsSpecified()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework)
+            .Should().Pass()
+            .And.HaveStdOutContaining("This string came from the test library!");
+    }
+
+    [Fact]
+    public void ItFailsInNonInteractiveMode_WhenMultiTFMProjectHasNoFrameworkSpecified()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        var result = new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--no-interactive");
+
+        result.Should().Fail();
+        
+        if (!TestContext.IsLocalized())
+        {
+            result.Should().HaveStdErrContaining("Unable to run your project");
+            result.Should().HaveStdErrContaining("multiple frameworks");
+            result.Should().HaveStdErrContaining("--framework");
+        }
+    }
+
+    [Fact]
+    public void ItRunsWithShortFormFrameworkOption()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("-f", ToolsetInfo.CurrentTargetFramework)
+            .Should().Pass()
+            .And.HaveStdOutContaining("This string came from the test library!");
+    }
+
+    [Fact]
+    public void ItRunsWithFrameworkPropertySyntax()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("-p:TargetFramework=" + ToolsetInfo.CurrentTargetFramework)
+            .Should().Pass()
+            .And.HaveStdOutContaining("This string came from the test library!");
+    }
+
+    [Fact]
+    public void ItPrefersExplicitFrameworkOptionOverProperty()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        // Pass both --framework and -p:TargetFramework
+        // The --framework option should take precedence
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .Execute(
+                "--framework", ToolsetInfo.CurrentTargetFramework,
+                "-p:TargetFramework=net462")
+            .Should().Pass()
+            .And.HaveStdOutContaining("This string came from the test library!");
+    }
+
+    [Fact]
+    public void ItShowsErrorMessageWithAvailableFrameworks_InNonInteractiveMode()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        var result = new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--no-interactive");
+
+        result.Should().Fail();
+        
+        if (!TestContext.IsLocalized())
+        {
+            // Should show the "Unable to run your project" message
+            result.Should().HaveStdErrContaining("Unable to run your project");
+            result.Should().HaveStdErrContaining("Your project targets multiple frameworks");
+            
+            // Should show available frameworks
+            result.Should().HaveStdErrContaining("Available target frameworks:");
+            
+            // Should show example command
+            result.Should().HaveStdErrContaining("Example:");
+            result.Should().HaveStdErrContaining("dotnet run --framework");
+        }
+    }
+
+    [Fact]
+    public void ItFailsForMultiTargetedAppWithoutFramework_InNonInteractiveMode()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset("DotnetRunMultiTarget")
+            .WithSource();
+
+        var result = new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--no-interactive");
+
+        result.Should().Fail();
+        
+        if (!TestContext.IsLocalized())
+        {
+            result.Should().HaveStdErrContaining("Unable to run your project");
+            result.Should().HaveStdErrContaining("multiple frameworks");
+        }
+    }
+
+    [Theory]
+    [InlineData("net8.0", ".NETCoreApp,Version=v8.0")]
+    [InlineData("net9.0", ".NETCoreApp,Version=v9.0")]
+    [InlineData(ToolsetInfo.CurrentTargetFramework, ToolsetInfo.CurrentTargetFrameworkMoniker)]
+    public void ItRunsDifferentFrameworksInMultiTargetedApp(string targetFramework, string expectedMoniker)
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset("DotnetRunMultiTarget")
+            .WithSource();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--framework", targetFramework)
+            .Should().Pass()
+            .And.HaveStdOutContaining($"Target Framework: {expectedMoniker}");
+    }
+
+    [Fact]
+    public void ItRunsSingleTFMProjectWithoutFrameworkSpecification()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset("HelloWorld")
+            .WithSource();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining("Hello World!");
+    }
+
+    [Fact]
+    public void ItRunsProjectWithOnlyTargetFrameworkProperty()
+    {
+        // Projects with only TargetFramework (not TargetFrameworks) should run without needing --framework
+        var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")
+            .WithSource();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining("Hello World!");
+    }
+
+    [Fact]
+    public void ItTreatsEmptyFrameworkSpecificationAsNotSpecified()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        var result = new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("-p:TargetFramework=", "--no-interactive"); // Empty string
+
+        result.Should().Fail();
+        
+        if (!TestContext.IsLocalized())
+        {
+            result.Should().HaveStdErrContaining("Unable to run your project");
+            result.Should().HaveStdErrContaining("multiple frameworks");
+        }
+    }
+
+    [Fact]
+    public void ItTreatsWhitespaceFrameworkSpecificationAsNotSpecified()
+    {
+        var testInstance = _testAssetsManager.CopyTestAsset(
+                "NETFrameworkReferenceNETStandard20",
+                testAssetSubdirectory: TestAssetSubdirectories.DesktopTestProjects)
+            .WithSource();
+
+        string projectDirectory = Path.Combine(testInstance.Path, "MultiTFMTestApp");
+
+        var result = new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(projectDirectory)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("-p:TargetFramework=   ", "--no-interactive"); // Whitespace
+
+        result.Should().Fail();
+        
+        if (!TestContext.IsLocalized())
+        {
+            result.Should().HaveStdErrContaining("Unable to run your project");
+            result.Should().HaveStdErrContaining("multiple frameworks");
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsTargetFramework.cs
@@ -91,23 +91,6 @@ public class GivenDotnetRunSelectsTargetFramework : SdkTest
     }
 
     [Fact]
-    public void ItPrefersExplicitFrameworkOptionOverProperty()
-    {
-        var testInstance = _testAssetsManager.CopyTestAsset("DotnetRunMultiTarget")
-            .WithSource();
-
-        // Pass both --framework and -p:TargetFramework
-        // The --framework option should take precedence
-        new DotnetCommand(Log, "run")
-            .WithWorkingDirectory(testInstance.Path)
-            .Execute(
-                "--framework", ToolsetInfo.CurrentTargetFramework,
-                "-p:TargetFramework=net8.0")
-            .Should().Pass()
-            .And.HaveStdOutContaining($"Target Framework: {ToolsetInfo.CurrentTargetFrameworkMoniker}");
-    }
-
-    [Fact]
     public void ItShowsErrorMessageWithAvailableFrameworks_InNonInteractiveMode()
     {
         var testInstance = _testAssetsManager.CopyTestAsset(


### PR DESCRIPTION
Implements the first part of the spec mentioned in:

https://github.com/dotnet/sdk/blob/522c88a6abfc4a011556f839d15844d07ba62cd9/documentation/specs/dotnet-run-for-maui.md?plain=1#L35-L46

Add interactive target framework selection to `dotnet run`

When running a multi-targeted project without specifying `--framework`, `dotnet run` now:

* Prompts interactively (using `Spectre.Console`) to select a framework with arrow keys

* Shows a formatted error list in non-interactive mode with available frameworks

* Handles selection early before project build/evaluation

* Removes redundant multi-TFM error checking from `ThrowUnableToRunError()`

* Adds a few unit tests to validate these changes.

This is currently WIP, as it introduces a "pre-built" `Spectre.Console` that I will need to setup in source-build in a PRs elsewhere.