### PR TITLE
Add a BenchmarkDotNet project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,9 @@
   <ItemGroup>
     <PackageVersion Include="Basic.CompilerLog.Util" Version="0.9.18" />
     <PackageVersion Include="AwesomeAssertions" Version="$(AwesomeAssertionsVersion)" />
-    <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="$(AwesomeAssertionsJsonVersion)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetDiagnosticsWindowsPackageVersion)" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsPackageVersion)" />
@@ -38,13 +39,11 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ExternalAccess.HotReload" Version="$(MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion)" />
-
     <!-- roslyn-sdk dependencies-->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="1.1.2" />
-
     <PackageVersion Include="Microsoft.Css.Parser" Version="$(MicrosoftCssParserVersion)" />
     <PackageVersion Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageVersion Include="Microsoft.Deployment.DotNet.Releases" Version="$(MicrosoftDeploymentDotNetReleasesVersion)" />
@@ -146,7 +145,6 @@
     <PackageVersion Include="xunit.assert" Version="$(XUnitVersion)" Condition="'$(IsTestProject)' != 'true'" />
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />
   </ItemGroup>
-
   <!-- Use different versions of Microsoft.Build.* depending on whether the output will be used in
        .NET Framework (VS) or only in the .NET SDK.
 

--- a/benchmarks/MicroBenchmark/Directory.Build.props
+++ b/benchmarks/MicroBenchmark/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <!--
+      We need to output to something other than the normal bin and obj folders to prevent picking up the global.json that
+      is being dropped there as that will break building the project that BenchmarkDotNet generates to run the benchmarks.
+    -->
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', 'artifacts', 'benchmarks', '$(MSBuildProjectName)', 'bin'))</BaseOutputPath>
+    <BaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', 'artifacts', 'benchmarks', '$(MSBuildProjectName)', 'obj'))</BaseIntermediateOutputPath>
+
+    <!--
+      Skipping here as we want the auto-generated projects to skip as well. The project file will copy this Directory.Build.props
+      to the output folder and the auto-generated projects will implicitly import it.
+    -->
+    <SkipCustomizeXlfSourceNames>true</SkipCustomizeXlfSourceNames>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))"/>
+</Project>

--- a/benchmarks/MicroBenchmark/InfoTests.cs
+++ b/benchmarks/MicroBenchmark/InfoTests.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmark;
+
+[MemoryDiagnoser]
+[SimpleJob(launchCount: 1, warmupCount: 1, iterationCount: 1, invocationCount: 1)]
+public class InfoTests
+{
+    private static readonly string[] s_args = ["--info"];
+
+    [Benchmark]
+    public int RunInfoCommand()
+    {
+        return Microsoft.DotNet.Cli.Program.Main(s_args);
+    }
+}

--- a/benchmarks/MicroBenchmark/MicroBenchmark.csproj
+++ b/benchmarks/MicroBenchmark/MicroBenchmark.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(ToolsetTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+    <CanRunTestAsTool>false</CanRunTestAsTool>
+    <IsTestProject>false</IsTestProject>
+    <IsUnitTestProject>false</IsUnitTestProject>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cli\dotnet\dotnet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Copy to output so BenchmarkDotNet generated projects inherit this as well -->
+    <None Include="Directory.Build.props" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/MicroBenchmark/Program.cs
+++ b/benchmarks/MicroBenchmark/Program.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Running;
+
+namespace Benchmark;
+
+internal class Program
+{
+    static void Main(string[] args)
+    {
+        BenchmarkRunner.Run(typeof(Program).Assembly);
+
+        // BenchmarkDotNet bakes a fair amount of assumptions into the way it generates
+        // projects for running its benchmarks. One of the key problems we run into is how
+        // it figures out the root of the repository. It walks up the directory structure
+        // to find the first folder with a `*.sln` or `*.slnx` or `global.json`. It then
+        // searches down from there to find the project file. In the SDK repo currently
+        // we have a `global.json` in the `artifacts/bin` folder- that prevents it from
+        // finding the project file.
+        //
+        // We work around this currently by redirecting the output to `artifacts/Benchmark`.
+        // One partially explored alternative was to derive the `CsProjGenerator` and customize
+        // its `GetProjectFilePath(Type benchmarkTarget, ILogger logger)`. There is a fair
+        // amount of logic there that needs reimplemented, and you have to create a custom
+        // toolchain something like this:
+        //
+        //    public class CustomToolchain : Toolchain
+        //    {
+        //        public CustomToolchain(string? tfm = default) : base(
+        //            "CustomToolchain",
+        //            new CustomCsProjGenerator(
+        //                targetFrameworkMoniker: tfm ?? GetCurrentTfm(),
+        //                cliPath: null,
+        //                packagesPath: null,
+        //                runtimeFrameworkVersion: null),
+        //            new DotNetCliBuilder(tfm ?? GetCurrentTfm()),
+        //            new DotNetCliExecutor(customDotNetCliPath: null)) { }
+        //    }
+        //
+        // Things still break with the `bin/global.json` with this. Pulling in and tweaking
+        // everything that is needed to get the temporary project to build successfully looks
+        // to be a potential whack-a-mole problem, so starting by rooting the output in a new
+        // folder in the `artifacts` directory that ensures the repo root's `global.json` is
+        // in "scope" so we don't have to modify the toolchain.
+        //
+        // https://github.com/dotnet/BenchmarkDotNet/blob/master/src/BenchmarkDotNet/Toolchains/CsProj/CsProjGenerator.cs
+    }
+}

--- a/build/GenerateResxSource.targets
+++ b/build/GenerateResxSource.targets
@@ -1,8 +1,13 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <CustomizeXlfSourceNamesDependsOn Condition="'$(SkipCustomizeXlfSourceNames)'!='true'">_CustomizeResourceNames</CustomizeXlfSourceNamesDependsOn>
+  </PropertyGroup>
+
   <Target Name="_CustomizeXlfSourceNames"
-          DependsOnTargets="_CustomizeResourceNames"
+          DependsOnTargets="$(CustomizeXlfSourceNamesDependsOn)"
           BeforeTargets="PrepareResourceNames;GatherXlf"
+          Condition="'$(SkipCustomizeXlfSourceNames)'!='true'"
           >
     <ItemGroup>
       <XlfSource Condition="'%(XlfSource.Namespace)' != ''">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -145,7 +145,8 @@
     <MoqPackageVersion>4.18.4</MoqPackageVersion>
     <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
     <MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>8.0.0-beta.23607.1</MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion>
-    <BenchmarkDotNetPackageVersion>0.14.0</BenchmarkDotNetPackageVersion>
+    <BenchmarkDotNetPackageVersion>0.15.6</BenchmarkDotNetPackageVersion>
+    <BenchmarkDotNetDiagnosticsWindowsPackageVersion>0.14.0</BenchmarkDotNetDiagnosticsWindowsPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Workload manifest package versions">
     <MauiFeatureBand>10.0.100</MauiFeatureBand>

--- a/sdk.slnx
+++ b/sdk.slnx
@@ -312,6 +312,9 @@
     <Project Path="template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj" />
     <Project Path="template_feed/Microsoft.DotNet.Common.ProjectTemplates.10.0/Microsoft.DotNet.Common.ProjectTemplates.10.0.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/MicroBenchmark/MicroBenchmark.csproj" />
+  </Folder>
   <Folder Name="/test/">
     <Project Path="src/Tasks/Microsoft.NET.Build.Extensions.Tasks.UnitTests/Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj" />
     <Project Path="test/ArgumentForwarding.Tests/ArgumentForwarding.Tests.csproj" />


### PR DESCRIPTION
This is to faciliate writing and running micro benchmarks.

Have to workaround a few issues to make this work:

1. Can't output to `artifacts/bin` as it contains a global.json (which breaks project finding logic and other things)
2. Need to be able to skip _CustomizeXlfSourceNames

Other things:

- Bump the BenchmarkDotNet version
- Add the Windows package versions to make it easy to use that functionality when needed