### PR TITLE
Add TypeScript Static Web Assets integration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,6 +96,7 @@
     <PackageVersion Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" />
     <PackageVersion Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixToolsetSdkVersion)" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.45" />
+    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="$(MicrosoftTypeScriptMSBuildPackageVersion)" />
     <PackageVersion Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageVersion Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />

--- a/build/InstallNode.ps1
+++ b/build/InstallNode.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Installs Node.js from https://nodejs.org/dist on a Helix agent.
+.DESCRIPTION
+    Based on dotnet/aspnetcore's eng/helix/content/InstallNode.ps1.
+    Downloads and extracts Node.js if not already available on PATH.
+.PARAMETER Version
+    The version of Node.js to install (e.g., "20.7.0").
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$InstallDir = Join-Path $PSScriptRoot 'nodejs'
+
+if (Get-Command "node.exe" -ErrorAction SilentlyContinue) {
+    try {
+        $v = & node --version 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Found node.exe in PATH: $v"
+            exit
+        } else {
+            Write-Host "node.exe found on PATH but not functional, installing fresh copy"
+        }
+    } catch {
+        Write-Host "node.exe found on PATH but not functional, installing fresh copy"
+    }
+}
+
+if (Test-Path "$InstallDir\node.exe") {
+    Write-Host "Node.exe already installed at $InstallDir"
+    exit
+}
+
+function DownloadAndInstall {
+    $nodeFile = "node-v$Version-win-x64"
+    $url = "https://nodejs.org/dist/v$Version/$nodeFile.zip"
+    $zipPath = Join-Path $env:TEMP "nodejs.zip"
+
+    Write-Host "Downloading Node.js $Version from $url"
+    $maxAttempts = 5
+    $attempt = 0
+    $success = $false
+
+    while ($attempt -lt $maxAttempts -and -not $success) {
+        $attempt++
+        try {
+            Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+            $success = $true
+        } catch {
+            Write-Host "Download attempt $attempt failed: $_"
+            if ($attempt -lt $maxAttempts) {
+                Start-Sleep -Seconds 5
+            }
+        }
+    }
+
+    if (-not $success) {
+        Write-Error "Failed to download Node.js after $maxAttempts attempts"
+        return $false
+    }
+
+    Write-Host "Extracting to $InstallDir"
+    $tempDir = Join-Path $env:TEMP "nodejs-extract"
+    if (Test-Path $tempDir) { Remove-Item $tempDir -Recurse -Force }
+
+    if (Get-Command -Name 'Microsoft.PowerShell.Archive\Expand-Archive' -ErrorAction Ignore) {
+        Microsoft.PowerShell.Archive\Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+    } else {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $tempDir)
+    }
+
+    if (Test-Path $InstallDir) { Remove-Item $InstallDir -Recurse -Force }
+    Move-Item (Join-Path $tempDir $nodeFile) $InstallDir
+
+    Remove-Item $zipPath -ErrorAction SilentlyContinue
+    Remove-Item $tempDir -Recurse -ErrorAction SilentlyContinue
+
+    if (Test-Path "$InstallDir\node.exe") {
+        Write-Host "Node.js $Version installed to $InstallDir"
+        return $true
+    } else {
+        Write-Error "node.exe not found after extraction"
+        return $false
+    }
+}
+
+$result = DownloadAndInstall
+if (-not $result) {
+    exit 1
+}

--- a/build/SetupHelixEnvironment.cmd
+++ b/build/SetupHelixEnvironment.cmd
@@ -54,3 +54,9 @@ dotnet nuget remove source dotnet-tools-transport --configfile %TestExecutionDir
 dotnet nuget remove source dotnet-libraries --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet-eng --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
+
+REM Install Node.js if version is specified (needed for TypeScript compilation tests)
+if "%DOTNET_SDK_TEST_NODE_VERSION%" NEQ "" (
+    PowerShell -ExecutionPolicy ByPass -File "%HELIX_CORRELATION_PAYLOAD%\t\InstallNode.ps1" %DOTNET_SDK_TEST_NODE_VERSION%
+    if exist "%HELIX_CORRELATION_PAYLOAD%\t\nodejs\node.exe" set PATH=%HELIX_CORRELATION_PAYLOAD%\t\nodejs;%PATH%
+)

--- a/build/SetupHelixEnvironment.sh
+++ b/build/SetupHelixEnvironment.sh
@@ -42,3 +42,12 @@ dotnet nuget remove source dotnet-tools-transport --configfile $TestExecutionDir
 dotnet nuget remove source dotnet-libraries --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet-eng --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
+
+# Install Node.js if version is specified (needed for TypeScript compilation tests)
+if [ -n "$DOTNET_SDK_TEST_NODE_VERSION" ]; then
+    chmod +x $HELIX_CORRELATION_PAYLOAD/t/installnode.sh
+    $HELIX_CORRELATION_PAYLOAD/t/installnode.sh "$DOTNET_SDK_TEST_NODE_VERSION" "${DOTNET_SDK_TEST_NODE_ARCH:-x64}"
+    if [ -d "$HELIX_CORRELATION_PAYLOAD/t/node/bin" ]; then
+        export PATH=$HELIX_CORRELATION_PAYLOAD/t/node/bin:$PATH
+    fi
+fi

--- a/build/installnode.sh
+++ b/build/installnode.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Installs Node.js on a Helix agent if not already available.
+# Usage: ./installnode.sh <version> <architecture>
+# Based on dotnet/aspnetcore's eng/helix/content/installnode.sh
+
+set -e
+
+if type -P "node" &>/dev/null; then
+    if node --version &>/dev/null; then
+        echo "node is already in \$PATH: $(node --version)"
+        exit
+    else
+        echo "node found on PATH but not functional, installing fresh copy"
+    fi
+fi
+
+node_version=$1
+arch=${2:-x64}
+osname=$(uname -s)
+if [ "$osname" = "Darwin" ]; then
+   platformarch="darwin-$arch"
+else
+   platformarch="linux-$arch"
+fi
+
+echo "PlatformArch: $platformarch"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+output_dir="$DIR/node"
+url="https://nodejs.org/dist/v$node_version/node-v$node_version-$platformarch.tar.gz"
+echo "Downloading Node.js $node_version from: $url"
+tmp="$(mktemp -d -t install-node.XXXXXX)"
+
+cleanup() {
+    exitcode=$?
+    if [ $exitcode -ne 0 ]; then
+      echo "Failed to install Node.js with exit code: $exitcode"
+    fi
+    rm -rf "$tmp"
+    exit $exitcode
+}
+
+trap "cleanup" EXIT
+cd "$tmp"
+curl -Lsfo "$(basename $url)" "$url" --retry 5
+echo "Installing Node.js from $(basename $url)"
+mkdir -p "$output_dir"
+echo "Unpacking to $output_dir"
+tar --strip-components 1 -xzf "node-v$node_version-$platformarch.tar.gz" --no-same-owner --directory "$output_dir"
+echo "Node.js $node_version installed to $output_dir"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,6 +137,7 @@
   <PropertyGroup>
     <AwesomeAssertionsVersion>8.0.2</AwesomeAssertionsVersion>
     <AwesomeAssertionsJsonVersion>8.0.0</AwesomeAssertionsJsonVersion>
+    <MicrosoftTypeScriptMSBuildPackageVersion>5.9.3</MicrosoftTypeScriptMSBuildPackageVersion>
     <MoqPackageVersion>4.18.4</MoqPackageVersion>
     <XunitCombinatorialVersion>2.0.24</XunitCombinatorialVersion>
     <XUnitRunnerVisualStudioPackageVersion>3.1.4</XUnitRunnerVisualStudioPackageVersion>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
@@ -1,0 +1,178 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<!--
+  Provides integration between the Microsoft.TypeScript.MSBuild NuGet package and
+  ASP.NET Core Static Web Assets for Razor Class Libraries.
+
+  Problem:
+    The TypeScript MSBuild package outputs compiled .js files to wwwroot, which is treated
+    as an input folder by the Static Web Assets SDK. However, TypeScript compilation runs
+    during the Compile phase, AFTER Static Web Assets discovery has already occurred.
+
+    This creates two problems:
+    1. Clean build: TypeScript outputs are not discovered as static web assets because
+       they don't exist yet when ResolveProjectStaticWebAssets runs.
+    2. Rebuild: The Razor SDK's default globbing adds wwwroot files to Content. During Clean,
+       TypeScript targets delete the .js files, but Content items persist in memory.
+       When Build runs, DefineStaticWebAssets fails because it finds Content items
+       referencing files that no longer exist.
+
+  Solution:
+    1. Hook into ResolveStaticWebAssetsInputsDependsOn to register TypeScript outputs
+       as static web assets AFTER compilation.
+    2. Remove TypeScript outputs from Content before CoreClean and ResolveProjectStaticWebAssets
+       to prevent stale item references.
+-->
+<Project ToolsVersion="14.0">
+
+  <!--
+    Target: ResolveTypeScriptStaticWebAssetsConfiguration
+
+    Sets up the path for the TypeScript manifest file.
+    DependsOnTargets ResolveStaticWebAssetsConfiguration to ensure
+    _StaticWebAssetsManifestBase is defined.
+  -->
+  <Target Name="ResolveTypeScriptStaticWebAssetsConfiguration"
+          DependsOnTargets="ResolveStaticWebAssetsConfiguration">
+    <PropertyGroup>
+      <_TypeScriptSwaManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.typescript.files.txt</_TypeScriptSwaManifestPath>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Hook into ResolveStaticWebAssetsInputs - this is the correct extension point
+    for adding computed/generated assets. It runs:
+      1. AFTER Compile phase (where TypeScript runs)
+      2. AFTER ResolveCoreStaticWebAssets (core SWA discovery)
+      3. BEFORE compression and endpoint generation
+  -->
+  <PropertyGroup>
+    <ResolveStaticWebAssetsInputsDependsOn>
+      RegisterTypeScriptStaticWebAssets;
+      $(ResolveStaticWebAssetsInputsDependsOn)
+    </ResolveStaticWebAssetsInputsDependsOn>
+  </PropertyGroup>
+
+  <!--
+    Target: RegisterTypeScriptStaticWebAssets
+
+    Registers TypeScript outputs as Static Web Assets using the SDK's
+    DefineStaticWebAssets and DefineStaticWebAssetEndpoints tasks.
+
+    This ensures TypeScript outputs get:
+      - Proper asset identity and metadata
+      - Compression (.gz, .br files)
+      - Endpoint definitions in the manifest
+      - Fingerprinting support (if enabled)
+
+    DependsOnTargets:
+      - CompileTypeScriptWithTSConfig: Ensures TypeScript is compiled first
+      - GetTypeScriptOutputForPublishing: Populates @(GeneratedJavascript) item group
+  -->
+  <Target Name="RegisterTypeScriptStaticWebAssets"
+          DependsOnTargets="ResolveTypeScriptStaticWebAssetsConfiguration;CompileTypeScriptWithTSConfig;GetTypeScriptOutputForPublishing">
+
+    <!-- Filter to only wwwroot outputs that exist on disk -->
+    <ItemGroup>
+      <_TypeScriptWwwrootAssets Include="@(GeneratedJavascript)"
+        Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')" />
+    </ItemGroup>
+
+    <!--
+      Write manifest file to track registered assets across builds.
+      WriteOnlyWhenDifferent prevents unnecessary timestamp changes for incremental builds.
+      FileWrites ensures the manifest is cleaned up during Clean target.
+    -->
+    <WriteLinesToFile
+      File="$(_TypeScriptSwaManifestPath)"
+      Lines="@(_TypeScriptWwwrootAssets)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
+      Condition="'@(_TypeScriptWwwrootAssets)' != ''" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_TypeScriptSwaManifestPath)" />
+    </ItemGroup>
+
+    <!--
+      Register TypeScript outputs as static web assets.
+      DefineStaticWebAssets is the SDK task that properly creates StaticWebAsset items
+      with all required metadata (Identity, RelativePath, ContentRoot, etc.)
+    -->
+    <DefineStaticWebAssets
+      Condition="'@(_TypeScriptWwwrootAssets)' != ''"
+      CandidateAssets="@(_TypeScriptWwwrootAssets)"
+      FingerprintCandidates="$(StaticWebAssetsFingerprintContent)"
+      FingerprintPatterns="@(StaticWebAssetFingerprintPattern)"
+      RelativePathPattern="wwwroot/**"
+      SourceType="Discovered"
+      SourceId="$(PackageId)"
+      ContentRoot="$(MSBuildProjectDirectory)\wwwroot\"
+      BasePath="$(StaticWebAssetBasePath)"
+      AssetMergeSource="$(StaticWebAssetMergeTarget)">
+      <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+      <Output TaskParameter="Assets" ItemName="_TypeScriptStaticWebAssets" />
+    </DefineStaticWebAssets>
+
+    <!--
+      Define endpoints for TypeScript assets.
+      This creates the endpoint entries that map URL paths to assets,
+      which are needed for the runtime to serve the files correctly.
+    -->
+    <DefineStaticWebAssetEndpoints
+      Condition="'@(_TypeScriptStaticWebAssets)' != ''"
+      CandidateAssets="@(_TypeScriptStaticWebAssets)"
+      ContentTypeMappings="@(StaticWebAssetContentTypeMapping)">
+      <Output TaskParameter="Endpoints" ItemName="StaticWebAssetEndpoint" />
+    </DefineStaticWebAssetEndpoints>
+
+  </Target>
+
+  <!--
+    Target: RemoveTypeScriptFromContentBeforeSwaDiscovery
+
+    Removes TypeScript outputs from Content items BEFORE two critical phases:
+
+    1. BEFORE CoreClean (during Rebuild):
+       The Razor SDK's globbing automatically adds *.js files in wwwroot to Content.
+       During Rebuild, Clean deletes these files but Content items still exist
+       (they come from SDK glob patterns, not the files themselves).
+       If we don't remove them before Clean, ResolveProjectStaticWebAssets will
+       try to process Content items pointing to deleted files and fail.
+
+    2. BEFORE ResolveProjectStaticWebAssets (during normal Build):
+       Prevents duplicate discovery - we register TypeScript outputs manually
+       via DefineStaticWebAssets, so we don't want the SDK to also discover
+       them via Content items.
+
+    The manifest file is read to know which files were previously registered.
+    The manifest itself is cleaned up by CoreClean via the FileWrites item group.
+  -->
+  <Target Name="RemoveTypeScriptFromContentBeforeSwaDiscovery"
+          DependsOnTargets="ResolveTypeScriptStaticWebAssetsConfiguration"
+          BeforeTargets="CoreClean;ResolveProjectStaticWebAssets">
+
+    <!-- Read the manifest to know what TypeScript files were registered -->
+    <ReadLinesFromFile File="$(_TypeScriptSwaManifestPath)"
+                       Condition="Exists('$(_TypeScriptSwaManifestPath)')">
+      <Output TaskParameter="Lines" ItemName="_RegisteredTypeScriptAssets" />
+    </ReadLinesFromFile>
+
+    <!-- Remove those from Content to prevent duplicate discovery and stale references -->
+    <ItemGroup>
+      <Content Remove="@(_RegisteredTypeScriptAssets)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
@@ -9,53 +9,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-
-<!--
-  Provides integration between the Microsoft.TypeScript.MSBuild NuGet package and
-  ASP.NET Core Static Web Assets for Razor Class Libraries.
-
-  Problem:
-    The TypeScript MSBuild package outputs compiled .js files to wwwroot, which is treated
-    as an input folder by the Static Web Assets SDK. However, TypeScript compilation runs
-    during the Compile phase, AFTER Static Web Assets discovery has already occurred.
-
-    This creates two problems:
-    1. Clean build: TypeScript outputs are not discovered as static web assets because
-       they don't exist yet when ResolveProjectStaticWebAssets runs.
-    2. Rebuild: The Razor SDK's default globbing adds wwwroot files to Content. During Clean,
-       TypeScript targets delete the .js files, but Content items persist in memory.
-       When Build runs, DefineStaticWebAssets fails because it finds Content items
-       referencing files that no longer exist.
-
-  Solution:
-    1. Hook into ResolveStaticWebAssetsInputsDependsOn to register TypeScript outputs
-       as static web assets AFTER compilation.
-    2. Remove TypeScript outputs from Content before CoreClean and ResolveProjectStaticWebAssets
-       to prevent stale item references.
--->
 <Project ToolsVersion="14.0">
 
-  <!--
-    Target: ResolveTypeScriptStaticWebAssetsConfiguration
-
-    Sets up the path for the TypeScript manifest file.
-    DependsOnTargets ResolveStaticWebAssetsConfiguration to ensure
-    _StaticWebAssetsManifestBase is defined.
-  -->
-  <Target Name="ResolveTypeScriptStaticWebAssetsConfiguration"
-          DependsOnTargets="ResolveStaticWebAssetsConfiguration">
-    <PropertyGroup>
-      <_TypeScriptSwaManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.typescript.files.txt</_TypeScriptSwaManifestPath>
-    </PropertyGroup>
-  </Target>
-
-  <!--
-    Hook into ResolveStaticWebAssetsInputs - this is the correct extension point
-    for adding computed/generated assets. It runs:
-      1. AFTER Compile phase (where TypeScript runs)
-      2. AFTER ResolveCoreStaticWebAssets (core SWA discovery)
-      3. BEFORE compression and endpoint generation
-  -->
   <PropertyGroup>
     <ResolveStaticWebAssetsInputsDependsOn>
       RegisterTypeScriptStaticWebAssets;
@@ -63,36 +18,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ResolveStaticWebAssetsInputsDependsOn>
   </PropertyGroup>
 
-  <!--
-    Target: RegisterTypeScriptStaticWebAssets
+  <Target Name="ResolveTypeScriptStaticWebAssetsConfiguration"
+          DependsOnTargets="ResolveStaticWebAssetsConfiguration">
+    <PropertyGroup>
+      <_TypeScriptSwaManifestPath>$(_StaticWebAssetsManifestBase)staticwebassets.typescript.files.txt</_TypeScriptSwaManifestPath>
+    </PropertyGroup>
+  </Target>
 
-    Registers TypeScript outputs as Static Web Assets using the SDK's
-    DefineStaticWebAssets and DefineStaticWebAssetEndpoints tasks.
-
-    This ensures TypeScript outputs get:
-      - Proper asset identity and metadata
-      - Compression (.gz, .br files)
-      - Endpoint definitions in the manifest
-      - Fingerprinting support (if enabled)
-
-    DependsOnTargets:
-      - CompileTypeScriptWithTSConfig: Ensures TypeScript is compiled first
-      - GetTypeScriptOutputForPublishing: Populates @(GeneratedJavascript) item group
-  -->
   <Target Name="RegisterTypeScriptStaticWebAssets"
           DependsOnTargets="ResolveTypeScriptStaticWebAssetsConfiguration;CompileTypeScriptWithTSConfig;GetTypeScriptOutputForPublishing">
 
-    <!-- Filter to only wwwroot outputs that exist on disk -->
     <ItemGroup>
       <_TypeScriptWwwrootAssets Include="@(GeneratedJavascript)"
         Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')" />
     </ItemGroup>
 
-    <!--
-      Write manifest file to track registered assets across builds.
-      WriteOnlyWhenDifferent prevents unnecessary timestamp changes for incremental builds.
-      FileWrites ensures the manifest is cleaned up during Clean target.
-    -->
     <WriteLinesToFile
       File="$(_TypeScriptSwaManifestPath)"
       Lines="@(_TypeScriptWwwrootAssets)"
@@ -104,11 +44,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FileWrites Include="$(_TypeScriptSwaManifestPath)" />
     </ItemGroup>
 
-    <!--
-      Register TypeScript outputs as static web assets.
-      DefineStaticWebAssets is the SDK task that properly creates StaticWebAsset items
-      with all required metadata (Identity, RelativePath, ContentRoot, etc.)
-    -->
     <DefineStaticWebAssets
       Condition="'@(_TypeScriptWwwrootAssets)' != ''"
       CandidateAssets="@(_TypeScriptWwwrootAssets)"
@@ -124,11 +59,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="Assets" ItemName="_TypeScriptStaticWebAssets" />
     </DefineStaticWebAssets>
 
-    <!--
-      Define endpoints for TypeScript assets.
-      This creates the endpoint entries that map URL paths to assets,
-      which are needed for the runtime to serve the files correctly.
-    -->
     <DefineStaticWebAssetEndpoints
       Condition="'@(_TypeScriptStaticWebAssets)' != ''"
       CandidateAssets="@(_TypeScriptStaticWebAssets)"
@@ -138,37 +68,15 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <!--
-    Target: RemoveTypeScriptFromContentBeforeSwaDiscovery
-
-    Removes TypeScript outputs from Content items BEFORE two critical phases:
-
-    1. BEFORE CoreClean (during Rebuild):
-       The Razor SDK's globbing automatically adds *.js files in wwwroot to Content.
-       During Rebuild, Clean deletes these files but Content items still exist
-       (they come from SDK glob patterns, not the files themselves).
-       If we don't remove them before Clean, ResolveProjectStaticWebAssets will
-       try to process Content items pointing to deleted files and fail.
-
-    2. BEFORE ResolveProjectStaticWebAssets (during normal Build):
-       Prevents duplicate discovery - we register TypeScript outputs manually
-       via DefineStaticWebAssets, so we don't want the SDK to also discover
-       them via Content items.
-
-    The manifest file is read to know which files were previously registered.
-    The manifest itself is cleaned up by CoreClean via the FileWrites item group.
-  -->
   <Target Name="RemoveTypeScriptFromContentBeforeSwaDiscovery"
           DependsOnTargets="ResolveTypeScriptStaticWebAssetsConfiguration"
           BeforeTargets="CoreClean;ResolveProjectStaticWebAssets">
 
-    <!-- Read the manifest to know what TypeScript files were registered -->
     <ReadLinesFromFile File="$(_TypeScriptSwaManifestPath)"
                        Condition="Exists('$(_TypeScriptSwaManifestPath)')">
       <Output TaskParameter="Lines" ItemName="_RegisteredTypeScriptAssets" />
     </ReadLinesFromFile>
 
-    <!-- Remove those from Content to prevent duplicate discovery and stale references -->
     <ItemGroup>
       <Content Remove="@(_RegisteredTypeScriptAssets)" />
     </ItemGroup>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
@@ -28,21 +28,33 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="RegisterTypeScriptStaticWebAssets"
           DependsOnTargets="ResolveTypeScriptStaticWebAssetsConfiguration;CompileTypeScriptWithTSConfig;GetTypeScriptOutputForPublishing">
 
+    <!--
+      Use project-relative paths (e.g. wwwroot/app.js) for the candidate items
+      instead of the absolute paths from @(GeneratedJavascript). On macOS, VsTsc
+      may report paths through the /tmp symlink while $(MSBuildProjectDirectory)
+      resolves to /private/tmp. DefineStaticWebAssets resolves candidate FullPath
+      via Path.GetFullPath which does not resolve symlinks, causing a StartsWith
+      mismatch against ContentRoot. Project-relative identities avoid this because
+      MSBuild resolves %(FullPath) through $(MSBuildProjectDirectory).
+    -->
     <ItemGroup>
-      <_TypeScriptWwwrootAssets Include="@(GeneratedJavascript)"
-        Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')">
-        <!--
-          Project-relative identity so RemoveTypeScriptFromContentBeforeSwaDiscovery
-          can match against the wwwroot\** Content items added by the Razor SDK
-          (whose Identity is project-relative, e.g. wwwroot\app.js).
-        -->
-        <_RelativeIdentity>$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '%(Identity)'))</_RelativeIdentity>
-      </_TypeScriptWwwrootAssets>
+      <_TypeScriptGeneratedInWwwroot Include="@(GeneratedJavascript)"
+        Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')" />
+
+      <!-- Strip everything up to and including "wwwroot/" (8 chars) from Identity,
+           then prepend "wwwroot/" to form a project-relative path. -->
+      <_TypeScriptGeneratedInWwwroot>
+        <_WwwrootSubPath>$([System.String]::new('%(Identity)').Substring(
+          $([MSBuild]::Add(
+            $([System.String]::new('%(Identity)').IndexOf('wwwroot')), 8))))</_WwwrootSubPath>
+      </_TypeScriptGeneratedInWwwroot>
+
+      <_TypeScriptWwwrootAssets Include="@(_TypeScriptGeneratedInWwwroot->'wwwroot\%(_WwwrootSubPath)')" />
     </ItemGroup>
 
     <WriteLinesToFile
       File="$(_TypeScriptSwaManifestPath)"
-      Lines="@(_TypeScriptWwwrootAssets->'%(_RelativeIdentity)')"
+      Lines="@(_TypeScriptWwwrootAssets)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true"
       Condition="'@(_TypeScriptWwwrootAssets)' != ''" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
@@ -30,12 +30,19 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <_TypeScriptWwwrootAssets Include="@(GeneratedJavascript)"
-        Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')" />
+        Condition="$([System.String]::new('%(Identity)').Contains('wwwroot')) And Exists('%(Identity)')">
+        <!--
+          Project-relative identity so RemoveTypeScriptFromContentBeforeSwaDiscovery
+          can match against the wwwroot\** Content items added by the Razor SDK
+          (whose Identity is project-relative, e.g. wwwroot\app.js).
+        -->
+        <_RelativeIdentity>$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '%(Identity)'))</_RelativeIdentity>
+      </_TypeScriptWwwrootAssets>
     </ItemGroup>
 
     <WriteLinesToFile
       File="$(_TypeScriptSwaManifestPath)"
-      Lines="@(_TypeScriptWwwrootAssets)"
+      Lines="@(_TypeScriptWwwrootAssets->'%(_RelativeIdentity)')"
       Overwrite="true"
       WriteOnlyWhenDifferent="true"
       Condition="'@(_TypeScriptWwwrootAssets)' != ''" />

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -885,4 +885,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="Microsoft.NET.Sdk.StaticWebAssets.HtmlAssetPlaceholders.targets" Condition="'$(OverrideHtmlAssetPlaceholders)' == 'true'" />
 
+  <Import Project="Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets" Condition="'$(EnableTypeScriptNuGetTarget)' == 'true'" />
+
 </Project>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
@@ -34,6 +34,10 @@
       <_Parameter1>DefaultTestBaselinePackageVersion</_Parameter1>
       <_Parameter2>5.0</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>MicrosoftTypeScriptMSBuildPackageVersion</_Parameter1>
+      <_Parameter2>$(MicrosoftTypeScriptMSBuildPackageVersion)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
@@ -1,0 +1,288 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System.Reflection;
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+
+namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
+
+public class TypeScriptIntegrationTest : IsolatedNuGetPackageFolderAspNetSdkBaselineTest
+{
+    public string TypeScriptMSBuildPackageVersion { get; }
+
+    public TypeScriptIntegrationTest(ITestOutputHelper log) : base(log, nameof(TypeScriptIntegrationTest))
+    {
+        var testAssemblyMetadata = TestAssembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+        TypeScriptMSBuildPackageVersion = testAssemblyMetadata.SingleOrDefault(a => a.Key == "MicrosoftTypeScriptMSBuildPackageVersion")?.Value ?? "5.9.3";
+    }
+
+    [Fact]
+    public void Build_RegistersTypeScriptOutputsAsStaticWebAssets()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+        var outputPath = build.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify the TypeScript manifest was created
+        var manifestPath = Path.Combine(intermediateOutputPath, "staticwebassets.typescript.files.txt");
+        new FileInfo(manifestPath).Should().Exist();
+
+        // Verify the static web assets manifest contains the TypeScript outputs
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+
+        buildManifest.Should().NotBeNull();
+        buildManifest.Assets.Should().Contain(a => a.RelativePath.EndsWith("app.js"));
+    }
+
+    [Fact]
+    public void Build_TypeScriptOutputsAreProperlyCompressed()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        // Enable compression
+        ProjectDirectory.WithProjectChanges(document =>
+        {
+            var propertyGroup = document.Root.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "PropertyGroup");
+            propertyGroup?.Add(new XElement("CompressionEnabled", "true"));
+        });
+
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify compression was applied
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+
+        // Should have compressed versions
+        buildManifest.Assets.Should().Contain(a => a.RelativePath.EndsWith("app.js.gz") || a.RelativePath.EndsWith("app.js.br"));
+    }
+
+    [Fact]
+    public void Rebuild_SucceedsWithTypeScriptOutputs()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        // First build
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        // Rebuild (clean + build)
+        var rebuild = CreateRebuildCommand(ProjectDirectory);
+        var rebuildResult = ExecuteCommand(rebuild);
+        rebuildResult.Should().Pass();
+
+        var intermediateOutputPath = rebuild.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify static web assets are still correctly registered after rebuild
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+
+        buildManifest.Should().NotBeNull();
+        buildManifest.Assets.Should().Contain(a => a.RelativePath.EndsWith("app.js"));
+    }
+
+    [Fact]
+    public async Task Build_IncrementalBuild_WorksCorrectly()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        // First build
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+        var manifestPath = Path.Combine(intermediateOutputPath, "staticwebassets.typescript.files.txt");
+
+        var firstBuildManifestTime = File.GetLastWriteTime(manifestPath);
+
+        // Wait a bit and do incremental build
+        await Task.Delay(100);
+
+        build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        // Manifest should not have changed (WriteOnlyWhenDifferent)
+        var secondBuildManifestTime = File.GetLastWriteTime(manifestPath);
+        secondBuildManifestTime.Should().Be(firstBuildManifestTime);
+    }
+
+    [Fact]
+    public void Build_ModifyTypeScriptFile_UpdatesStaticWebAssets()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        // First build
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        // Modify the TypeScript file
+        var tsFilePath = Path.Combine(ProjectDirectory.TestRoot, "Scripts", "app.ts");
+        File.WriteAllText(tsFilePath, "console.log('Modified!');");
+
+        // Rebuild
+        build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify the output was updated
+        var jsFilePath = Path.Combine(ProjectDirectory.TestRoot, "wwwroot", "app.js");
+        new FileInfo(jsFilePath).Should().Exist();
+        File.ReadAllText(jsFilePath).Should().Contain("Modified");
+    }
+
+    [Fact]
+    public void Publish_IncludesTypeScriptOutputs()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        var publish = CreatePublishCommand(ProjectDirectory);
+        ExecuteCommand(publish).Should().Pass();
+
+        var intermediateOutputPath = publish.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify publish manifest includes TypeScript outputs
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.publish.json");
+        var publishManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+
+        publishManifest.Should().NotBeNull();
+        publishManifest.Assets.Should().Contain(a => a.RelativePath.EndsWith("app.js"));
+    }
+
+    [Fact]
+    public void Clean_ThenBuild_SucceedsWithTypeScriptOutputs()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        // First build
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        // Clean
+        var clean = new CleanCommand(Log, ProjectDirectory.Path);
+        clean.WithWorkingDirectory(ProjectDirectory.TestRoot);
+        ExecuteCommand(clean).Should().Pass();
+
+        // Build again
+        build = CreateBuildCommand(ProjectDirectory);
+        var result = ExecuteCommand(build);
+        result.Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // Verify static web assets are correctly registered
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+
+        buildManifest.Should().NotBeNull();
+        buildManifest.Assets.Should().Contain(a => a.RelativePath.EndsWith("app.js"));
+    }
+
+    [Fact]
+    public void Build_TypeScriptDisabled_DoesNotRegisterAssets()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory, enableTypeScript: false);
+
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        // TypeScript manifest should not exist when disabled
+        var manifestPath = Path.Combine(intermediateOutputPath, "staticwebassets.typescript.files.txt");
+        new FileInfo(manifestPath).Should().NotExist();
+    }
+
+    /// <summary>
+    /// Sets up a test project with TypeScript configuration using the
+    /// Microsoft.TypeScript.MSBuild NuGet package.
+    /// </summary>
+    private void SetupTypeScriptProject(TestAsset projectDirectory, bool enableTypeScript = true)
+    {
+        // Create Scripts folder and TypeScript file
+        var scriptsDir = Path.Combine(projectDirectory.TestRoot, "Scripts");
+        Directory.CreateDirectory(scriptsDir);
+        File.WriteAllText(Path.Combine(scriptsDir, "app.ts"), "console.log('Hello from TypeScript!');");
+
+        // Create tsconfig.json that outputs to wwwroot
+        var tsconfig = @"{
+  ""compilerOptions"": {
+    ""target"": ""ES2020"",
+    ""module"": ""ES2020"",
+    ""outDir"": ""wwwroot"",
+    ""rootDir"": ""Scripts"",
+    ""strict"": true,
+    ""sourceMap"": true
+  },
+  ""include"": [""Scripts/**/*""]
+}";
+        File.WriteAllText(Path.Combine(projectDirectory.TestRoot, "tsconfig.json"), tsconfig);
+
+        // Ensure wwwroot exists
+        Directory.CreateDirectory(Path.Combine(projectDirectory.TestRoot, "wwwroot"));
+
+        // Modify project to add the TypeScript MSBuild package
+        projectDirectory.WithProjectChanges(document =>
+        {
+            var root = document.Root;
+            var ns = root.Name.Namespace;
+
+            // Add PropertyGroup with TypeScript output directory
+            var propertyGroup = root.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "PropertyGroup");
+
+            if (propertyGroup != null)
+            {
+                propertyGroup.Add(new XElement(ns + "TypeScriptOutDir", "wwwroot"));
+            }
+
+            if (enableTypeScript)
+            {
+                // Add Microsoft.TypeScript.MSBuild package reference
+                var itemGroup = new XElement(ns + "ItemGroup",
+                    new XElement(ns + "PackageReference",
+                        new XAttribute("Include", "Microsoft.TypeScript.MSBuild"),
+                        new XAttribute("Version", TypeScriptMSBuildPackageVersion),
+                        new XElement(ns + "PrivateAssets", "all"),
+                        new XElement(ns + "IncludeAssets", "runtime; build; native; contentfiles; analyzers; buildtransitive")
+                    )
+                );
+                root.Add(itemGroup);
+            }
+        });
+    }
+}

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
@@ -30,12 +30,10 @@ public class TypeScriptIntegrationTest : IsolatedNuGetPackageFolderAspNetSdkBase
         ExecuteCommand(build).Should().Pass();
 
         var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
-        var outputPath = build.GetOutputDirectory(DefaultTfm, "Debug").ToString();
 
         // Verify the TypeScript manifest was created
         var manifestPath = Path.Combine(intermediateOutputPath, "staticwebassets.typescript.files.txt");
         new FileInfo(manifestPath).Should().Exist();
-
         // Verify the static web assets manifest contains the TypeScript outputs
         var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
         var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
@@ -116,7 +116,7 @@ public class TypeScriptIntegrationTest : IsolatedNuGetPackageFolderAspNetSdkBase
         var firstBuildManifestTime = File.GetLastWriteTime(manifestPath);
 
         // Wait a bit and do incremental build
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         build = CreateBuildCommand(ProjectDirectory);
         ExecuteCommand(build).Should().Pass();

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -158,7 +158,9 @@
 
       <FilesInHelixRoot Include="$(TestLayoutDir)\NuGet.config" />
       <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(RepoRoot)build\SetupHelixEnvironment.cmd" />
+      <FilesInHelixRoot Condition="$([MSBuild]::IsOSPlatform(`Windows`))" Include="$(RepoRoot)build\InstallNode.ps1" />
       <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)build\SetupHelixEnvironment.sh" />
+      <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)build\installnode.sh" />
       <FilesInHelixRoot Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' " Include="$(RepoRoot)build\helix-debug-entitlements.plist" />
     </ItemGroup>
 
@@ -201,8 +203,15 @@
 
   <Target Name="AppendHelixPreCommand" BeforeTargets="CoreTest" DependsOnTargets="CopyHelixFiles">
     <PropertyGroup>
-      <HelixPreCommands Condition="!$(IsPosixShell)">call %HELIX_CORRELATION_PAYLOAD%\t\SetupHelixEnvironment.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
-      <HelixPreCommands Condition="$(IsPosixShell)">. $HELIX_CORRELATION_PAYLOAD/t/SetupHelixEnvironment.sh;$(HelixPreCommands)</HelixPreCommands>
+      <!-- Node.js version for TypeScript tests on Helix (Microsoft.TypeScript.MSBuild requires Node 20+) -->
+      <NodeVersion>22.22.3</NodeVersion>
+      <_NodeArchitecture Condition="'$(TargetArchitecture)' != ''">$(TargetArchitecture)</_NodeArchitecture>
+      <_NodeArchitecture Condition="'$(TargetArchitecture)' == ''">x64</_NodeArchitecture>
+      <!-- Install Node.js for TypeScript compilation tests.
+           Done inside SetupHelixEnvironment scripts to avoid PATH semicolons
+           conflicting with HelixPreCommands separator. -->
+      <HelixPreCommands Condition="!$(IsPosixShell)">set DOTNET_SDK_TEST_NODE_VERSION=$(NodeVersion);call %HELIX_CORRELATION_PAYLOAD%\t\SetupHelixEnvironment.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
+      <HelixPreCommands Condition="$(IsPosixShell)">export DOTNET_SDK_TEST_NODE_VERSION=$(NodeVersion);export DOTNET_SDK_TEST_NODE_ARCH=$(_NodeArchitecture);. $HELIX_CORRELATION_PAYLOAD/t/SetupHelixEnvironment.sh;$(HelixPreCommands)</HelixPreCommands>
       <!-- Install wasm-tools workload on Helix for AoT tests (see: https://github.com/dotnet/sdk/issues/22655).
            This must happen on Helix (not the build machine) because cross-arch builds produce a dotnet binary
            that cannot execute on the build machine's architecture.


### PR DESCRIPTION
## Summary

Fixes #51822, #52301

This PR adds support for integrating TypeScript outputs from the `Microsoft.TypeScript.MSBuild` NuGet package with ASP.NET Core Static Web Assets in Razor Class Libraries.

## Problem

When using TypeScript with Static Web Assets in RCLs, rebuild operations fail because:

1. **Timing issue**: TypeScript compilation runs during the Compile phase, AFTER Static Web Assets discovery has already occurred
2. **Stale references**: During Clean, TypeScript targets delete the `.js` files, but `Content` items (added by Razor SDK globbing) persist in memory
3. **Build failure**: `DefineStaticWebAssets` then fails because it finds `Content` items referencing files that no longer exist

## Solution

Added `Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets` which:

- **Hooks into `ResolveStaticWebAssetsInputsDependsOn`** to register TypeScript outputs AFTER compilation
- **Removes TypeScript outputs from `Content`** before `CoreClean` and `ResolveProjectStaticWebAssets` to prevent stale item references
- **Uses `DefineStaticWebAssets`/`DefineStaticWebAssetEndpoints`** for proper integration with compression, fingerprinting, and manifest generation
- **Creates a manifest file** (`staticwebassets.typescript.files.txt`) to track registered assets across builds

## Changes

| File | Description |
|------|-------------|
| `Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets` | New targets file with TypeScript integration logic |
| `Microsoft.NET.Sdk.StaticWebAssets.targets` | Added conditional import when TypeScript package is detected |
| `TypeScriptIntegrationTest.cs` | 8 E2E integration tests |
| `Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj` | Added assembly metadata for TypeScript version |
| `eng/Versions.props` | Added `MicrosoftTypeScriptMSBuildPackageVersion` |
| `Directory.Packages.props` | Added `Microsoft.TypeScript.MSBuild` package reference |

## Test Coverage

All 8 integration tests pass:
- ✅ `Build_RegistersTypeScriptOutputsAsStaticWebAssets`
- ✅ `Build_TypeScriptOutputsAreProperlyCompressed`
- ✅ `Rebuild_SucceedsWithTypeScriptOutputs` (main scenario from #51822)
- ✅ `Build_IncrementalBuild_WorksCorrectly`
- ✅ `Build_ModifyTypeScriptFile_UpdatesStaticWebAssets`
- ✅ `Publish_IncludesTypeScriptOutputs`
- ✅ `Clean_ThenBuild_SucceedsWithTypeScriptOutputs`
- ✅ `Build_TypeScriptDisabled_DoesNotRegisterAssets`

## How It Works

```
┌─────────────────────────────────────────────────────────────────────┐
│                         Build Pipeline                               │
├─────────────────────────────────────────────────────────────────────┤
│  1. ResolveCoreStaticWebAssets     (discovers existing wwwroot)     │
│  2. CompileTypeScriptWithTSConfig  (TypeScript → JS in wwwroot)     │
│  3. RegisterTypeScriptStaticWebAssets ◄── NEW: hooks in here        │
│     └─ DefineStaticWebAssets       (registers JS as SWA)            │
│     └─ DefineStaticWebAssetEndpoints (creates endpoint mappings)    │
│  4. Compression, fingerprinting, manifest generation                │
└─────────────────────────────────────────────────────────────────────┘
```

During rebuild, the `RemoveTypeScriptFromContentBeforeSwaDiscovery` target runs before `CoreClean` to prevent stale Content item references.