### PR TITLE
Fix package reference to Microsoft.DotNet.NativeWrapper in Microsoft.DotNet.Installation NuGet package

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -18,7 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)src\Resolvers\Microsoft.DotNet.NativeWrapper\**\*.cs" LinkBase="Microsoft.DotNet.NativeWrapper" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
-    <ProjectReference Include="..\..\Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Compile NativeWrapper into installation library instead of using project reference

This avoids the NuGet package for the installation library having a package reference to NativeWrapper, which we don't create a NuGet package for.