### PR TITLE
Ensure that a virtual project doesn't pick up BaseOutputPath/BaseIntermediateOutputPath from Directory.Build.props

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1180,11 +1180,16 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             // Note that ArtifactsPath needs to be specified before Sdk.props
             // (usually it's recommended to specify it in Directory.Build.props
             // but importing Sdk.props manually afterwards also works).
+            //
+            // An empty value is always given for BaseIntermediateOutputPath and BaseOutputPath, to ensure that
+            // the SDK targets will initialize them based on ArtifactsPath, and not use values for those paths coming in from Directory.Build.props.
             writer.WriteLine($"""
                 <Project>
 
                   <PropertyGroup>
                     <IncludeProjectNameInArtifactsPaths>false</IncludeProjectNameInArtifactsPaths>
+                    <BaseIntermediateOutputPath></BaseIntermediateOutputPath>
+                    <BaseOutputPath></BaseOutputPath>
                     <ArtifactsPath>{EscapeValue(artifactsPath)}</ArtifactsPath>
                     <PublishDir>artifacts/$(MSBuildProjectName)</PublishDir>
                     <PackageOutputPath>artifacts/$(MSBuildProjectName)</PackageOutputPath>


### PR DESCRIPTION
See https://github.com/microsoft/vscode-dotnettools/issues/2443#issuecomment-3499545901

I think when a Directory.Build.props specifies `BaseOutputPath`, `BaseIntermediateOutputPath`, or `ArtifactsPath`, it should basically be ignored in virtual projects. The reason is that we strongly want to avoid putting the artifacts for those projects in the source tree with a file-based app.

Right now the test is failing, I need to come back and investigate in more details. I also think the `<ArtifactsPath>` in D.B.props case should be tested, I didn't see an existing test.

Opening PR now to try and share understanding of the issue and get buy-in on proposed solution.