### PR TITLE
Add progress abstraction for installation library

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/IProgressReporter.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/IProgressReporter.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Dotnet.Installation;
+
+public interface IProgressTarget
+{
+    public IProgressReporter CreateProgressReporter();
+}
+
+public interface IProgressReporter : IDisposable
+{
+    public IProgressTask AddTask(string description, double maxValue);
+}
+
+public interface IProgressTask
+{
+    double Value { get; set; }
+}
+
+public class NullProgressTarget : IProgressTarget
+{
+    public IProgressReporter CreateProgressReporter() => new NullProgressReporter();
+    class NullProgressReporter : IProgressReporter
+    {
+        public void Dispose()
+        {
+        }
+        public IProgressTask AddTask(string description, double maxValue)
+        {
+            return new NullProgressTask();
+        }
+    }
+    class NullProgressTask : IProgressTask
+    {
+        public double Value { get; set; }
+    }
+}

--- a/src/Installer/Microsoft.Dotnet.Installation/IProgressTarget.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/IProgressTarget.cs
@@ -19,7 +19,11 @@ public interface IProgressReporter : IDisposable
 
 public interface IProgressTask
 {
+    string Description { get; set; }
     double Value { get; set; }
+    double MaxValue { get; set; }
+
+
 }
 
 public class NullProgressTarget : IProgressTarget
@@ -32,11 +36,18 @@ public class NullProgressTarget : IProgressTarget
         }
         public IProgressTask AddTask(string description, double maxValue)
         {
-            return new NullProgressTask();
+            return new NullProgressTask(description);
         }
     }
     class NullProgressTask : IProgressTask
     {
+        public NullProgressTask(string description)
+        {
+            Description = description;
+        }
+
         public double Value { get; set; }
+        public string Description { get; set; }
+        public double MaxValue { get; set; }
     }
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/InstallerFactory.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/InstallerFactory.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Dotnet.Installation;
 
 public static class InstallerFactory
 {
-    public static IDotnetInstaller CreateInstaller()
+    public static IDotnetInstaller CreateInstaller(IProgressTarget progressTarget)
     {
-        return new DotnetInstaller();
+        return new DotnetInstaller(progressTarget);
     }
 
     public static IDotnetReleaseInfoProvider CreateReleaseInfoProvider()

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstaller.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstaller.cs
@@ -5,17 +5,23 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Deployment.DotNet.Releases;
-using Spectre.Console;
 
 namespace Microsoft.Dotnet.Installation.Internal
 {
     internal class DotnetInstaller : IDotnetInstaller
     {
+        IProgressTarget _progressTarget;
+
+        public DotnetInstaller(IProgressTarget progressTarget)
+        {
+            _progressTarget = progressTarget;
+        }
+
         public void Install(DotnetInstallRoot dotnetRoot, InstallComponent component, ReleaseVersion version)
         {
             var installRequest = new DotnetInstallRequest(dotnetRoot, new UpdateChannel(version.ToString()), component, new InstallRequestOptions());
 
-            using ArchiveDotnetExtractor installer = new(installRequest, version, noProgress: true);
+            using ArchiveDotnetExtractor installer = new(installRequest, version, _progressTarget);
             installer.Prepare();
             installer.Commit();
         }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DownloadProgressReporter.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DownloadProgressReporter.cs
@@ -1,16 +1,15 @@
 using System;
-using Spectre.Console;
 using Microsoft.Dotnet.Installation;
 
 namespace Microsoft.Dotnet.Installation.Internal
 {
-    public class SpectreDownloadProgressReporter : IProgress<DownloadProgress>
+    public class DownloadProgressReporter : IProgress<DownloadProgress>
     {
-        private readonly ProgressTask _task;
+        private readonly IProgressTask _task;
         private readonly string _description;
         private long? _totalBytes;
 
-        public SpectreDownloadProgressReporter(ProgressTask task, string description)
+        public DownloadProgressReporter(IProgressTask task, string description)
         {
             _task = task;
             _description = description;

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -19,8 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
-    <!-- TODO: Create logging / progress abstraction and remove this dependency from the library -->
-    <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 
 </Project>

--- a/src/Installer/dnup/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dnup/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -209,7 +209,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
 
         //  TODO: Implement transaction / rollback?
 
-        SpectreAnsiConsole.MarkupInterpolated($"Installing .NET SDK [blue]{resolvedVersion}[/] to [blue]{resolvedInstallPath}[/]...");
+        SpectreAnsiConsole.MarkupLineInterpolated($"Installing .NET SDK [blue]{resolvedVersion}[/] to [blue]{resolvedInstallPath}[/]...");
 
         DotnetInstall? mainInstall;
 

--- a/src/Installer/dnup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dnup/InstallerOrchestratorSingleton.cs
@@ -51,8 +51,7 @@ internal class InstallerOrchestratorSingleton
             }
         }
 
-        //  TODO: Change noProgress logic so that output should still be printed, just not updates
-        IProgressTarget progressTarget = noProgress ? new NullProgressTarget() : new SpectreProgressTarget();
+        IProgressTarget progressTarget = noProgress ? new NonUpdatingProgressTarget() : new SpectreProgressTarget();
 
         using ArchiveDotnetExtractor installer = new(installRequest, versionToInstall, progressTarget);
         installer.Prepare();

--- a/src/Installer/dnup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dnup/InstallerOrchestratorSingleton.cs
@@ -51,7 +51,10 @@ internal class InstallerOrchestratorSingleton
             }
         }
 
-        using ArchiveDotnetExtractor installer = new(installRequest, versionToInstall, noProgress);
+        //  TODO: Change noProgress logic so that output should still be printed, just not updates
+        IProgressTarget progressTarget = noProgress ? new NullProgressTarget() : new SpectreProgressTarget();
+
+        using ArchiveDotnetExtractor installer = new(installRequest, versionToInstall, progressTarget);
         installer.Prepare();
 
         // Extract and commit the install to the directory

--- a/src/Installer/dnup/NonUpdatingProgressTarget.cs
+++ b/src/Installer/dnup/NonUpdatingProgressTarget.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+public class NonUpdatingProgressTarget : IProgressTarget
+{
+    public IProgressReporter CreateProgressReporter() => new Reporter();
+
+    class Reporter : IProgressReporter
+    {
+        List<ProgressTaskImpl> _tasks = new();
+
+        public IProgressTask AddTask(string description, double maxValue)
+        {
+            var task = new ProgressTaskImpl(description)
+            {
+                MaxValue = maxValue
+            };
+            _tasks.Add(task);
+            Spectre.Console.AnsiConsole.WriteLine(description + "...");
+            return task;
+        }
+        public void Dispose()
+        {
+            foreach (var task in _tasks)
+            {
+                task.Complete();
+            }
+        }
+    }
+
+    class ProgressTaskImpl : IProgressTask
+    {
+        bool _completed = false;
+        double _value;
+
+        public ProgressTaskImpl(string description)
+        {
+            Description = description;
+        }
+
+        public double Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                if (_value >= MaxValue)
+                {
+                    Complete();
+                }
+            }
+        }
+        public string Description { get; set; }
+        public double MaxValue { get; set; }
+
+        public void Complete()
+        {
+            if (!_completed)
+            {
+                Spectre.Console.AnsiConsole.MarkupLine($"[green]Completed:[/] {Description}");
+                _completed = true;
+            }
+        }
+    }
+}

--- a/src/Installer/dnup/SpectreProgressTarget.cs
+++ b/src/Installer/dnup/SpectreProgressTarget.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using Spectre.Console;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+public class SpectreProgressTarget : IProgressTarget
+{
+    public IProgressReporter CreateProgressReporter() => new Reporter();
+
+    class Reporter : IProgressReporter
+    {
+        TaskCompletionSource _overallTask = new TaskCompletionSource();
+        ProgressContext _progressContext;
+
+        public Reporter()
+        {
+            TaskCompletionSource<ProgressContext> tcs = new TaskCompletionSource<ProgressContext>();
+            var progressTask = AnsiConsole.Progress().StartAsync(async ctx =>
+            {
+                tcs.SetResult(ctx);
+                await _overallTask.Task;
+            });
+
+            _progressContext = tcs.Task.GetAwaiter().GetResult();
+        }
+
+        public IProgressTask AddTask(string description, double maxValue)
+        {
+            return new ProgressTaskImpl(_progressContext.AddTask(description, maxValue: maxValue));
+        }
+
+        public void Dispose()
+        {
+            _overallTask.SetResult();
+        }
+    }
+
+    class ProgressTaskImpl : IProgressTask
+    {
+        private readonly Spectre.Console.ProgressTask _task;
+        public ProgressTaskImpl(Spectre.Console.ProgressTask task)
+        {
+            _task = task;
+        }
+
+        public double Value
+        {
+            get => _task.Value;
+            set => _task.Value = value;
+        }
+    }
+}

--- a/src/Installer/dnup/SpectreProgressTarget.cs
+++ b/src/Installer/dnup/SpectreProgressTarget.cs
@@ -54,5 +54,15 @@ public class SpectreProgressTarget : IProgressTarget
             get => _task.Value;
             set => _task.Value = value;
         }
+        public string Description
+        {
+            get => _task.Description;
+            set => _task.Description = value;
+        }
+        public double MaxValue
+        {
+            get => _task.MaxValue;
+            set => _task.MaxValue = value;
+        }
     }
 }

--- a/test/dnup.Tests/LibraryTests.cs
+++ b/test/dnup.Tests/LibraryTests.cs
@@ -29,7 +29,7 @@ public class LibraryTests
         var latestVersion = releaseInfoProvider.GetLatestVersion(InstallComponent.SDK, channel);
         Log.WriteLine($"Latest version for channel '{channel}' is '{latestVersion}'");
 
-        var installer = InstallerFactory.CreateInstaller();
+        var installer = InstallerFactory.CreateInstaller(new NullProgressTarget());
 
         using var testEnv = DnupTestUtilities.CreateTestEnvironment();
 


### PR DESCRIPTION
Installation library no longer uses Spectre.Console directly but now goes through an `IProgressTarget` interface.  Updated the `--nno-progress` option to use a different implementation of this interface, rather than passing the option as a parameter down to the library.

Currently, the output looks like this (without progress updates and with them):

<img width="1115" height="571" alt="image" src="https://github.com/user-attachments/assets/1272d6f8-5a11-4bac-8b7e-155d4c627803" />
