### PR TITLE
[release/10.0.1xx] Reduce noise from CA1873 (#51818)

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/docs/Analyzer Configuration.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/docs/Analyzer Configuration.md
@@ -877,6 +877,31 @@ Default Value: `false`
 
 Example: `dotnet_code_quality.CA1851.assume_method_enumerates_parameters = true`
 
+### Maximum log level for expensive call analysis
+
+Option Name: `max_log_level`
+
+Configurable Rules: [CA1873](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/CA1873)
+
+Option Values: One of the following log level values (case-insensitive):
+
+| Option Value | Summary |
+| --- | --- |
+| `trace` | Analyze expensive calls at Trace level and below. |
+| `debug` | Analyze expensive calls at Debug level and below. |
+| `information` | Analyze expensive calls at Information level and below. |
+| `warning` | Analyze expensive calls at Warning level and below. |
+| `error` | Analyze expensive calls at Error level and below. |
+| `critical` | Analyze expensive calls at Critical level. |
+
+This option configures the maximum log level for which CA1873 should flag potentially expensive operations in logging calls. Log levels higher than the configured value will not be analyzed, as they are typically always enabled in production scenarios.
+
+Default Value: `information`
+
+Example: `dotnet_code_quality.CA1873.max_log_level = warning`
+
+With the above configuration, the analyzer will flag expensive operations in log calls at Trace, Debug, Information, and Warning levels, but not at Error or Critical levels.
+
 ### Proceed with analysis even if InternalsVisibleTo is present
 
 Option Name: `ignore_internalsvisibleto`

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -234,5 +234,13 @@ namespace Analyzer.Utilities
         /// Boolean option whether to perform the analysis even if the assembly exposes its internals.
         /// </summary>
         public const string IgnoreInternalsVisibleTo = "ignore_internalsvisibleto";
+
+        /// <summary>
+        /// String option to configure the maximum log level for which expensive calls should be flagged.
+        /// Configurable rule: CA1873 (https://learn.microsoft.com/visualstudio/code-quality/ca1873).
+        /// Allowed option values: trace, debug, information, warning, error, critical.
+        /// Default value: information.
+        /// </summary>
+        public const string MaxLogLevel = "max_log_level";
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLoggingTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLoggingTests.cs
@@ -2631,10 +2631,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                             logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|]);
                 
                         if (logger.IsEnabled(LogLevel.Critical))
-                            logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall());
                 
                         if (logger.IsEnabled(LogLevel.Critical))
-                            logger.Log(LogLevel.Error, eventId, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Error, eventId, exception, ExpensiveMethodCall());
                     }
 
                     string ExpensiveMethodCall()
@@ -2647,11 +2647,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
@@ -2660,16 +2659,16 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     void M(ILogger logger, EventId eventId, Exception exception)
                     {
                         if (logger.IsEnabled(LogLevel.None))
-                            logger.Log{{logLevel}}([|ExpensiveMethodCall()|]);
+                            logger.LogInformation([|ExpensiveMethodCall()|]);
                         
                         if (logger.IsEnabled(LogLevel.None))
-                            logger.Log{{logLevel}}(eventId, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(eventId, [|ExpensiveMethodCall()|]);
 
                         if (logger.IsEnabled(LogLevel.None))
-                            logger.Log{{logLevel}}(exception, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(exception, [|ExpensiveMethodCall()|]);
 
                         if (logger.IsEnabled(LogLevel.None))
-                            logger.Log{{logLevel}}(eventId, exception, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(eventId, exception, [|ExpensiveMethodCall()|]);
                     }
 
                     string ExpensiveMethodCall()
@@ -2682,17 +2681,16 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
                 static partial class C
                 {
-                    [LoggerMessage(EventId = 0, Level = LogLevel.{{logLevel}}, Message = "Static log level `{argument}`")]
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Static log level `{argument}`")]
                     static partial void StaticLogLevel(this ILogger logger, string argument);
 
                     [LoggerMessage(EventId = 1, Message = "Dynamic log level `{argument}`")]
@@ -2707,7 +2705,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                         if (logger.IsEnabled(LogLevel.None))
                         {
-                            logger.DynamicLogLevel(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|]);
+                            logger.DynamicLogLevel(LogLevel.Information, [|ExpensiveMethodCall()|]);
                         }
                     }
 
@@ -2742,10 +2740,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                             logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|]);
                 
                         if (logger.IsEnabled(level))
-                            logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall());
                 
                         if (logger.IsEnabled(level))
-                            logger.Log(LogLevel.Error, eventId, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Error, eventId, exception, ExpensiveMethodCall());
                     }
 
                     string ExpensiveMethodCall()
@@ -2758,11 +2756,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongDynamicLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongDynamicLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
@@ -2771,16 +2768,16 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     void M(ILogger logger, EventId eventId, Exception exception, LogLevel level)
                     {
                         if (logger.IsEnabled(level))
-                            logger.Log{{logLevel}}([|ExpensiveMethodCall()|]);
+                            logger.LogInformation([|ExpensiveMethodCall()|]);
                         
                         if (logger.IsEnabled(level))
-                            logger.Log{{logLevel}}(eventId, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(eventId, [|ExpensiveMethodCall()|]);
 
                         if (logger.IsEnabled(level))
-                            logger.Log{{logLevel}}(exception, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(exception, [|ExpensiveMethodCall()|]);
 
                         if (logger.IsEnabled(level))
-                            logger.Log{{logLevel}}(eventId, exception, [|ExpensiveMethodCall()|]);
+                            logger.LogInformation(eventId, exception, [|ExpensiveMethodCall()|]);
                     }
 
                     string ExpensiveMethodCall()
@@ -2793,17 +2790,16 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongDynamicLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongDynamicLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
                 static partial class C
                 {
-                    [LoggerMessage(EventId = 0, Level = LogLevel.{{logLevel}}, Message = "Static log level `{argument}`")]
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Static log level `{argument}`")]
                     static partial void StaticLogLevel(this ILogger logger, string argument);
 
                     [LoggerMessage(EventId = 1, Message = "Dynamic log level `{argument}`")]
@@ -2818,7 +2814,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                         if (logger.IsEnabled(level))
                         {
-                            logger.DynamicLogLevel(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|]);
+                            logger.DynamicLogLevel(LogLevel.Information, [|ExpensiveMethodCall()|]);
                         }
                     }
 
@@ -2855,10 +2851,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                             logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|]);
                 
                         if (_otherLogger.IsEnabled(LogLevel.Warning))
-                            logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall());
                 
                         if (_otherLogger.IsEnabled(LogLevel.Error))
-                            logger.Log(LogLevel.Error, eventId, exception, [|ExpensiveMethodCall()|]);
+                            logger.Log(LogLevel.Error, eventId, exception, ExpensiveMethodCall());
                     }
 
                     string ExpensiveMethodCall()
@@ -2871,11 +2867,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongInstanceGuardedWorkInLogNamed_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongInstanceGuardedWorkInLogNamed_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
@@ -2885,17 +2880,17 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                     void M(ILogger logger, EventId eventId, Exception exception)
                     {
-                        if (_otherLogger.IsEnabled(LogLevel.{{logLevel}}))
-                            logger.Log{{logLevel}}([|ExpensiveMethodCall()|]);
+                        if (_otherLogger.IsEnabled(LogLevel.Information))
+                            logger.LogInformation([|ExpensiveMethodCall()|]);
                         
-                        if (_otherLogger.IsEnabled(LogLevel.{{logLevel}}))
-                            logger.Log{{logLevel}}(eventId, [|ExpensiveMethodCall()|]);
+                        if (_otherLogger.IsEnabled(LogLevel.Information))
+                            logger.LogInformation(eventId, [|ExpensiveMethodCall()|]);
 
-                        if (_otherLogger.IsEnabled(LogLevel.{{logLevel}}))
-                            logger.Log{{logLevel}}(exception, [|ExpensiveMethodCall()|]);
+                        if (_otherLogger.IsEnabled(LogLevel.Information))
+                            logger.LogInformation(exception, [|ExpensiveMethodCall()|]);
 
-                        if (_otherLogger.IsEnabled(LogLevel.{{logLevel}}))
-                            logger.Log{{logLevel}}(eventId, exception, [|ExpensiveMethodCall()|]);
+                        if (_otherLogger.IsEnabled(LogLevel.Information))
+                            logger.LogInformation(eventId, exception, [|ExpensiveMethodCall()|]);
                     }
 
                     string ExpensiveMethodCall()
@@ -2908,11 +2903,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongInstanceGuardedWorkInLoggerMessage_ReportsDiagnostic_CS(string logLevel)
+        [Fact]
+        public async Task WrongInstanceGuardedWorkInLoggerMessage_ReportsDiagnostic_CS()
         {
-            string source = $$"""
+            string source = """
                 using System;
                 using Microsoft.Extensions.Logging;
 
@@ -2920,7 +2914,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 {
                     private static ILogger _otherLogger;
 
-                    [LoggerMessage(EventId = 0, Level = LogLevel.{{logLevel}}, Message = "Static log level `{argument}`")]
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Static log level `{argument}`")]
                     static partial void StaticLogLevel(this ILogger logger, string argument);
 
                     [LoggerMessage(EventId = 1, Message = "Dynamic log level `{argument}`")]
@@ -2928,7 +2922,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                     static void M(ILogger logger)
                     {
-                        if (_otherLogger.IsEnabled(LogLevel.{{logLevel}}))
+                        if (_otherLogger.IsEnabled(LogLevel.Information))
                         {
                             logger.StaticLogLevel([|ExpensiveMethodCall()|]);
                         }
@@ -3014,6 +3008,63 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        public async Task SimpleValueTypeCast_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<long, Exception, string> formatter, int value)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, (long)value, exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ReferenceTypeCast_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<object, Exception, string> formatter, string value)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, (object)value, exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ReferenceTypeDowncast_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter, object value)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, (string)value, exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
         public async Task BinaryOperationWithBoxing_ReportsDiagnostic_CS()
         {
             string source = """
@@ -3043,7 +3094,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 {
                     void M(ILogger logger)
                     {
-                        [|logger.LogError("Test: {Number1} and {Number2}", 1, 2)|];
+                        [|logger.LogInformation("Test: {Number1} and {Number2}", 1, 2)|];
                     }
                 }
                 """;
@@ -5261,8 +5312,8 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                         If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Trace, eventId, [|ExpensiveMethodCall()|], exception, formatter)
                         If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Debug, [|ExpensiveMethodCall()|])                
                         If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.[Error], eventId, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall())
+                        If logger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.[Error], eventId, exception, ExpensiveMethodCall())
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5274,21 +5325,20 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports Microsoft.Extensions.Logging
                 
                 Class C
                     Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of String, Exception, String))
-                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|], exception, formatter)
-                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, exception, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|], exception, formatter)
+                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, exception, [|ExpensiveMethodCall()|])
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5300,18 +5350,17 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports System.Runtime.CompilerServices
                 Imports Microsoft.Extensions.Logging
                 
                 Partial Module C
                 	<Extension>
-                	<LoggerMessage(EventId:=0, Level:=LogLevel.{{logLevel}}, Message:="Static log level `{argument}`")>
+                	<LoggerMessage(EventId:=0, Level:=LogLevel.Information, Message:="Static log level `{argument}`")>
                 	Partial Private Sub StaticLogLevel(logger As ILogger, argument As String)
                 	End Sub
                 
@@ -5322,7 +5371,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 
                 	Sub M(logger As ILogger)
                         If logger.IsEnabled(LogLevel.None) Then logger.StaticLogLevel([|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(LogLevel.None) Then logger.DynamicLogLevel(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(LogLevel.None) Then logger.DynamicLogLevel(LogLevel.Information, [|ExpensiveMethodCall()|])
                 	End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5346,8 +5395,8 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                         If logger.IsEnabled(level) Then logger.Log(LogLevel.Trace, eventId, [|ExpensiveMethodCall()|], exception, formatter)
                         If logger.IsEnabled(level) Then logger.Log(LogLevel.Debug, [|ExpensiveMethodCall()|])                
                         If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.[Error], eventId, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall())
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.[Error], eventId, exception, ExpensiveMethodCall())
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5359,21 +5408,20 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongDynamicLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongDynamicLogLevelGuardedWorkInLogNamed_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports Microsoft.Extensions.Logging
                 
                 Class C
                     Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of String, Exception, String), level As LogLevel)
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|], exception, formatter)
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.{{logLevel}}, exception, [|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.Log(LogLevel.{{logLevel}}, eventId, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|], exception, formatter)
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, exception, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.Log(LogLevel.Information, eventId, exception, [|ExpensiveMethodCall()|])
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5385,18 +5433,17 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongDynamicLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongDynamicLogLevelGuardedWorkInLoggerMessage_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports System.Runtime.CompilerServices
                 Imports Microsoft.Extensions.Logging
                 
                 Partial Module C
                 	<Extension>
-                	<LoggerMessage(EventId:=0, Level:=LogLevel.{{logLevel}}, Message:="Static log level `{argument}`")>
+                	<LoggerMessage(EventId:=0, Level:=LogLevel.Information, Message:="Static log level `{argument}`")>
                 	Partial Private Sub StaticLogLevel(logger As ILogger, argument As String)
                 	End Sub
                 
@@ -5407,7 +5454,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 
                 	Sub M(logger As ILogger, level As LogLevel)
                         If logger.IsEnabled(level) Then logger.StaticLogLevel([|ExpensiveMethodCall()|])
-                        If logger.IsEnabled(level) Then logger.DynamicLogLevel(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
+                        If logger.IsEnabled(level) Then logger.DynamicLogLevel(LogLevel.Information, [|ExpensiveMethodCall()|])
                 	End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5433,8 +5480,8 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                         If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Trace, eventId, [|ExpensiveMethodCall()|], exception, formatter)
                         If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Debug, [|ExpensiveMethodCall()|])                
                         If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Warning, exception, [|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.[Error], eventId, exception, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.Warning, exception, ExpensiveMethodCall())
+                        If _otherLogger.IsEnabled(LogLevel.Critical) Then logger.Log(LogLevel.[Error], eventId, exception, ExpensiveMethodCall())
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5446,11 +5493,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongInstanceGuardedWorkInLogNamed_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongInstanceGuardedWorkInLogNamed_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports Microsoft.Extensions.Logging
                 
@@ -5458,11 +5504,11 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     Private _otherLogger As ILogger
 
                     Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of String, Exception, String))
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|], exception, formatter)
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, [|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, exception, [|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.{{logLevel}}, eventId, exception, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|], exception, formatter)
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, exception, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.Log(LogLevel.Information, eventId, exception, [|ExpensiveMethodCall()|])
                     End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5474,11 +5520,10 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(LogLevels))]
-        public async Task WrongInstanceGuardedWorkInLoggerMessage_ReportsDiagnostic_VB(string logLevel)
+        [Fact]
+        public async Task WrongInstanceGuardedWorkInLoggerMessage_ReportsDiagnostic_VB()
         {
-            string source = $$"""
+            string source = """
                 Imports System
                 Imports System.Runtime.CompilerServices
                 Imports Microsoft.Extensions.Logging
@@ -5487,7 +5532,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     Private _otherLogger As ILogger
 
                 	<Extension>
-                	<LoggerMessage(EventId:=0, Level:=LogLevel.{{logLevel}}, Message:="Static log level `{argument}`")>
+                	<LoggerMessage(EventId:=0, Level:=LogLevel.Information, Message:="Static log level `{argument}`")>
                 	Partial Private Sub StaticLogLevel(logger As ILogger, argument As String)
                 	End Sub
                 
@@ -5498,7 +5543,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 
                 	Sub M(logger As ILogger)
                         If _otherLogger.IsEnabled(LogLevel.None) Then logger.StaticLogLevel([|ExpensiveMethodCall()|])
-                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.DynamicLogLevel(LogLevel.{{logLevel}}, [|ExpensiveMethodCall()|])
+                        If _otherLogger.IsEnabled(LogLevel.None) Then logger.DynamicLogLevel(LogLevel.Information, [|ExpensiveMethodCall()|])
                 	End Sub
                 
                     Function ExpensiveMethodCall() As String
@@ -5570,6 +5615,57 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        public async Task SimpleValueTypeCast_NoDiagnostic_VB()
+        {
+            string source = """
+                Imports System
+                Imports Microsoft.Extensions.Logging
+
+                Class C
+                    Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of Long, Exception, String), value As Integer)
+                        logger.Log(LogLevel.Debug, eventId, CLng(value), exception, formatter)
+                    End Sub
+                End Class
+                """;
+
+            await VerifyBasicDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ReferenceTypeCast_NoDiagnostic_VB()
+        {
+            string source = """
+                Imports System
+                Imports Microsoft.Extensions.Logging
+
+                Class C
+                    Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of Object, Exception, String), value As String)
+                        logger.Log(LogLevel.Debug, eventId, CObj(value), exception, formatter)
+                    End Sub
+                End Class
+                """;
+
+            await VerifyBasicDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ReferenceTypeDowncast_NoDiagnostic_VB()
+        {
+            string source = """
+                Imports System
+                Imports Microsoft.Extensions.Logging
+
+                Class C
+                    Sub M(logger As ILogger, eventId As EventId, exception As Exception, formatter As Func(Of String, Exception, String), value As Object)
+                        logger.Log(LogLevel.Debug, eventId, CStr(value), exception, formatter)
+                    End Sub
+                End Class
+                """;
+
+            await VerifyBasicDiagnosticAsync(source);
+        }
+
+        [Fact]
         public async Task BinaryOperationWithBoxing_ReportsDiagnostic_VB()
         {
             string source = """
@@ -5595,7 +5691,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                 Class C
                     Sub M(logger As ILogger)
-                        [|logger.LogError("Test: {Number1} and {Number2}", 1, 2)|]
+                        [|logger.LogInformation("Test: {Number1} and {Number2}", 1, 2)|]
                     End Sub
                 End Class
                 """;
@@ -5603,28 +5699,505 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyBasicDiagnosticAsync(source);
         }
 
+        // Tests for trivial operations that should not be flagged
+
+        [Fact]
+        public async Task GetTypeInLog_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<Type, Exception, string> formatter, object obj)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, obj.GetType(), exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task GetTypeNameInLog_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter, object obj)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, obj.GetType().Name, exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task GetTypeFullNameInLog_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter, object obj)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, obj.GetType().FullName, exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Theory]
+        [MemberData(nameof(LogLevels))]
+        public async Task GetTypeInLogNamed_NoDiagnostic_CS(string logLevel)
+        {
+            string source = $$"""
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, object obj)
+                    {
+                        logger.Log{{logLevel}}(obj.GetType().Name);
+                        logger.Log{{logLevel}}(eventId, obj.GetType().FullName);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task GetHashCodeOnReferenceTypeInLog_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<int, Exception, string> formatter, object obj)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, obj.GetHashCode(), exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task GetHashCodeOnValueTypeInLog_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<int, Exception, string> formatter, int value)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, [|value.GetHashCode()|], exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task StopwatchGetTimestampInLog_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using System.Diagnostics;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<long, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Debug, eventId, Stopwatch.GetTimestamp(), exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        // Tests for LogLevel configuration
+
+        [Fact]
+        public async Task InformationLevelWithDefaultConfig_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Information, eventId, [|exception.ToString()|], exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task WarningLevelWithDefaultConfig_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Warning, eventId, exception.ToString(), exception, formatter);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task WarningLevelWithConfiguredMaxWarning_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Warning, eventId, [|exception.ToString()|], exception, formatter);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = warning
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task ErrorLevelWithConfiguredMaxWarning_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Error, eventId, exception.ToString(), exception, formatter);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = warning
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task TraceLevelWithConfiguredMaxTrace_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Trace, eventId, [|exception.ToString()|], exception, formatter);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = trace
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task CriticalLevelWithConfiguredMaxCritical_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, EventId eventId, Exception exception, Func<string, Exception, string> formatter)
+                    {
+                        logger.Log(LogLevel.Critical, eventId, [|exception.ToString()|], exception, formatter);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = critical
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task LoggerMessageInformationLevelWithDefaultConfig_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Message")]
+                    static partial void LogMethod(ILogger logger, string arg);
+
+                    void M(ILogger logger, Exception exception)
+                    {
+                        LogMethod(logger, [|exception.ToString()|]);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task LoggerMessageWarningLevelWithDefaultConfig_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Warning, Message = "Message")]
+                    static partial void LogMethod(ILogger logger, string arg);
+
+                    void M(ILogger logger, Exception exception)
+                    {
+                        LogMethod(logger, exception.ToString());
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task LoggerMessageWarningLevelWithConfiguredMaxWarning_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Warning, Message = "Message")]
+                    static partial void LogMethod(ILogger logger, string arg);
+
+                    void M(ILogger logger, Exception exception)
+                    {
+                        LogMethod(logger, [|exception.ToString()|]);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = warning
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task LoggerMessageErrorLevelWithConfiguredMaxWarning_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Error, Message = "Message")]
+                    static partial void LogMethod(ILogger logger, string arg);
+
+                    void M(ILogger logger, Exception exception)
+                    {
+                        LogMethod(logger, exception.ToString());
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = warning
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
+        [Fact]
+        public async Task LoggerMessageDynamicLevelWithDefaultConfig_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Message = "Message")]
+                    static partial void LogMethod(ILogger logger, LogLevel level, string arg);
+
+                    void M(ILogger logger, Exception exception)
+                    {
+                        LogMethod(logger, LogLevel.Information, [|exception.ToString()|]);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ExtensionMethodLogInformationWithDefaultConfig_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, Exception exception)
+                    {
+                        logger.LogInformation([|exception.ToString()|]);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ExtensionMethodLogWarningWithDefaultConfig_NoDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, Exception exception)
+                    {
+                        logger.LogWarning(exception.ToString());
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ExtensionMethodLogWarningWithConfiguredMaxWarning_ReportsDiagnostic_CS()
+        {
+            string source = """
+                using System;
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, Exception exception)
+                    {
+                        logger.LogWarning([|exception.ToString()|]);
+                    }
+                }
+                """;
+
+            var editorconfig = ("/.editorconfig", """
+                is_global = true
+                
+                dotnet_code_quality.CA1873.max_log_level = warning
+                """);
+
+            await VerifyCSharpDiagnosticAsync(source, editorConfigText: editorconfig);
+        }
+
         // Helpers
 
-        private static async Task VerifyCSharpDiagnosticAsync([StringSyntax($"{LanguageNames.CSharp}-Test")] string source, CodeAnalysis.CSharp.LanguageVersion? languageVersion = null)
+        private static async Task VerifyCSharpDiagnosticAsync([StringSyntax($"{LanguageNames.CSharp}-Test")] string source, CodeAnalysis.CSharp.LanguageVersion? languageVersion = null, (string, string)? editorConfigText = null)
         {
-            await new VerifyCS.Test
+            var test = new VerifyCS.Test
             {
                 TestCode = source,
                 FixedCode = source,
                 ReferenceAssemblies = Net60WithMELogging,
                 LanguageVersion = languageVersion ?? CodeAnalysis.CSharp.LanguageVersion.CSharp10
-            }.RunAsync();
+            };
+
+            if (editorConfigText.HasValue)
+            {
+                test.TestState.AnalyzerConfigFiles.Add((editorConfigText.Value.Item1, editorConfigText.Value.Item2));
+            }
+
+            await test.RunAsync();
         }
 
-        private static async Task VerifyBasicDiagnosticAsync(string source, CodeAnalysis.VisualBasic.LanguageVersion? languageVersion = null)
+        private static async Task VerifyBasicDiagnosticAsync(string source, CodeAnalysis.VisualBasic.LanguageVersion? languageVersion = null, (string, string)? editorConfigText = null)
         {
-            await new VerifyVB.Test
+            var test = new VerifyVB.Test
             {
                 TestCode = source,
                 FixedCode = source,
                 ReferenceAssemblies = Net60WithMELogging,
                 LanguageVersion = languageVersion ?? CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic16_9
-            }.RunAsync();
+            };
+
+            if (editorConfigText.HasValue)
+            {
+                test.TestState.AnalyzerConfigFiles.Add((editorConfigText.Value.Item1, editorConfigText.Value.Item2));
+            }
+
+            await test.RunAsync();
         }
 
         private static readonly ReferenceAssemblies Net60WithMELogging =


### PR DESCRIPTION
Backport of #51818 to release/10.0.1xx

Addresses feedback on the noise level for [CA1873: Avoid potentially expensive logging (code analysis)](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873).

## Customer Issue

Customers that enabled this analyzer with adoption of .NET 10 reported the volume of diagnostics reported was greater than expected and that there were varying degrees of severity yet all diagnostics were reported equally. Finding signal within the noise was a challenge, leading to the reaction of disabling the analyzer despite it offering many suggestions that would be valuable.

The analyzer did not provide any ability to configure the diagnostics to focus on expensive logging within hot paths vs. expensive logging in code paths where the expense is acceptable or even purposeful. The only workarounds would be to either disable the analyzer or to go through all diagnostics and suppress at call sites where the expensive logging is intended.

## Description

The analyzer is updated in a couple ways:

1. Because property accesses are common in logging calls and property accesses are supposed to be cheap, we avoid raising diagnostics for property accesses.
2. As `GetType`/`GetHashCode`/`GetTimestamp` are used reasonably-frequently in logging calls; special-case them to avoid diagnostics for them even though they could be considered expensive.
3. Add configurability of the Log levels that the analyzer reports diagnostics for, defaulting to only kick in for Information and below. The main reason this rule exists is to eliminate cost on hot paths. Generally such hot paths aren't raising warning/error/critical diagnostics, such that the more rare warning/errors don't need as much attention to overheads.

## Was this a regression?

- [ ] Yes
- [x] No

## Testing

A high-volume diagnostic code base was used to validate the developer experience improves as desired with these changes. The code base now reports diagnostics that are clearly actionable and valuable while avoiding diagnostics for call sites and log levels where the expensive logging is acceptable.

## Risk

Low. This analyzer is new in .NET 10, it is disabled by default, and now we are _reducing_ the volume of diagnostics reported while also providing configuration to further reduce it.