### PR TITLE
Add process to check in prune package data after a major release

### DIFF
--- a/src/Layout/redist/targets/GeneratePackagePruneData.targets
+++ b/src/Layout/redist/targets/GeneratePackagePruneData.targets
@@ -21,6 +21,10 @@
 
       <!-- Add metadata for downloading and binplacing -->
       <TargetingPackForPruneData Version="$(TargetingPackPruneVersion).0.0" TargetFrameworkVersion="$(TargetingPackPruneVersion).0" PackageName="%(Identity).Ref" />
+
+      <!-- Add metadata for where the PackagesOverride file should be in repo source -->
+      <TargetingPackForPruneData RepoSourcePath="$(MSBuildProjectDirectory)\PrunePackageData\%(TargetFrameworkVersion)\%(Identity)\PackageOverrides.txt" />
+      
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFile)"
@@ -34,16 +38,45 @@
   <Target Name="AddTargetingPacksForPruneDataAsPackageDownloads"
           BeforeTargets="CollectPackageDownloads"
           DependsOnTargets="GetTargetingPacksForPruneData">
-    <CollatePackageDownloads Packages="@(TargetingPackForPruneData->Metadata('PackageName'))"
-                             Condition="'@(TargetingPackForPruneData)' != ''">
+
+    <ItemGroup>
+      <TargetingPackToDownloadForPruneData Include="@(TargetingPackForPruneData)"
+                               Condition="!Exists('%(RepoSourcePath)')" />
+    </ItemGroup>
+    
+    <CollatePackageDownloads Packages="@(TargetingPackToDownloadForPruneData->Metadata('PackageName'))"
+                             Condition="'@(TargetingPackToDownloadForPruneData)' != ''">
       <Output TaskParameter="PackageDownloads" ItemName="PackageDownload" />
     </CollatePackageDownloads>
   </Target>
 
-  <Target Name="GeneratePackagePruneData" DependsOnTargets="GetTargetingPacksForPruneData">
+  <!-- After each major release, we want to check in the prune package data for that release.  Downloading the targeting packs during the
+       build would require them to be added to the source-build prebuilts, which we want to avoid.  So the build will download the
+       targeting packs if the corresponding files are not found in the repo source, but this target will generate an error unless
+       CopyPrunePackageDataToSource is set to true.  Setting that to true will copy the data from the targeting packs to the repo source
+       where they can be checked in. -->
+  
+  <Target Name="CopyPruneDataToSource" DependsOnTargets="GetTargetingPacksForPruneData">
+    <ItemGroup>
+      <PrunePackageDataToCopyToSource Include="@(TargetingPackForPruneData)"
+        Source="$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(PackageName)', '').ToLower())\%(Version)\data\PackageOverrides.txt"
+        Condition="!Exists('%(RepoSourcePath)')" />
+    </ItemGroup>
+
+    <Error Condition="'@(PrunePackageDataToCopyToSource)' != '' And '$(CopyPrunePackageDataToSource)' != 'true'"
+           Text="Prune package data not found: %(PrunePackageDataToCopyToSource.RepoSourcePath)
+Build with CopyPrunePackageDataToSource set to true to copy these files into the source tree. Then check them in."/>
+    
+    <Copy SourceFiles="%(PrunePackageDataToCopyToSource.Source)"
+          DestinationFiles="%(RepoSourcePath)"
+          SkipUnchangedFiles="true" />    
+    
+  </Target>
+
+  <Target Name="GeneratePackagePruneData" DependsOnTargets="CopyPruneDataToSource">
     <ItemGroup>
       <PrunePackageCopyData Include="@(TargetingPackForPruneData)"
-        Source="$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(PackageName)', '').ToLower())\%(Version)\data\PackageOverrides.txt"
+        Source="%(RepoSourcePath)"
         Destination="$(OutputPath)PrunePackageData\%(TargetFrameworkVersion)\%(Identity)\PackageOverrides.txt" />
     </ItemGroup>
 

--- a/src/Layout/redist/targets/GeneratePackagePruneData.targets
+++ b/src/Layout/redist/targets/GeneratePackagePruneData.targets
@@ -22,7 +22,7 @@
       <!-- Add metadata for downloading and binplacing -->
       <TargetingPackForPruneData Version="$(TargetingPackPruneVersion).0.0" TargetFrameworkVersion="$(TargetingPackPruneVersion).0" PackageName="%(Identity).Ref" />
 
-      <!-- Add metadata for where the PackagesOverride file should be in repo source -->
+      <!-- Add metadata for where the PackageOverrides file should be in repo source -->
       <TargetingPackForPruneData RepoSourcePath="$(MSBuildProjectDirectory)\PrunePackageData\%(TargetFrameworkVersion)\%(Identity)\PackageOverrides.txt" />
       
     </ItemGroup>


### PR DESCRIPTION
Per discussion in https://github.com/dotnet/dotnet/pull/2271/, we don't want to download targeting packs to get prune package data during the SDK build, because that would require adding them to source build externals.

Instead, we will check the prune package data into the SDK after each major release.  This PR adds support for that.

- If the prune package data exists under `src\Layout\redist\PrunePackageData`, it will be used from there without being downloaded
- If the data isn't there, then the targeting pack will be downloaded, but an error will be generated
- The error will direct you to build with CopyPrunePackageDataToSource set to true, which will suppress the error and copy the data from the downloaded targeting pack into the repo.
- Once a year, when we see the error (while updating to support targeting the next target framework version), we should run the build with CopyPrunePackageDataToSource set to true and check in the new prune package data files.