### PR TITLE
Virtual project builder

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
@@ -382,4 +382,11 @@ public sealed class MSBuildArgs
             RestoreGlobalProperties = new(newdict);
         }
     }
+
+    internal string[]? GetResolvedTargets()
+        => RequestedTargets is null or { Length: 0 }
+        ? GetTargetResult
+        : GetTargetResult is null or { Length: 0 }
+        ? RequestedTargets : 
+          [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)];
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
@@ -384,9 +384,10 @@ public sealed class MSBuildArgs
     }
 
     internal string[]? GetResolvedTargets()
-        => RequestedTargets is null or { Length: 0 }
-        ? GetTargetResult
-        : GetTargetResult is null or { Length: 0 }
-        ? RequestedTargets
-        : [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)];
+        => this switch
+        {
+            { RequestedTargets: null or [] } => GetTargetResult,
+            { GetTargetResult: null or [] } => RequestedTargets,
+            _ => [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)]
+        };
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
@@ -386,8 +386,8 @@ public sealed class MSBuildArgs
     internal string[]? GetResolvedTargets()
         => this switch
         {
-            { RequestedTargets: null or [] } => GetTargetResult,
-            { GetTargetResult: null or [] } => RequestedTargets,
+            { RequestedTargets: null or { Length: 0 } } => GetTargetResult,
+            { GetTargetResult: null or { Length: 0 } } => RequestedTargets,
             _ => [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)]
         };
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
@@ -387,6 +387,6 @@ public sealed class MSBuildArgs
         => RequestedTargets is null or { Length: 0 }
         ? GetTargetResult
         : GetTargetResult is null or { Length: 0 }
-        ? RequestedTargets : 
-          [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)];
+        ? RequestedTargets
+        : [.. RequestedTargets.Union(GetTargetResult, StringComparer.OrdinalIgnoreCase)];
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\Microsoft.DotNet.Cli.CommandLine\Microsoft.DotNet.Cli.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" GlobalPropertiesToRemove="PublishDir" />
-    <ProjectReference Include="..\..\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -20,9 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Microsoft.DotNet.Cli.CommandLine/Microsoft.DotNet.Cli.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir" />
-    <ProjectReference Include="../Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj" GlobalPropertiesToRemove="PublishDir" />
-    <ProjectReference Include="../Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <ProjectReference Include="..\Microsoft.DotNet.Cli.CommandLine\Microsoft.DotNet.Cli.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <ProjectReference Include="..\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <ProjectReference Include="..\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TelemetryHelper.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TelemetryHelper.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -4,6 +4,7 @@
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
+using Microsoft.DotNet.Utilities;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.Commands;

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/CompositeCommandResolver.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/CompositeCommandResolver.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 

--- a/src/Cli/dotnet/Commands/Build/BuildCommand.cs
+++ b/src/Cli/dotnet/Commands/Build/BuildCommand.cs
@@ -30,15 +30,14 @@ public static class BuildCommand
         return CommandFactory.CreateVirtualOrPhysicalCommand(
             BuildCommandParser.GetCommand(),
             BuildCommandDefinition.SlnOrProjectOrFileArgument,
-            (msbuildArgs, appFilePath) => new VirtualProjectBuildingCommand(
+            configureVirtualCommand: (msbuildArgs, appFilePath) => new VirtualProjectBuildingCommand(
                 entryPointFileFullPath: Path.GetFullPath(appFilePath),
-                msbuildArgs: msbuildArgs
-            )
+                msbuildArgs: msbuildArgs)
             {
                 NoRestore = noRestore,
                 NoCache = true,
             },
-            (msbuildArgs, msbuildPath) => new RestoringCommand(
+            createPhysicalCommand: (msbuildArgs, msbuildPath) => new RestoringCommand(
                 msbuildArgs: msbuildArgs.CloneWithAdditionalArgs("-consoleloggerparameters:Summary"),
                 noRestore: noRestore,
                 msbuildPath: msbuildPath

--- a/src/Cli/dotnet/Commands/Clean/CleanCommand.cs
+++ b/src/Cli/dotnet/Commands/Clean/CleanCommand.cs
@@ -24,8 +24,8 @@ public class CleanCommand(MSBuildArgs msbuildArgs, string? msbuildPath = null) :
             CleanCommandParser.GetCommand(),
             CleanCommandDefinition.SlnOrProjectOrFileArgument,
             static (msbuildArgs, appFilePath) => new VirtualProjectBuildingCommand(
-                    entryPointFileFullPath: appFilePath,
-                    msbuildArgs: msbuildArgs)
+                entryPointFileFullPath: appFilePath,
+                msbuildArgs: msbuildArgs)
             {
                 NoBuild = false,
                 NoRestore = true,

--- a/src/Cli/dotnet/Commands/Clean/FileBasedAppArtifacts/CleanFileBasedAppArtifactsCommand.cs
+++ b/src/Cli/dotnet/Commands/Clean/FileBasedAppArtifacts/CleanFileBasedAppArtifactsCommand.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Commands.Clean.FileBasedAppArtifacts;
 
@@ -60,7 +61,7 @@ internal sealed class CleanFileBasedAppArtifactsCommand(ParseResult parseResult)
 
     private IEnumerable<DirectoryInfo> GetFoldersToRemove()
     {
-        var directory = new DirectoryInfo(VirtualProjectBuildingCommand.GetTempSubdirectory());
+        var directory = new DirectoryInfo(VirtualProjectBuilder.GetTempSubdirectory());
 
         if (!directory.Exists)
         {
@@ -84,7 +85,7 @@ internal sealed class CleanFileBasedAppArtifactsCommand(ParseResult parseResult)
 
     private static FileInfo GetMetadataFile()
     {
-        return new FileInfo(VirtualProjectBuildingCommand.GetTempSubpath(RunFileArtifactsMetadata.FilePath));
+        return new FileInfo(VirtualProjectBuilder.GetTempSubpath(RunFileArtifactsMetadata.FilePath));
     }
 
     private FileStream? OpenMetadataFile()

--- a/src/Cli/dotnet/Commands/CommandFactory.cs
+++ b/src/Cli/dotnet/Commands/CommandFactory.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Commands;
 
@@ -23,7 +24,7 @@ public static class CommandFactory
         var args = parseResult.GetValue(catchAllUserInputArgument) ?? [];
         LoggerUtility.SeparateBinLogArguments(args, out var binLogArgs, out var nonBinLogArgs);
         var forwardedArgs = parseResult.OptionValuesToBeForwarded(command);
-        if (nonBinLogArgs is [{ } arg] && VirtualProjectBuildingCommand.IsValidEntryPointPath(arg))
+        if (nonBinLogArgs is [{ } arg] && VirtualProjectBuilder.IsValidEntryPointPath(arg))
         {
             var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments([.. forwardedArgs, .. binLogArgs],
             [

--- a/src/Cli/dotnet/Commands/Hidden/InternalReportInstallSuccess/InternalReportInstallSuccessCommand.cs
+++ b/src/Cli/dotnet/Commands/Hidden/InternalReportInstallSuccess/InternalReportInstallSuccessCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
 

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.Commands.MSBuild;
 

--- a/src/Cli/dotnet/Commands/New/MSBuildEvaluation/MSBuildEvaluator.cs
+++ b/src/Cli/dotnet/Commands/New/MSBuildEvaluation/MSBuildEvaluator.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using NuGet.ProjectModel;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Commands.Package.Add;
 
@@ -25,7 +26,7 @@ internal class PackageAddCommand(ParseResult parseResult) : CommandBase(parseRes
     {
         var (fileOrDirectory, allowedAppKinds) = PackageCommandDefinition.ProcessPathOptions(_parseResult);
 
-        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuildingCommand.IsValidEntryPointPath(fileOrDirectory))
+        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuilder.IsValidEntryPointPath(fileOrDirectory))
         {
             return ExecuteForFileBasedApp(fileOrDirectory);
         }

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
@@ -6,15 +6,14 @@ using System.Diagnostics;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Commands.NuGet;
 using Microsoft.DotNet.Cli.Commands.Run;
-using Microsoft.DotNet.Cli.CommandLine;
-using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
-using NuGet.ProjectModel;
 using Microsoft.DotNet.ProjectTools;
+using NuGet.ProjectModel;
 
 namespace Microsoft.DotNet.Cli.Commands.Package.Add;
 

--- a/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Add/PackageAddCommand.cs
@@ -192,6 +192,7 @@ internal class PackageAddCommand(ParseResult parseResult) : CommandBase(parseRes
             NoCache = true,
             NoBuild = true,
         };
+
         var projectCollection = new ProjectCollection();
         var projectInstance = command.CreateProjectInstance(projectCollection);
 

--- a/src/Cli/dotnet/Commands/Package/Remove/PackageRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Remove/PackageRemoveCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Commands.Package.Remove;
 
@@ -24,7 +25,7 @@ internal class PackageRemoveCommand(ParseResult parseResult) : CommandBase(parse
 
         var (fileOrDirectory, allowedAppKinds) = PackageCommandDefinition.ProcessPathOptions(_parseResult);
 
-        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuildingCommand.IsValidEntryPointPath(fileOrDirectory))
+        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuilder.IsValidEntryPointPath(fileOrDirectory))
         {
             return ExecuteForFileBasedApp(path: fileOrDirectory, packageId: packageToRemove);
         }

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -24,7 +24,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
     {
         // Check the entry point file path.
         string file = Path.GetFullPath(_file);
-        if (!VirtualProjectBuildingCommand.IsValidEntryPointPath(file))
+        if (!VirtualProjectBuilder.IsValidEntryPointPath(file))
         {
             throw new GracefulException(CliCommandStrings.InvalidFilePath, file);
         }

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -60,7 +60,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         }
         else
         {
-            VirtualProjectBuildingCommand.RemoveDirectivesFromFile(evaluatedDirectives, builder.EntryPointSourceFile.Text, targetFile);
+            VirtualProjectBuilder.RemoveDirectivesFromFile(evaluatedDirectives, builder.EntryPointSourceFile.Text, targetFile);
         }
 
         // Create project file.

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -41,7 +41,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
             VirtualProjectBuildingCommand.ThrowingReporter,
             out var projectInstance,
             out var evaluatedDirectives,
-            validateAllDirectives: true);
+            validateAllDirectives: !_force);
 
         // Find other items to copy over, e.g., default Content items like JSON files in Web apps.
         var includeItems = FindIncludedItems().ToList();

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -46,7 +46,7 @@ internal sealed class ProjectConvertCommand(ParseResult parseResult) : CommandBa
         var projectInstance = command.CreateProjectInstance(projectCollection);
 
         // Evaluate directives.
-        directives = VirtualProjectBuildingCommand.EvaluateDirectives(projectInstance, directives, sourceFile, VirtualProjectBuildingCommand.ThrowingReporter);
+        directives = VirtualProjectBuilder.EvaluateDirectives(projectInstance, directives, sourceFile, VirtualProjectBuildingCommand.ThrowingReporter);
         command.Directives = directives;
         projectInstance = command.CreateProjectInstance(projectCollection);
 

--- a/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Commands.Run.Api;
 
@@ -66,10 +67,16 @@ internal abstract class RunApiInput
         {
             var sourceFile = SourceFile.Load(EntryPointFileFullPath);
             var directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, reportAllErrors: true, ErrorReporters.CreateCollectingReporter(out var diagnostics));
-            string artifactsPath = ArtifactsPath ?? VirtualProjectBuildingCommand.GetArtifactsPath(EntryPointFileFullPath);
+            string artifactsPath = ArtifactsPath ?? VirtualProjectBuilder.GetArtifactsPath(EntryPointFileFullPath);
 
             var csprojWriter = new StringWriter();
-            VirtualProjectBuildingCommand.WriteProjectFile(csprojWriter, directives, isVirtualProject: true, targetFilePath: EntryPointFileFullPath, artifactsPath: artifactsPath);
+            VirtualProjectBuilder.WriteProjectFile(
+                csprojWriter,
+                directives,
+                VirtualProjectBuilder.GetDefaultProperties(VirtualProjectBuildingCommand.TargetFrameworkVersion),
+                isVirtualProject: true,
+                targetFilePath: EntryPointFileFullPath,
+                artifactsPath: artifactsPath);
 
             return new RunApiOutput.Project
             {
@@ -88,11 +95,8 @@ internal abstract class RunApiInput
         {
             var msbuildArgs = MSBuildArgs.FromVerbosity(VerbosityOptions.quiet);
             var buildCommand = new VirtualProjectBuildingCommand(
-                entryPointFileFullPath: EntryPointFileFullPath,
-                msbuildArgs: msbuildArgs)
-            {
-                CustomArtifactsPath = ArtifactsPath,
-            };
+                EntryPointFileFullPath, msbuildArgs, artifactsPath: ArtifactsPath);
+
             buildCommand.MarkArtifactsFolderUsed();
 
             var runCommand = new RunCommand(

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -14,7 +14,6 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.CommandFactory;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Restore;
-using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -19,6 +19,8 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Microsoft.DotNet.Utilities;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.DotNet.Cli.Commands.Run;
 
@@ -545,7 +547,7 @@ public class RunCommand
 
         static ICommand CreateCommandForCscBuiltProgram(string entryPointFileFullPath, string[] args)
         {
-            var artifactsPath = VirtualProjectBuildingCommand.GetArtifactsPath(entryPointFileFullPath);
+            var artifactsPath = VirtualProjectBuilder.GetArtifactsPath(entryPointFileFullPath);
             var exePath = Path.Join(artifactsPath, "bin", "debug", Path.GetFileNameWithoutExtension(entryPointFileFullPath) + FileNameSuffixes.CurrentPlatform.Exe);
             var commandSpec = new CommandSpec(path: exePath, args: ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
             var command = CommandFactoryUsingResolver.Create(commandSpec);
@@ -749,7 +751,7 @@ public class RunCommand
             // If '-' is specified as the input file, read all text from stdin into a temporary file and use that as the entry point.
             // We create a new directory for each file so other files are not included in the compilation.
             // We fail if the file already exists to avoid reusing the same file for multiple stdin runs (in case the random name is duplicate).
-            string directory = VirtualProjectBuildingCommand.GetTempSubpath(Path.GetRandomFileName());
+            string directory = VirtualProjectBuilder.GetTempSubpath(Path.GetRandomFileName());
             VirtualProjectBuildingCommand.CreateTempSubdirectory(directory);
             entryPointFilePath = Path.Join(directory, "app.cs");
             using (var stdinStream = Console.OpenStandardInput())

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -666,7 +666,7 @@ public class RunCommand
 
             if (!readCodeFromStdin)
             {
-                if (VirtualProjectBuildingCommand.IsValidEntryPointPath(arg))
+                if (VirtualProjectBuilder.IsValidEntryPointPath(arg))
                 {
                     arg = Path.GetFullPath(arg);
                 }

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -14,13 +14,13 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.CommandFactory;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Restore;
+using Microsoft.DotNet.Cli.Commands.Run.LaunchSettings;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
 using Microsoft.DotNet.Utilities;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.DotNet.Cli.Commands.Run;
 

--- a/src/Cli/dotnet/Commands/Run/RunTelemetry.cs
+++ b/src/Cli/dotnet/Commands/Run/RunTelemetry.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.Commands.Run;
 

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1091,32 +1091,6 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         }
     }
 
-    public static bool IsValidEntryPointPath(string entryPointFilePath)
-    {
-        if (!File.Exists(entryPointFilePath))
-        {
-            return false;
-        }
-
-        if (entryPointFilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        // Check if the first two characters are #!
-        try
-        {
-            using var stream = File.OpenRead(entryPointFilePath);
-            int first = stream.ReadByte();
-            int second = stream.ReadByte();
-            return first == '#' && second == '!';
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
     public static readonly ErrorReporter ThrowingReporter =
         static (sourceFile, textSpan, message) => throw new GracefulException($"{sourceFile.GetLocationString(textSpan)}: {FileBasedProgramsResources.DirectiveError}: {message}");
 }

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1,26 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Xml;
-using Microsoft.Build.Construction;
-using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Logging.SimpleErrorLogger;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Cli.Commands.Clean.FileBasedAppArtifacts;
 using Microsoft.DotNet.Cli.Commands.Restore;
-using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.FileBasedPrograms;

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1065,32 +1065,6 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         }
     }
 
-    public static SourceText? RemoveDirectivesFromFile(ImmutableArray<CSharpDirective> directives, SourceText text)
-    {
-        if (directives.Length == 0)
-        {
-            return null;
-        }
-
-        Debug.Assert(directives.OrderBy(d => d.Info.Span.Start).SequenceEqual(directives), "Directives should be ordered by source location.");
-
-        for (int i = directives.Length - 1; i >= 0; i--)
-        {
-            var directive = directives[i];
-            text = text.Replace(directive.Info.Span, string.Empty);
-        }
-
-        return text;
-    }
-
-    public static void RemoveDirectivesFromFile(ImmutableArray<CSharpDirective> directives, SourceText text, string filePath)
-    {
-        if (RemoveDirectivesFromFile(directives, text) is { } modifiedText)
-        {
-            new SourceFile(filePath, modifiedText).Save();
-        }
-    }
-
     public static readonly ErrorReporter ThrowingReporter =
         static (sourceFile, textSpan, message) => throw new GracefulException($"{sourceFile.GetLocationString(textSpan)}: {FileBasedProgramsResources.DirectiveError}: {message}");
 }

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -1035,11 +1035,11 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
     {
         Builder.CreateProjectInstance(
             projectCollection,
-            Directives,
-            addGlobalProperties,
             ThrowingReporter,
             out var project,
-            out var evaluatedDirectives);
+            out var evaluatedDirectives,
+            Directives,
+            addGlobalProperties);
 
         Directives = evaluatedDirectives;
 

--- a/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
+++ b/src/Cli/dotnet/Installer/Windows/WindowsUtils.cs
@@ -7,6 +7,7 @@ using System.Runtime.Versioning;
 using System.Security.Principal;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Installer.Windows;

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -18,6 +18,7 @@ using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.ProjectTools;
 using Microsoft.DotNet.Utilities;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Frameworks;
@@ -308,7 +309,7 @@ public class Program
             // If we didn't match any built-in commands, and a C# file path is the first argument,
             // parse as `dotnet run --file file.cs ..rest_of_args` instead.
             if (parseResult.GetResult(Parser.DotnetSubCommand) is { Tokens: [{ Type: TokenType.Argument, Value: { } } unmatchedCommandOrFile] }
-                && VirtualProjectBuildingCommand.IsValidEntryPointPath(unmatchedCommandOrFile.Value))
+                && VirtualProjectBuilder.IsValidEntryPointPath(unmatchedCommandOrFile.Value))
             {
                 List<string> otherTokens = new(parseResult.Tokens.Count - 1);
                 foreach (var token in parseResult.Tokens)

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -18,6 +18,7 @@ using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Utilities;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Frameworks;
 using CommandResult = System.CommandLine.Parsing.CommandResult;

--- a/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
+++ b/src/Cli/dotnet/ReleasePropertyProjectLocator.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectTools;
 using Microsoft.NET.Build.Tasks;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
 
@@ -110,7 +111,7 @@ internal class ReleasePropertyProjectLocator
     {
         foreach (string arg in _slnOrProjectArgs.Append(Directory.GetCurrentDirectory()))
         {
-            if (VirtualProjectBuildingCommand.IsValidEntryPointPath(arg))
+            if (VirtualProjectBuilder.IsValidEntryPointPath(arg))
             {
                 return new VirtualProjectBuildingCommand(Path.GetFullPath(arg), MSBuildArgs.FromProperties(globalProps))
                     .CreateProjectInstance(ProjectCollection.GlobalProjectCollection);

--- a/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -6,6 +6,7 @@
 using System.Collections.Frozen;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Utilities;
 using RuntimeEnvironment = Microsoft.DotNet.Cli.Utils.RuntimeEnvironment;
 using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
 

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -45,7 +45,6 @@
     <ProjectReference Include="..\..\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\..\Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\..\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" GlobalPropertiesToRemove="PublishDir" />
-    <ProjectReference Include="..\..\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Cli\Microsoft.TemplateEngine.Cli.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\..\System.CommandLine.StaticCompletions\System.CommandLine.StaticCompletions.csproj" GlobalPropertiesToRemove="PublishDir" />
     <ProjectReference Include="..\Microsoft.DotNet.Cli.CommandLine\Microsoft.DotNet.Cli.CommandLine.csproj" />

--- a/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
+++ b/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet" />
     <InternalsVisibleTo Include="dotnet.Tests" />
-    <InternalsVisibleTo Include="Microsoft.DotNet.Cli.Utils"/>
     <InternalsVisibleTo Include="Microsoft.DotNet.HotReload.Watch" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
+++ b/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
@@ -12,12 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet" />
     <InternalsVisibleTo Include="dotnet.Tests" />
+    <InternalsVisibleTo Include="Microsoft.DotNet.Cli.Utils"/>
     <InternalsVisibleTo Include="Microsoft.DotNet.HotReload.Watch" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.ProjectTools/Utilities/Sha256Hasher.cs
+++ b/src/Microsoft.DotNet.ProjectTools/Utilities/Sha256Hasher.cs
@@ -11,18 +11,8 @@ public static class Sha256Hasher
     /// The hashed mac address needs to be the same hashed value as produced by the other distinct sources given the same input. (e.g. VsCode)
     /// </summary>
     public static string Hash(string text)
-    {
-        byte[] bytes = Encoding.UTF8.GetBytes(text);
-        byte[] hash = SHA256.HashData(bytes);
-#if NET9_0_OR_GREATER
-        return Convert.ToHexStringLower(hash);
-#else
-        return Convert.ToHexString(hash).ToLowerInvariant();
-#endif
-    }
+        => Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
 
     public static string HashWithNormalizedCasing(string text)
-    {
-        return Hash(text.ToUpperInvariant());
-    }
+        => Hash(text.ToUpperInvariant());
 }

--- a/src/Microsoft.DotNet.ProjectTools/Utilities/Sha256Hasher.cs
+++ b/src/Microsoft.DotNet.ProjectTools/Utilities/Sha256Hasher.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET
-
 using System.Security.Cryptography;
 
-namespace Microsoft.DotNet.Cli.Utils;
+namespace Microsoft.DotNet.Utilities;
 
 public static class Sha256Hasher
 {
@@ -28,5 +26,3 @@ public static class Sha256Hasher
         return Hash(text.ToUpperInvariant());
     }
 }
-
-#endif

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -54,7 +54,7 @@ internal sealed class VirtualProjectBuilder
     }
 
     /// <remarks>
-    /// Kept in sync with the default <c>dotnet new console</c> project file (enforced by <c>DotnetProjectAddTests.SameAsTemplate</c>).
+    /// Kept in sync with the default <c>dotnet new console</c> project file (enforced by <c>DotnetProjectConvertTests.SameAsTemplate</c>).
     /// </remarks>
     public static IEnumerable<(string name, string value)> GetDefaultProperties(string targetFrameworkVersion) =>
     [
@@ -125,7 +125,7 @@ internal sealed class VirtualProjectBuilder
 
     /// <summary>
     /// If there are any <c>#:project</c> <paramref name="directives"/>,
-    /// evaluates their values as MSBuild expressions (i.e. substitutes <c>$()</c> and <c>@()</c> with property and item values) and
+    /// evaluates their values as MSBuild expressions (i.e. substitutes <c>$()</c> and <c>@()</c> with property and item values, etc.) and
     /// resolves the evaluated values to full project file paths (e.g. if the evaluted value is a directory finds a project in that directory).
     /// </summary>
     internal static ImmutableArray<CSharpDirective> EvaluateDirectives(

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -1,0 +1,449 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Security;
+using System.Xml;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectTools;
+
+internal sealed class VirtualProjectBuilder
+{
+    private readonly IEnumerable<(string name, string value)> _defaultProperties;
+
+    public string EntryPointFileFullPath { get; }
+
+    public SourceFile EntryPointSourceFile
+    {
+        get
+        {
+            if (field == default)
+            {
+                field = SourceFile.Load(EntryPointFileFullPath);
+            }
+
+            return field;
+        }
+    }
+
+    public string ArtifactsPath
+        => field ??= GetArtifactsPath(EntryPointFileFullPath);
+
+    public VirtualProjectBuilder(
+        string entryPointFileFullPath,
+        string targetFrameworkVersion,
+        string? artifactsPath = null)
+    {
+        Debug.Assert(Path.IsPathFullyQualified(entryPointFileFullPath));
+
+        EntryPointFileFullPath = entryPointFileFullPath;
+        ArtifactsPath = artifactsPath;
+        _defaultProperties = GetDefaultProperties(targetFrameworkVersion);
+    }
+
+    /// <remarks>
+    /// Kept in sync with the default <c>dotnet new console</c> project file (enforced by <c>DotnetProjectAddTests.SameAsTemplate</c>).
+    /// </remarks>
+    public static IEnumerable<(string name, string value)> GetDefaultProperties(string targetFrameworkVersion) =>
+    [
+        ("OutputType", "Exe"),
+        ("TargetFramework", $"net{targetFrameworkVersion}"),
+        ("ImplicitUsings", "enable"),
+        ("Nullable", "enable"),
+        ("PublishAot", "true"),
+        ("PackAsTool", "true"),
+    ];
+
+    public static string GetArtifactsPath(string entryPointFileFullPath)
+    {
+        // Include entry point file name so the directory name is not completely opaque.
+        string fileName = Path.GetFileNameWithoutExtension(entryPointFileFullPath);
+        string hash = Sha256Hasher.HashWithNormalizedCasing(entryPointFileFullPath);
+        string directoryName = $"{fileName}-{hash}";
+
+        return GetTempSubpath(directoryName);
+    }
+
+    /// <summary>
+    /// Obtains a temporary subdirectory for file-based app artifacts, e.g., <c>/tmp/dotnet/runfile/</c>.
+    /// </summary>
+    public static string GetTempSubdirectory()
+    {
+        // We want a location where permissions are expected to be restricted to the current user.
+        string directory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Path.GetTempPath()
+            : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        return Path.Join(directory, "dotnet", "runfile");
+    }
+
+    /// <summary>
+    /// Obtains a specific temporary path in a subdirectory for file-based app artifacts, e.g., <c>/tmp/dotnet/runfile/{name}</c>.
+    /// </summary>
+    public static string GetTempSubpath(string name)
+    {
+        return Path.Join(GetTempSubdirectory(), name);
+    }
+
+    public ProjectInstance CreateProjectInstance(
+        ProjectCollection projectCollection,
+        ImmutableArray<CSharpDirective> directives,
+        bool includeRuntimeConfigInformation,
+        Action<IDictionary<string, string>>? addGlobalProperties = null)
+    {
+        var projectRoot = CreateProjectRootElement(projectCollection);
+
+        var globalProperties = projectCollection.GlobalProperties;
+        if (addGlobalProperties is not null)
+        {
+            globalProperties = new Dictionary<string, string>(projectCollection.GlobalProperties, StringComparer.OrdinalIgnoreCase);
+            addGlobalProperties(globalProperties);
+        }
+
+        return ProjectInstance.FromProjectRootElement(projectRoot, new ProjectOptions
+        {
+            ProjectCollection = projectCollection,
+            GlobalProperties = globalProperties,
+        });
+
+        ProjectRootElement CreateProjectRootElement(ProjectCollection projectCollection)
+        {
+            var projectFileFullPath = Path.ChangeExtension(EntryPointFileFullPath, ".csproj");
+            var projectFileWriter = new StringWriter();
+
+            WriteProjectFile(
+                projectFileWriter,
+                directives,
+                _defaultProperties,
+                isVirtualProject: true,
+                targetFilePath: EntryPointFileFullPath,
+                artifactsPath: ArtifactsPath,
+                includeRuntimeConfigInformation: includeRuntimeConfigInformation);
+
+            var projectFileText = projectFileWriter.ToString();
+
+            using var reader = new StringReader(projectFileText);
+            using var xmlReader = XmlReader.Create(reader);
+            var projectRoot = ProjectRootElement.Create(xmlReader, projectCollection);
+            projectRoot.FullPath = projectFileFullPath;
+            return projectRoot;
+        }
+    }
+
+    public static void WriteProjectFile(
+        TextWriter writer,
+        ImmutableArray<CSharpDirective> directives,
+        IEnumerable<(string name, string value)> defaultProperties,
+        bool isVirtualProject,
+        string? targetFilePath = null,
+        string? artifactsPath = null,
+        bool includeRuntimeConfigInformation = true,
+        string? userSecretsId = null)
+    {
+        Debug.Assert(userSecretsId == null || !isVirtualProject);
+
+        int processedDirectives = 0;
+
+        var sdkDirectives = directives.OfType<CSharpDirective.Sdk>();
+        var propertyDirectives = directives.OfType<CSharpDirective.Property>();
+        var packageDirectives = directives.OfType<CSharpDirective.Package>();
+        var projectDirectives = directives.OfType<CSharpDirective.Project>();
+
+        const string defaultSdkName = "Microsoft.NET.Sdk";
+        string firstSdkName;
+        string? firstSdkVersion;
+
+        if (sdkDirectives.FirstOrDefault() is { } firstSdk)
+        {
+            firstSdkName = firstSdk.Name;
+            firstSdkVersion = firstSdk.Version;
+            processedDirectives++;
+        }
+        else
+        {
+            firstSdkName = defaultSdkName;
+            firstSdkVersion = null;
+        }
+
+        if (isVirtualProject)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(artifactsPath));
+
+            // Note that ArtifactsPath needs to be specified before Sdk.props
+            // (usually it's recommended to specify it in Directory.Build.props
+            // but importing Sdk.props manually afterwards also works).
+            writer.WriteLine($"""
+                <Project>
+
+                  <PropertyGroup>
+                    <IncludeProjectNameInArtifactsPaths>false</IncludeProjectNameInArtifactsPaths>
+                    <ArtifactsPath>{EscapeValue(artifactsPath)}</ArtifactsPath>
+                    <PublishDir>artifacts/$(MSBuildProjectName)</PublishDir>
+                    <PackageOutputPath>artifacts/$(MSBuildProjectName)</PackageOutputPath>
+                    <FileBasedProgram>true</FileBasedProgram>
+                    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                    <DisableDefaultItemsInProjectFolder>true</DisableDefaultItemsInProjectFolder>
+                """);
+
+            // Only set these to false when using the default SDK with no additional SDKs
+            // to avoid including .resx and other files that are typically not expected in simple file-based apps.
+            // When other SDKs are used (e.g., Microsoft.NET.Sdk.Web), keep the default behavior.
+            bool usingOnlyDefaultSdk = firstSdkName == defaultSdkName && sdkDirectives.Count() <= 1;
+            if (usingOnlyDefaultSdk)
+            {
+                writer.WriteLine($"""
+                        <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+                        <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+                    """);
+            }
+
+            // Write default properties before importing SDKs so they can be overridden by SDKs
+            // (and implicit build files which are imported by the default .NET SDK).
+            foreach (var (name, value) in defaultProperties)
+            {
+                writer.WriteLine($"""
+                        <{name}>{EscapeValue(value)}</{name}>
+                    """);
+            }
+
+            writer.WriteLine($"""
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <Clean Include="{EscapeValue(artifactsPath)}/*" />
+                  </ItemGroup>
+
+                """);
+
+            if (firstSdkVersion is null)
+            {
+                writer.WriteLine($"""
+                      <Import Project="Sdk.props" Sdk="{EscapeValue(firstSdkName)}" />
+                    """);
+            }
+            else
+            {
+                writer.WriteLine($"""
+                      <Import Project="Sdk.props" Sdk="{EscapeValue(firstSdkName)}" Version="{EscapeValue(firstSdkVersion)}" />
+                    """);
+            }
+        }
+        else
+        {
+            string slashDelimited = firstSdkVersion is null
+                ? firstSdkName
+                : $"{firstSdkName}/{firstSdkVersion}";
+            writer.WriteLine($"""
+                <Project Sdk="{EscapeValue(slashDelimited)}">
+
+                """);
+        }
+
+        foreach (var sdk in sdkDirectives.Skip(1))
+        {
+            if (isVirtualProject)
+            {
+                WriteImport(writer, "Sdk.props", sdk);
+            }
+            else if (sdk.Version is null)
+            {
+                writer.WriteLine($"""
+                      <Sdk Name="{EscapeValue(sdk.Name)}" />
+                    """);
+            }
+            else
+            {
+                writer.WriteLine($"""
+                      <Sdk Name="{EscapeValue(sdk.Name)}" Version="{EscapeValue(sdk.Version)}" />
+                    """);
+            }
+
+            processedDirectives++;
+        }
+
+        if (isVirtualProject || processedDirectives > 1)
+        {
+            writer.WriteLine();
+        }
+
+        // Write default and custom properties.
+        {
+            writer.WriteLine("""
+                  <PropertyGroup>
+                """);
+
+            // First write the default properties except those specified by the user.
+            if (!isVirtualProject)
+            {
+                var customPropertyNames = propertyDirectives
+                    .Select(static d => d.Name)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var (name, value) in defaultProperties)
+                {
+                    if (!customPropertyNames.Contains(name))
+                    {
+                        writer.WriteLine($"""
+                                <{name}>{EscapeValue(value)}</{name}>
+                            """);
+                    }
+                }
+
+                if (userSecretsId != null && !customPropertyNames.Contains("UserSecretsId"))
+                {
+                    writer.WriteLine($"""
+                            <UserSecretsId>{EscapeValue(userSecretsId)}</UserSecretsId>
+                        """);
+                }
+            }
+
+            // Write custom properties.
+            foreach (var property in propertyDirectives)
+            {
+                writer.WriteLine($"""
+                        <{property.Name}>{EscapeValue(property.Value)}</{property.Name}>
+                    """);
+
+                processedDirectives++;
+            }
+
+            // Write virtual-only properties which cannot be overridden.
+            if (isVirtualProject)
+            {
+                writer.WriteLine("""
+                        <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
+                        <Features>$(Features);FileBasedProgram</Features>
+                    """);
+            }
+
+            writer.WriteLine("""
+                  </PropertyGroup>
+
+                """);
+        }
+
+        if (packageDirectives.Any())
+        {
+            writer.WriteLine("""
+                  <ItemGroup>
+                """);
+
+            foreach (var package in packageDirectives)
+            {
+                if (package.Version is null)
+                {
+                    writer.WriteLine($"""
+                            <PackageReference Include="{EscapeValue(package.Name)}" />
+                        """);
+                }
+                else
+                {
+                    writer.WriteLine($"""
+                            <PackageReference Include="{EscapeValue(package.Name)}" Version="{EscapeValue(package.Version)}" />
+                        """);
+                }
+
+                processedDirectives++;
+            }
+
+            writer.WriteLine("""
+                  </ItemGroup>
+
+                """);
+        }
+
+        if (projectDirectives.Any())
+        {
+            writer.WriteLine("""
+                  <ItemGroup>
+                """);
+
+            foreach (var projectReference in projectDirectives)
+            {
+                writer.WriteLine($"""
+                        <ProjectReference Include="{EscapeValue(projectReference.Name)}" />
+                    """);
+
+                processedDirectives++;
+            }
+
+            writer.WriteLine("""
+                  </ItemGroup>
+
+                """);
+        }
+
+        Debug.Assert(processedDirectives + directives.OfType<CSharpDirective.Shebang>().Count() == directives.Length);
+
+        if (isVirtualProject)
+        {
+            Debug.Assert(targetFilePath is not null);
+
+            // Only add explicit Compile item when EnableDefaultCompileItems is not true.
+            // When EnableDefaultCompileItems=true, the file is included via default MSBuild globbing.
+            // See https://github.com/dotnet/sdk/issues/51785
+            writer.WriteLine($"""
+                  <ItemGroup>
+                    <Compile Condition="'$(EnableDefaultCompileItems)' != 'true'" Include="{EscapeValue(targetFilePath)}" />
+                  </ItemGroup>
+
+                """);
+
+            if (includeRuntimeConfigInformation)
+            {
+                var targetDirectory = Path.GetDirectoryName(targetFilePath) ?? "";
+                writer.WriteLine($"""
+                      <ItemGroup>
+                        <RuntimeHostConfigurationOption Include="EntryPointFilePath" Value="{EscapeValue(targetFilePath)}" />
+                        <RuntimeHostConfigurationOption Include="EntryPointFileDirectoryPath" Value="{EscapeValue(targetDirectory)}" />
+                      </ItemGroup>
+
+                    """);
+            }
+
+            foreach (var sdk in sdkDirectives)
+            {
+                WriteImport(writer, "Sdk.targets", sdk);
+            }
+
+            if (!sdkDirectives.Any())
+            {
+                Debug.Assert(firstSdkName == defaultSdkName && firstSdkVersion == null);
+                writer.WriteLine($"""
+                      <Import Project="Sdk.targets" Sdk="{defaultSdkName}" />
+                    """);
+            }
+
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("""
+            </Project>
+            """);
+
+        static string EscapeValue(string value) => SecurityElement.Escape(value);
+
+        static void WriteImport(TextWriter writer, string project, CSharpDirective.Sdk sdk)
+        {
+            if (sdk.Version is null)
+            {
+                writer.WriteLine($"""
+                      <Import Project="{EscapeValue(project)}" Sdk="{EscapeValue(sdk.Name)}" />
+                    """);
+            }
+            else
+            {
+                writer.WriteLine($"""
+                      <Import Project="{EscapeValue(project)}" Sdk="{EscapeValue(sdk.Name)}" Version="{EscapeValue(sdk.Version)}" />
+                    """);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -124,7 +124,9 @@ internal sealed class VirtualProjectBuilder
     }
 
     /// <summary>
-    /// If there are any <c>#:project</c> <paramref name="directives"/>, expands <c>$()</c> in them and ensures they point to project files (not directories).
+    /// If there are any <c>#:project</c> <paramref name="directives"/>,
+    /// evaluates their values as MSBuild expressions (i.e. substitutes <c>$()</c> and <c>@()</c> with property and item values) and
+    /// resolves the evaluated values to full project file paths (e.g. if the evaluted value is a directory finds a project in that directory).
     /// </summary>
     internal static ImmutableArray<CSharpDirective> EvaluateDirectives(
         ProjectInstance? project,

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -96,6 +96,32 @@ internal sealed class VirtualProjectBuilder
         return Path.Join(GetTempSubdirectory(), name);
     }
 
+    public static bool IsValidEntryPointPath(string entryPointFilePath)
+    {
+        if (!File.Exists(entryPointFilePath))
+        {
+            return false;
+        }
+
+        if (entryPointFilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Check if the first two characters are #!
+        try
+        {
+            using var stream = File.OpenRead(entryPointFilePath);
+            int first = stream.ReadByte();
+            int second = stream.ReadByte();
+            return first == '#' && second == '!';
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     /// <summary>
     /// If there are any <c>#:project</c> <paramref name="directives"/>, expands <c>$()</c> in them and ensures they point to project files (not directories).
     /// </summary>

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -99,7 +99,7 @@ internal sealed class VirtualProjectBuilder
     /// <summary>
     /// If there are any <c>#:project</c> <paramref name="directives"/>, expands <c>$()</c> in them and ensures they point to project files (not directories).
     /// </summary>
-    public static ImmutableArray<CSharpDirective> EvaluateDirectives(
+    internal static ImmutableArray<CSharpDirective> EvaluateDirectives(
         ProjectInstance? project,
         ImmutableArray<CSharpDirective> directives,
         SourceFile sourceFile,
@@ -126,11 +126,12 @@ internal sealed class VirtualProjectBuilder
         out ProjectInstance project,
         out ImmutableArray<CSharpDirective> evaluatedDirectives,
         ImmutableArray<CSharpDirective> directives = default,
-        Action<IDictionary<string, string>>? addGlobalProperties = null)
+        Action<IDictionary<string, string>>? addGlobalProperties = null,
+        bool validateAllDirectives = false)
     {
         if (directives.IsDefault)
         {
-            directives = FileLevelDirectiveHelpers.FindDirectives(EntryPointSourceFile, reportAllErrors: false, errorReporter);
+            directives = FileLevelDirectiveHelpers.FindDirectives(EntryPointSourceFile, validateAllDirectives, errorReporter);
         }
 
         project = CreateProjectInstance(projectCollection, directives, addGlobalProperties);

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -122,12 +122,17 @@ internal sealed class VirtualProjectBuilder
 
     public void CreateProjectInstance(
         ProjectCollection projectCollection,
-        ImmutableArray<CSharpDirective> directives,
-        Action<IDictionary<string, string>>? addGlobalProperties,
         ErrorReporter errorReporter,
         out ProjectInstance project,
-        out ImmutableArray<CSharpDirective> evaluatedDirectives)
+        out ImmutableArray<CSharpDirective> evaluatedDirectives,
+        ImmutableArray<CSharpDirective> directives = default,
+        Action<IDictionary<string, string>>? addGlobalProperties = null)
     {
+        if (directives.IsDefault)
+        {
+            directives = FileLevelDirectiveHelpers.FindDirectives(EntryPointSourceFile, reportAllErrors: false, errorReporter);
+        }
+
         project = CreateProjectInstance(projectCollection, directives, addGlobalProperties);
 
         evaluatedDirectives = EvaluateDirectives(project, directives, EntryPointSourceFile, errorReporter);

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -86,6 +86,11 @@ internal sealed class VirtualProjectBuilder
             ? Path.GetTempPath()
             : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
+        if (string.IsNullOrEmpty(directory))
+        {
+            throw new InvalidOperationException(FileBasedProgramsResources.EmptyTempPath);
+        }
+
         return Path.Join(directory, "dotnet", "runfile");
     }
 

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreAppForTelemetry.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
-using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.NET.Build.Tests
 {

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <!-- Make sure tasks project is built, but don't directly reference it as an assembly. -->
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\..\src\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" />
 
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -35,9 +35,9 @@
 
   <ItemGroup>
     <!-- Make sure tasks project is built, but don't directly reference it as an assembly. -->
-    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\..\src\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" />
 
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
     <ProjectReference Include="..\TelemetryStdOutLogger\TelemetryStdOutLogger.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" />

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TelemetryHelperTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TelemetryHelperTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FakeItEasy;
-using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Parameters;
 using Microsoft.TemplateEngine.Utils;

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Run.Tests;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Project.Convert.Tests;
 
@@ -1700,7 +1701,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, reportAllErrors: !force, diagnosticBag);
         directives = VirtualProjectBuildingCommand.EvaluateDirectives(project: null, directives, sourceFile, diagnosticBag);
         var projectWriter = new StringWriter();
-        VirtualProjectBuildingCommand.WriteProjectFile(projectWriter, directives, isVirtualProject: false);
+        VirtualProjectBuilder.WriteProjectFile(projectWriter, directives, VirtualProjectBuilder.GetDefaultProperties(VirtualProjectBuildingCommand.TargetFrameworkVersion), isVirtualProject: false);
         actualProject = projectWriter.ToString();
         actualCSharp = VirtualProjectBuildingCommand.RemoveDirectivesFromFile(directives, sourceFile.Text)?.ToString();
     }

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1005,6 +1005,51 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void ForceOption_Off()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var filePath = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(filePath, """
+            #:property Prop1=1
+            #define X
+            #:property Prop2=2
+            Console.WriteLine();
+            #:property Prop1=3
+            """);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErrContaining(FileBasedProgramsResources.CannotConvertDirective);
+
+        new DirectoryInfo(Path.Join(testInstance.Path))
+            .EnumerateDirectories().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ForceOption_On()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var filePath = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(filePath, """
+            #:property Prop1=1
+            #define X
+            #:property Prop2=2
+            Console.WriteLine();
+            #:property Prop1=3
+            """);
+
+        new DotnetCommand(Log, "project", "convert", "--force", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        new DirectoryInfo(Path.Join(testInstance.Path))
+            .EnumerateDirectories().Should().NotBeEmpty();
+    }
+
+    [Fact]
     public void Directives()
     {
         VerifyConversion(

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1703,7 +1703,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var projectWriter = new StringWriter();
         VirtualProjectBuilder.WriteProjectFile(projectWriter, directives, VirtualProjectBuilder.GetDefaultProperties(VirtualProjectBuildingCommand.TargetFrameworkVersion), isVirtualProject: false);
         actualProject = projectWriter.ToString();
-        actualCSharp = VirtualProjectBuildingCommand.RemoveDirectivesFromFile(directives, sourceFile.Text)?.ToString();
+        actualCSharp = VirtualProjectBuilder.RemoveDirectivesFromFile(directives, sourceFile.Text)?.ToString();
     }
 
     /// <param name="expectedCSharp">

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1699,7 +1699,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         actualDiagnostics = null;
         var diagnosticBag = collectDiagnostics ? ErrorReporters.CreateCollectingReporter(out actualDiagnostics) : VirtualProjectBuildingCommand.ThrowingReporter;
         var directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, reportAllErrors: !force, diagnosticBag);
-        directives = VirtualProjectBuildingCommand.EvaluateDirectives(project: null, directives, sourceFile, diagnosticBag);
+        directives = VirtualProjectBuilder.EvaluateDirectives(project: null, directives, sourceFile, diagnosticBag);
         var projectWriter = new StringWriter();
         VirtualProjectBuilder.WriteProjectFile(projectWriter, directives, VirtualProjectBuilder.GetDefaultProperties(VirtualProjectBuildingCommand.TargetFrameworkVersion), isVirtualProject: false);
         actualProject = projectWriter.ToString();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Cli.Run.Tests;
 
@@ -912,7 +913,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
 
         var workDir = TestPathUtility.ResolveTempPrefixLink(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance,
@@ -961,7 +962,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
 
         var workDir = TestPathUtility.ResolveTempPrefixLink(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance,
@@ -1668,7 +1669,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         // It is an error when never restored before.
@@ -1700,7 +1701,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         // It is an error when never restored before.
@@ -1744,7 +1745,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, "Console.WriteLine();");
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "restore", "Program.cs")
@@ -1764,7 +1765,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "restore", "Program.cs")
@@ -1782,7 +1783,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         // It is an error when never built before.
@@ -1822,7 +1823,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         // It is an error when never built before.
@@ -1865,7 +1866,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             class C;
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "lib.cs")
@@ -1905,7 +1906,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             </Project>
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "lib.cs")
@@ -1940,7 +1941,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             class C;
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "module.cs")
@@ -1968,7 +1969,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             Console.WriteLine("Hello WinExe");
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "winexe.cs")
@@ -1993,7 +1994,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             Console.WriteLine("Hello Exe");
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "exe.cs")
@@ -2030,7 +2031,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             </Project>
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "exe.cs")
@@ -2061,7 +2062,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             Console.WriteLine("Hello AppContainerExe");
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "appcontainerexe.cs")
@@ -2086,7 +2087,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var programFile = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(programFile, s_program);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(testInstance.Path, "artifacts");
@@ -2117,7 +2118,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var programFile = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(programFile, s_program);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(testInstance.Path, "artifacts");
@@ -2152,7 +2153,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             { "MyKey": "MyValue" }
             """);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(testInstance.Path, "artifacts");
@@ -2176,7 +2177,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var programFile = Path.Join(testInstance.Path, "Program.cs");
         File.WriteAllText(programFile, s_program);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(testInstance.Path, "artifacts");
@@ -2201,7 +2202,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var programFile = Path.Join(testInstance.Path, "MyCustomProgram.cs");
         File.WriteAllText(programFile, s_program);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(testInstance.Path, "artifacts");
@@ -2269,7 +2270,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var programFile = Path.Join(subDir.FullName, "Program.cs");
         File.WriteAllText(programFile, s_program);
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var publishDir = Path.Join(subDir.FullName, "artifacts");
@@ -2304,7 +2305,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().Pass()
             .And.HaveStdOut("Hello; EntryPointFilePath set? True");
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var outputDir = Path.Join(testInstance.Path, "artifacts");
@@ -2348,7 +2349,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().Pass()
             .And.HaveStdOut("Hello; EntryPointFilePath set? True");
 
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var outputDir = Path.Join(testInstance.Path, "custom");
@@ -2384,7 +2385,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Should().Pass()
             .And.HaveStdOut("Hello from Program");
 
-        var artifactsDir = new DirectoryInfo(VirtualProjectBuildingCommand.GetArtifactsPath(programFile));
+        var artifactsDir = new DirectoryInfo(VirtualProjectBuilder.GetArtifactsPath(programFile));
         artifactsDir.Should().HaveFiles(["build-start.cache", "build-success.cache"]);
 
         var dllFile = artifactsDir.File("bin/debug/Program.dll");
@@ -2409,7 +2410,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programFile, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programFile);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programFile);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "build", "Program.cs")
@@ -2898,7 +2899,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         if (useIdArg)
@@ -2953,7 +2954,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(entryPointPath, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(entryPointPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(entryPointPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         // Build using MSBuild.
@@ -3235,7 +3236,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         string programName = Path.GetFileNameWithoutExtension(fileName);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(entryPointPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(entryPointPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
         var artifactsBackupDir = Path.ChangeExtension(artifactsDir, ".bak");
         if (Directory.Exists(artifactsBackupDir)) Directory.Delete(artifactsBackupDir, recursive: true);
@@ -3310,7 +3311,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.Csc, expectedOutput: "Hello v1");
@@ -3683,7 +3684,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.Csc, expectedOutput: "v1");
@@ -3801,7 +3802,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), "<Project />");
@@ -3844,7 +3845,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(Path.Join(testInstance.Path, "Program.cs"));
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         new DotnetCommand(Log, "run", "Program.cs", "-bl", "--no-restore")
@@ -3890,7 +3891,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.Csc, expectedOutput: "v1", programFileName: programFileName);
@@ -3904,7 +3905,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, s_program);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.Csc, args: ["test", "args"], expectedOutput: """
@@ -3970,7 +3971,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1 Release");
@@ -4029,7 +4030,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1 Release", programFileName: programFileName);
@@ -4057,7 +4058,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, args: ["test", "args"], expectedOutput: """
@@ -4096,7 +4097,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All);
@@ -4183,7 +4184,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var programFileName = "App/Program.cs";
@@ -4235,7 +4236,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1 Release");
@@ -4266,7 +4267,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1 Release");
@@ -4565,7 +4566,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             """");
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(filePath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(filePath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var prefix = cscOnly

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3534,7 +3534,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.CreateSymbolicLink(path: programPath, pathToTarget: intermediatePath);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1", programFileName: programFileName);

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3494,7 +3494,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.CreateSymbolicLink(path: programPath, pathToTarget: originalPath);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1", programFileName: programFileName);
@@ -3589,7 +3589,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.WriteAllText(programPath, code);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         var programFileName = "App/Program.cs";
@@ -3936,7 +3936,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.CreateSymbolicLink(path: programPath, pathToTarget: originalPath);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.Csc, expectedOutput: "v1", programFileName: programFileName);
@@ -4131,7 +4131,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         File.CreateSymbolicLink(path: programPath, pathToTarget: originalPath);
 
         // Remove artifacts from possible previous runs of this test.
-        var artifactsDir = VirtualProjectBuildingCommand.GetArtifactsPath(programPath);
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
         if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
 
         Build(testInstance, BuildLevel.All, expectedOutput: "v1", programFileName: programFileName);

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -6,6 +6,7 @@
 using Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Tests
 {

--- a/test/dotnet.Tests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryFilterTest.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Utilities;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests


### PR DESCRIPTION
Separate stateless, CLI-independent logic from `VirtualProjectBuildingCommand` to a new type `VirtualProjectBuilder`.
This can be used to create `ProjectInstance` for file-based project, e.g. in dotnet-watch.