### PR TITLE
Add IsShipping property to FileBasedPrograms project file

### DIFF
--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/Microsoft.DotNet.FileBasedPrograms.Package.csproj
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/Microsoft.DotNet.FileBasedPrograms.Package.csproj
@@ -12,6 +12,7 @@
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
     <IsSourcePackage>true</IsSourcePackage>
     <PackageId>Microsoft.DotNet.FileBasedPrograms</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
It looks like absence of this property may have caused this package to fail to get published in the official build.

See the HotReload client package for comparison: https://github.com/dotnet/sdk/blob/main/src/BuiltInTools/HotReloadClient/Microsoft.DotNet.HotReload.Client.Package.csproj

@MiYanni @jjonescz @333fred for review.