### PR TITLE
Sign `Microsoft.Installation` library package

### DIFF
--- a/eng/pipelines/templates/jobs/dnup/dnup-library-package.yml
+++ b/eng/pipelines/templates/jobs/dnup/dnup-library-package.yml
@@ -44,7 +44,6 @@ jobs:
         targetPath: '$(Build.SourcesDirectory)/artifacts/packages/Release/NonShipping/'
         artifactName: 'dnup-library-packages'
         publishLocation: Container
-
     steps:
     - ${{ if eq(parameters.pool.os, 'windows') }}:
       - powershell: |
@@ -54,5 +53,11 @@ jobs:
           & .\.dotnet\dotnet build test\dnup.Tests\dnup.Tests.csproj -c Release
         displayName: 💻 Build Windows
       - powershell: |
-           & .\.dotnet\dotnet pack .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.csproj
+          & .\.dotnet\dotnet pack .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.csproj
         displayName: 📦 Package dnup library
+      - powershell: |
+          & .\.dotnet\dotnet build .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.sign.proj
+        displayName: 🖋️ Sign dnup library packages with full.sign.proj (no sign target)
+      - powershell: |
+          & .\.dotnet\dotnet build .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.sign.proj /t:Sign
+        displayName: 🖋️ Sign dnup library packages with arcade signtool

--- a/eng/pipelines/templates/jobs/dnup/dnup-library-package.yml
+++ b/eng/pipelines/templates/jobs/dnup/dnup-library-package.yml
@@ -56,8 +56,5 @@ jobs:
           & .\.dotnet\dotnet pack .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.csproj
         displayName: 📦 Package dnup library
       - powershell: |
-          & .\.dotnet\dotnet build .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.sign.proj
-        displayName: 🖋️ Sign dnup library packages with full.sign.proj (no sign target)
-      - powershell: |
           & .\.dotnet\dotnet build .\src\Installer\Microsoft.Dotnet.Installation\Microsoft.Dotnet.Installation.sign.proj /t:Sign
         displayName: 🖋️ Sign dnup library packages with arcade signtool

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.sign.proj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.sign.proj
@@ -19,14 +19,6 @@
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />
 
-  <!-- The name of the .NET specific certificate, which is a general replacement for Microsoft400
-       If UseDotNetCert is specific in a repo's eng/Signing.props, all usage of Microsoft400 is replaced
-       with MicrosoftDotNet500 -->
-  <PropertyGroup>
-    <DotNetCertificateName>MicrosoftDotNet500</DotNetCertificateName>
-    <UseDotNetCertificate>false</UseDotNetCertificate>
-  </PropertyGroup>
-
   <ItemGroup>
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".dll" CertificateName="Microsoft400" />

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.sign.proj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.sign.proj
@@ -1,0 +1,66 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Determine repository root when the pipeline variables are unavailable (e.g. local invocations). -->
+    <_RepoRoot Condition="'$(RepoRoot)' != ''">$(RepoRoot)</_RepoRoot>
+    <_RepoRoot Condition="'$(_RepoRoot)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\'))</_RepoRoot>
+
+    <!-- Allow callers to override these directories; fall back to repo-relative defaults. -->
+    <PackagesDir Condition="'$(PackagesDir)' == ''">$(_RepoRoot)artifacts\packages\Release\</PackagesDir>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(_RepoRoot)artifacts\obj\Sign\</IntermediateOutputPath>
+    <LogDir Condition="'$(LogDir)' == ''">$(_RepoRoot)artifacts\log\Sign\</LogDir>
+
+    <!-- SignTool requires explicit dotnet path; default to repo-local SDK. -->
+    <DotNetPath Condition="'$(DotNetPath)' == ''">$(_RepoRoot).dotnet\dotnet.exe</DotNetPath>
+
+    <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
+    <MicroBuild_SigningEnabled>true</MicroBuild_SigningEnabled>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />
+
+  <!-- The name of the .NET specific certificate, which is a general replacement for Microsoft400
+       If UseDotNetCert is specific in a repo's eng/Signing.props, all usage of Microsoft400 is replaced
+       with MicrosoftDotNet500 -->
+  <PropertyGroup>
+    <DotNetCertificateName>MicrosoftDotNet500</DotNetCertificateName>
+    <UseDotNetCertificate>false</UseDotNetCertificate>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
+    <FileExtensionSignInfo Include=".dll" CertificateName="Microsoft400" />
+    <FileSignInfo Include="Microsoft.Dotnet.Installation.dll" CertificateName="Microsoft400" />
+    <FileSignInfo Include="Microsoft.Dotnet.Installation*.nupkg" CertificateName="NuGet" />
+    <ItemsToSign Include="$(PackagesDir)**\Microsoft.Dotnet.Installation*.nupkg">
+      <Authenticode>NuGet</Authenticode>
+    </ItemsToSign>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(SignType)' == ''">
+      <SignType>test</SignType>
+      <TestSign>true</TestSign>
+  </PropertyGroup>
+
+ <PropertyGroup Condition="'$(TestSign)' == ''">
+      <TestSign>false</TestSign>
+  </PropertyGroup>
+
+
+  <Target Name="Sign" AfterTargets="Build">
+    <Microsoft.DotNet.SignTool.SignToolTask
+        DryRun="false"
+        TestSign="$(TestSign)"
+        ItemsToSign="@(ItemsToSign)"
+        FileSignInfo="@(FileSignInfo)"
+        FileExtensionSignInfo="@(FileExtensionSignInfo)"
+        TempDir="$(IntermediateOutputPath)"
+        LogDir="$(LogDir)"
+        DoStrongNameCheck="false"
+        DotNetPath="$(DotNetPath)"
+        MicroBuildCorePath="$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.core\$(MicrosoftVisualStudioEngMicroBuildCoreVersion)"
+        SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
+        >
+    </Microsoft.DotNet.SignTool.SignToolTask>
+  </Target>
+</Project>


### PR DESCRIPTION
- CI now properly signs the library package for internal consumption.

Resolves https://github.com/dotnet/sdk/issues/50621 (there should be another tracking issue for signing the library)

The actual additions:
`src/Installer/Microsoft.Dotnet.Installation/Install.sign.proj` -> uses `SignTool` to sign the `dnup library` package with NuGet's Authenticode.
`eng/pipelines/templates/jobs/dnup/dnup-library-package.yml` -> now runs the .sign.proj to sign the library package.

We still need to push the package to a public stream for consumption, aka dotnet/tools feed in dnceng-public. That's being tracked here: https://github.com/dotnet/sdk/issues/51513

Notes:
- `.sign.proj` is used over `.signproj` as a convention because `code` and other editors don't have xml highlighting for `.signproj`
- I considered the ESRP/MicroBuild/SignTool task but felt this was more traceable to call via MSBuild - since the binlog shows all of the 'hidden' arcade magic and variables that flow around.
- I was surprised to find that having a very simple `FilesToSign` itemgroup (as many other repos do) and that following the internal documentation for signing a nuget package did not work. `SignTool` was the most robust way I could find to do it. 

For the first example of a successful run, See the drop at https://dev.azure.com/dnceng/internal/_build/results?buildId=2828736&view=artifacts&pathAsName=false&type=publishedArtifacts, download the `dnup-library-packages-unsigned` artifact (which is incorrect, and fixed), clone dotnet/arcade, build, and run
`.\artifacts\bin\Microsoft.DotNet.SignCheck\x86\Debug\net472\Microsoft.DotNet.SignCheck.exe -v Detailed -i "drop_path"`
or
`dotnet nuget verify "drop_path" -v Detailed`
