### PR TITLE
Fix build of multi-targeted test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,9 +76,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <!-- <TestRunnerAdditionalArguments>-parallel none</TestRunnerAdditionalArguments> -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -169,7 +169,7 @@
                             CreateNupkgWithPreviewFromSource">
     <ItemGroup>
       <TestAssetFiles Include="$(BaseOutputPath)\TestAsset\**\*.*" />
-      <TestAssetLocalNugetFeed Include="$(BaseOutputPath)\$(Configuration)\TestAssetLocalNugetFeed\**\*.*" />
+      <TestAssetLocalNugetFeed Include="$(BaseOutputPath)\$(Configuration)\$(TargetFramework)\TestAssetLocalNugetFeed\**\*.*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(TestAssetFiles)" DestinationFiles="@(TestAssetFiles->'$(PublishDir)\TestAsset\%(RecursiveDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
For some reason AppendTargetFrameworkToOutputPath property was set to false for test projects, which breaks the build of multi-targeted test projects

Blocked on https://github.com/dotnet/sdk/pull/52255