### PR TITLE
Fix template resolution ordering bug

### DIFF
--- a/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
+++ b/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
@@ -85,7 +85,7 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
         return versionFileInfo;
     }
 
-    private static IList<string> GetBestVersionsByMajorMinor(IReadOnlyDictionary<string, SemanticVersion> versionDirInfo)
+    internal static IList<string> GetBestVersionsByMajorMinor(IReadOnlyDictionary<string, SemanticVersion> versionDirInfo)
     {
         IDictionary<string, (string path, SemanticVersion version)> bestVersionsByBucket = new Dictionary<string, (string path, SemanticVersion version)>();
 
@@ -105,6 +105,6 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
             }
         }
 
-        return [.. bestVersionsByBucket.OrderBy(x => x.Key).Select(x => x.Value.path)];
+        return [.. bestVersionsByBucket.OrderBy(x => x.Value.version).Select(x => x.Value.path)];
     }
 }

--- a/test/dotnet.Tests/CommandTests/New/BuiltInTemplatePackageProviderTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/BuiltInTemplatePackageProviderTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.New;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.New.Tests;
+
+// Regression tests for https://github.com/dotnet/sdk/issues/51669
+// Specifically validates numeric ordering across one vs two digit majors (9 vs 10) to ensure we do NOT alpha-sort "10" ahead of "9".
+public class BuiltInTemplatePackageProviderTests
+{
+    [Fact]
+    public void GetBestVersionsByMajorMinor_UsesHighestPatchAndNumericOrderingAcrossSingleAndDoubleDigitMajors()
+    {
+        // SDK version (NewCommandParser) must be >= 10.x for both 9.x and 10.x buckets to be included.
+        var sdkVersion = typeof(NewCommandParser).Assembly.GetName().Version ?? new();
+        Assert.True(sdkVersion.Major >= 10, "This test requires running under an SDK whose major version is at least 10.");
+
+        // Build synthetic version directories:
+        // 9.0 bucket: highest patch should be 200 (release preferred over preview)
+        // 10.0 bucket: highest patch should be 300 (release preferred over rc)
+        var versionDirInfo = new Dictionary<string, SemanticVersion>
+        {
+            { @"templates\9.0.101", new SemanticVersion(9, 0, 101) },
+            { @"templates\9.0.200-preview.1", new SemanticVersion(9, 0, 200, releaseLabel: "preview.1") },
+            { @"templates\9.0.200", new SemanticVersion(9, 0, 200) },
+
+            { @"templates\10.0.100", new SemanticVersion(10, 0, 100) },
+            { @"templates\10.0.300-rc.1", new SemanticVersion(10, 0, 300, releaseLabel: "rc.1") },
+            { @"templates\10.0.300", new SemanticVersion(10, 0, 300) }
+        };
+
+        var result = BuiltInTemplatePackageProvider.GetBestVersionsByMajorMinor(versionDirInfo);
+
+        // Expect one entry per (Major.Minor) bucket: 9.0 and 10.0
+        Assert.Equal(2, result.Count);
+
+        // Parse back selected versions (strip any prerelease suffix).
+        var parsed = result.Select(p =>
+        {
+            var name = p.Split('\\').Last();
+            var baseVersion = name.Split('-', 2)[0];
+            return (Path: p, Version: SemanticVersion.Parse(baseVersion));
+        }).ToList();
+
+        // Validate that ordering is numeric ascending: 9.x then 10.x
+        Assert.Equal(9, parsed[0].Version.Major);
+        Assert.Equal(10, parsed[1].Version.Major);
+
+        // Validate highest patch chosen per bucket (release preferred over prerelease)
+        Assert.Equal(200, parsed[0].Version.Patch); // 9.0.200
+        Assert.Equal(300, parsed[1].Version.Patch); // 10.0.300
+
+        // Ensure we did not accidentally select prerelease directories
+        Assert.DoesNotContain(result, r => r.Contains("preview.1"));
+        Assert.DoesNotContain(result, r => r.Contains("rc.1"));
+    }
+
+    [Fact]
+    public void GetBestVersionsByMajorMinor_DoesNotAlphabeticallyPlaceTenBeforeNine()
+    {
+        // This is a more direct assertion against the original bug: alpha ordering of keys would have produced "10.0.*" before "9.0.*".
+        var sdkVersion = typeof(NewCommandParser).Assembly.GetName().Version ?? new();
+        Assert.True(sdkVersion.Major >= 10, "This test requires running under an SDK whose major version is at least 10.");
+
+        var versionDirInfo = new Dictionary<string, SemanticVersion>
+        {
+            { @"templates\9.0.150", new SemanticVersion(9, 0, 150) },
+            { @"templates\10.0.250", new SemanticVersion(10, 0, 250) }
+        };
+
+        var result = BuiltInTemplatePackageProvider.GetBestVersionsByMajorMinor(versionDirInfo);
+
+        Assert.Equal(2, result.Count);
+
+        // Under the buggy alpha key ordering, index 0 would be 10.0.250.
+        // Correct numeric ordering must yield 9.x first.
+        var firstName = result[0].Split('\\').Last();
+        Assert.StartsWith("9.0.", firstName);
+        var secondName = result[1].Split('\\').Last();
+        Assert.StartsWith("10.0.", secondName);
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/51669

## Summary

The issue was that with SDK 9 and SDK 10 installed, the templates used when running `dotnet new` would prefer 9 over 10.  This was happening because when we resolve the template folders, we decided to order the folders. However, the order of the folders was determined by the string key, which is just the string value of the folder name. When sorting strings, they'll be alphabetical, so `"10"` comes before `"9"` because 1 is less than 9. To fix, I simply sort them by the (already parsed) SemanticVersion value of the folder name. Thus, 9 would come before 10.

## Testing

For local testing, it would build `10.0.0` as the template folder name. I copied a template folder from an installed SDK 9, `9.0.11`, and dropped it in there beside the 10 folder. The local template directory path is `artifacts\bin\redist\Debug\dotnet\templates`. I copied a 9 version out of the installed path of `C:\Program Files\dotnet\templates`.

For `dotnet new sln`, the 10 version creates a `.slnx` file. For the 9 version, a `.sln` file. So, testing was just adding and removing the 9 folder and observing the unintentional change in behavior. When the 9 folder is added, only a `.sln` would be created. After making the change to the order within `GetBestVersionsByMajorMinor`, I observed that when adding/removing the 9 folder, the 10 templates were now always being loaded. Meaning, a `.slnx` was always created, which is the intended behavior.

Additionally, I fought a bit with Copilot to create a couple of unit tests. It originally created tests that would not actually test this issue. Meaning, I could revert my change and the test would still pass. 😟 I got it to revise it a couple times and it ended up making okay-enough tests that just check that 9/10 barrier. I made the method internal so the unit tests could directly run it. The test project has InternalsVisibleTo access to the CLI project.