### PR TITLE
[Backport][10.0.1xx] Add suppressor support for `dotnet format`

### DIFF
--- a/src/BuiltInTools/dotnet-format/Analyzers/AnalyzerFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/Analyzers/AnalyzerFormatter.cs
@@ -315,6 +315,13 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                     .Where(analyzer => DoesAnalyzerSupportLanguage(analyzer, project.Language));
                 foreach (var analyzer in filteredAnalyzer)
                 {
+                    // Allow suppressors unconditionally
+                    if (analyzer is DiagnosticSuppressor suppressor)
+                    {
+                        analyzers.Add(suppressor);
+                        continue;
+                    }
+
                     // Filter by excluded diagnostics
                     if (!excludeDiagnostics.IsEmpty &&
                         analyzer.SupportedDiagnostics.All(descriptor => excludeDiagnostics.Contains(descriptor.Id)))

--- a/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/.editorconfig
+++ b/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+dotnet_diagnostic.IDE0051.severity = warning # Remove unused private member

--- a/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/Program.cs
+++ b/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+namespace for_code_formatter
+{
+    class Program : MonoBehaviour
+    {
+        // This method should trigger IDE0051 (remove unused private member) in a regular project.
+        // But given we simulate a Unity MonoBehavior and we include Microsoft.Unity.Analyzers nuget,
+        // given Update is a well-known Unity message, this IDE0051 should be suppressed by USP0003.
+        // see https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/USP0003.md
+        void Update()
+        {
+
+        }
+    }
+}
+
+namespace UnityEngine
+{
+    public class MonoBehaviour
+    {
+        // This is a placeholder for the Unity MonoBehaviour class.
+        // In a real Unity project, this would be part of the Unity engine.
+    }
+}

--- a/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/suppressor_project.csproj
+++ b/test/TestAssets/dotnet-format/for_code_formatter/suppressor_project/suppressor_project.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.22.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/dotnet-format.UnitTests/CodeFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/CodeFormatterTests.cs
@@ -39,6 +39,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         private static readonly string s_generatorSolutionPath = Path.Combine("for_code_formatter", "generator_solution");
         private static readonly string s_generatorSolutionFileName = "generator_solution.sln";
 
+        private static readonly string s_suppressorProjectPath = Path.Combine("for_code_formatter", "suppressor_project");
+        private static readonly string s_suppressorProjectFilePath = Path.Combine(s_suppressorProjectPath, "suppressor_project.csproj");
+
         private static string[] EmptyFilesList => Array.Empty<string>();
 
         private Regex FindFormattingLogLine => new Regex(@"((.*)\(\d+,\d+\): (.*))\r|((.*)\(\d+,\d+\): (.*))");
@@ -625,6 +628,21 @@ Greeter.Greeter() -> void";
                     // On Windows the generator library may still be locked
                 }
             }
+        }
+
+        [MSBuildFact]
+        public async Task SuppressorsHandledInProject()
+        {
+            await TestFormatWorkspaceAsync(
+                s_suppressorProjectFilePath,
+                include: EmptyFilesList,
+                exclude: EmptyFilesList,
+                includeGenerated: false,
+                expectedExitCode: 0,
+                expectedFilesFormatted: 0,
+                expectedFileCount: 3,
+                codeStyleSeverity: DiagnosticSeverity.Warning,
+                fixCategory: FixCategory.CodeStyle);
         }
 
         internal async Task<string> TestFormatWorkspaceAsync(


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/48512

**Context**:

[Microsoft.Unity.Analyzers](https://github.com/microsoft/Microsoft.Unity.Analyzers) is able to add Unity-specific diagnostics or to remove general C# diagnostics that do not apply to Unity projects (through diagnostic suppressors).

One common usage is to run the `dotnet format` command on a unity solution to ensure projects obey the `.editorconfig` linting rules:

`dotnet format --verify-no-changes --severity warn`

But currently this command does not support diagnostic suppressors, which implies a lack of consistency with our IDEs and command-line build tools, which now manage suppressors.

See https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/387 for a minimal repro.

Other scenarios are likely to be similar, such as the linting of test projects (`NUnit` and `XUnit` make use of diagnostic suppressors).

For this PR we tried to have a minimal impact, by just registering local project suppressors, when running the 
code-style phase.

Added unit tests as well.

fixes https://github.com/dotnet/format/issues/1998
fixes https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/387
fixes https://github.com/dotnet/sdk/issues/44867
fixes https://github.com/dotnet/sdk/issues/51136