### PR TITLE
Add BundledNETCoreAppTargetFramework to BundledVersions.props

### DIFF
--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -610,6 +610,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_NetFrameworkHostedCompilersVersion>$(MicrosoftNetCompilersToolsetFrameworkPackageVersion)</_NetFrameworkHostedCompilersVersion>
     <NETCoreAppMaximumVersion>$(_NETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
+    <BundledNETCoreAppTargetFramework>net$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFramework>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
     <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
     <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/issues/29949 but initially just adding a property so that we can easier target the TFM that the SDK provides offline packs for.