### PR TITLE
Prevent duplicate entries in `_SourceItemsToCopyToPublishDirectory*`

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -956,13 +956,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <_SourceItemsToCopyToPublishDirectoryAlways KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryAlways KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                                  KeepMetadata="$(_GCTPDIKeepMetadata)"
                                                   Include="@(_NoneWithTargetPath->'%(FullPath)')"
                                                   Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectory KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(_NoneWithTargetPath->'%(FullPath)')"
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
-      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(_NoneWithTargetPath->'%(FullPath)')"
                                             Condition="'%(_NoneWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -911,25 +911,31 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Get items from this project last so that they will be copied last. -->
     <ItemGroup>
-      <_SourceItemsToCopyToPublishDirectoryAlways KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryAlways KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                                  KeepMetadata="$(_GCTPDIKeepMetadata)"
                                                   Include="@(ContentWithTargetPath->'%(FullPath)')"
                                                   Condition="'%(ContentWithTargetPath.CopyToPublishDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectory KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(ContentWithTargetPath->'%(FullPath)')"
                                             Condition="'%(ContentWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
-      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(ContentWithTargetPath->'%(FullPath)')"
                                             Condition="'%(ContentWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_SourceItemsToCopyToPublishDirectoryAlways KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryAlways KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                                  KeepMetadata="$(_GCTPDIKeepMetadata)"
                                                   Include="@(EmbeddedResource->'%(FullPath)')"
                                                   Condition="'%(EmbeddedResource.CopyToPublishDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectory KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(EmbeddedResource->'%(FullPath)')"
                                             Condition="'%(EmbeddedResource.CopyToPublishDirectory)'=='PreserveNewest'"/>
-      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                            KeepMetadata="$(_GCTPDIKeepMetadata)"
                                             Include="@(EmbeddedResource->'%(FullPath)')"
                                             Condition="'%(EmbeddedResource.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>
@@ -944,13 +950,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     </AssignTargetPath>
 
     <ItemGroup>
-      <_SourceItemsToCopyToPublishDirectoryAlways KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryAlways KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                                  KeepMetadata="$(_GCTPDIKeepMetadata)"
                                                   Include="@(_CompileItemsToPublishWithTargetPath)"
                                                   Condition="'%(_CompileItemsToPublishWithTargetPath.CopyToPublishDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToPublishDirectory KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectory KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                           KeepMetadata="$(_GCTPDIKeepMetadata)"
                                            Include="@(_CompileItemsToPublishWithTargetPath)"
                                            Condition="'%(_CompileItemsToPublishWithTargetPath.CopyToPublishDirectory)'=='PreserveNewest'"/>
-      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepMetadata="$(_GCTPDIKeepMetadata)"
+      <_SourceItemsToCopyToPublishDirectoryIfDifferent KeepDuplicates=" '$(_GCTPDIKeepDuplicates)' != 'false' "
+                                           KeepMetadata="$(_GCTPDIKeepMetadata)"
                                            Include="@(_CompileItemsToPublishWithTargetPath)"
                                            Condition="'%(_CompileItemsToPublishWithTargetPath.CopyToPublishDirectory)'=='IfDifferent'"/>
     </ItemGroup>


### PR DESCRIPTION
We can end up with duplicated items if they exist both in child projects as well as in the current project that we are building. These end up added to `ResolvedFileToPublish` and later on passed to crossgen2, which doesn't accept duplicate assembly inputs.