### PR TITLE
Avoid loading middleware when Hot Reload is disabled

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
@@ -25,4 +25,10 @@
   </ItemGroup>
 
   <Import Project="..\Web.Middleware\Microsoft.DotNet.HotReload.Web.Middleware.projitems" Label="Shared" />
+
+  <ItemGroup>
+    <EmbeddedResource Update="@(EmbeddedResource)">
+      <LogicalName>%(FileName)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -84,15 +84,17 @@ internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPa
             throw new InvalidOperationException("Server not started");
         }
 
-        builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint] = string.Join(",", _lazyHost.EndPoints);
-        builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSKey] = _sharedSecretProvider.GetPublicKey();
-        builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadVirtualDirectory] = _lazyHost.VirtualDirectory;
-
-        builder.InsertListItem(MiddlewareEnvironmentVariables.DotNetStartupHooks, middlewareAssemblyPath, Path.PathSeparator);
-        builder.InsertListItem(MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies, Path.GetFileNameWithoutExtension(middlewareAssemblyPath), MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssembliesSeparator);
-
         if (enableHotReload)
         {
+            // If Hot Reload is disabled do not load the middleware and do not set env variables that configure its behavior.
+
+            builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint] = string.Join(",", _lazyHost.EndPoints);
+            builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSKey] = _sharedSecretProvider.GetPublicKey();
+            builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadVirtualDirectory] = _lazyHost.VirtualDirectory;
+
+            builder.InsertListItem(MiddlewareEnvironmentVariables.DotNetStartupHooks, middlewareAssemblyPath, Path.PathSeparator);
+            builder.InsertListItem(MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies, Path.GetFileNameWithoutExtension(middlewareAssemblyPath), MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssembliesSeparator);
+
             // Note:
             // Microsoft.AspNetCore.Components.WebAssembly.Server.ComponentWebAssemblyConventions and Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware
             // expect DOTNET_MODIFIABLE_ASSEMBLIES to be set in the blazor-devserver process, even though we are not performing Hot Reload in this process.

--- a/src/BuiltInTools/Web.Middleware/BrowserRefreshMiddleware.cs
+++ b/src/BuiltInTools/Web.Middleware/BrowserRefreshMiddleware.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -21,7 +22,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         private static readonly MediaTypeHeaderValue s_applicationJsonMediaType = new("application/json");
         private readonly RequestDelegate _next;
         private readonly ILogger<BrowserRefreshMiddleware> _logger;
-        private string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
+        private string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue(MiddlewareEnvironmentVariables.DotNetModifiableAssemblies);
         private string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
 
         public BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger)

--- a/src/BuiltInTools/Web.Middleware/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/Web.Middleware/BrowserScriptMiddleware.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
@@ -58,8 +59,8 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
         internal static ReadOnlyMemory<byte> GetBrowserRefreshJS()
         {
-            var endpoint = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT")!;
-            var serverKey = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY") ?? string.Empty;
+            var endpoint = Environment.GetEnvironmentVariable(MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint) ?? "";
+            var serverKey = Environment.GetEnvironmentVariable(MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSKey) ?? "";
 
             return GetWebSocketClientJavaScript(endpoint, serverKey);
         }

--- a/src/BuiltInTools/Web.Middleware/BrowserScriptMiddleware.cs
+++ b/src/BuiltInTools/Web.Middleware/BrowserScriptMiddleware.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         // for backwards compat only
         internal static ReadOnlyMemory<byte> GetBlazorHotReloadJS()
         {
-            var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorHotReload.js";
+            var jsFileName = "BlazorHotReload.js";
             using var stream = new MemoryStream();
             var manifestStream = typeof(BrowserScriptMiddleware).Assembly.GetManifestResourceStream(jsFileName)!;
             manifestStream.CopyTo(stream);
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
         internal static ReadOnlyMemory<byte> GetWebSocketClientJavaScript(string hostString, string serverKey)
         {
-            var jsFileName = "Microsoft.AspNetCore.Watch.BrowserRefresh.WebSocketScriptInjection.js";
+            var jsFileName = "WebSocketScriptInjection.js";
             using var reader = new StreamReader(typeof(BrowserScriptMiddleware).Assembly.GetManifestResourceStream(jsFileName)!);
             var script = reader.ReadToEnd()
                 .Replace("{{hostString}}", hostString)

--- a/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.Package.csproj
+++ b/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.Package.csproj
@@ -39,6 +39,10 @@
     <Using Remove="@(Using)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\HotReloadClient\Web\MiddlewareEnvironmentVariables.cs" Link="MiddlewareEnvironmentVariables.cs" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddJSFilesToSourcePackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
@@ -50,7 +54,7 @@
     <ItemGroup>
       <!-- Must be in 'cs' directory since NuGet filters the files based on consuming project language -->
       <_File Include="$(MSBuildProjectDirectory)\**\*.js" TargetDir="contentFiles/cs/$(TargetFramework)" BuildAction="EmbeddedResource" />
-      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.Package.csproj
+++ b/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.Package.csproj
@@ -38,4 +38,19 @@
   <ItemGroup>
     <Using Remove="@(Using)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddJSFilesToSourcePackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!--
+    Add .js files as embedded resources in the source package.
+  -->
+  <Target Name="_AddJSFilesToSourcePackage">
+    <ItemGroup>
+      <!-- Must be in 'cs' directory since NuGet filters the files based on consuming project language -->
+      <_File Include="$(MSBuildProjectDirectory)\**\*.js" TargetDir="contentFiles/cs/$(TargetFramework)" BuildAction="EmbeddedResource" />
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.projitems
+++ b/src/BuiltInTools/Web.Middleware/Microsoft.DotNet.HotReload.Web.Middleware.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)**\*.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\HotReloadClient\Web\MiddlewareEnvironmentVariables.cs" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)**\*.js" />
   </ItemGroup>
 </Project>

--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -34,19 +34,21 @@ public class BrowserRefreshServerTests
         var envBuilder = new Dictionary<string, string>();
         server.ConfigureLaunchEnvironment(envBuilder, enableHotReload);
 
-        Assert.True(envBuilder.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
-
-        var expected = new List<string>()
-        {
-            "ASPNETCORE_AUTO_RELOAD_VDIR=/test/virt/dir",
-            "ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT=http://test.endpoint",
-            "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=" + middlewareFileName,
-            "DOTNET_STARTUP_HOOKS=" + middlewarePath,
-        };
+        var expected = new List<string>();
 
         if (enableHotReload)
         {
+            Assert.True(envBuilder.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
+
+            expected.Add("ASPNETCORE_AUTO_RELOAD_VDIR=/test/virt/dir");
+            expected.Add("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT=http://test.endpoint");
             expected.Add("DOTNET_MODIFIABLE_ASSEMBLIES=debug");
+            expected.Add("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=" + middlewareFileName);
+            expected.Add("DOTNET_STARTUP_HOOKS=" + middlewarePath);
+        }
+        else
+        {
+            Assert.False(envBuilder.ContainsKey("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
         }
 
         if (logLevel == LogLevel.Trace)


### PR DESCRIPTION
When Hot Reload is disabled we should not load middleware (e.g. in Release builds).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2581354