### PR TITLE
Fix duplicate parameter in github merge flow

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -4,42 +4,50 @@
         // Automate opening PRs to merge cli release/8.0.1xx to 8.0.3xx
         "release/8.0.1xx":{
             "MergeToBranch": "release/8.0.3xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         },
         // Automate opening PRs to merge cli release/8.0.3xx to 8.0.4xx
         "release/8.0.3xx":{
             "MergeToBranch": "release/8.0.4xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from release/8.0.4xx to 9.0.1xx
         "release/8.0.4xx":{
             "MergeToBranch": "release/9.0.1xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         },        
         // Automate opening PRs to merge sdk repos from release/9.0.1xx to release/9.0.3xx
         "release/9.0.1xx":{
             "MergeToBranch": "release/9.0.3xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from release/9.0.3xx to release/10.0.1xx
         "release/9.0.3xx":{
             "MergeToBranch": "release/10.0.1xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.1xx to release/10.0.2xx
         "release/10.0.1xx":{
             "MergeToBranch": "release/10.0.2xx",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.2xx to main
         "release/10.0.2xx":{
             "MergeToBranch": "main",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from dnup to release/dnup
         "dnup":{
             "MergeToBranch": "release/dnup",
-            "ExtraSwitches": "-QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
         }
     }
 }


### PR DESCRIPTION
The [branch merge workflow](https://github.com/dotnet/sdk/actions/workflows/inter-branch-merge-flow.yml) seems to be completely broken in the sdk repo these days with errors like:

```
Run D:\a\sdk\sdk\arcade-repository\.github\workflows\scripts\inter-branch-merge.ps1 -RepoName sdk -RepoOwner dotnet -MergeFromBranch $env:GITHUB_REF_NAME -MergeToBranch main -ResetToTargetPaths "" -QuietComments -ResetToTargetPaths global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*
inter-branch-merge.ps1: D:\a\_temp\99bd6d72-4688-4ba6-a447-0fd0ca3d76d0.ps1:2
Line |
   2 |  … ain -ResetToTargetPaths "" -QuietComments -ResetToTargetPaths global. …
     |                                              ~~~~~~~~~~~~~~~~~~~
     | Cannot bind parameter because parameter 'ResetToTargetPaths' is specified more than once. To provide multiple
     | values to parameters that can accept multiple values, use the array syntax. For example, "-parameter
     | value1,value2,value3".
Error: Process completed with exit code 1.
```

I believe this PR should fix that.