### PR TITLE
Remove the vs-sdk feed as it's not required and is risky

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -57,8 +57,6 @@
     <add key="dotnet-tools-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-transport/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
-    <add key="vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <!-- Used for Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />

--- a/test/TestAssets/Directory.Build.props
+++ b/test/TestAssets/Directory.Build.props
@@ -5,6 +5,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.tmp</DefaultItemExcludes>
+    <NuGetAudit>false</NuGetAudit> 
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/test/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    <NuGetAudit>false</NuGetAudit> 
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/test/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <NuGetAudit>false</NuGetAudit> 
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
That feed can have alternative versions of MSBuild and lead to issues like the issue in 9.0.307. Remove that feed.

Additionally, internal builds were flagging the test builds for audit issues. Since we're intentionally targeting old runtimes, broadly disable nuget audit there (we could do it individually but I think for tests, we're ok with it broadly disabled and leaving it to CG to flag us).