### PR TITLE
[HotReloadAgent] fix possible `NullReferenceException`

### DIFF
--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -311,10 +311,7 @@ internal sealed class HotReloadAgent : IDisposable, IHotReloadAgent
     // internal for testing
     internal static string RemoveCurrentAssembly(Type startupHookType, string environment)
     {
-        if (environment is "")
-        {
-            return environment;
-        }
+        Debug.Assert(!string.IsNullOrEmpty(environment), $"{nameof(environment)} must be set");
 
         var comparison = Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -298,18 +298,18 @@ internal sealed class HotReloadAgent : IDisposable, IHotReloadAgent
     public static void ClearHotReloadEnvironmentVariables(Type startupHookType)
     {
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks,
-            RemoveCurrentAssembly(startupHookType, Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks)!));
+            RemoveCurrentAssembly(startupHookType, Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks)));
 
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName, null);
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages, null);
     }
 
     // internal for testing
-    internal static string RemoveCurrentAssembly(Type startupHookType, string environment)
+    internal static string RemoveCurrentAssembly(Type startupHookType, string? environment)
     {
-        if (environment is "")
+        if (string.IsNullOrEmpty(environment))
         {
-            return environment;
+            return "";
         }
 
         var comparison = Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
+++ b/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs
@@ -297,19 +297,23 @@ internal sealed class HotReloadAgent : IDisposable, IHotReloadAgent
     /// </summary>
     public static void ClearHotReloadEnvironmentVariables(Type startupHookType)
     {
-        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks,
-            RemoveCurrentAssembly(startupHookType, Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks)));
+        var startupHooks = Environment.GetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks);
+        if (!string.IsNullOrEmpty(startupHooks))
+        {
+            Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetStartupHooks,
+                RemoveCurrentAssembly(startupHookType, startupHooks));
+        }
 
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName, null);
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages, null);
     }
 
     // internal for testing
-    internal static string RemoveCurrentAssembly(Type startupHookType, string? environment)
+    internal static string RemoveCurrentAssembly(Type startupHookType, string environment)
     {
-        if (string.IsNullOrEmpty(environment))
+        if (environment is "")
         {
-            return "";
+            return environment;
         }
 
         var comparison = Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -10,6 +10,20 @@ namespace Microsoft.DotNet.Watch.UnitTests
     public class HotReloadAgentTest
     {
         [Fact]
+        public void RemoveCurrentAssembly_ReturnsEmptyString_WhenEnvironmentIsNull()
+        {
+            Assert.Equal("",
+                HotReloadAgent.RemoveCurrentAssembly(typeof(StartupHook), null));
+        }
+
+        [Fact]
+        public void RemoveCurrentAssembly_ReturnsEmptyString_WhenEnvironmentIsEmpty()
+        {
+            Assert.Equal("",
+                HotReloadAgent.RemoveCurrentAssembly(typeof(StartupHook), ""));
+        }
+
+        [Fact]
         public void ClearHotReloadEnvironmentVariables_ClearsStartupHook()
         {
             Assert.Equal("",

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -10,17 +10,21 @@ namespace Microsoft.DotNet.Watch.UnitTests
     public class HotReloadAgentTest
     {
         [Fact]
-        public void RemoveCurrentAssembly_ReturnsEmptyString_WhenEnvironmentIsNull()
+        public void ClearHotReloadEnvironmentVariables_DoesNotThrow_WhenStartupHooksNotSet()
         {
-            Assert.Equal("",
-                HotReloadAgent.RemoveCurrentAssembly(typeof(StartupHook), null));
-        }
+            // Ensure DOTNET_STARTUP_HOOKS is not set
+            var original = Environment.GetEnvironmentVariable("DOTNET_STARTUP_HOOKS");
+            try
+            {
+                Environment.SetEnvironmentVariable("DOTNET_STARTUP_HOOKS", null);
 
-        [Fact]
-        public void RemoveCurrentAssembly_ReturnsEmptyString_WhenEnvironmentIsEmpty()
-        {
-            Assert.Equal("",
-                HotReloadAgent.RemoveCurrentAssembly(typeof(StartupHook), ""));
+                // Should not throw NullReferenceException
+                HotReloadAgent.ClearHotReloadEnvironmentVariables(typeof(StartupHook));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("DOTNET_STARTUP_HOOKS", original);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
When running on a platform like Android, startup hooks can run via .NET's `runtimeconfig.json`, such as:

    <ItemGroup>
      <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="Microsoft.Extensions.DotNetDeltaApplier" />
    </ItemGroup>

If done this way, `$DOTNET_STARTUP_HOOKS` can be `null`, leading to:

    01-08 16:07:49.336 14598 14598 F mono-rt :  System.NullReferenceException: Object reference not set to an instance of an object.
    01-08 16:07:49.336 14598 14598 F mono-rt :    at Microsoft.DotNet.HotReload.HotReloadAgent.RemoveCurrentAssembly(Type startupHookType, String environment)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at Microsoft.DotNet.HotReload.HotReloadAgent.ClearHotReloadEnvironmentVariables(Type startupHookType)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at StartupHook.Initialize()
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    01-08 16:07:49.336 14598 14598 F mono-rt :    --- End of inner exception stack trace ---
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.StartupHookProvider.CallStartupHook(StartupHookNameOrPath startupHook)
    01-08 16:07:49.336 14598 14598 F mono-rt :    at System.StartupHookProvider.ProcessStartupHooks(String diagnosticStartupHooks)

I think we should remove the `!` and do a better null check, to just prevent this from happening.

I don't know yet if we'll use the env var or the `runtimeconfig.json` by default, but this seems reasonable to fix.

With the fix, it makes it to an expected state:

    01-08 16:20:20.560 17468 17468 I DOTNET  : [HotReload] Environment variable DOTNET_WATCH_HOTRELOAD_NAMEDPIPE_NAME has no value