### PR TITLE
Support shared .NET installation

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -16,26 +16,30 @@ stages:
     - script: |
         source ./eng/common/tools.sh
         InitializeDotNetCli true
-        cd src/sdk
-        ../../.dotnet/dotnet tool restore
-      displayName: Initialize tooling
+        echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
+      displayName: Initialize .NET CLI
       workingDirectory: $(Build.SourcesDirectory)
 
     - script: |
+        $(DotNetPath)/dotnet tool restore
+      displayName: Restore tools
+      workingDirectory: $(Build.SourcesDirectory)/src/sdk
+
+    - script: |
         set -e
-        sha=`../../.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" sdk`
+        sha=`$(DotNetPath)/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" sdk`
         echo "##vso[build.addbuildtag]$sha"
       displayName: Tag the build
       workingDirectory: $(Build.SourcesDirectory)/src/sdk
 
     - script: |
-        ./eng/detect-binaries.sh
+        ./eng/detect-binaries.sh --with-sdk $(DotNetPath)
       displayName: Scan for binaries
       workingDirectory: $(Build.SourcesDirectory)
       continueOnError: true
 
     - script: >
-        ../../.dotnet/dotnet darc vmr scan-cloaked-files
+        $(DotNetPath)/dotnet darc vmr scan-cloaked-files
         --vmr "$(Build.SourcesDirectory)"
         --tmp "$(Agent.TempDirectory)"
         || (echo '##[error]Found cloaked files in the VMR' && exit 1)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5408

VMR's `Tag & Scan` stage runs multiple commands that require .NET. All scripts in the stage assumed that .NET is installed locally, to `.dotnet`. Installation is done via `arcade`'s `InitializeDotNetCli` function (in eng/common/tools.sh).

`InitializeDotNetCli` skips .NET installation if the machine has the required version installed to a shared location. `InitializeDotNetCli` sets the `_InitializeDotNetCli` to the .NET path, local or shared.

The fix is to use the .NET path that was obtained with `InitializeDotNetCli`.

[Validation build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2838317&view=results)