### PR TITLE
Add SetAction to dotnet nuget trust subcommands

### DIFF
--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandDefinition.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandDefinition.cs
@@ -173,6 +173,7 @@ internal static class NuGetCommandDefinition
         {
             command.Options.Add(configFile);
             command.Options.Add(CommonOptions.VerbosityOption(Utils.VerbosityOptions.normal));
+            command.SetAction(NuGetCommand.Run);
         }
 
         Command CreateAuthorCommand() => new("author") {

--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandDefinition.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandDefinition.cs
@@ -173,7 +173,6 @@ internal static class NuGetCommandDefinition
         {
             command.Options.Add(configFile);
             command.Options.Add(CommonOptions.VerbosityOption(Utils.VerbosityOptions.normal));
-            command.SetAction(NuGetCommand.Run);
         }
 
         Command CreateAuthorCommand() => new("author") {

--- a/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
+++ b/src/Cli/dotnet/Commands/NuGet/NuGetCommandParser.cs
@@ -20,7 +20,7 @@ internal static class NuGetCommandParser
 
         foreach (var subcommand in command.Subcommands)
         {
-            subcommand.SetAction(NuGetCommand.Run);
+            SetAction(subcommand);
         }
 
         return command;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/52220

In a previous refactoring PR https://github.com/dotnet/sdk/pull/51624, there was a missing SetAction to dotnet nuget trust subcommands that broke them. 