### PR TITLE
Stable versioning for placeholder MSI

### DIFF
--- a/src/Layout/pkg/windows/msis/placeholder/placeholder.wixproj
+++ b/src/Layout/pkg/windows/msis/placeholder/placeholder.wixproj
@@ -1,5 +1,9 @@
 ﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project Sdk="Microsoft.WixToolset.Sdk">
+  <PropertyGroup>
+    <IsShippingPackage>true</IsShippingPackage>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix5\product\dotnethome_x64.wxs" />
     <Compile Include="..\provider.wxs" />


### PR DESCRIPTION
Fixes the issue with .NET SDK version in ARP. Placeholder MSI is installed with VS and it holds the value that is displayed in ARP, in `ProductName` property.

This PR changes how `Version` property is evaluated to ensure the prerelease suffix is not included.

Tested in [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2827257&view=artifacts&pathAsName=false&type=publishedArtifacts)

Similar fix was previously made for bundle package.