### PR TITLE
CA1708: Ignore 'extension' blocks for naming check.

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -142,11 +142,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             using var membersByName = PooledDictionary<string, PooledHashSet<ISymbol>>.GetInstance(StringComparer.OrdinalIgnoreCase);
             foreach (var member in members)
             {
-                // Ignore constructors, indexers, operators and destructors for name check
+                // Ignore constructors, indexers, operators, destructors and extension blocks for name check
                 if (member.IsConstructor() ||
                     member.IsDestructor() ||
                     member.IsIndexer() ||
                     member.IsUserDefinedOperator() ||
+                    member.IsExtension() ||
                     overloadsToSkip.Contains(member))
                 {
                     continue;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
@@ -17,7 +17,11 @@ namespace Analyzer.Utilities.Extensions
 
         private static readonly Func<INamedTypeSymbol, bool> s_isFileLocal = LightupHelpers.CreateSymbolPropertyAccessor<INamedTypeSymbol, bool>(typeof(INamedTypeSymbol), nameof(IsFileLocal), fallbackResult: false);
 
+        private static readonly Func<INamedTypeSymbol, bool> s_isExtension = LightupHelpers.CreateSymbolPropertyAccessor<INamedTypeSymbol, bool>(typeof(INamedTypeSymbol), nameof(IsExtension), fallbackResult: false);
+
         public static bool IsFileLocal(this INamedTypeSymbol symbol) => s_isFileLocal(symbol);
+
+        public static bool IsExtension(this INamedTypeSymbol symbol) => s_isExtension(symbol);
 
         public static IEnumerable<INamedTypeSymbol> GetBaseTypesAndThis(this INamedTypeSymbol type)
         {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -161,6 +161,11 @@ namespace Analyzer.Utilities.Extensions
             return symbol is IMethodSymbol { MethodKind: MethodKind.Conversion };
         }
 
+        public static bool IsExtension([NotNullWhen(returnValue: true)] this ISymbol? symbol)
+        {
+            return symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.IsExtension();
+        }
+
         public static ImmutableArray<IParameterSymbol> GetParameters(this ISymbol? symbol)
         {
             return symbol switch

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCaseTests.cs
@@ -419,6 +419,35 @@ namespace N
             GetCA1708CSharpResultAt(30, 30, Parameter, "N.D.SomeDelegate"));
         }
 
+        [Fact]
+        public async Task TestMultipleExtensionBlocks()
+        {
+            string code = @"
+public static class StringExtensions
+{
+    private const string ExtensionString = ""Extension"";
+
+    // Static class extensions
+    extension(string)
+    {
+        public static string CreateExtension() => ExtensionString;
+    }
+
+    // Instance extensions
+    extension(string s)
+    {
+        public bool IsExtensionString() => s == ExtensionString;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp14,
+            }.RunAsync();
+        }
+
         #endregion
 
         #region Helper Methods


### PR DESCRIPTION
Fixes #51716 

* Added unit test with two extension blocks. Ensuring it fails in existing implementation.
* Add `IsExtension` for `INamedTypeSymbol` using `LightupHelpers`.
* Ignore extension blocks in `IdentifiersShouldDifferByMoreThanCaseAnalyzer`
