### PR TITLE
Add support for IfDifferent

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets
@@ -200,6 +200,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_PublishStaticWebAssetsCopyAlways Include="@(_PublishStaticWebAssetsTargetPath)" Condition="'%(CopyToPublishDirectory)' == 'Always'" />
       <_PublishStaticWebAssetsPreserveNewest Include="@(_PublishStaticWebAssetsTargetPath)" Condition="'%(CopyToPublishDirectory)' == 'PreserveNewest'" />
+      <_PublishStaticWebAssetsIfDifferent Include="@(_PublishStaticWebAssetsTargetPath)" Condition="'%(CopyToPublishDirectory)' == 'IfDifferent'" />
     </ItemGroup>
 
   </Target>
@@ -207,7 +208,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_PublishCopyStaticWebAssetsPreserveNewest"
     Inputs="@(_PublishStaticWebAssetsPreserveNewest)"
     Outputs="@(_PublishStaticWebAssetsPreserveNewest->'$(PublishDir)%(TargetPath)')"
-    AfterTargets="_SplitPublishStaticWebAssetsByCopyOptions">
+    AfterTargets="_SplitPublishStaticWebAssetsByCopyOptions"
+    Condition=" '@(_PublishStaticWebAssetsPreserveNewest)' != '' ">
 
     <Copy SourceFiles="@(_PublishStaticWebAssetsPreserveNewest)"
       DestinationFiles="@(_PublishStaticWebAssetsPreserveNewest->'$(PublishDir)%(TargetPath)')"
@@ -224,10 +226,33 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_PublishCopyStaticWebAssetsAlways"
-    AfterTargets="_SplitPublishStaticWebAssetsByCopyOptions">
+    AfterTargets="_SplitPublishStaticWebAssetsByCopyOptions"
+    Condition=" '@(_PublishStaticWebAssetsCopyAlways)' != '' ">
 
     <Copy SourceFiles="@(_PublishStaticWebAssetsCopyAlways)"
       DestinationFiles="@(_PublishStaticWebAssetsCopyAlways->'$(PublishDir)%(TargetPath)')"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+      UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+  </Target>
+  
+  <Target Name="_PublishCopyStaticWebAssetsIfDifferent"
+    AfterTargets="_SplitPublishStaticWebAssetsByCopyOptions"
+    Condition=" '@(_PublishStaticWebAssetsIfDifferent)' != '' ">
+
+    <!--
+        Using SkipUnchangedFiles="true" because we want only differing files.
+    -->
+    <Copy SourceFiles="@(_PublishStaticWebAssetsIfDifferent)"
+      DestinationFiles="@(_PublishStaticWebAssetsIfDifferent->'$(PublishDir)%(TargetPath)')"
+      SkipUnchangedFiles="true"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -498,6 +498,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_BuildStaticWebAssetsCopyAlways Include="@(_BuildStaticWebAssetsTargetPath)" Condition="'%(CopyToOutputDirectory)' == 'Always'" />
       <_BuildStaticWebAssetsPreserveNewest Include="@(_BuildStaticWebAssetsTargetPath)" Condition="'%(CopyToOutputDirectory)' == 'PreserveNewest'" />
+      <_BuildStaticWebAssetsIfDifferent Include="@(_BuildStaticWebAssetsTargetPath)" Condition="'%(CopyToOutputDirectory)' == 'IfDifferent'" />
     </ItemGroup>
 
   </Target>
@@ -537,8 +538,29 @@ Copyright (c) .NET Foundation. All rights reserved.
     </Copy>
 
   </Target>
+  
+  <Target Name="_BuildCopyStaticWebAssetsIfDifferent"
+    AfterTargets="_SplitStaticWebAssetsByCopyOptions">
 
-  <Target Name="WriteStaticWebAssetsUpToDateCheck" DependsOnTargets="_BuildCopyStaticWebAssetsPreserveNewest;_BuildCopyStaticWebAssetsAlways">
+    <!--
+        Using SkipUnchangedFiles="true" because we want only differing files.
+    -->
+    <Copy SourceFiles="@(_BuildStaticWebAssetsIfDifferent)"
+      DestinationFiles="@(_BuildStaticWebAssetsIfDifferent->'%(TargetPath)')"
+      SkipUnchangedFiles="true"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+      UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+  </Target>
+
+  <Target Name="WriteStaticWebAssetsUpToDateCheck" DependsOnTargets="_BuildCopyStaticWebAssetsPreserveNewest;_BuildCopyStaticWebAssetsAlways;_BuildCopyStaticWebAssetsIfDifferent">
 
     <ItemGroup>
       <_UpToDateCheckStaticWebAssetCandidate Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -839,21 +839,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     so they can be processed by GetCopyToPublishDirectoryItems.
     ============================================================
     -->
-<!--
   <Target Name="_IncludeContentItemsWithOnlyPublishMetadata"
           AfterTargets="AssignTargetPaths">
     <ItemGroup>
       <_ContentWithPublishMetadata Include="@(Content)"
                                    Condition="'%(Content.CopyToPublishDirectory)' != '' and '%(Content.CopyToPublishDirectory)' != 'Never' and '%(Content.CopyToOutputDirectory)' == ''">
-        <TargetPath Condition="'%(Content.Link)' != ''">%(Content.Link)</TargetPath>
-        <TargetPath Condition="'%(Content.Link)' == '' and '%(Content.DefiningProjectDirectory)' != '' and '%(Content.DefiningProjectFullPath)' != ''">$([MSBuild]::MakeRelative(%(Content.DefiningProjectDirectory), %(Content.FullPath)))</TargetPath>
-        <TargetPath Condition="'%(Content.Link)' == '' and ('%(Content.DefiningProjectDirectory)' == '' or '%(Content.DefiningProjectFullPath)' == '')">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
+        <!-- Preserve existing TargetPath if already set, otherwise compute it -->
+        <TargetPath Condition="'%(Content.TargetPath)' != ''">%(Content.TargetPath)</TargetPath>
+        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' != ''">%(Content.Link)</TargetPath>
+        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == '' and '%(Content.DefiningProjectDirectory)' != '' and '%(Content.DefiningProjectFullPath)' != ''">$([MSBuild]::MakeRelative(%(Content.DefiningProjectDirectory), %(Content.FullPath)))</TargetPath>
+        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == '' and ('%(Content.DefiningProjectDirectory)' == '' or '%(Content.DefiningProjectFullPath)' == '')">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
       </_ContentWithPublishMetadata>
       
       <ContentWithTargetPath Include="@(_ContentWithPublishMetadata)" />
     </ItemGroup>
   </Target>
--->
   <!--
     ============================================================
                                         GetCopyToPublishDirectoryItems

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -268,6 +268,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_IncrementalCleanPublishDirectory;
                             _CopyResolvedFilesToPublishPreserveNewest;
                             _CopyResolvedFilesToPublishAlways;
+                            _CopyResolvedFilesToPublishIfDifferent;
                             _HandleFileConflictsForPublish" />
 
   <!--
@@ -410,6 +411,33 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </Copy>
   </Target>
+  
+  <!--
+    ============================================================
+                                        _CopyResolvedFilesToPublishIfDifferent
+
+    Copy _ResolvedFileToPublishIfDifferent items to the publish directory
+    ============================================================
+    -->
+  <Target Name="_CopyResolvedFilesToPublishIfDifferent"
+          DependsOnTargets="_ComputeResolvedFilesToPublishTypes">
+
+    <!--
+      Using SkipUnchangedFiles="true" because we want only differing files.
+      -->
+    <Copy SourceFiles = "@(_ResolvedFileToPublishIfDifferent)"
+          DestinationFiles="@(_ResolvedFileToPublishIfDifferent->'$(PublishDir)%(RelativePath)')"
+          SkipUnchangedFiles="true"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForPublishFilesIfPossible)"
+          UseSymboliclinksIfPossible="$(CreateSymbolicLinksForPublishFilesIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+  </Target>
 
   <UsingTask TaskName="ResolveReadyToRunCompilers" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="ResolveReadyToRunCompilers">
@@ -431,7 +459,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
                                         _ComputeResolvedFilesToPublishTypes
 
-    Splits ResolvedFileToPublish items into 'PreserveNewest' and 'Always' buckets.
+    Splits ResolvedFileToPublish items into 'PreserveNewest', 'Always' and 'IfDifferent' buckets.
     Then further splits those into 'Unbundled' buckets based on the single file setting.
     ============================================================
     -->
@@ -443,6 +471,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ResolvedFileToPublishAlways Include="@(ResolvedFileToPublish)"
                                     Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='Always'" />
+                                    
+      <_ResolvedFileToPublishIfDifferent Include="@(ResolvedFileToPublish)"
+                                    Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)'=='IfDifferent'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -456,6 +487,11 @@ Copyright (c) .NET Foundation. All rights reserved.
               Include="@(_ResolvedFileToPublishAlways)"
               Condition="'$(PublishSingleFile)' != 'true' or
                          '%(_ResolvedFileToPublishAlways.ExcludeFromSingleFile)'=='true'" />
+                         
+      <_ResolvedUnbundledFileToPublishIfDifferent
+              Include="@(_ResolvedFileToPublishIfDifferent)"
+              Condition="'$(PublishSingleFile)' != 'true' or
+                         '%(_ResolvedFileToPublishIfDifferent.ExcludeFromSingleFile)'=='true'" />
     </ItemGroup>
   </Target>
 
@@ -784,6 +820,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <IsKeyOutput Condition="'%(_SourceItemsToCopyToPublishDirectory.FullPath)' == '$(AppHostIntermediatePath)'">True</IsKeyOutput>
       </ResolvedFileToPublish>
+      
+      <ResolvedFileToPublish Include="@(_SourceItemsToCopyToPublishDirectoryIfDifferent)">
+        <RelativePath>%(_SourceItemsToCopyToPublishDirectoryIfDifferent.TargetPath)</RelativePath>
+        <CopyToPublishDirectory>IfDifferent</CopyToPublishDirectory>
+        <IsKeyOutput Condition="'%(_SourceItemsToCopyToPublishDirectoryIfDifferent.FullPath)' == '$(AppHostIntermediatePath)'">True</IsKeyOutput>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
   </Target>
@@ -845,6 +887,10 @@ Copyright (c) .NET Foundation. All rights reserved.
                                             KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(_AllChildProjectPublishItemsWithTargetPath->'%(FullPath)')"
                                             Condition="'%(_AllChildProjectPublishItemsWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
+                                            Include="@(_AllChildProjectPublishItemsWithTargetPath->'%(FullPath)')"
+                                            Condition="'%(_AllChildProjectPublishItemsWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
@@ -860,6 +906,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(ContentWithTargetPath->'%(FullPath)')"
                                             Condition="'%(ContentWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+                                            Include="@(ContentWithTargetPath->'%(FullPath)')"
+                                            Condition="'%(ContentWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -869,11 +918,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(EmbeddedResource->'%(FullPath)')"
                                             Condition="'%(EmbeddedResource.CopyToPublishDirectory)'=='PreserveNewest'"/>
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+                                            Include="@(EmbeddedResource->'%(FullPath)')"
+                                            Condition="'%(EmbeddedResource.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
       <_CompileItemsToPublish Include="@(Compile->'%(FullPath)')"
-                              Condition="'%(Compile.CopyToPublishDirectory)'=='Always' or '%(Compile.CopyToPublishDirectory)'=='PreserveNewest'"/>
+                              Condition="'%(Compile.CopyToPublishDirectory)'=='Always' or '%(Compile.CopyToPublishDirectory)'=='PreserveNewest'" or '%(Compile.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <AssignTargetPath Files="@(_CompileItemsToPublish)" RootFolder="$(MSBuildProjectDirectory)">
@@ -887,6 +939,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
                                            Include="@(_CompileItemsToPublishWithTargetPath)"
                                            Condition="'%(_CompileItemsToPublishWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+                                           Include="@(_CompileItemsToPublishWithTargetPath)"
+                                           Condition="'%(_CompileItemsToPublishWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -896,12 +951,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(_NoneWithTargetPath->'%(FullPath)')"
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+                                            Include="@(_NoneWithTargetPath->'%(FullPath)')"
+                                            Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(_UseSingleFileHostForPublish)' == 'true' and Exists('$(SingleFileHostIntermediatePath)')">
       <!-- Remove non-single-file apphost from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent Remove="$(AppHostIntermediatePath)" />
 
       <!-- Add the single-file host created as part of publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Include="$(SingleFileHostIntermediatePath)" CopyToOutputDirectory="Always" TargetPath="$(AssemblyName)$(_NativeExecutableExtension)" />
@@ -911,13 +970,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Remove apphost from build from items to publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Remove="$(AppHostIntermediatePath)" />
       <_SourceItemsToCopyToPublishDirectory Remove="$(AppHostIntermediatePath)" />
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent Remove="$(AppHostIntermediatePath)" />
 
       <!-- Add the apphost created as part of publish -->
       <_SourceItemsToCopyToPublishDirectoryAlways Include="$(AppHostForPublishIntermediatePath)" CopyToOutputDirectory="Always" TargetPath="$(AssemblyName)$(_NativeExecutableExtension)" />
     </ItemGroup>
 
     <ItemGroup>
-      <AllPublishItemsFullPathWithTargetPath Include="@(_SourceItemsToCopyToPublishDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToPublishDirectory->'%(FullPath)')"/>
+      <AllPublishItemsFullPathWithTargetPath Include="@(_SourceItemsToCopyToPublishDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToPublishDirectory->'%(FullPath)');@(_SourceItemsToCopyToPublishDirectoryIfDifferent->'%(FullPath)')"/>
     </ItemGroup>
 
   </Target>
@@ -927,7 +987,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                         DefaultCopyToPublishDirectoryMetadata
 
     If CopyToPublishDirectory isn't set on these items, the value should be taken from CopyToOutputDirectory.
-    This way, projects can just set "CopyToOutputDirectory = Always/PreserveNewest" and by default the item will be copied
+    This way, projects can just set "CopyToOutputDirectory = Always/PreserveNewest/IfDifferent" and by default the item will be copied
     to both the build output and publish directories.
     ============================================================
     -->
@@ -942,12 +1002,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ContentWithTargetPath Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' and '%(ContentWithTargetPath.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ContentWithTargetPath>
+      <ContentWithTargetPath Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' and '%(ContentWithTargetPath.CopyToPublishDirectory)' == ''">
+        <CopyToPublishDirectory>IfDifferent</CopyToPublishDirectory>
+      </ContentWithTargetPath>
 
       <EmbeddedResource Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' and '%(EmbeddedResource.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>
       </EmbeddedResource>
       <EmbeddedResource Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' and '%(EmbeddedResource.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='IfDifferent' and '%(EmbeddedResource.CopyToPublishDirectory)' == ''">
+        <CopyToPublishDirectory>IfDifferent</CopyToPublishDirectory>
       </EmbeddedResource>
 
       <Compile Condition="'%(Compile.CopyToOutputDirectory)'=='Always' and '%(Compile.CopyToPublishDirectory)' == ''">
@@ -956,12 +1022,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Compile Condition="'%(Compile.CopyToOutputDirectory)'=='PreserveNewest' and '%(Compile.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Compile>
+      <Compile Condition="'%(Compile.CopyToOutputDirectory)'=='IfDifferent' and '%(Compile.CopyToPublishDirectory)' == ''">
+        <CopyToPublishDirectory>IfDifferent</CopyToPublishDirectory>
+      </Compile>
 
       <_NoneWithTargetPath Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' and '%(_NoneWithTargetPath.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>Always</CopyToPublishDirectory>
       </_NoneWithTargetPath>
       <_NoneWithTargetPath Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' and '%(_NoneWithTargetPath.CopyToPublishDirectory)' == ''">
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </_NoneWithTargetPath>
+      <_NoneWithTargetPath Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' and '%(_NoneWithTargetPath.CopyToPublishDirectory)' == ''">
+        <CopyToPublishDirectory>IfDifferent</CopyToPublishDirectory>
       </_NoneWithTargetPath>
 
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -925,7 +925,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_CompileItemsToPublish Include="@(Compile->'%(FullPath)')"
-                              Condition="'%(Compile.CopyToPublishDirectory)'=='Always' or '%(Compile.CopyToPublishDirectory)'=='PreserveNewest'" or '%(Compile.CopyToPublishDirectory)'=='IfDifferent'"/>
+                              Condition="'%(Compile.CopyToPublishDirectory)'=='Always' or '%(Compile.CopyToPublishDirectory)'=='PreserveNewest' or '%(Compile.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <AssignTargetPath Files="@(_CompileItemsToPublish)" RootFolder="$(MSBuildProjectDirectory)">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -832,6 +832,30 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        _IncludeContentItemsWithOnlyPublishMetadata
+    
+    Content items with CopyToPublishDirectory set but without CopyToOutputDirectory are not
+    included in ContentWithTargetPath by AssignTargetPaths. This target ensures they are included
+    so they can be processed by GetCopyToPublishDirectoryItems.
+    ============================================================
+    -->
+<!--
+  <Target Name="_IncludeContentItemsWithOnlyPublishMetadata"
+          AfterTargets="AssignTargetPaths">
+    <ItemGroup>
+      <_ContentWithPublishMetadata Include="@(Content)"
+                                   Condition="'%(Content.CopyToPublishDirectory)' != '' and '%(Content.CopyToPublishDirectory)' != 'Never' and '%(Content.CopyToOutputDirectory)' == ''">
+        <TargetPath Condition="'%(Content.Link)' != ''">%(Content.Link)</TargetPath>
+        <TargetPath Condition="'%(Content.Link)' == '' and '%(Content.DefiningProjectDirectory)' != '' and '%(Content.DefiningProjectFullPath)' != ''">$([MSBuild]::MakeRelative(%(Content.DefiningProjectDirectory), %(Content.FullPath)))</TargetPath>
+        <TargetPath Condition="'%(Content.Link)' == '' and ('%(Content.DefiningProjectDirectory)' == '' or '%(Content.DefiningProjectFullPath)' == '')">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
+      </_ContentWithPublishMetadata>
+      
+      <ContentWithTargetPath Include="@(_ContentWithPublishMetadata)" />
+    </ItemGroup>
+  </Target>
+-->
+  <!--
+    ============================================================
                                         GetCopyToPublishDirectoryItems
 
     Get all project items that may need to be transferred to the publish directory.

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -21,6 +21,10 @@ namespace Microsoft.NET.Publish.Tests
                 IsExe = true
             };
 
+            // Add Program.cs to fix compilation
+            testProject.SourceFiles["Program.cs"] = @"using System;
+class Program { static void Main() => Console.WriteLine(""Hello""); }";
+            
             // Add content files with different CopyToPublishDirectory metadata values
             testProject.SourceFiles["data1.txt"] = "Data file 1 content";
             testProject.SourceFiles["data2.txt"] = "Data file 2 content";
@@ -67,6 +71,10 @@ namespace Microsoft.NET.Publish.Tests
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true
             };
+
+            // Add Program.cs to fix compilation
+            testProject.SourceFiles["Program.cs"] = @"using System;
+class Program { static void Main() => Console.WriteLine(""Hello""); }";
 
             testProject.SourceFiles["unchangedData.txt"] = "Original content";
             testProject.SourceFiles["changedData.txt"] = "Original content";
@@ -134,6 +142,7 @@ namespace Microsoft.NET.Publish.Tests
                 IsExe = true
             };
 
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
             testProject.SourceFiles["config.json"] = "{ \"setting\": \"value\" }";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -169,6 +178,7 @@ namespace Microsoft.NET.Publish.Tests
                 IsExe = true
             };
 
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
             testProject.SourceFiles["SourceFile.cs"] = @"
 namespace PublishCompileWithIfDifferent
 {
@@ -214,6 +224,10 @@ namespace PublishCompileWithIfDifferent
                 ReferencedProjects = { referencedProject }
             };
 
+            // Add Program.cs to fix compilation
+            mainProject.SourceFiles["Program.cs"] = @"using System;
+class Program { static void Main() => Console.WriteLine(""Hello""); }";
+            
             mainProject.SourceFiles["main.txt"] = "Main project content";
 
             var testAsset = _testAssetsManager.CreateTestProject(mainProject);
@@ -261,6 +275,7 @@ namespace PublishCompileWithIfDifferent
                 IsExe = true
             };
 
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
             testProject.SourceFiles["always.txt"] = "Always copy";
             testProject.SourceFiles["preserveNewest.txt"] = "PreserveNewest copy";
             testProject.SourceFiles["ifDifferent.txt"] = "IfDifferent copy";
@@ -302,6 +317,7 @@ namespace PublishCompileWithIfDifferent
                 IsExe = true
             };
 
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
             testProject.SourceFiles["source\\data.txt"] = "Data in subfolder";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
@@ -340,6 +356,7 @@ namespace PublishCompileWithIfDifferent
             };
 
             testProject.AdditionalProperties["SelfContained"] = "true";
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
             testProject.SourceFiles["appdata.txt"] = "Application data";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -1,0 +1,368 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+namespace Microsoft.NET.Publish.Tests
+{
+    public class GivenThatWeWantToPublishWithIfDifferent : SdkTest
+    {
+        public GivenThatWeWantToPublishWithIfDifferent(ITestOutputHelper log) : base(log)
+        {
+        }
+
+        [Fact]
+        public void It_publishes_content_files_with_IfDifferent_metadata()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "PublishWithIfDifferent",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            // Add content files with different CopyToPublishDirectory metadata values
+            testProject.SourceFiles["data1.txt"] = "Data file 1 content";
+            testProject.SourceFiles["data2.txt"] = "Data file 2 content";
+            testProject.SourceFiles["data3.txt"] = "Data file 3 content";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            // Update the project file to set CopyToPublishDirectory metadata
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""data1.txt"" CopyToPublishDirectory=""IfDifferent"" />
+    <Content Include=""data2.txt"" CopyToPublishDirectory=""Always"" />
+    <Content Include=""data3.txt"" CopyToPublishDirectory=""PreserveNewest"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Verify all content files are published
+            publishDirectory.Should().HaveFile("data1.txt");
+            publishDirectory.Should().HaveFile("data2.txt");
+            publishDirectory.Should().HaveFile("data3.txt");
+
+            // Verify file contents
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "data1.txt")).Should().Be("Data file 1 content");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "data2.txt")).Should().Be("Data file 2 content");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "data3.txt")).Should().Be("Data file 3 content");
+        }
+
+        [Fact]
+        public void It_skips_unchanged_files_with_IfDifferent_on_republish()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "PublishIfDifferentSkipUnchanged",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["unchangedData.txt"] = "Original content";
+            testProject.SourceFiles["changedData.txt"] = "Original content";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""unchangedData.txt"" CopyToPublishDirectory=""IfDifferent"" />
+    <Content Include=""changedData.txt"" CopyToPublishDirectory=""IfDifferent"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            // First publish
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Record timestamps after first publish
+            var unchangedFileInfo = new FileInfo(Path.Combine(publishDirectory.FullName, "unchangedData.txt"));
+            var changedFileInfo = new FileInfo(Path.Combine(publishDirectory.FullName, "changedData.txt"));
+            
+            unchangedFileInfo.Exists.Should().BeTrue();
+            changedFileInfo.Exists.Should().BeTrue();
+
+            var unchangedOriginalTime = unchangedFileInfo.LastWriteTimeUtc;
+            var changedOriginalTime = changedFileInfo.LastWriteTimeUtc;
+
+            // Wait to ensure timestamp difference would be detectable
+            System.Threading.Thread.Sleep(1000);
+
+            // Modify only one source file
+            var changedSourcePath = Path.Combine(testAsset.Path, testProject.Name, "changedData.txt");
+            File.WriteAllText(changedSourcePath, "Modified content");
+
+            // Second publish
+            publishCommand.Execute().Should().Pass();
+
+            // Refresh file info
+            unchangedFileInfo.Refresh();
+            changedFileInfo.Refresh();
+
+            // The unchanged file should have the same timestamp (wasn't copied)
+            unchangedFileInfo.LastWriteTimeUtc.Should().Be(unchangedOriginalTime);
+
+            // The changed file should have a new timestamp (was copied)
+            changedFileInfo.LastWriteTimeUtc.Should().BeAfter(changedOriginalTime);
+
+            // Verify content
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "unchangedData.txt")).Should().Be("Original content");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "changedData.txt")).Should().Be("Modified content");
+        }
+
+        [Fact]
+        public void It_handles_None_items_with_IfDifferent_metadata()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "PublishNoneWithIfDifferent",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["config.json"] = "{ \"setting\": \"value\" }";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <None Include=""config.json"" CopyToPublishDirectory=""IfDifferent"">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Verify the None item with IfDifferent is published
+            publishDirectory.Should().HaveFile("config.json");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "config.json")).Should().Be("{ \"setting\": \"value\" }");
+        }
+
+        [Fact]
+        public void It_handles_Compile_items_with_IfDifferent_metadata()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "PublishCompileWithIfDifferent",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["SourceFile.cs"] = @"
+namespace PublishCompileWithIfDifferent
+{
+    public class SourceClass { }
+}";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Compile Update=""SourceFile.cs"" CopyToPublishDirectory=""IfDifferent"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Verify the Compile item with IfDifferent is published
+            publishDirectory.Should().HaveFile("SourceFile.cs");
+        }
+
+        [Fact]
+        public void It_copies_IfDifferent_files_correctly_with_referenced_projects()
+        {
+            var referencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+
+            referencedProject.SourceFiles["shared.txt"] = "Shared content from library";
+
+            var mainProject = new TestProject()
+            {
+                Name = "MainProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+                ReferencedProjects = { referencedProject }
+            };
+
+            mainProject.SourceFiles["main.txt"] = "Main project content";
+
+            var testAsset = _testAssetsManager.CreateTestProject(mainProject);
+
+            // Configure the referenced project to include the file with IfDifferent
+            var referencedProjectFile = Path.Combine(testAsset.Path, referencedProject.Name, $"{referencedProject.Name}.csproj");
+            var referencedProjectContent = File.ReadAllText(referencedProjectFile);
+            referencedProjectContent = referencedProjectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""shared.txt"" CopyToPublishDirectory=""IfDifferent"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(referencedProjectFile, referencedProjectContent);
+
+            // Configure the main project
+            var mainProjectFile = Path.Combine(testAsset.Path, mainProject.Name, $"{mainProject.Name}.csproj");
+            var mainProjectContent = File.ReadAllText(mainProjectFile);
+            mainProjectContent = mainProjectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""main.txt"" CopyToPublishDirectory=""IfDifferent"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(mainProjectFile, mainProjectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(mainProject.TargetFrameworks);
+
+            // Verify files from both projects are published
+            publishDirectory.Should().HaveFile("main.txt");
+            publishDirectory.Should().HaveFile("shared.txt");
+
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "main.txt")).Should().Be("Main project content");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "shared.txt")).Should().Be("Shared content from library");
+        }
+
+        [Fact]
+        public void It_handles_mixed_CopyToPublishDirectory_metadata_values()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "MixedCopyMetadata",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["always.txt"] = "Always copy";
+            testProject.SourceFiles["preserveNewest.txt"] = "PreserveNewest copy";
+            testProject.SourceFiles["ifDifferent.txt"] = "IfDifferent copy";
+            testProject.SourceFiles["doNotCopy.txt"] = "Do not copy";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""always.txt"" CopyToPublishDirectory=""Always"" />
+    <Content Include=""preserveNewest.txt"" CopyToPublishDirectory=""PreserveNewest"" />
+    <Content Include=""ifDifferent.txt"" CopyToPublishDirectory=""IfDifferent"" />
+    <Content Include=""doNotCopy.txt"" CopyToPublishDirectory=""Never"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Verify the correct files are published
+            publishDirectory.Should().HaveFile("always.txt");
+            publishDirectory.Should().HaveFile("preserveNewest.txt");
+            publishDirectory.Should().HaveFile("ifDifferent.txt");
+            publishDirectory.Should().NotHaveFile("doNotCopy.txt");
+        }
+
+        [Fact]
+        public void It_publishes_IfDifferent_files_with_TargetPath()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "IfDifferentWithTargetPath",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["source\\data.txt"] = "Data in subfolder";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""source\data.txt"" CopyToPublishDirectory=""IfDifferent"">
+      <TargetPath>output\data.txt</TargetPath>
+    </Content>
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+
+            // Verify the file is published to the target path
+            var targetFile = Path.Combine(publishDirectory.FullName, "output", "data.txt");
+            File.Exists(targetFile).Should().BeTrue();
+            File.ReadAllText(targetFile).Should().Be("Data in subfolder");
+        }
+
+        [Fact]
+        public void It_handles_IfDifferent_with_self_contained_publish()
+        {
+            var testProject = new TestProject()
+            {
+                Name = "IfDifferentSelfContained",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+                RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid(ToolsetInfo.CurrentTargetFramework)
+            };
+
+            testProject.AdditionalProperties["SelfContained"] = "true";
+            testProject.SourceFiles["appdata.txt"] = "Application data";
+
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
+
+            var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""appdata.txt"" CopyToPublishDirectory=""IfDifferent"" />
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand.Execute().Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(
+                testProject.TargetFrameworks,
+                runtimeIdentifier: testProject.RuntimeIdentifier);
+
+            // Verify the content file is published
+            publishDirectory.Should().HaveFile("appdata.txt");
+            File.ReadAllText(Path.Combine(publishDirectory.FullName, "appdata.txt")).Should().Be("Application data");
+        }
+    }
+}

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -318,16 +318,16 @@ class Program { static void Main() => Console.WriteLine(""Hello""); }";
             };
 
             testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
-            testProject.SourceFiles["source\\data.txt"] = "Data in subfolder";
+            testProject.SourceFiles[Path.Combine("source", "data.txt")] = "Data in subfolder";
 
             var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var projectFile = Path.Combine(testAsset.Path, testProject.Name, $"{testProject.Name}.csproj");
             var projectContent = File.ReadAllText(projectFile);
-            projectContent = projectContent.Replace("</Project>", @"
+            projectContent = projectContent.Replace("</Project>", $@"
   <ItemGroup>
-    <Content Include=""source\data.txt"" CopyToPublishDirectory=""IfDifferent"">
-      <TargetPath>output\data.txt</TargetPath>
+    <Content Include=""{Path.Combine("source", "data.txt")}"" CopyToPublishDirectory=""IfDifferent"">
+      <TargetPath>{Path.Combine("output", "data.txt")}</TargetPath>
     </Content>
   </ItemGroup>
 </Project>");


### PR DESCRIPTION
### Context

https://github.com/dotnet/msbuild/pull/11052 Added support for `IfDifferent` value of `CopyToOutputDirectory` metadata.
The building/publishing of static web assets was not honoring this. It should be supported, so that the new copy action can be added to Project System copy action dropdown without risk of causing issues.

FYI @baronfel @drewnoakes 