### PR TITLE
`dnup` CI Pipeline

### DIFF
--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -1,0 +1,265 @@
+# Pipeline: https://dev.azure.com/dnceng/internal/_build?definitionId=
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - dnup
+
+pr:
+  branches:
+    include:
+    - dnup
+
+parameters:
+# When true, runs the pipeline in the same way as the PR pipeline.
+- name: runTestBuild
+  displayName: Run A Test Build
+  type: boolean
+  default: false
+- name: enableArm64Job
+  displayName: Enables the ARM64 job
+  type: boolean
+  default: false
+
+variables:
+- template: /eng/pipelines/templates/variables/sdk-defaults.yml
+# Variables used: DncEngInternalBuildPool
+- template: /eng/common/templates-official/variables/pool-providers.yml
+# Helix testing requires a token when internally run.
+# Variables used: HelixApiAccessToken
+- group: DotNet-HelixApi-Access
+- group: AzureDevOps-Artifact-Feeds-Pats
+# Allows Arcade to run a signed build by disabling post-build signing for release-branch builds or manual builds that are not running tests.
+- ${{ if and(eq(parameters.runTestBuild, false), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
+  - name: PostBuildSign
+    value: false
+# Provides TSA variables for automatic bug reporting.
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - group: DotNet-CLI-SDLValidation-Params
+### LOCAL ONLY ###
+- name: _publishArgument
+  value: -publish
+- name: _signArgument
+  value: -sign /p:SignCoreSdk=true
+- name: _officialBuildProperties
+  # The OfficialBuilder property is set to Microsoft for the official build only.
+  # This property is checked in Directory.Build.props and adds the MICROSOFT_ENABLE_TELEMETRY constant.
+  # This constant is used in CompileOptions.cs to set both TelemetryOptOutDefault and TelemetryOptOutDefaultString.
+  value: /p:DotNetPublishUsingPipelines=true /p:OfficialBuilder=Microsoft /p:OfficialBuildId=$(Build.BuildNumber)
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    containers:
+      azureLinux30Amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
+      binskim:
+        enabled: true
+      ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+        componentgovernance:
+          # Refdoc: https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
+          ignoreDirectories: artifacts, .packages
+
+    stages:
+    ############### BUILD STAGE ###############
+    - stage: build
+      displayName: Build
+      jobs:
+      ############### WINDOWS ###############
+      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+        parameters:
+          pool:
+            name: $(DncEngInternalBuildPool)
+            image: windows.vs2022.amd64
+            os: windows
+          helixTargetQueue: windows.amd64.vs2022.pre
+          oneESCompat:
+            templateFolderName: templates-official
+            publishTaskPrefix: 1ES.
+          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+          locBranch: release/10.0.1xx
+          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+          preSteps:
+          - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
+            displayName: Create artifacts/bin directory
+          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            timeoutInMinutes: 180
+            windowsJobParameterSets:
+            ### OFFICIAL ###
+            - categoryName: Official
+              publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
+              officialBuildProperties: $(_officialBuildProperties) /p:BuildWorkloads=true
+              enableDefaultArtifacts: true
+              runTests: false
+              publishRetryConfig: true
+              variables:
+                _SignType: real
+            - categoryName: Official
+              targetArchitecture: x86
+              publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              runTests: false
+              variables:
+                _SignType: real
+              dependsOn: Official_windows_x64
+              downloadManifestMsiPackages: true
+            - categoryName: Official
+              targetArchitecture: arm64
+              publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              runTests: false
+              variables:
+                _SignType: real
+              dependsOn: Official_windows_x64
+              downloadManifestMsiPackages: true
+
+      ############### LINUX ###############
+      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+        parameters:
+          pool:
+            name: $(DncEngInternalBuildPool)
+            image: 1es-ubuntu-2204
+            os: linux
+          helixTargetQueue: ubuntu.2204.amd64
+          oneESCompat:
+            templateFolderName: templates-official
+            publishTaskPrefix: 1ES.
+          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            timeoutInMinutes: 90
+            linuxJobParameterSets:
+            ### OFFICIAL ###
+            # Note: These builds are also glibc like the glibc category, but that category uses containers, and doesn't publish zips and tarballs.
+            - categoryName: Official
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: $(linuxOsglibcProperties)
+              runTests: false
+            - categoryName: Official
+              targetArchitecture: arm
+              runtimeIdentifier: linux-arm
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: $(linuxOsglibcProperties)
+              runTests: false
+            - categoryName: Official
+              targetArchitecture: arm64
+              runtimeIdentifier: linux-arm64
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: $(linuxOsglibcProperties)
+              runTests: false
+            ### glibc ###
+            - categoryName: glibc
+              # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
+              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
+              runTests: false
+            - categoryName: glibc
+              targetArchitecture: arm64
+              runtimeIdentifier: linux-arm64
+              # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
+              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
+              runTests: false
+            ### musl ###
+            - categoryName: musl
+              container: azureLinux30Amd64
+              runtimeIdentifier: linux-musl-x64
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              # Use HostOSName when running on alpine.
+              osProperties: /p:HostOSName=linux-musl
+              # SBOM generation is not supported for alpine.
+              enableSbom: false
+              runTests: false
+              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+              disableJob: true
+            - categoryName: musl
+              container: azureLinux30Amd64
+              targetArchitecture: arm
+              runtimeIdentifier: linux-musl-arm
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: /p:OSName=linux-musl
+              runTests: false
+              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+              disableJob: true
+            - categoryName: musl
+              targetArchitecture: arm64
+              runtimeIdentifier: linux-musl-arm64
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              osProperties: /p:OSName=linux-musl
+              runTests: false
+
+      ############### MACOS ###############
+      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+        parameters:
+          pool:
+            name: Azure Pipelines
+            image: macOS-latest
+            os: macOS
+          helixTargetQueue: osx.15.amd64
+          oneESCompat:
+            templateFolderName: templates-official
+            publishTaskPrefix: 1ES.
+          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
+            timeoutInMinutes: 90
+            macOSJobParameterSets:
+            ### OFFICIAL ###
+            - categoryName: Official
+              runtimeIdentifier: osx-x64
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              runTests: false
+            - categoryName: Official
+              targetArchitecture: arm64
+              runtimeIdentifier: osx-arm64
+              publishArgument: $(_publishArgument)
+              officialBuildProperties: $(_officialBuildProperties)
+              runTests: false
+ 
+    ############### PUBLISH STAGE ###############
+    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      - stage: publish
+        displayName: Publish
+        dependsOn: []
+        jobs:
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            isAssetlessBuild: true
+            repositoryAlias: self
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-windows-2022
+              os: windows

--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -5,11 +5,13 @@ trigger:
   branches:
     include:
     - dnup
+    - release/dnup
 
 pr:
   branches:
     include:
     - dnup
+    - release/dnup
 
 parameters:
 # When true, runs the pipeline in the same way as the PR pipeline.
@@ -83,22 +85,19 @@ extends:
 
     stages:
     ############### BUILD STAGE ###############
-    - stage: build
-      displayName: Build
-      jobs:
       ############### WINDOWS ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+      - template: /eng/pipelines/templates/jobs/dnup-tests.yml@self
         parameters:
           pool:
-            name: $(DncEngInternalBuildPool)
+            name: $($(DncEngInternalBuildPool))
             image: windows.vs2022.amd64
             os: windows
+            emoji: 🪟
           helixTargetQueue: windows.amd64.vs2022.pre
           oneESCompat:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          locBranch: release/10.0.1xx
           # WORKAROUND: BinSkim requires the folder exist prior to scanning.
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
@@ -116,144 +115,14 @@ extends:
               publishRetryConfig: true
               variables:
                 _SignType: real
-            - categoryName: Official
-              targetArchitecture: x86
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-              dependsOn: Official_windows_x64
-              downloadManifestMsiPackages: true
-            - categoryName: Official
-              targetArchitecture: arm64
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-              dependsOn: Official_windows_x64
-              downloadManifestMsiPackages: true
 
-      ############### LINUX ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-        parameters:
-          pool:
-            name: $(DncEngInternalBuildPool)
-            image: 1es-ubuntu-2204
-            os: linux
-          helixTargetQueue: ubuntu.2204.amd64
-          oneESCompat:
-            templateFolderName: templates-official
-            publishTaskPrefix: 1ES.
-          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            timeoutInMinutes: 90
-            linuxJobParameterSets:
-            ### OFFICIAL ###
-            # Note: These builds are also glibc like the glibc category, but that category uses containers, and doesn't publish zips and tarballs.
-            - categoryName: Official
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm
-              runtimeIdentifier: linux-arm
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            ### glibc ###
-            - categoryName: glibc
-              # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
-              runTests: false
-            - categoryName: glibc
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
-              runTests: false
-            ### musl ###
-            - categoryName: musl
-              container: azureLinux30Amd64
-              runtimeIdentifier: linux-musl-x64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              # Use HostOSName when running on alpine.
-              osProperties: /p:HostOSName=linux-musl
-              # SBOM generation is not supported for alpine.
-              enableSbom: false
-              runTests: false
-              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-              disableJob: true
-            - categoryName: musl
-              container: azureLinux30Amd64
-              targetArchitecture: arm
-              runtimeIdentifier: linux-musl-arm
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: /p:OSName=linux-musl
-              runTests: false
-              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-              disableJob: true
-            - categoryName: musl
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-musl-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: /p:OSName=linux-musl
-              runTests: false
-
-      ############### MACOS ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-        parameters:
-          pool:
-            name: Azure Pipelines
-            image: macOS-latest
-            os: macOS
-          helixTargetQueue: osx.15.amd64
-          oneESCompat:
-            templateFolderName: templates-official
-            publishTaskPrefix: 1ES.
-          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
-            timeoutInMinutes: 90
-            macOSJobParameterSets:
-            ### OFFICIAL ###
-            - categoryName: Official
-              runtimeIdentifier: osx-x64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm64
-              runtimeIdentifier: osx-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
- 
-    ############### PUBLISH STAGE ###############
+    ############### PACKAGE STAGE ###############
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
       - stage: publish
         displayName: Publish
         dependsOn: []
         jobs:
-        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        - template: /eng/pipelines/templates/jobs/dnup-library-package.yml@self
           parameters:
             publishUsingPipelines: true
             publishAssetsImmediately: true

--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -124,10 +124,6 @@ extends:
         jobs:
         - template: /eng/pipelines/templates/jobs/dnup-library-package.yml@self
           parameters:
-            publishUsingPipelines: true
-            publishAssetsImmediately: true
-            isAssetlessBuild: true
-            repositoryAlias: self
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-windows-2022

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -14,6 +14,7 @@
     <IsShipping>false</IsShipping>
     <Title>.NET Installation Library</Title>
     <Version>1.0.0-alpha</Version>
+    <PackageVersion Condition="'$(PackageVersion)'==''">$(Version)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -8,8 +8,12 @@
 
     <!-- Strong naming not needed on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
     <PackageId>Microsoft.Dotnet.Installation</PackageId>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsShipping>false</IsShipping>
+    <Title>.NET Installation Library</Title>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -8,11 +8,13 @@
 
     <!-- Strong naming not needed on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <PackageId>Microsoft.Dotnet.Installation</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
-    <!-- TODO: Create logging / progress abstraction and remove this dipendency from the library -->
+    <!-- TODO: Create logging / progress abstraction and remove this dependency from the library -->
     <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 


### PR DESCRIPTION
- Enables us to produce a library package for testing.
- Helps us check compliance with the product before public release by hooking into an official CI pipeline.

The pipeline is certainly not done, however, I will merge it so that the yml file exists, so we can point the internal pipeline to a yml file. Then when engineering services makes the pipeline to run, I can actually run and test the pipeline 😁 