### PR TITLE
[dotnet-watch] Include AddExplicitInterfaceImplementation capability

### DIFF
--- a/src/BuiltInTools/HotReloadClient/DefaultHotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/DefaultHotReloadClient.cs
@@ -77,12 +77,15 @@ namespace Microsoft.DotNet.HotReload
                     // When the client connects, the first payload it sends is the initialization payload which includes the apply capabilities.
 
                     var capabilities = (await ClientInitializationResponse.ReadAsync(_pipe, cancellationToken)).Capabilities;
-                    Logger.Log(LogEvents.Capabilities, capabilities);
+
+                    var result = AddImplicitCapabilities(capabilities.Split(' '));
+
+                    Logger.Log(LogEvents.Capabilities, string.Join(" ", result));
 
                     // fire and forget:
                     _ = ListenForResponsesAsync(cancellationToken);
 
-                    return [.. capabilities.Split(' ')];
+                    return result;
                 }
                 catch (Exception e) when (e is not OperationCanceledException)
                 {

--- a/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/HotReloadClient.cs
@@ -41,6 +41,13 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     internal Task PendingUpdates
         => _pendingUpdates;
 
+    /// <summary>
+    /// .NET Framework runtime does not support adding MethodImpl entries, therefore the capability is not in the baseline capability set.
+    /// All other runtimes (.NET and Mono) support it and rather than servicing all of them we include the capability here.
+    /// </summary>
+    protected static ImmutableArray<string> AddImplicitCapabilities(IEnumerable<string> capabilities)
+        => [.. capabilities, "AddExplicitInterfaceImplementation"];
+
     public abstract void ConfigureLaunchEnvironment(IDictionary<string, string> environmentBuilder);
 
     /// <summary>

--- a/src/BuiltInTools/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -41,24 +41,30 @@ namespace Microsoft.DotNet.HotReload
 
         private static ImmutableArray<string> GetUpdateCapabilities(ILogger logger, ImmutableArray<string> projectHotReloadCapabilities, Version projectTargetFrameworkVersion)
         {
-            var capabilities = projectHotReloadCapabilities;
-
-            if (capabilities.IsEmpty)
-            {
-                logger.LogDebug("Using capabilities based on project target framework version: '{Version}'.", projectTargetFrameworkVersion);
-
-                capabilities = projectTargetFrameworkVersion.Major switch
+            var capabilities = projectHotReloadCapabilities.IsEmpty
+                ? projectTargetFrameworkVersion.Major switch
                 {
                     9 => s_defaultCapabilities90,
                     8 => s_defaultCapabilities80,
                     7 => s_defaultCapabilities70,
                     6 => s_defaultCapabilities60,
                     _ => [],
-                };
+                }
+                : projectHotReloadCapabilities;
+
+            if (capabilities is not [])
+            {
+                capabilities = AddImplicitCapabilities(capabilities);
+            }
+
+            var capabilitiesStr = string.Join(", ", capabilities);
+            if (projectHotReloadCapabilities.IsEmpty)
+            {
+                logger.LogDebug("Project specifies capabilities: {Capabilities}.", capabilitiesStr);
             }
             else
             {
-                logger.LogDebug("Project specifies capabilities: '{Capabilities}'", string.Join(" ", capabilities));
+                logger.LogDebug("Using capabilities based on project target framework version: '{Version}': {Capabilities}.", projectTargetFrameworkVersion, capabilitiesStr);
             }
 
             return capabilities;

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
@@ -57,7 +57,7 @@ public class HotReloadClientTests(ITestOutputHelper output)
         await using var test = new Test(output, agent);
 
         var actualCapabilities = await test.Client.GetUpdateCapabilitiesAsync(CancellationToken.None);
-        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType"], actualCapabilities);
+        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], actualCapabilities);
 
         var update = new HotReloadManagedCodeUpdate(
             moduleId: moduleId,
@@ -86,7 +86,7 @@ public class HotReloadClientTests(ITestOutputHelper output)
         await using var test = new Test(output, agent);
 
         var actualCapabilities = await test.Client.GetUpdateCapabilitiesAsync(CancellationToken.None);
-        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType"], actualCapabilities);
+        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], actualCapabilities);
 
         var update = new HotReloadManagedCodeUpdate(
             moduleId: moduleId,
@@ -125,7 +125,7 @@ public class HotReloadClientTests(ITestOutputHelper output)
         await using var test = new Test(output, agent);
 
         var actualCapabilities = await test.Client.GetUpdateCapabilitiesAsync(CancellationToken.None);
-        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType"], actualCapabilities);
+        AssertEx.SequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], actualCapabilities);
 
         var update = new HotReloadManagedCodeUpdate(
             moduleId: Guid.NewGuid(),

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -69,6 +69,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
             UpdateSourceFile(Path.Combine(dependencyDir, "Foo.cs"), newSrc);
 
             await App.AssertOutputLineStartsWith("Changed!");
+
+            App.AssertOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddFieldRva AddInstanceFieldToExistingType AddMethodToExistingType AddStaticFieldToExistingType Baseline ChangeCustomAttributes GenericAddFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod NewTypeDefinition UpdateParameters.");
         }
 
         [Fact]
@@ -892,11 +894,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
             // check project specified capapabilities:
             if (projectSpecifiesCapabilities)
             {
-                App.AssertOutputContains("dotnet watch 🔥 Hot reload capabilities: Baseline AddMethodToExistingType.");
+                App.AssertOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddMethodToExistingType Baseline.");
             }
             else
             {
-                App.AssertOutputContains("dotnet watch 🔥 Hot reload capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType.");
+                App.AssertOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddFieldRva AddInstanceFieldToExistingType AddMethodToExistingType AddStaticFieldToExistingType Baseline ChangeCustomAttributes GenericAddFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod NewTypeDefinition UpdateParameters.");
             }
         }
 
@@ -963,10 +965,10 @@ namespace Microsoft.DotNet.Watch.UnitTests
             App.AssertOutputContains(MessageDescriptor.ApplicationKind_BlazorHosted);
 
             // client capabilities:
-            App.AssertOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Project 'blazorwasm ({tfm})' specifies capabilities: 'Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType'");
+            App.AssertOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Project specifies capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType AddExplicitInterfaceImplementation.");
 
             // server capabilities:
-            App.AssertOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Capabilities: 'Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType AddFieldRva'");
+            App.AssertOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType AddFieldRva AddExplicitInterfaceImplementation.");
         }
 
         [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759


### PR DESCRIPTION
We have two code paths that get capabilities from the runtime: the debugger reads them via [VIL evaluation](https://devdiv.visualstudio.com/DevDiv/_git/Concord?path=/src/vil/host/VisualStudioHost/EE/VilEvaluationServices.cs&version=GBmain&line=3000&lineEnd=3000&lineStartColumn=9&lineEndColumn=83&lineStyle=plain&_a=contents) and the Hot Reload agent reads them [here](https://github.com/dotnet/sdk/blob/e300dea82e0248b0801f706914c96073c1bd5350/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs#L83) .

The latter is missing `AddExplicitInterfaceImplementation` capability, which is an implicit capability that is not returned by the runtime but is supported by .NET runtime (and not by .NET Framework). 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2655394

Follow ups:
- [x] Update source package version in Project System: https://github.com/dotnet/project-system/pull/9822
- [x] Delete https://github.com/dotnet/roslyn/blob/ac3431e351642a7ab47d1a8d82a3964efe57bdc8/src/Features/ExternalAccess/HotReload/Api/HotReloadService.cs#L154 as it's no longer needed
- [ ] Consider eliminating the VIL evaluation code path to avoid duplication: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2657157