### PR TITLE
Fix StaticWebAssets base path prefix detection using path segment comparison

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeEndpointsForReferenceStaticWebAssets.cs
@@ -24,6 +24,9 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
 
         var result = CandidateEndpoints;
 
+        var routeSegments = new List<PathTokenizer.Segment>();
+        var basePathSegments = new List<PathTokenizer.Segment>();
+
         for (var i = 0; i < CandidateEndpoints.Length; i++)
         {
             var candidateEndpoint = StaticWebAssetEndpoint.FromTaskItem(CandidateEndpoints[i]);
@@ -35,7 +38,7 @@ public class ComputeEndpointsForReferenceStaticWebAssets : Task
                 // destined to be used as a reference by other project are passed to this task.
 
                 var oldRoute = candidateEndpoint.Route;
-                if (oldRoute.StartsWith(asset.BasePath))
+                if (StaticWebAssetEndpoint.RouteHasPathPrefix(oldRoute, asset.BasePath, routeSegments, basePathSegments))
                 {
                     Log.LogMessage(MessageImportance.Low, "Skipping endpoint '{0}' because route '{1}' is already updated.", asset.Identity, oldRoute);
                 }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -538,4 +538,38 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
     IDictionary ITaskItem.CloneCustomMetadata() => ((ITaskItem2)this).CloneCustomMetadataEscaped();
 
     #endregion
+
+    public static bool RouteHasPathPrefix(
+        ReadOnlySpan<char> route,
+        ReadOnlySpan<char> prefix,
+        List<PathTokenizer.Segment> routeSegments,
+        List<PathTokenizer.Segment> prefixSegments)
+    {
+        routeSegments.Clear();
+        prefixSegments.Clear();
+
+        var routeTokenizer = new PathTokenizer(route);
+        var routeSegmentCollection = routeTokenizer.Fill(routeSegments);
+
+        var prefixTokenizer = new PathTokenizer(prefix);
+        var prefixSegmentCollection = prefixTokenizer.Fill(prefixSegments);
+
+        if (prefixSegmentCollection.Count > routeSegmentCollection.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < prefixSegmentCollection.Count; i++)
+        {
+            var prefixSegmentSpan = prefixSegmentCollection[i];
+            var routeSegmentSpan = routeSegmentCollection[i];
+
+            if (!prefixSegmentSpan.Equals(routeSegmentSpan, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetEndpointTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetEndpointTest.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+
+namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
+
+public class StaticWebAssetEndpointTest
+{
+    [Theory]
+    [InlineData("App1/css/app.css", "App1")]
+    [InlineData("App1", "App1")]
+    [InlineData("App1/css/styles/app.css", "App1/css")]
+    [InlineData("App1/css/app.css", "")]
+    [InlineData("", "")]
+    [InlineData("App1\\css\\app.css", "App1")]
+    [InlineData("App1/css\\app.css", "App1")]
+    [InlineData("App1/App1.lib.module.js", "App1")]
+    [InlineData("app1/css/app.css", "App1")]
+    [InlineData("APP1/css/app.css", "app1")]
+    public void RouteHasPathPrefix_ReturnsTrue_WhenRouteStartsWithPrefixAsPathSegment(string route, string prefix)
+    {
+        var routeSegments = new List<PathTokenizer.Segment>();
+        var prefixSegments = new List<PathTokenizer.Segment>();
+
+        var result = StaticWebAssetEndpoint.RouteHasPathPrefix(route, prefix, routeSegments, prefixSegments);
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("App1.styles.css", "App1")]
+    [InlineData("App1", "App1/css/app.css")]
+    [InlineData("App1/js/app.js", "App1/css")]
+    [InlineData("App12/css/app.css", "App1")]
+    [InlineData("App1Bundle/app.js", "App1")]
+    [InlineData("App1.lib.module.js", "App1")]
+    public void RouteHasPathPrefix_ReturnsFalse_WhenRouteDoesNotStartWithPrefixAsPathSegment(string route, string prefix)
+    {
+        var routeSegments = new List<PathTokenizer.Segment>();
+        var prefixSegments = new List<PathTokenizer.Segment>();
+
+        var result = StaticWebAssetEndpoint.RouteHasPathPrefix(route, prefix, routeSegments, prefixSegments);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RouteHasPathPrefix_ReusesSegmentLists()
+    {
+        var routeSegments = new List<PathTokenizer.Segment>();
+        var prefixSegments = new List<PathTokenizer.Segment>();
+
+        StaticWebAssetEndpoint.RouteHasPathPrefix("a/b/c", "a", routeSegments, prefixSegments);
+        StaticWebAssetEndpoint.RouteHasPathPrefix("x/y/z", "x/y", routeSegments, prefixSegments);
+
+        var result = StaticWebAssetEndpoint.RouteHasPathPrefix("App1/css/app.css", "App1", routeSegments, prefixSegments);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

When computing endpoints for reference static web assets, the base path prefix check was using `string.StartsWith` which incorrectly matched routes like `App1.styles.css` against base path `App1`. This caused the base path to not be prepended, resulting in missing routes.

## Problem

The bug occurs in `ComputeEndpointsForReferenceStaticWebAssets` when determining if a route already has the base path applied. The original check:

```csharp
if (oldRoute.StartsWith(asset.BasePath, StringComparison.Ordinal))
```

Would incorrectly match:
- Route `App1.styles.css` with base path `App1` → **incorrectly skipped** (starts with "App1")
- Route `App1.lib.module.js` with base path `App1` → **incorrectly skipped**

This resulted in these files being served without the proper base path prefix in multi-project Blazor scenarios.

## Solution

Introduced `StaticWebAssetEndpoint.RouteHasPathPrefix` method that uses `PathTokenizer` to compare paths segment-by-segment, ensuring only proper path segment boundaries are matched:

| Route | Prefix | Result | Reason |
|-------|--------|--------|--------|
| `App1/css/app.css` | `App1` | ✅ true | Proper segment match |
| `App1.styles.css` | `App1` | ❌ false | Not a segment boundary |
| `App1Bundle/app.js` | `App1` | ❌ false | Different segment |
| `App1` | `App1` | ✅ true | Exact match |

The comparison is case-insensitive and handles both `/` and `\` path separators.

## Testing

- Added unit tests for `RouteHasPathPrefix` covering positive and negative matches
- Added regression tests in `ComputeEndpointsForReferenceStaticWebAssetsTest`
- Validated E2E with multi-project Blazor WebAssembly app (App1, App2, AppHost)

## Files Changed

- `ComputeEndpointsForReferenceStaticWebAssets.cs` - Use new segment-based prefix check
- `StaticWebAssetEndpoint.cs` - Add `RouteHasPathPrefix` helper method
- `StaticWebAssetEndpointTest.cs` - Unit tests for `RouteHasPathPrefix`
- `ComputeEndpointsForReferenceStaticWebAssetsTest.cs` - Regression tests