### PR TITLE
Include all file paths in analyzer redirecting metadata file

### DIFF
--- a/documentation/general/analyzer-redirecting.md
+++ b/documentation/general/analyzer-redirecting.md
@@ -48,11 +48,31 @@ And metadata at `metadata.json`:
 
 ```json
 {
-  "AspNetCoreAnalyzers": "9.0.0-preview.5.24306.11",
-  "NetCoreAnalyzers": "9.0.0-preview.5.24306.7",
-  "WindowsDesktopAnalyzers": "9.0.0-preview.5.24306.8",
-  "SDKAnalyzers": "9.0.100-dev",
-  "WebSDKAnalyzers": "9.0.100-dev",
+  "AspNetCoreAnalyzers":
+  {
+    "Version": "9.0.0-preview.5.24306.11",
+    "Files": ["analyzers\\dotnet\\cs\\Microsoft.AspNetCore.App.Analyzers.dll"]
+  },
+  "NetCoreAnalyzers":
+  {
+    "Version": "9.0.0-preview.5.24306.7",
+    "Files": ["analyzers\\dotnet\\cs\\System.Text.RegularExpressions.Generator.dll"]
+  },
+  "WindowsDesktopAnalyzers":
+  {
+    "Version": "9.0.0-preview.5.24306.8",
+    "Files": ["analyzers\\dotnet\\System.Windows.Forms.Analyzers.dll"]
+  },
+  "SDKAnalyzers":
+  {
+    "Version": "9.0.100-dev",
+    "Files": ["Sdks\\Microsoft.NET.Sdk\\analyzers\\Microsoft.CodeAnalysis.NetAnalyzers.dll"]
+  },
+  "WebSDKAnalyzers":
+  {
+    "Version": "9.0.100-dev",
+    "Files": ["Sdks\\Microsoft.NET.Sdk.Web\\analyzers\\cs\\Microsoft.AspNetCore.Analyzers.dll"]
+  },
 }
 ```
 
@@ -73,7 +93,7 @@ will be redirected to
 {InstallDir}\SDKAnalyzers\Sdks\Microsoft.NET.Sdk\analyzers\Microsoft.CodeAnalysis.NetAnalyzers.dll
 ```
 
-where `metadata.json` has `"SDKAnalyzers": "9.0.100-dev"`, because
+where `metadata.json` has `"SDKAnalyzers": { "Version": "9.0.100-dev" }`, because
 1. the suffix `Sdks\Microsoft.NET.Sdk\analyzers\Microsoft.CodeAnalysis.NetAnalyzers.dll` matches, and
 2. the version `9.0.100-preview.5.24307.3` has the same major and minor component (`9.0`) as the version `9.0.100-dev`
    (both versions are read from the paths, not DLL metadata).

--- a/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
+++ b/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
@@ -29,9 +29,9 @@ public sealed class ProcessRuntimeAnalyzerVersions : Task
         foreach (var input in Inputs ?? [])
         {
             var deploymentSubpath = input.GetMetadata("DeploymentSubpath");
-            var recursiveDir = input.GetMetadata("CustomRecursiveDir");
+            var recursiveDir = input.GetMetadata("CustomRecursiveDir").Replace('/', '\\');
 
-            var slashIndex = recursiveDir.IndexOfAny('/', '\\');
+            var slashIndex = recursiveDir.IndexOf('\\');
             var version = recursiveDir.Substring(0, slashIndex);
             var rest = recursiveDir.Substring(slashIndex + 1);
 
@@ -49,7 +49,7 @@ public sealed class ProcessRuntimeAnalyzerVersions : Task
                 return false;
             }
 
-            if (!rest.EndsWith("/") && !rest.EndsWith("\\"))
+            if (!rest.EndsWith("\\"))
             {
                 rest += '\\';
             }

--- a/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
+++ b/src/Tasks/sdk-tasks/ProcessRuntimeAnalyzerVersions.cs
@@ -21,7 +21,7 @@ public sealed class ProcessRuntimeAnalyzerVersions : Task
 
     public override bool Execute()
     {
-        var metadata = new Dictionary<string, string>();
+        var metadata = new Dictionary<string, MetadataEntry>();
 
         // Extract version from a path like:
         //   ...\packs\Microsoft.NetCore.App.Ref\<version>\analyzers\**\*.*
@@ -37,16 +37,24 @@ public sealed class ProcessRuntimeAnalyzerVersions : Task
 
             input.SetMetadata("CustomRecursiveDir", rest);
 
-            if (!metadata.TryGetValue(deploymentSubpath, out var existingVersion))
+            if (!metadata.TryGetValue(deploymentSubpath, out var entry))
             {
-                metadata.Add(deploymentSubpath, version);
+                entry = new MetadataEntry(version);
+                metadata.Add(deploymentSubpath, entry);
             }
-            else if (existingVersion != version)
+            else if (entry.Version != version)
             {
-                Log.LogError($"Version mismatch for '{deploymentSubpath}': '{existingVersion}' != '{version}'. " +
+                Log.LogError($"Version mismatch for '{deploymentSubpath}': '{entry.Version}' != '{version}'. " +
                     $"Expected only one version of '{input.GetMetadata("Identity")}'.");
                 return false;
             }
+
+            if (!rest.EndsWith("/") && !rest.EndsWith("\\"))
+            {
+                rest += '\\';
+            }
+
+            entry.Files.Add($"{rest}{input.GetMetadata("Filename")}{input.GetMetadata("Extension")}");
         }
 
         Directory.CreateDirectory(Path.GetDirectoryName(MetadataFilePath)!);
@@ -54,5 +62,11 @@ public sealed class ProcessRuntimeAnalyzerVersions : Task
 
         Outputs = Inputs;
         return true;
+    }
+
+    private sealed class MetadataEntry(string version)
+    {
+        public string Version { get; } = version;
+        public List<string> Files { get; } = [];
     }
 }


### PR DESCRIPTION
Including file paths in the metadata file to avoid needing to discover them at runtime - see https://github.com/dotnet/roslyn/pull/80969#discussion_r2641786465.