### PR TITLE
[dotnet-run] fix logging and `Restore` for device selection

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -304,6 +304,10 @@ public class RunCommand
                 if (!string.IsNullOrEmpty(runtimeIdentifier))
                 {
                     properties["RuntimeIdentifier"] = runtimeIdentifier;
+
+                    // If the device added a RuntimeIdentifier, we need to re-restore with that RID
+                    // because the previous restore (if any) didn't include it
+                    _restoreDoneForDeviceSelection = false;
                 }
 
                 var additionalProperties = new ReadOnlyDictionary<string, string>(properties);

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -96,6 +96,12 @@ public class RunCommand
     /// </summary>
     public bool ListDevices { get; }
 
+    /// <summary>
+    /// Tracks whether restore was performed during device selection phase.
+    /// If true, we should skip restore in the build phase to avoid redundant work.
+    /// </summary>
+    private bool _restoreDoneForDeviceSelection;
+
     /// <param name="applicationArgs">unparsed/arbitrary CLI tokens to be passed to the running application</param>
     public RunCommand(
         bool noBuild,
@@ -257,7 +263,7 @@ public class RunCommand
         }
 
         // Create a single selector for both framework and device selection
-        using var selector = new RunCommandSelector(ProjectFileFullPath, globalProperties, Interactive, logger);
+        using var selector = new RunCommandSelector(ProjectFileFullPath, globalProperties, Interactive, MSBuildArgs, logger);
         
         // Step 1: Select target framework if needed
         if (!selector.TrySelectTargetFramework(out string? selectedFramework))
@@ -284,8 +290,10 @@ public class RunCommand
         // Step 3: Select device if needed
         if (selector.TrySelectDevice(
             ListDevices,
+            NoRestore,
             out string? selectedDevice,
-            out string? runtimeIdentifier))
+            out string? runtimeIdentifier,
+            out _restoreDoneForDeviceSelection))
         {
             // If a device was selected (either by user or by prompt), apply it to MSBuildArgs
             if (selectedDevice is not null)
@@ -474,7 +482,7 @@ public class RunCommand
             virtualCommand = null;
             buildResult = new RestoringCommand(
                 MSBuildArgs.CloneWithExplicitArgs([ProjectFileFullPath, .. MSBuildArgs.OtherMSBuildArgs]),
-                NoRestore,
+                NoRestore || _restoreDoneForDeviceSelection,
                 advertiseWorkloadUpdates: false
             ).Execute();
         }

--- a/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Utils;
 using Spectre.Console;
 
@@ -26,6 +27,7 @@ internal sealed class RunCommandSelector : IDisposable
     private readonly Dictionary<string, string> _globalProperties;
     private readonly FacadeLogger? _binaryLogger;
     private readonly bool _isInteractive;
+    private readonly MSBuildArgs _msbuildArgs;
     
     private ProjectCollection? _collection;
     private Microsoft.Build.Evaluation.Project? _project;
@@ -39,11 +41,13 @@ internal sealed class RunCommandSelector : IDisposable
         string projectFilePath,
         Dictionary<string, string> globalProperties,
         bool isInteractive,
+        MSBuildArgs msbuildArgs,
         FacadeLogger? binaryLogger = null)
     {
         _projectFilePath = projectFilePath;
         _globalProperties = globalProperties;
         _isInteractive = isInteractive;
+        _msbuildArgs = msbuildArgs;
         _binaryLogger = binaryLogger;
     }
 
@@ -119,7 +123,7 @@ internal sealed class RunCommandSelector : IDisposable
         {
             _collection = new ProjectCollection(
                 globalProperties: _globalProperties,
-                loggers: null,
+                loggers: GetLoggers(),
                 toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
             _project = _collection.LoadProject(_projectFilePath);
             _projectInstance = _project.CreateProjectInstance();
@@ -216,11 +220,14 @@ internal sealed class RunCommandSelector : IDisposable
     /// <summary>
     /// Computes available devices by calling the ComputeAvailableDevices MSBuild target if it exists.
     /// </summary>
+    /// <param name="noRestore">Whether restore should be skipped before computing devices</param>
     /// <param name="devices">List of available devices if the target exists, null otherwise</param>
+    /// <param name="restoreWasPerformed">True if restore was performed, false otherwise</param>
     /// <returns>True if the target was found and executed, false otherwise</returns>
-    public bool TryComputeAvailableDevices(out List<DeviceItem>? devices)
+    public bool TryComputeAvailableDevices(bool noRestore, out List<DeviceItem>? devices, out bool restoreWasPerformed)
     {
         devices = null;
+        restoreWasPerformed = false;
 
         if (!OpenProjectIfNeeded(out var projectInstance))
         {
@@ -234,10 +241,27 @@ internal sealed class RunCommandSelector : IDisposable
             return false;
         }
 
+        // If restore is allowed, run restore first so device computation sees the restored assets
+        if (!noRestore)
+        {
+            // Run the Restore target
+            var restoreResult = projectInstance.Build(
+                targets: ["Restore"],
+                loggers: GetLoggers(),
+                remoteLoggers: null,
+                out _);
+            if (!restoreResult)
+            {
+                return false;
+            }
+
+            restoreWasPerformed = true;
+        }
+
         // Build the target
         var buildResult = projectInstance.Build(
             targets: [Constants.ComputeAvailableDevices],
-            loggers: _binaryLogger is null ? null : [_binaryLogger],
+            loggers: GetLoggers(),
             remoteLoggers: null,
             out var targetOutputs);
 
@@ -274,19 +298,24 @@ internal sealed class RunCommandSelector : IDisposable
     /// or shows an error (non-interactive mode).
     /// </summary>
     /// <param name="listDevices">Whether to list devices and exit</param>
+    /// <param name="noRestore">Whether restore should be skipped</param>
     /// <param name="selectedDevice">The selected device, or null if not needed</param>
     /// <param name="runtimeIdentifier">The RuntimeIdentifier for the selected device, or null if not provided</param>
+    /// <param name="restoreWasPerformed">True if restore was performed, false otherwise</param>
     /// <returns>True if we should continue, false if we should exit</returns>
     public bool TrySelectDevice(
         bool listDevices,
+        bool noRestore,
         out string? selectedDevice,
-        out string? runtimeIdentifier)
+        out string? runtimeIdentifier,
+        out bool restoreWasPerformed)
     {
         selectedDevice = null;
         runtimeIdentifier = null;
+        restoreWasPerformed = false;
 
         // Try to get available devices from the project
-        bool targetExists = TryComputeAvailableDevices(out var devices);
+        bool targetExists = TryComputeAvailableDevices(noRestore, out var devices, out bool restorePerformed);
         
         // If the target doesn't exist, continue without device selection
         if (!targetExists)
@@ -355,8 +384,6 @@ internal sealed class RunCommandSelector : IDisposable
             runtimeIdentifier = devices[0].RuntimeIdentifier;
             return true;
         }
-
-
 
         if (_isInteractive)
         {
@@ -432,5 +459,16 @@ internal sealed class RunCommandSelector : IDisposable
             // If Spectre.Console fails (e.g., terminal doesn't support it), return null
             return null;
         }
+    }
+
+    /// <summary>
+    /// Gets the list of loggers to use for MSBuild operations.
+    /// Creates a fresh console logger each time to avoid disposal issues when calling Build() multiple times.
+    /// </summary>
+    private IEnumerable<ILogger> GetLoggers()
+    {
+        if (_binaryLogger is not null)
+            yield return _binaryLogger;
+        yield return CommonRunHelpers.GetConsoleLogger(_msbuildArgs);
     }
 }

--- a/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
@@ -315,7 +315,7 @@ internal sealed class RunCommandSelector : IDisposable
         restoreWasPerformed = false;
 
         // Try to get available devices from the project
-        bool targetExists = TryComputeAvailableDevices(noRestore, out var devices, out bool restorePerformed);
+        bool targetExists = TryComputeAvailableDevices(noRestore, out var devices, out restoreWasPerformed);
         
         // If the target doesn't exist, continue without device selection
         if (!targetExists)

--- a/test/TestAssets/TestProjects/DotnetRunDevices/DotnetRunDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetRunDevices/DotnetRunDevices.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net9.0;$(CurrentTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
-  <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
+  <Target Name="ComputeAvailableDevices" Returns="@(Devices)" DependsOnTargets="ResolveFrameworkReferences">
     <!-- If SingleDevice property is set, return only one device -->
     <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' == 'true'">
       <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />


### PR DESCRIPTION
c164a9bc is mostly working with two issues I've discovered while testing:

1. If `ComputeAvailableDevices` requires `Restore` to have run (which is actually the case for iOS and Android), `dotnet run` would fail unless you did an explicit `dotnet restore` first:

```
D:\src\helloandroid> D:\src\dotnet\sdk\artifacts\bin\redist\Debug\dotnet\dotnet.exe run -bl
  failed with 1 error(s) (0.1s)
  D:\src\dotnet\sdk\artifacts\bin\redist\Debug\dotnet\sdk\11.0.100-dev\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1004: Assets file 'D:\src\helloandroid\obj\project.assets.json' not found. Run a NuGet package restore to generate this file.
```

We can test this by changing `DotnetRunDevices.csproj`:

    <Target Name="ComputeAvailableDevices" DependsOnTargets="ResolveFrameworkReferences">

Doing an explicit `Restore` step before `ComputeAvailableDevices` resolves this.

2. We were not passing all loggers to `ProjectInstance.Build()` calls in `RunCommandSelector`, so no logging output was shown during device computation. This is now fixed by creating a fresh console logger each time we call `Build()`.

I tested this manually with a console app with a `ComputeAvailableDevices` target and a lengthy sleep:

    helloconsole                 ComputeAvailableDevices (9.1s)