### PR TITLE
Update version of installation NuGet package to 0.1.1

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -13,7 +13,7 @@
     <PackageId>Microsoft.Dotnet.Installation</PackageId>
     <IsShipping>false</IsShipping>
     <Title>.NET Installation Library</Title>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
The prerelease version of the library changed from `-preview.2` to `-preview.0`, probably as a result merging changes from the main branch which switched to .NET 10.  So this updates the version to 0.1.1 so that new builds will have a semantically higher version than the older ones.