### PR TITLE
Disable NuGetAudit for test assets

### DIFF
--- a/test/TestAssets/Directory.Build.props
+++ b/test/TestAssets/Directory.Build.props
@@ -5,6 +5,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.tmp</DefaultItemExcludes>
+    <NuGetAudit>false</NuGetAudit> 
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Many of these tests intentionally target out of support versions. We build many of them into packages as part of the build.