### PR TITLE
[8.0.4xx] Disable Registry Related Containers Tests

### DIFF
--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -22,7 +22,7 @@ public class CreateImageIndexTests
         _testOutput = testOutput;
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public async Task CreateImageIndex_Baseline()
     {
         DirectoryInfo newProjectDir = CreateNewProject();

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -20,7 +20,7 @@ public class CreateNewImageTests
         _testOutput = testOutput;
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public void CreateNewImage_Baseline()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -69,7 +69,7 @@ public class CreateNewImageTests
         return new(task.GeneratedContainerConfiguration);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public void ParseContainerProperties_EndToEnd()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -132,7 +132,7 @@ public class CreateNewImageTests
     /// <summary>
     /// Creates a console app that outputs the environment variable added to the image.
     /// </summary>
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public void Tasks_EndToEnd_With_EnvironmentVariable_Validation()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());
@@ -215,7 +215,7 @@ public class CreateNewImageTests
             .And.HaveStdOut("Foo");
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
     {
         const string RootlessBase ="dotnet/rootlessbase";
@@ -296,7 +296,7 @@ public class CreateNewImageTests
     }
 
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public void CanOverrideContainerImageFormat()
     {
         DirectoryInfo newProjectDir = new(GetTestDirectoryName());

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -17,7 +17,7 @@ public class DockerRegistryTests
         _loggerFactory = new TestLoggerFactory(testOutput);
     }
 
-    [DockerAvailableFact]
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public async Task GetFromRegistry()
     {
         var loggerFactory = new TestLoggerFactory(_testOutput);

--- a/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1379,7 +1379,7 @@ public class EndToEndTests : IDisposable
     [DockerSupportsArchInlineData("linux/386", "linux-x86", "/app", Skip = "There's no apphost for linux-x86 so we can't execute self-contained, and there's no .NET runtime base image for linux-x86 so we can't execute framework-dependent.")]
     [DockerSupportsArchInlineData("windows/amd64", "win-x64", "C:\\app")]
     [DockerSupportsArchInlineData("linux/amd64", "linux-x64", "/app")]
-    [DockerAvailableTheory]
+    [DockerAvailableTheory(Skip = "https://github.com/dotnet/sdk/issues/49502")]
     public async Task CanPackageForAllSupportedContainerRIDs(string dockerPlatform, string rid, string workingDir)
     {
         ILogger logger = _loggerFactory.CreateLogger(nameof(CanPackageForAllSupportedContainerRIDs));

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
@@ -25,7 +25,7 @@ public class DockerDaemonTests : IDisposable
         _loggerFactory.Dispose();
     }
     
-    [DockerAvailableFact(skipPodman: true)] // podman is a local cli not meant for connecting to remote Docker daemons.
+    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502", skipPodman: true)] // podman is a local cli not meant for connecting to remote Docker daemons.
     public async Task Can_detect_when_no_daemon_is_running() {
         // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
         try {

--- a/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Containers.UnitTests/DockerDaemonTests.cs
@@ -25,7 +25,7 @@ public class DockerDaemonTests : IDisposable
         _loggerFactory.Dispose();
     }
     
-    [DockerAvailableFact(Skip = "https://github.com/dotnet/sdk/issues/49502", skipPodman: true)] // podman is a local cli not meant for connecting to remote Docker daemons.
+    [DockerAvailableFact(skipPodman: true, Skip = "https://github.com/dotnet/sdk/issues/49502")] // podman is a local cli not meant for connecting to remote Docker daemons.
     public async Task Can_detect_when_no_daemon_is_running() {
         // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
         try {


### PR DESCRIPTION
Manual attempt at backporting #49773 to 8.0.4xx.  This should disable failing docker tests and keep our CI clean.