### PR TITLE
Handle assemblies gracefully

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -404,11 +404,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         string? standardOutput,
         string? errorOutput)
     {
-        if (!_assemblies.TryGetValue(executionId, out TestProgressState? asm))
-        {
-            // This should not happen in normal scenarios, but handle gracefully
-            return;
-        }
+        TestProgressState asm = _assemblies[executionId];
         var attempt = asm.TryCount;
 
         if (_options.ShowActiveTests)
@@ -735,21 +731,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         // In single process run, like with testing platform .exe we report these via messages, and run exit.
         int exitCode, string? outputData, string? errorData)
     {
-        // The executionId may not exist in the dictionary if the host type is not "TestHost"
-        // (e.g., TestHostController), since AssemblyRunStarted is only called for TestHost.
-        if (!_assemblies.TryGetValue(executionId, out TestProgressState? assemblyRun))
-        {
-            // No assembly run state to update, but still report on non-zero exit codes
-            if (exitCode != 0)
-            {
-                _terminalWithProgress.WriteToTerminal(terminal =>
-                {
-                    AppendExecutableSummary(terminal, exitCode, outputData, errorData);
-                });
-            }
-            return;
-        }
-
+        TestProgressState assemblyRun = _assemblies[executionId];
         assemblyRun.Success = exitCode == 0 && assemblyRun.FailedTests == 0;
         assemblyRun.Stopwatch.Stop();
 
@@ -921,11 +903,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             return;
         }
 
-        if (!_assemblies.TryGetValue(executionId, out TestProgressState? asm))
-        {
-            // This should not happen in normal scenarios, but handle gracefully
-            return;
-        }
+        TestProgressState asm = _assemblies[executionId];
 
         // TODO: add mode for discovered tests to the progress bar - jajares
         asm.DiscoverTest(displayName, uid);
@@ -1011,11 +989,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         string displayName,
         string executionId)
     {
-        if (!_assemblies.TryGetValue(executionId, out TestProgressState? asm))
-        {
-            // This should not happen in normal scenarios, but handle gracefully
-            return;
-        }
+        TestProgressState asm = _assemblies[executionId];
 
         if (_options.ShowActiveTests)
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -15,6 +15,7 @@ internal sealed class TestApplicationHandler
     private readonly Dictionary<string, (int TestSessionStartCount, int TestSessionEndCount)> _testSessionEventCountPerSessionUid = new();
 
     private (string? TargetFramework, string? Architecture, string ExecutionId)? _handshakeInfo;
+    private bool _receivedTestHostHandshake;
 
     public TestApplicationHandler(TerminalTestReporter output, TestModule module, TestOptions options)
     {
@@ -62,6 +63,7 @@ internal sealed class TestApplicationHandler
         // https://github.com/microsoft/testfx/blob/2a9a353ec2bb4ce403f72e8ba1f29e01e7cf1fd4/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs#L87-L97
         if (hostType == "TestHost")
         {
+            _receivedTestHostHandshake = true;
             // AssemblyRunStarted counts "retry count", and writes to terminal "(Try <number-of-try>) Running tests from <assembly>"
             // So, we want to call it only for test host, and not for test host controller (or orchestrator, if in future it will handshake as well)
             // Calling it for both test host and test host controllers means we will count retries incorrectly, and will messages twice.
@@ -265,7 +267,16 @@ internal sealed class TestApplicationHandler
     {
         if (_handshakeInfo.HasValue)
         {
-            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
+            // If we received a handshake from TestHostController but not from TestHost,
+            // call HandshakeFailure instead of AssemblyRunCompleted
+            if (!_receivedTestHostHandshake)
+            {
+                _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
+            }
+            else
+            {
+                _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
+            }
         }
         else
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -265,7 +265,7 @@ internal sealed class TestApplicationHandler
 
     internal void OnTestProcessExited(int exitCode, string outputData, string errorData)
     {
-        if (_handshakeInfo.HasValue)
+        if (_receivedTestHostHandshake)
         {
             // If we received a handshake from TestHostController but not from TestHost,
             // call HandshakeFailure instead of AssemblyRunCompleted

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -265,7 +265,7 @@ internal sealed class TestApplicationHandler
 
     internal void OnTestProcessExited(int exitCode, string outputData, string errorData)
     {
-        if (_receivedTestHostHandshake)
+        if (_receivedTestHostHandshake && _handshakeInfo.HasValue)
         {
             // If we received a handshake from TestHostController but not from TestHost,
             // call HandshakeFailure instead of AssemblyRunCompleted

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -269,14 +269,7 @@ internal sealed class TestApplicationHandler
         {
             // If we received a handshake from TestHostController but not from TestHost,
             // call HandshakeFailure instead of AssemblyRunCompleted
-            if (!_receivedTestHostHandshake)
-            {
-                _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
-            }
-            else
-            {
-                _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
-            }
+            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
         }
         else
         {


### PR DESCRIPTION
This pull request improves the robustness of the `TerminalTestReporter` class by adding safe dictionary access for test progress state lookups. Instead of directly accessing the `_assemblies` dictionary, the code now uses `TryGetValue` to prevent potential exceptions when an execution ID is missing. This ensures smoother error handling and avoids crashes in edge cases.

Error handling and robustness improvements:

* Replaced direct dictionary access with `TryGetValue` in methods such as `TestCompleted`, `TestDiscovered`, and `TestInProgress` to gracefully handle missing execution IDs and prevent exceptions. [[1]](diffhunk://#diff-e888046e95ed94b1c7f3301b020f4421f378734af1d8ea5152084a07c3db2d31L407-R411) [[2]](diffhunk://#diff-e888046e95ed94b1c7f3301b020f4421f378734af1d8ea5152084a07c3db2d31L906-R928) [[3]](diffhunk://#diff-e888046e95ed94b1c7f3301b020f4421f378734af1d8ea5152084a07c3db2d31L992-R1018)
* Updated `AssemblyRunCompleted` to handle cases where the execution ID does not exist by reporting non-zero exit codes to the terminal and skipping state updates, improving stability for non-"TestHost" scenarios.