### PR TITLE
Explore if allowPrerelease fixes vs22 preview rejections

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,6 +16,9 @@
   "native-tools": {
     "cmake": "latest"
   },
+  "sdk": {
+    "allowPrerelease": true
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25515.2",
     "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.25515.2",


### PR DESCRIPTION
I edited the json wrong in https://github.com/dotnet/sdk/pull/51558. If this is all that's needed, the fix can be simpler. I think this likely isn't the case since there are tests with a custom global.json file, but it's worth trying.