### PR TITLE
[dotnet-watch] avoid `PlatformNotSupportedException` on various platforms

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.Host/StartupHook.cs
+++ b/src/BuiltInTools/HotReloadAgent.Host/StartupHook.cs
@@ -22,6 +22,10 @@ internal sealed class StartupHook
 {
     private static readonly string? s_standardOutputLogPrefix = Environment.GetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages);
     private static readonly string? s_namedPipeName = Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName);
+    private static readonly bool s_supportsConsoleColor = !OperatingSystem.IsAndroid()
+                                                       && !OperatingSystem.IsIOS()
+                                                       && !OperatingSystem.IsTvOS()
+                                                       && !OperatingSystem.IsBrowser();
 
 #if NET10_0_OR_GREATER
     private static PosixSignalRegistration? s_signalRegistration;
@@ -160,9 +164,17 @@ internal sealed class StartupHook
         var prefix = s_standardOutputLogPrefix;
         if (!string.IsNullOrEmpty(prefix))
         {
-            Console.ForegroundColor = ConsoleColor.DarkGray;
+            if (s_supportsConsoleColor)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+            }
+
             Console.Error.WriteLine($"{prefix} {message}");
-            Console.ResetColor();
+
+            if (s_supportsConsoleColor)
+            {
+                Console.ResetColor();
+            }
         }
     }
 }


### PR DESCRIPTION
In `Microsoft.Extensions.DotNetDeltaApplier.dll`, which is used by `dotnet-watch`.

Running `StartupHook.Initialize()` on Android results in:

    01-07 14:12:27.328  7304  7304 I DOTNET  : System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    01-07 14:12:27.328  7304  7304 I DOTNET  :  ---> System.PlatformNotSupportedException: Operation is not supported on this platform.
    01-07 14:12:27.328  7304  7304 I DOTNET  :    at System.ConsolePal.set_ForegroundColor(ConsoleColor value)
    01-07 14:12:27.328  7304  7304 I DOTNET  :    at System.Console.set_ForegroundColor(ConsoleColor value)
    01-07 14:12:27.328  7304  7304 I DOTNET  :    at StartupHook.Log(String message)
    01-07 14:12:27.328  7304  7304 I DOTNET  :    at StartupHook.Initialize()

If you review the System.Console APIs, you can see they are decorated with:

    [UnsupportedOSPlatform("android")]
    [UnsupportedOSPlatform("browser")]
    [UnsupportedOSPlatform("ios")]
    [UnsupportedOSPlatform("tvos")]

* https://github.com/dotnet/runtime/blob/242f7b23752599f22157268de41fee91cb97ef6c/src/libraries/System.Console/src/System/Console.cs#L334-L351

Checking for these platforms makes the exception go away, and we get a bit further now:

    01-07 14:39:37.433  8293  8293 I DOTNET  : [HotReload] Environment variable DOTNET_WATCH_HOTRELOAD_NAMEDPIPE_NAME has no value

To be investigated next...