### PR TITLE
Update SDK minor version in main to 1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
   <PropertyGroup Label="Repo version information">
     <VersionMajor>11</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionSDKMinor>2</VersionSDKMinor>
+    <VersionSDKMinor>1</VersionSDKMinor>
     <VersionFeature>00</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any


### PR DESCRIPTION
It looks like the 2xx branding [flowed](https://github.com/dotnet/sdk/commit/b471af6b1fa598c20903dc80031da4523c319753) back to main inadvertently.