### PR TITLE
[template engine cli] Remove dependency on filter definitions from command definitions

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/CommandDefinitions/SharedOptions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CommandDefinitions/SharedOptions.cs
@@ -7,6 +7,14 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 {
     public static class SharedOptions
     {
+        // fitler options:
+        public static Option<string> AuthorOption { get; } = SharedOptionsFactory.CreateAuthorOption();
+        public static Option<string> BaselineOption { get; } = SharedOptionsFactory.CreateBaselineOption();
+        public static Option<string> LanguageOption { get; } = SharedOptionsFactory.CreateLanguageOption();
+        public static Option<string> TypeOption { get; } = SharedOptionsFactory.CreateTypeOption();
+        public static Option<string> TagOption { get; } = SharedOptionsFactory.CreateTagOption();
+        public static Option<string> PackageOption { get; } = SharedOptionsFactory.CreatePackageOption();
+
         public static Option<FileInfo> OutputOption { get; } = new("--output", "-o")
         {
             Description = SymbolStrings.Option_Output,

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseFilterableArgs.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/BaseFilterableArgs.cs
@@ -53,12 +53,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         private static IReadOnlyDictionary<FilterOptionDefinition, OptionResult> ParseFilters(IFilterableCommand filterableCommand, ParseResult parseResult)
         {
             Dictionary<FilterOptionDefinition, OptionResult> filterValues = new();
-            foreach (var filter in filterableCommand.Filters)
+            foreach (var option in filterableCommand.FilterOptions)
             {
-                OptionResult? value = parseResult.GetResult(filter.Value);
+                OptionResult? value = parseResult.GetResult(option);
                 if (value != null)
                 {
-                    filterValues[filter.Key] = value;
+                    filterValues[FilterOptionDefinition.AllDefinitions[option.Name]] = value;
                 }
             }
             return filterValues;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/FilterOptionDefinition.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/FilterOptionDefinition.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplateFiltering;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
@@ -16,55 +15,52 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     /// </summary>
     internal class FilterOptionDefinition
     {
-        internal FilterOptionDefinition(Func<Option> optionFactory)
-        {
-            OptionFactory = optionFactory ?? throw new ArgumentNullException(nameof(optionFactory));
-        }
-
         internal static FilterOptionDefinition AuthorFilter { get; } =
              new TemplateFilterOptionDefinition(
-                 optionFactory: () => SharedOptionsFactory.CreateAuthorOption(),
                  matchFilter: authorArg => WellKnownSearchFilters.AuthorFilter(authorArg),
                  mismatchCriteria: resolutionResult => resolutionResult.HasAuthorMismatch,
                  matchInfoName: MatchInfo.BuiltIn.Author);
 
         internal static FilterOptionDefinition BaselineFilter { get; } =
             new TemplateFilterOptionDefinition(
-                optionFactory: () => SharedOptionsFactory.CreateBaselineOption(),
                 matchFilter: baselineArg => WellKnownSearchFilters.BaselineFilter(baselineArg),
                 mismatchCriteria: resolutionResult => resolutionResult.HasBaselineMismatch,
                 matchInfoName: MatchInfo.BuiltIn.Baseline);
 
         internal static FilterOptionDefinition LanguageFilter { get; } =
             new TemplateFilterOptionDefinition(
-                optionFactory: () => SharedOptionsFactory.CreateLanguageOption(),
                 matchFilter: languageArg => WellKnownSearchFilters.LanguageFilter(languageArg),
                 mismatchCriteria: resolutionResult => resolutionResult.HasLanguageMismatch,
                 matchInfoName: MatchInfo.BuiltIn.Language);
 
         internal static FilterOptionDefinition TagFilter { get; } =
             new TemplateFilterOptionDefinition(
-                optionFactory: () => SharedOptionsFactory.CreateTagOption(),
                 matchFilter: tagArg => WellKnownSearchFilters.ClassificationFilter(tagArg),
                 mismatchCriteria: resolutionResult => resolutionResult.HasClassificationMismatch,
                 matchInfoName: MatchInfo.BuiltIn.Classification);
 
         internal static FilterOptionDefinition TypeFilter { get; } =
             new TemplateFilterOptionDefinition(
-                optionFactory: () => SharedOptionsFactory.CreateTypeOption(),
                 matchFilter: typeArg => WellKnownSearchFilters.TypeFilter(typeArg),
                 mismatchCriteria: resolutionResult => resolutionResult.HasTypeMismatch,
                 matchInfoName: MatchInfo.BuiltIn.Type);
 
         internal static FilterOptionDefinition PackageFilter { get; } =
             new PackageFilterOptionDefinition(
-                optionFactory: () => SharedOptionsFactory.CreatePackageOption(),
                 matchFilter: PackageMatchFilter);
 
         /// <summary>
-        /// A predicate that creates instance of option.
+        /// Maps option name to the corresponding filter definition.
         /// </summary>
-        internal Func<Option> OptionFactory { get; }
+        public static readonly IReadOnlyDictionary<string, FilterOptionDefinition> AllDefinitions = new Dictionary<string, FilterOptionDefinition>()
+        {
+            { SharedOptions.AuthorOption.Name, AuthorFilter },
+            { SharedOptions.BaselineOption.Name, BaselineFilter },
+            { SharedOptions.LanguageOption.Name, LanguageFilter },
+            { SharedOptions.TagOption.Name, TagFilter },
+            { SharedOptions.TypeOption.Name, TypeFilter },
+            { SharedOptions.PackageOption.Name, PackageFilter }
+        };
 
         private static Func<ITemplatePackageInfo, bool> PackageMatchFilter(string? packageArg)
         {
@@ -82,19 +78,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     /// <summary>
     /// Defines supported dotnet new command filter option applicable to the template.
     /// </summary>
-    internal class TemplateFilterOptionDefinition : FilterOptionDefinition
+    internal sealed class TemplateFilterOptionDefinition(
+        Func<string?, Func<ITemplateInfo, MatchInfo?>> matchFilter,
+        Func<TemplateResolutionResult, bool> mismatchCriteria,
+        string matchInfoName) : FilterOptionDefinition
     {
-        internal TemplateFilterOptionDefinition(
-            Func<Option> optionFactory,
-            Func<string?, Func<ITemplateInfo, MatchInfo?>> matchFilter,
-            Func<TemplateResolutionResult, bool> mismatchCriteria,
-            string matchInfoName) : base(optionFactory)
-        {
-            TemplateMatchFilter = matchFilter ?? throw new ArgumentNullException(nameof(matchFilter));
-            MismatchCriteria = mismatchCriteria ?? throw new ArgumentNullException(nameof(mismatchCriteria));
-            MatchInfoName = matchInfoName ?? throw new ArgumentNullException(nameof(matchInfoName));
-        }
-
         /// <summary>
         /// A predicate that returns the template match filter for the filter option.
         /// Template match filter should return the MatchInfo for the given template based on filter value.
@@ -102,35 +90,28 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         /// <remarks>
         /// Common template match filters are defined in Microsoft.TemplateEngine.Utils.WellKnonwnSearchFilter class.
         /// </remarks>
-        internal Func<string?, Func<ITemplateInfo, MatchInfo?>> TemplateMatchFilter { get; set; }
+        internal Func<string?, Func<ITemplateInfo, MatchInfo?>> TemplateMatchFilter { get; } = matchFilter;
 
         /// <summary>
         /// A predicate that returns if the filter option caused a mismatch in <see cref="TemplateResolutionResult"/> in case of partial match.
         /// </summary>
-        internal Func<TemplateResolutionResult, bool> MismatchCriteria { get; set; }
+        internal Func<TemplateResolutionResult, bool> MismatchCriteria { get; } = mismatchCriteria;
 
         /// <summary>
         /// A <see cref="MatchInfo"/> name used in match dispositions.
         /// </summary>
-        internal string MatchInfoName { get; set; }
+        internal string MatchInfoName { get; } = matchInfoName;
     }
 
     /// <summary>
     /// Defines supported dotnet new command filter option applicable to the package.
     /// </summary>
-    internal class PackageFilterOptionDefinition : FilterOptionDefinition
+    internal sealed class PackageFilterOptionDefinition(Func<string?, Func<ITemplatePackageInfo, bool>> matchFilter) : FilterOptionDefinition
     {
-        internal PackageFilterOptionDefinition(
-            Func<Option> optionFactory,
-            Func<string?, Func<ITemplatePackageInfo, bool>> matchFilter) : base(optionFactory)
-        {
-            PackageMatchFilter = matchFilter ?? throw new ArgumentNullException(nameof(matchFilter));
-        }
-
         /// <summary>
         /// A predicate that returns the package match filter for the filter option
         /// Package match filter should if package is a match based on filter value.
         /// </summary>
-        internal Func<string?, Func<ITemplatePackageInfo, bool>> PackageMatchFilter { get; set; }
+        internal Func<string?, Func<ITemplatePackageInfo, bool>> PackageMatchFilter { get; } = matchFilter;
     }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/IFilterableCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/IFilterableCommand.cs
@@ -7,6 +7,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 {
     internal interface IFilterableCommand
     {
-        IReadOnlyDictionary<FilterOptionDefinition, Option> Filters { get; }
+        IEnumerable<Option> FilterOptions { get; }
     }
 }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/list/BaseListCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             _definition = definition;
         }
 
-        public IReadOnlyDictionary<FilterOptionDefinition, Option> Filters => _definition.Filters;
+        public IEnumerable<Option> FilterOptions => _definition.FilterOptions;
 
         public Option<bool> ColumnsAllOption => _definition.ColumnsAllOption;
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/BaseSearchCommand.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/search/BaseSearchCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             _definition = definition;
         }
 
-        public IReadOnlyDictionary<FilterOptionDefinition, Option> Filters => _definition.Filters;
+        public IEnumerable<Option> FilterOptions => _definition.FilterOptions;
 
         public Option<bool> ColumnsAllOption => _definition.ColumnsAllOption;
 

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -43,7 +43,10 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
         internal static bool HasMismatchOnListFilters(this ITemplateMatchInfo templateMatchInfo)
         {
-            IEnumerable<string> supportedFilters = CommandDefinition.List.SupportedFilters.OfType<TemplateFilterOptionDefinition>().Select(f => f.MatchInfoName);
+            var supportedFilters = CommandDefinition.List.SupportedFilterOptions
+                .Select(option => FilterOptionDefinition.AllDefinitions[option.Name])
+                .OfType<TemplateFilterOptionDefinition>()
+                .Select(f => f.MatchInfoName);
 
             var filterMatches = templateMatchInfo.MatchDisposition.Where(mi => supportedFilters.Any(f => f == mi.Name));
             var otherMatches = templateMatchInfo.MatchDisposition.Where(mi => !supportedFilters.Any(f => f == mi.Name));

--- a/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -253,7 +253,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             // && !commandInput.RemainingParameters.Any())
             {
                 Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Error_NoTemplateName.Red().Bold());
-                Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", CommandDefinition.Search.SupportedFilters.Select(f => $"'{f.OptionFactory().Name}'")));
+                Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", CommandDefinition.Search.SupportedFilterOptions.Select(static option => $"'{option.Name}'")));
                 Reporter.Error.WriteLine(LocalizableStrings.Generic_ExamplesHeader);
                 Reporter.Error.WriteCommand(
                     Example


### PR DESCRIPTION
`FilterOptionDefinition` brings in dependencies on most of template engine, which we want to avoid in command definitions.
Factor these definitions out.

Follow up on https://github.com/dotnet/sdk/pull/51747.
Contributes to https://github.com/dotnet/sdk/issues/51748.

