### PR TITLE
Limit PR builds to reduce wasted builds

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -9,6 +9,14 @@ pr:
     - release/*
     - internal/release/*
   paths:
+    include:
+    - eng
+    - build
+    - src
+    - test
+    - '*.yml'
+    - '*.props'
+    - '*.targets'
     exclude:
     - documentation/*
     - README.md


### PR DESCRIPTION
When copilot spins up a new PR, it starts with an empty one. Our PR pipeline starts running anyway which is just wasting resources. I added a bunch of includes so hopefully in the future, copilot PRs will wait to build until there are changes. Note that this doesn't cover everything in the root node that could need a build but that list is much longer (editorconfig, json, sln, cmd, sh, etc). These are the main ones.


Added include paths for various directories and file types.