### PR TITLE
Fix bundled versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,6 +40,7 @@
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
     <VersionFeature80>22</VersionFeature80>
     <VersionFeature90>11</VersionFeature90>
+    <VersionFeature100>1</VersionFeature100>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>

--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -85,12 +85,12 @@
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
       <!-- TODO: Once .NET 10.0.X has released, update these version numbers to 10.0.$(VersionFeature100) -->
-      <_NET100RuntimePackVersion>10.0.100-rtm.25523.111</_NET100RuntimePackVersion>
-      <_NET100TargetingPackVersion>10.0.100-rtm.25523.111</_NET100TargetingPackVersion>
-      <_WindowsDesktop100RuntimePackVersion>10.0.0-rtm.25523.111</_WindowsDesktop100RuntimePackVersion>
-      <_WindowsDesktop100TargetingPackVersion>10.0.0-rtm.25523.111</_WindowsDesktop100TargetingPackVersion>
-      <_AspNet100RuntimePackVersion>10.0.0-rtm.25523.111</_AspNet100RuntimePackVersion>
-      <_AspNet100TargetingPackVersion>10.0.0-rtm.25523.111</_AspNet100TargetingPackVersion>
+      <_NET100RuntimePackVersion>10.0.$(VersionFeature100)</_NET100RuntimePackVersion>
+      <_NET100TargetingPackVersion>10.0.$(VersionFeature100)</_NET100TargetingPackVersion>
+      <_WindowsDesktop100RuntimePackVersion>10.0.$(VersionFeature100)</_WindowsDesktop100RuntimePackVersion>
+      <_WindowsDesktop100TargetingPackVersion>10.0.$(VersionFeature100)</_WindowsDesktop100TargetingPackVersion>
+      <_AspNet100RuntimePackVersion>10.0.$(VersionFeature100)</_AspNet100RuntimePackVersion>
+      <_AspNet100TargetingPackVersion>10.0.$(VersionFeature100)</_AspNet100TargetingPackVersion>
 
       <_NET90RuntimePackVersion>9.0.$(VersionFeature90)</_NET90RuntimePackVersion>
       <_NET90TargetingPackVersion>9.0.$(VersionFeature90)</_NET90TargetingPackVersion>
@@ -744,10 +744,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                               TargetFramework="net10.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppDefaultRuntimeFrameworkVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                              DefaultRuntimeFrameworkVersion="10.0.0"
+                              LatestRuntimeFrameworkVersion="$(_NET100RuntimePackVersion)"
                               TargetingPackName="Microsoft.NETCore.App.Ref"
-                              TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
+                              TargetingPackVersion="$(_NET100TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(Net100RuntimePackRids, '%3B')"
                               />
@@ -755,65 +755,58 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownAppHostPack Include="Microsoft.NETCore.App"
                       TargetFramework="net10.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-                      AppHostPackVersion="$(_NETCoreAppPackageVersion)"
-                      AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
+                      AppHostPackVersion="$(_NET100RuntimePackVersion)"
+                      AppHostRuntimeIdentifiers="@(Net100AppHostRids, '%3B')"
                       ExcludedRuntimeIdentifiers="android"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"
                         TargetFramework="net10.0"
                         Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
-                        Crossgen2PackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
-                        Crossgen2PortableRuntimeIdentifiers="@(Crossgen2SupportedPortableRids, '%3B')"
-                        Crossgen2RuntimeIdentifiers="@(Crossgen2SupportedRids, '%3B')"
+                        Crossgen2PackVersion="$(_NET100RuntimePackVersion)"
+                        Crossgen2RuntimeIdentifiers="@(Net100Crossgen2SupportedRids, '%3B')"
                         />
 
     <KnownILCompilerPack Include="Microsoft.DotNet.ILCompiler"
                          TargetFramework="net10.0"
                          ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler"
-                         ILCompilerRuntimePackNamePattern="Microsoft.NETCore.App.Runtime.NativeAOT.**RID**"
-                         ILCompilerPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
-                         ILCompilerPortableRuntimeIdentifiers="@(ILCompilerSupportedPortableRids, '%3B')"
-                         ILCompilerRuntimeIdentifiers="@(ILCompilerSupportedRids, '%3B')"
+                         ILCompilerPackVersion="$(_NET100RuntimePackVersion)"
+                         ILCompilerRuntimeIdentifiers="@(Net100ILCompilerSupportedRids, '%3B')"
                          />
 
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net10.0"
                       RuntimeFrameworkName="Microsoft.NETCore.App"
-                      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                      LatestRuntimeFrameworkVersion="$(_NET100RuntimePackVersion)"
                       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.NativeAOT.**RID**"
-                      RuntimePackRuntimeIdentifiers="@(NativeAOTRuntimePackRids, '%3B')"
+                      RuntimePackRuntimeIdentifiers="@(Net100NativeAOTRuntimePackRids, '%3B')"
                       RuntimePackLabels="NativeAOT"
                       />
 
     <KnownILLinkPack Include="Microsoft.NET.ILLink.Tasks"
                      TargetFramework="net10.0"
-                     ILLinkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
+                     ILLinkPackVersion="$(_NET100RuntimePackVersion)" />
 
     <KnownWebAssemblySdkPack Include="Microsoft.NET.Sdk.WebAssembly.Pack"
                              TargetFramework="net10.0"
                              WebAssemblySdkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
 
-    <KnownAspNetCorePack Include="Microsoft.AspNetCore.App.Internal.Assets"
-                             TargetFramework="net10.0"
-                             AspNetCorePackVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)" />
-
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net10.0"
                       RuntimeFrameworkName="Microsoft.NETCore.App"
-                      LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                      LatestRuntimeFrameworkVersion="$(_NET100RuntimePackVersion)"
                       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
-                      RuntimePackRuntimeIdentifiers="@(MonoRuntimePackRids, '%3B')"
+                      RuntimePackRuntimeIdentifiers="@(Net100MonoRuntimePackRids, '%3B')"
                       RuntimePackLabels="Mono"
                       />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="net10.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
+                              DefaultRuntimeFrameworkVersion="10.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop100RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
+                              TargetingPackVersion="$(_WindowsDesktop100TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
                               IsWindowsOnly="true"
@@ -822,10 +815,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
                               TargetFramework="net10.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
+                              DefaultRuntimeFrameworkVersion="10.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop100RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
+                              TargetingPackVersion="$(_WindowsDesktop100TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
                               IsWindowsOnly="true"
@@ -835,10 +828,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
                               TargetFramework="net10.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
+                              DefaultRuntimeFrameworkVersion="10.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop100RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
+                              TargetingPackVersion="$(_WindowsDesktop100TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
                               IsWindowsOnly="true"
@@ -848,12 +841,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
                               TargetFramework="net10.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppDefaultRuntimeFrameworkVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)"
+                              DefaultRuntimeFrameworkVersion="10.0.0"
+                              LatestRuntimeFrameworkVersion="$(_AspNet100RuntimePackVersion)"
                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
-                              TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
+                              TargetingPackVersion="$(_AspNet100TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
+                              RuntimePackRuntimeIdentifiers="@(AspNetCore100RuntimePackRids, '%3B')"
                               RuntimePackExcludedRuntimeIdentifiers="android%3Blinux-bionic"
                               />
 


### PR DESCRIPTION
The 10 bundled versions were using the current runtime pack versions, which is incorrect as it generated framework version for 10.0.0 as 11.0.0