### PR TITLE
[release/9.0.1xx] Support shared .NET installation - baseline update,…

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -106,15 +106,19 @@ jobs:
 
       eng/common/build.sh -bl --projects $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.SmokeTests/Microsoft.DotNet.SourceBuild.SmokeTests.csproj --restore
 
+      source ./eng/common/tools.sh
+      InitializeDotNetCli true
+
       echo "##vso[task.setvariable variable=Platform]$platform"
       echo "##vso[task.setvariable variable=MsftSdkTarballPath]$(Pipeline.Workspace)/Artifacts/$msft_sdk_tarball_name"
       echo "##vso[task.setvariable variable=SdkTarballPath]$(Pipeline.Workspace)/Artifacts/$sdk_tarball_name"
       echo "##vso[task.setvariable variable=SourceBuiltArtifactsPath]$(Pipeline.Workspace)/Artifacts/$artifacts_path"
+      echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
     displayName: Prepare Tests
     workingDirectory: $(Build.SourcesDirectory)
 
   - script: >
-      .dotnet/dotnet test
+      $(DotNetPath)/dotnet test
       $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.SmokeTests/Microsoft.DotNet.SourceBuild.SmokeTests.csproj
       --filter "Category=SdkContent"
       --logger:'trx;LogFileName=$(Agent.JobName)_SDKDiffTests.trx'
@@ -168,6 +172,7 @@ jobs:
   - ${{ if and(eq(parameters.publishTestResultsPr, 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}:
       - template: ../steps/create-baseline-update-pr.yml
         parameters:
+          dotnetPath: $(DotNetPath)
           pipeline: sdk
           repo: dotnet/sdk
           originalFilesDirectory: src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets

--- a/src/SourceBuild/content/eng/pipelines/templates/steps/create-baseline-update-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/steps/create-baseline-update-pr.yml
@@ -1,4 +1,8 @@
 parameters:
+- name: dotnetPath
+  type: string
+  default: '$(Build.SourcesDirectory)/.dotnet'
+
 # The pipeline that is being run
 # Used to determine the correct baseline update tool to run
 # Currently only supports "sdk" and "license"
@@ -31,7 +35,7 @@ steps:
 
       branchName=$(echo "$(Build.SourceBranch)" | sed 's/refs\/heads\///g')
 
-      .dotnet/dotnet run \
+      ${{ parameters.dotnetPath }}/dotnet run \
         --project eng/tools/CreateBaselineUpdatePR/ \
         --property:RestoreSources="$restoreSources" \
         "${{ parameters.pipeline }}" \

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -159,6 +159,7 @@ jobs:
   - script: |
       source ./eng/common/tools.sh
       InitializeDotNetCli true
+      echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
     displayName: Install .NET SDK
     workingDirectory: $(Build.SourcesDirectory)
 
@@ -176,6 +177,7 @@ jobs:
 
   - template: templates/steps/create-baseline-update-pr.yml
     parameters:
+      dotnetPath: $(DotNetPath)
       pipeline: license
       repo: dotnet/sdk
       originalFilesDirectory: src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests


### PR DESCRIPTION
… license scan, sdk diffs

Manual port of https://github.com/dotnet/dotnet/pull/3518 to release/9.0.1xx. `vmr-scan` changes were addressed in https://github.com/dotnet/sdk/pull/51725