### PR TITLE
[wasm] Switch between Mono and CoreCLR runtimes

### DIFF
--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -272,6 +272,7 @@
         maccatalyst-x64;
         maccatalyst-arm64;
         haiku-x64;
+        browser-wasm;
         " />
 
       <NetCoreAppHostRids Include="@(Net110AppHostRids)" />

--- a/src/WasmSdk/Sdk/Sdk.props
+++ b/src/WasmSdk/Sdk/Sdk.props
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- WASM projects defaults to browser-wasm -->
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">browser-wasm</RuntimeIdentifier>
-    <UseMonoRuntime>true</UseMonoRuntime>
+    <UseMonoRuntime Condition="'$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
     <SelfContained>true</SelfContained>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
 


### PR DESCRIPTION
- Allow to override `UseMonoRuntime`
- Add `browser-wasm` to supported RuntimeIdentifiers for CoreCLR runtime pack

Fixes https://github.com/dotnet/sdk/issues/51213