### PR TITLE
Fix slnf test assets to use `\\`

### DIFF
--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/MultiTestProjectSolutionWithTests.sln
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/MultiTestProjectSolutionWithTests.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35322.30 main
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject/TestProject.csproj", "{C43FCD94-028D-4DE8-96EC-A3663AE225B4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{C43FCD94-028D-4DE8-96EC-A3663AE225B4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherTestProject", "OtherTestProject/OtherTestProject.csproj", "{6171FC1F-E2F2-4F66-A8DE-EC4765081661}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherTestProject", "OtherTestProject\OtherTestProject.csproj", "{6171FC1F-E2F2-4F66-A8DE-EC4765081661}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/SolutionFilter/OtherTestProjects.slnf
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/SolutionFilter/OtherTestProjects.slnf
@@ -1,8 +1,8 @@
 {
   "solution": {
-    "path": "../MultiTestProjectSolutionWithTests.sln",
+    "path": "..\\MultiTestProjectSolutionWithTests.sln",
     "projects": [
-      "TestProject/TestProject.csproj"
+      "TestProject\\TestProject.csproj"
     ]
   }
 }

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProjects.slnf
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithTests/TestProjects.slnf
@@ -2,7 +2,7 @@
   "solution": {
     "path": "MultiTestProjectSolutionWithTests.sln",
     "projects": [
-      "TestProject/TestProject.csproj"
+      "TestProject\\TestProject.csproj"
     ]
   }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/sdk/issues/51521

I think the PR might fail currently, but hopefully will pass after https://github.com/dotnet/sdk/pull/51411 is merged.