### PR TITLE
Add a template for servicing pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/servicing.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing.md
@@ -1,0 +1,34 @@
+---
+name: Request Servicing Approval
+about: Prepare a PR that needs to be approved by .NET Servicing, for example to apply to a released version of the .NET SDK.
+---
+
+<!--
+Please use this template when creating a pull request that requires servicing approval.
+After creating the PR, apply the "Servicing-consider" label so that it can be located and
+reviewed by the servicing group.
+You can also send mail if an asynchronous review is preferred.
+-->
+
+Fixes #<issue_number>
+
+## Customer Issue
+
+<!-- Describe the impact of the issue here. Be as customer-focused as possible. Customer Impact is a key part of the servicing approval rubric. Make sure to think about how frequent the issue is, how many customers it affects, and the ease/availability of a workaround. -->
+
+## Description
+
+<!-- Describe the changes made in this PR at a high level. Remember to, as a rule, keep changes as targeted as possible for servicing-fixes. Push any refactoring to in-development branches. -->
+
+## Was this a regression?
+
+- [ ] Yes
+- [ ] No
+
+## Testing
+
+<!-- Describe the testing that has been done to validate the changes in this PR. -->
+
+## Risk
+
+<!-- Describe the risk associated with this PR. For example, is it low risk because it only affects a small area of code, or high risk because it changes fundamental behavior? -->


### PR DESCRIPTION
This is a very simple PR template since we often have servicing PRs. It won't be _automatically_ available due to limitations in GitHub UX, but it is usable via URI query strings, and having it in-repo should make it more findable.