### PR TITLE
create a tasks-focused solution filter, and make repo tests more usable in VSCode

### DIFF
--- a/tasks.slnf
+++ b/tasks.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "sdk.slnx",
+    "projects": [
+      "src\\Tasks\\Microsoft.NET.Build.Tasks\\Microsoft.NET.Build.Tasks.csproj",
+      "src\\Compatibility\\ApiCompat\\Microsoft.DotNet.ApiCompat.Task\\Microsoft.DotNet.ApiCompat.Task.csproj",
+      "src\\Tasks\\Microsoft.NET.Build.Tasks.UnitTests\\Microsoft.NET.Build.Tasks.UnitTests.csproj",
+      "test\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj"
+    ]
+  }
+}

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -83,5 +83,8 @@
   <Import Project="BuildTestPackages.targets" Condition="'$(BuildTestPackages)' != 'false'" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
 
 </Project>

--- a/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
+++ b/test/Microsoft.NET.TestFramework/ProjectConstruction/TestProject.cs
@@ -87,6 +87,12 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
         /// </summary>
         public List<string> PropertiesToRecord { get; } = new List<string>();
 
+        /// <summary>
+        /// The target before which to record properties specified in <see cref="PropertiesToRecord"/>.
+        /// Defaults to "AfterBuild".
+        /// </summary>
+        public string TargetToRecordPropertiesBefore { get; private set; } = "AfterBuild";
+
         public IEnumerable<string> TargetFrameworkIdentifiers
         {
             get
@@ -252,7 +258,7 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
                     if(importGroup?.Attribute("Project") is not null)
                     {
                         importGroup.Attribute("Project")!.Value = "$(VSINSTALLDIR)\\MSBuild\\Microsoft\\Portable\\$(TargetFrameworkVersion)\\Microsoft.Portable.CSharp.targets";
-                    }  
+                    }
                 }
 
                 if(TargetFrameworkVersion is not null)
@@ -375,12 +381,12 @@ namespace Microsoft.NET.TestFramework.ProjectConstruction
 
                 propertyGroup?.Add(new XElement(ns + "CustomAfterDirectoryBuildTargets", $"$(CustomAfterDirectoryBuildTargets);{customAfterDirectoryBuildTargetsPath.FullName}"));
                 propertyGroup?.Add(new XElement(ns + "CustomAfterMicrosoftCommonCrossTargetingTargets", $"$(CustomAfterMicrosoftCommonCrossTargetingTargets);{customAfterDirectoryBuildTargetsPath.FullName}"));
-                
+
                 var customAfterDirectoryBuildTargets = new XDocument(new XElement(ns + "Project"));
 
                 var target = new XElement(ns + "Target",
                     new XAttribute("Name", "WritePropertyValues"),
-                    new XAttribute("BeforeTargets", "AfterBuild"));
+                    new XAttribute("BeforeTargets", TargetToRecordPropertiesBefore));
 
                 customAfterDirectoryBuildTargets.Root?.Add(target);
 
@@ -489,6 +495,15 @@ namespace {safeThisName}
         public void RecordProperties(params string[] propertyNames)
         {
             PropertiesToRecord.AddRange(propertyNames);
+        }
+
+        /// <summary>
+        /// Tells this TestProject to record properties specified in <see cref="PropertiesToRecord"/> before the specified target.
+        /// By default properties are recorded before the "AfterBuild" target (so after the actual compile+copy targets have run).
+        /// </summary>
+        public void RecordPropertiesBeforeTarget(string targetName)
+        {
+            TargetToRecordPropertiesBefore = targetName;
         }
 
         /// <returns>


### PR DESCRIPTION
This is some stuff carved off of https://github.com/dotnet/sdk/pull/51765 to minimize the diffs.

* add a tasks.slnf alongside the other use-case-focused solution filters to make working in the repo easier for vscode developers
* slightly alter the TestFramework library project so that it doesn't blow up test discovery, so that vscode based devs can actually run tests in vscode
* add a capability to the TestProject system to make it possible to run targets other than _build_ when testing and recording property values