### PR TITLE
Upgrade Spectre.Console to version 0.54.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -114,7 +114,7 @@
     <PackageVersion Include="runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageVersion Include="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
-    <PackageVersion Include="Spectre.Console" Version="0.52.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersPackageVersion)" />
     <PackageVersion Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />


### PR DESCRIPTION
I'd like to use Spectre.Console in NuGet.Client. However, Spectre.Console.Testing version 0.52.0 has a dependency on Spectre.Console.Cli which in turn has a bunch of additional transitive dependencies: OpenCli.Source, NJsonSchema, Namotion.Reflection.

However, Spectre.Console version 0.54.0 has removed all external dependencies, so it reduces source build complications, fewer packages to check for compatible licenses, etc.

edit: source build package updates: https://github.com/dotnet/source-build-reference-packages/pull/1482