### PR TITLE
Fix ScopedCss incrementalism to detect CssScope metadata changes

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
@@ -142,6 +142,33 @@ Integration with static web assets:
   </ComputeCssScope>
 </Target>
 
+<!--
+  Creates a cache file containing the CssScope values for all scoped CSS files.
+  This file is used as an input to _ProcessScopedCssFiles to ensure that changes
+  to CssScope metadata (e.g., custom scopes defined in the project file) trigger
+  a rebuild of the scoped CSS files.
+  See: https://github.com/dotnet/sdk/issues/50646
+-->
+<Target Name="_CreateScopedCssScopeCache" DependsOnTargets="ComputeCssScope">
+  <PropertyGroup>
+    <_ScopedCssIntermediatePath>$([System.IO.Path]::GetFullPath($(IntermediateOutputPath)scopedcss\))</_ScopedCssIntermediatePath>
+    <_ScopedCssScopeCacheFile>$(_ScopedCssIntermediatePath)scopedcss.cache</_ScopedCssScopeCacheFile>
+  </PropertyGroup>
+
+  <MakeDir Directories="$(_ScopedCssIntermediatePath)" />
+
+  <!-- Write a line for each scoped CSS file with its identity and scope, only when different -->
+  <WriteLinesToFile
+    File="$(_ScopedCssScopeCacheFile)"
+    Lines="@(_ScopedCss->'%(Identity)=%(CssScope)')"
+    Overwrite="true"
+    WriteOnlyWhenDifferent="true" />
+
+  <ItemGroup>
+    <FileWrites Include="$(_ScopedCssScopeCacheFile)" />
+  </ItemGroup>
+</Target>
+
 <!-- Sets the output path for the processed scoped css files. They will all have a '.rz.scp.css' extension to flag them as processed
      scoped css files. -->
 <Target Name="ResolveScopedCssOutputs" DependsOnTargets="$(ResolveScopedCssOutputsDependsOn)">
@@ -171,10 +198,12 @@ Integration with static web assets:
     BeforeTargets="CollectUpToDateCheckInputDesignTime;CollectUpToDateCheckBuiltDesignTime" />
 
 <!-- Transforms the original scoped CSS files into their scoped versions on their designated output paths -->
-<Target Name="_ProcessScopedCssFiles" Inputs="@(_ScopedCss)" Outputs="@(_ScopedCssOutputs)" DependsOnTargets="ResolveScopedCssOutputs">
+<Target Name="_ProcessScopedCssFiles" Inputs="@(_ScopedCss);$(_ScopedCssScopeCacheFile)" Outputs="@(_ScopedCssOutputs)" DependsOnTargets="ResolveScopedCssOutputs;_CreateScopedCssScopeCache">
 
   <MakeDir Directories="$(_ScopedCssIntermediatePath)" />
-  <RewriteCss FilesToTransform="@(_ScopedCss)" />
+  <!-- SkipIfOutputIsNewer is false because the target's Inputs/Outputs already handles incrementalism.
+       The cache file in Inputs tracks CssScope metadata changes that wouldn't be detected by file timestamps alone. -->
+  <RewriteCss FilesToTransform="@(_ScopedCss)" SkipIfOutputIsNewer="false" />
 
   <ItemGroup>
     <FileWrites Include="%(_ScopedCss.OutputFile)" />


### PR DESCRIPTION
## Summary

This PR fixes the ScopedCss build pipeline to properly regenerate scoped CSS files when the `CssScope` metadata changes.

## Problem

When users specify a custom `CssScope` metadata on their scoped CSS files (via `<None Update="..." CssScope="custom-scope" />`), changing that value did not trigger regeneration of the scoped CSS output. This was because MSBuild's `Inputs/Outputs` incrementalism only tracks file timestamps, not item metadata like `CssScope`.

Fixes #50646

## Solution

1. **Added `_CreateScopedCssScopeCache` target** - Creates a cache file containing all `CssScope` values using `WriteLinesToFile` with `WriteOnlyWhenDifferent="true"`. This file only updates when scope values actually change.

2. **Updated `_ProcessScopedCssFiles` target** - Added the cache file to the target's `Inputs`, so MSBuild's incrementalism detects when scopes change.

3. **Set `SkipIfOutputIsNewer="false"` on `RewriteCss`** - Since target-level incrementalism now correctly determines when to run, the task's internal timestamp check is disabled to avoid conflicts.

## Testing

- Added integration test `Build_RegeneratesScopedCss_WhenCssScopeMetadataChanges` that verifies:
  - Initial build uses auto-generated scope
  - Adding custom `CssScope` regenerates files with new scope
  - Changing `CssScope` value regenerates files again
  - Subsequent builds without changes remain incremental