### PR TITLE
Expose NetCoreSdkRoot property

### DIFF
--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -604,7 +604,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <NetCoreRoot Condition="'%24(NetCoreRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\'))</NetCoreRoot>
-    <NetCoreSdkRoot>%24(MSBuildThisFileDirectory)</NetCoreSdkRoot>
+    <NetCoreSdkRoot Condition="'%24(NetCoreSdkRoot)' == ''">%24(MSBuildThisFileDirectory)</NetCoreSdkRoot>
     <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(NetCoreRoot)'))packs</NetCoreTargetingPackRoot>
     <PrunePackageDataRoot Condition="'%24(PrunePackageDataRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(MSBuildThisFileDirectory)'))PrunePackageData</PrunePackageDataRoot>
 

--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -604,6 +604,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <NetCoreRoot Condition="'%24(NetCoreRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\'))</NetCoreRoot>
+    <NetCoreSdkRoot>%24(MSBuildThisFileDirectory)</NetCoreSdkRoot>
     <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(NetCoreRoot)'))packs</NetCoreTargetingPackRoot>
     <PrunePackageDataRoot Condition="'%24(PrunePackageDataRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(MSBuildThisFileDirectory)'))PrunePackageData</PrunePackageDataRoot>
 


### PR DESCRIPTION
This is useful for different reasons:
- MSBuild currently reads from `BundledRuntimeIdentifierGraphFile` to find the SDK root for "NET" task host support.
- We often need to import or reference assets from the sdk root. This provides a property to find that path.