### PR TITLE
Skip up-to-date optimization in dotnet-run-file when there are `#:project` directives

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -756,6 +756,12 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
     {
         cache = ComputeCacheEntry();
 
+        if (Directives.Any(static d => d is CSharpDirective.Project))
+        {
+            Reporter.Verbose.WriteLine("Building because there are project directives.");
+            return true;
+        }
+
         // Check cache files.
 
         string artifactsDirectory = ArtifactsPath;


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/52057.