### PR TITLE
Mention deprecation of RoslynCompilerType=Framework in the docs

### DIFF
--- a/documentation/general/decouple-vs-and-net-sdk.md
+++ b/documentation/general/decouple-vs-and-net-sdk.md
@@ -145,7 +145,7 @@ Based on the value of the `RoslynCompilerType` property, the SDK (or compiler to
 
 These values are recognized for property `RoslynCompilerType`:
 - `Core`: use the compiler that comes with the .NET SDK
-- `Framework`: use the compiler that comes with .NET Framework MSBuild
+- `Framework`: use the compiler that comes with .NET Framework MSBuild (this option is [deprecated and will be removed in .NET 11](https://aka.ms/roslyn-compiler-type-framework))
 - `FrameworkPackage`: download the Microsoft.Net.Sdk.Compilers.Toolset package which contains the .NET Framework compiler corresponding to the .NET SDK version
 - `Custom`: the SDK will not override `RoslynTasksAssembly` and the other properties listed above - used for example by Microsoft.Net.Compilers.Toolset package which injects its own version of the build task
 


### PR DESCRIPTION
Follow up on https://github.com/dotnet/sdk/pull/51723.
Part of https://github.com/dotnet/roslyn/issues/81184.