### PR TITLE
Remove dotnet-format shims

### DIFF
--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -17,14 +17,6 @@
     <!-- Copy nuget assemblies to build directory. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
-    <SignableShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</SignableShimRuntimeIdentifiers>
-
-    <!--
-      These identifiers are for generating the shim'd core executables for signing. Not all options
-      from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
-    -->
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true'">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
-
     <!-- Avoid https://github.com/dotnet/arcade/issues/9305 -->
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #51743 

I'm not finding a reason these are needed.  We aren't including them in the other bundled tools. Therefore I am proposing we remove them.  The size gain is trivial, it is more about cleanliness of not shipping these on non-windows rids.