### PR TITLE
Update osx arm64 helix images

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -270,7 +270,7 @@ extends:
               name: Azure Pipelines
               vmImage: macOS-latest
               os: macOS
-            helixTargetQueue: osx.13.arm64
+            helixTargetQueue: osx.15.arm64
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             macOSJobParameterSets:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -77,7 +77,7 @@ stages:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
-        helixTargetQueue: osx.13.arm64.open
+        helixTargetQueue: osx.15.arm64.open
         macOSJobParameterSets:
         - categoryName: TestBuild
           targetArchitecture: arm64


### PR DESCRIPTION
Fixes this failure I'm seeing in PRs (https://github.com/dotnet/sdk/pull/52326 and many others):

<p><samp>
SENDHELIXJOB(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Helix queue osx.13.arm64.open was set for estimated removal date of 2026-01-01. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.
</samp></p>