### PR TITLE
Hot Reload: Do not add empty div when diagnostics are empty (1xx)

### DIFF
--- a/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
+++ b/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js
@@ -267,6 +267,11 @@ setTimeout(async function () {
 
   function displayDiagnostics(diagnostics) {
     document.querySelectorAll('#dotnet-compile-error').forEach(el => el.remove());
+
+    if (diagnostics.length == 0) {
+      return;
+    }
+    
     const el = document.body.appendChild(document.createElement('div'));
     el.id = 'dotnet-compile-error';
     el.setAttribute('style', 'z-index:1000000; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black; overflow: scroll;');


### PR DESCRIPTION
## Description

Browser displays gray overlay when changes are applied that do not modify C# code (e.g. CSS only changes). The overlay obscures web page content.

We shouldn't display gray overlay when no errors are being reported.

Fixes https://github.com/dotnet/sdk/issues/51825 and https://github.com/dotnet/aspnetcore/issues/64051
Port of https://github.com/dotnet/sdk/pull/51836

## Customer Impact

Impacts Hot Reload for web apps: CSS editing and saving C#/Razor files without changing their content.

## Regression?

- [x] Yes
- [ ] No  

Regressed by https://github.com/dotnet/sdk/pull/51210

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

## Verification

- [x] Manual (required)  
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  