### PR TITLE
Remove razor_tooling from format example ci test

### DIFF
--- a/eng/dotnet-format/dotnet-format-integration.yml
+++ b/eng/dotnet-format/dotnet-format-integration.yml
@@ -50,13 +50,6 @@ parameters:
     _branchName: "main"
     _sha: "1b2ff365399ab6736a9ea4c98ab1b60acda5d917"
     _useParentSdk: 0
-  - Name: razor_tooling
-    _repo: "https://github.com/dotnet/razor"
-    _repoName: "dotnet/razor"
-    _targetSolution: "Razor.sln"
-    _branchName: "main"
-    _sha: "ecb4b595e3322a18c240f50a763868540f51eaaa"
-    _useParentSdk: 0
 
 - name: timeoutInMinutes
   type: number


### PR DESCRIPTION
As discussed in https://github.com/dotnet/sdk/pull/51376, dotnet format launches another process for doing MSBuild invocations; the issue is we're trying to talk on the named pipe to that process and it just ... never connects. This appears to be an issue thats consistent across main and 10.0.1xx at the very least and only in razor_tooling.

It might be due to some workspace configuration for razor. The dotnet-format team is working on a PR, but for now to unblock we will do this.