### PR TITLE
Fix dotnet-run-file up-to-date checks across symlinks

### DIFF
--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -847,7 +847,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         }
 
         // Check that the source file is not modified.
-        var targetFile = ResolveLinkTarget(entryPointFile);
+        var targetFile = ResolveLinkTargetOrSelf(entryPointFile);
         if (targetFile.LastWriteTimeUtc > buildTimeUtc)
         {
             cache.CanUseCscViaPreviousArguments = true;
@@ -858,7 +858,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         // Check that implicit build files are not modified.
         foreach (var implicitBuildFilePath in previousCacheEntry.ImplicitBuildFiles)
         {
-            var implicitBuildFileInfo = ResolveLinkTarget(new FileInfo(implicitBuildFilePath));
+            var implicitBuildFileInfo = ResolveLinkTargetOrSelf(new FileInfo(implicitBuildFilePath));
             if (!implicitBuildFileInfo.Exists || implicitBuildFileInfo.LastWriteTimeUtc > buildTimeUtc)
             {
                 Reporter.Verbose.WriteLine("Building because implicit build file is missing or modified: " + implicitBuildFileInfo.FullName);
@@ -878,7 +878,7 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
         return false;
 
-        static FileSystemInfo ResolveLinkTarget(FileSystemInfo fileSystemInfo)
+        static FileSystemInfo ResolveLinkTargetOrSelf(FileSystemInfo fileSystemInfo)
         {
             return fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) ?? fileSystemInfo;
         }

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -880,6 +880,11 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
 
         static FileSystemInfo ResolveLinkTargetOrSelf(FileSystemInfo fileSystemInfo)
         {
+            if (!fileSystemInfo.Exists)
+            {
+                return fileSystemInfo;
+            }
+
             return fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) ?? fileSystemInfo;
         }
     }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -1066,6 +1066,15 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .Execute()
             .Should().Pass()
             .And.HaveStdOut("Hello from LinkedAssemblyName");
+
+        // Removing the Directory.Build.props should be detected by up-to-date check.
+        File.Delete(Path.Join(dir2, "Directory.Build.props"));
+
+        new DotnetCommand(Log, "run", programFileName)
+            .WithWorkingDirectory(dir2)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello from linked");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/52063.