### PR TITLE
Include FileBasedPrograms package project in the solution

### DIFF
--- a/sdk.slnx
+++ b/sdk.slnx
@@ -64,6 +64,7 @@
     <Project Path="src/Cli/dotnet/dotnet.csproj" />
     <Project Path="src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj" />
     <Project Path="src/Cli/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj" />
+    <Project Path="src/Cli/Microsoft.DotNet.FileBasedPrograms/Microsoft.DotNet.FileBasedPrograms.Package.csproj" />
     <Project Path="src/Cli/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.csproj" />
     <Project Path="src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj" />
   </Folder>


### PR DESCRIPTION
Follow up to #51581 and #51373.

PackageArtifacts for FileBasedPrograms were still not present in the official build after the IsShipping change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2832403&view=artifacts&pathAsName=false&type=publishedArtifacts.

Kinda funny how far I managed to get without ever actually adding the new project to the solution. (It looks like the project was built in CI basically just due to being referenced by `dotnet.csproj`.)

This time I ran `build.cmd -pack` locally and saw that the FileBasedPrograms nupkg with an up to date timestamp actually appears in my local `artifacts/packages` folder. That did not happen prior to this change. So I feel somewhat more confident that *stuff really should get published this time*.

@jjonescz if you are able to sign off once you see this is green that would be great, I am hoping I can get up in the morning and actually start using the package.