### PR TITLE
[dotnet-watch ] Improves option forwarding

### DIFF
--- a/src/BuiltInTools/dotnet-watch/CommandLine/DotnetWatchCommandDefinition.cs
+++ b/src/BuiltInTools/dotnet-watch/CommandLine/DotnetWatchCommandDefinition.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Microsoft.DotNet.Watch;
+
+internal sealed class DotnetWatchCommandDefinition : RootCommand
+{
+    // dotnet-watch specific options:
+    public readonly Option<bool> QuietOption = new("--quiet", "-q") { Description = Resources.Help_Quiet, Arity = ArgumentArity.Zero };
+    public readonly Option<bool> VerboseOption = new("--verbose") { Description = Resources.Help_Verbose, Arity = ArgumentArity.Zero };
+    public readonly Option<bool> ListOption = new("--list") { Description = Resources.Help_List, Arity = ArgumentArity.Zero };
+    public readonly Option<bool> NoHotReloadOption = new("--no-hot-reload") { Description = Resources.Help_NoHotReload, Arity = ArgumentArity.Zero };
+    public readonly Option<bool> NonInteractiveOption = new("--non-interactive") { Description = Resources.Help_NonInteractive, Arity = ArgumentArity.Zero };
+
+    // Options we need to know about. They are passed through to the subcommand if the subcommand supports them.
+    public readonly Option<string> ShortProjectOption = new("-p") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+    public readonly Option<string> LongProjectOption = new("--project") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+    public readonly Option<string> LaunchProfileOption = new("--launch-profile", "-lp") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
+    public readonly Option<bool> NoLaunchProfileOption = new("--no-launch-profile") { Hidden = true, Arity = ArgumentArity.Zero };
+
+    public DotnetWatchCommandDefinition()
+        : base(Resources.Help)
+    {
+        Directives.Add(new EnvironmentVariablesDirective());
+
+        // We process all tokens that do not match any of the above options
+        // to find the subcommand (the first unmatched token preceding "--")
+        // and all its options and arguments.
+        TreatUnmatchedTokensAsErrors = false;
+
+        Options.Add(QuietOption);
+        Options.Add(VerboseOption);
+        Options.Add(ListOption);
+        Options.Add(NoHotReloadOption);
+        Options.Add(NonInteractiveOption);
+
+        Options.Add(LongProjectOption);
+        Options.Add(ShortProjectOption);
+        Options.Add(LaunchProfileOption);
+        Options.Add(NoLaunchProfileOption);
+
+        VerboseOption.Validators.Add(v =>
+        {
+            if (v.GetValue(QuietOption) && v.GetValue(VerboseOption))
+            {
+                v.AddError(Resources.Error_QuietAndVerboseSpecified);
+            }
+        });
+    }
+
+    public bool IsWatchOption(Option option)
+        => option == QuietOption ||
+           option == VerboseOption ||
+           option == ListOption ||
+           option == NoHotReloadOption ||
+           option == NonInteractiveOption;
+}

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -456,7 +456,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData(new[] { "-binaryLogger" }, new[] { NugetInteractiveProperty, "-binaryLogger" })]
         [InlineData(new[] { "/binaryLogger" }, new[] { NugetInteractiveProperty, "/binaryLogger" })]
         [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { NugetInteractiveProperty, "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
-        public void ForwardedBuildOptions_Run(string[] args, string[] buildArgs, string[] commandArgs = null)
+        public void ForwardedOptionsAndArguments_Run(string[] args, string[] buildArgs, string[] commandArgs = null)
         {
             var runOptions = VerifyOptions(["run", .. args]);
             AssertEx.SequenceEqual(buildArgs, runOptions.BuildArguments);
@@ -467,23 +467,51 @@ namespace Microsoft.DotNet.Watch.UnitTests
         // Test MTP: https://github.com/dotnet/sdk/issues/52383
 
         [Theory]
-        [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1" })]
-        [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1" })]
-        [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1" })]
-        [InlineData(new[] { "/bl" }, new[] { "/bl" })]
-        [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+        [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
+        [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
+        [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1" }, new[] { "/p", "b=1" })]
+        [InlineData(new[] { "/bl" }, new[] { "/bl" }, new[] { "/bl" })]
+        [InlineData(
+            new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
+            new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
+            new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
         [InlineData(new[] { "--launch-profile", "x" }, new string[0])]
         [InlineData(new[] { "--no-launch-profile" }, new string[0])]
-        [InlineData(new[] { "--project", "x.csproj" }, new string[0])]
+        [InlineData(new[] { "--project", "x.csproj" }, new string[0], new[] { "x.csproj" })]
         [InlineData(new[] { "--verbose" }, new string[0])]
-        public void ForwardedBuildOptions_Test(string[] args, string[] commandArgs)
+        public void ForwardedOptionsAndArguments_Test(string[] args, string[] buildArgs, string[] commandArgs = null)
         {
-            var isProperty = args[0].Contains("-p") || args[0].Contains("/p");
             var runOptions = VerifyOptions(["test", .. args]);
-            string[] expected = isProperty
-                ? ["--property:VSTestNoLogo=true", "--property:NuGetInteractive=false", .. commandArgs, "--target:VSTest"]
-                : ["--property:VSTestNoLogo=true", "--property:NuGetInteractive=false", "--target:VSTest", .. commandArgs];
-            AssertEx.SequenceEqual(expected, runOptions.BuildArguments);
+
+            var isShortProperty = args[0].Contains("-p") || args[0].Contains("/p");
+            string[] expectedBuildArgs = isShortProperty
+                ? ["--property:VSTestNoLogo=true", "--property:NuGetInteractive=false", .. buildArgs, "--target:VSTest"]
+                : ["--property:VSTestNoLogo=true", "--property:NuGetInteractive=false", "--target:VSTest", .. buildArgs];
+            AssertEx.SequenceEqual(expectedBuildArgs, runOptions.BuildArguments);
+
+            AssertEx.SequenceEqual(commandArgs ?? [], runOptions.CommandArguments);
+        }
+
+        [Theory]
+        [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
+        [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
+        [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "/p", "b=1" })]
+        [InlineData(new[] { "/bl" }, new[] { "--property:NuGetInteractive=false", "--nologo", "/bl" }, new[] { "/bl" })]
+        [InlineData(
+            new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
+            new[] { "--property:NuGetInteractive=false", "--nologo", "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
+            new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+        [InlineData(new[] { "--launch-profile", "x" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+        [InlineData(new[] { "--no-launch-profile" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+        [InlineData(new[] { "--project", "x.csproj" }, new[] { "--property:NuGetInteractive=false", "--nologo" }, new[] { "x.csproj" })]
+        [InlineData(new[] { "--verbose" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+        public void ForwardedOptionsAndArguments_Build(string[] args, string[] buildArgs, string[] commandArgs = null)
+        {
+            var runOptions = VerifyOptions(["build", .. args]);
+
+            AssertEx.SequenceEqual(buildArgs, runOptions.BuildArguments);
+
+            AssertEx.SequenceEqual(commandArgs ?? [], runOptions.CommandArguments);
         }
 
         [Fact]

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -97,33 +97,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         [Theory]
         [CombinatorialData]
-        public void RunOptions_LaunchProfile_NotPassedThrough(bool beforeCommand)
-        {
-            var options = VerifyOptions(beforeCommand ? ["--launch-profile", "p", "test"] : ["test", "--launch-profile", "p"]);
-            Assert.Equal("test", options.Command);
-            AssertEx.SequenceEqual([], options.CommandArguments);
-        }
-
-        [Theory]
-        [CombinatorialData]
-        public void RunOptions_NoLaunchProfile_NotPassedThrough(bool beforeCommand)
-        {
-            var options = VerifyOptions(beforeCommand ? ["--no-launch-profile", "test"] : ["test", "--no-launch-profile"]);
-            Assert.Equal("test", options.Command);
-            AssertEx.SequenceEqual([], options.CommandArguments);
-        }
-
-        [Theory]
-        [CombinatorialData]
-        public void RunOption_Project_NotPassedThrough(bool beforeCommand)
-        {
-            var options = VerifyOptions(beforeCommand ? ["--project", "MyProject.csproj", "test"] : ["test", "--project", "MyProject.csproj"]);
-            Assert.Equal("test", options.Command);
-            AssertEx.SequenceEqual([], options.CommandArguments);
-        }
-
-        [Theory]
-        [CombinatorialData]
         public void WatchOptions_NotPassedThrough(
             [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
             bool beforeCommand)
@@ -464,12 +437,16 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData(new[] { "--framework", "net9.0" }, new[] { "--property:TargetFramework=net9.0", NugetInteractiveProperty })]
         [InlineData(new[] { "--runtime", "arm64" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=arm64", "--property:_CommandLineDefinedRuntimeIdentifier=true" })]
         [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
+        [InlineData(new[] { "--project", "x.csproj" }, new[] { NugetInteractiveProperty }, new[] { "--project", "x.csproj" })]
+        [InlineData(new[] { "--launch-profile", "x" }, new[] { NugetInteractiveProperty }, new[] { "--launch-profile", "x" })]
+        [InlineData(new[] { "--no-launch-profile" }, new[] { NugetInteractiveProperty }, new[] { "--no-launch-profile" })]
         [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1", NugetInteractiveProperty }, new[] { "/p", "b=1" })] // it's ok to split the argument into two since `dotnet run` handles `/p b=1`
         [InlineData(new[] { "--interactive" }, new[] { "--property:NuGetInteractive=true" })]
         [InlineData(new[] { "--no-restore" }, new[] { NugetInteractiveProperty, "-restore:false" })]
         [InlineData(new[] { "--sc" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
         [InlineData(new[] { "--self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
         [InlineData(new[] { "--no-self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=false", "--property:_CommandLineDefinedSelfContained=true" })]
+        [InlineData(new[] { "--verbose" }, new[] { NugetInteractiveProperty }, new string[0])]
         [InlineData(new[] { "--verbosity", "q" }, new[] { NugetInteractiveProperty, "--verbosity:q" })]
         [InlineData(new[] { "--arch", "arm", "--os", "win" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=win-arm" })]
         [InlineData(new[] { "--disable-build-servers" }, new[] { NugetInteractiveProperty, "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
@@ -486,12 +463,19 @@ namespace Microsoft.DotNet.Watch.UnitTests
             AssertEx.SequenceEqual(commandArgs ?? args, runOptions.CommandArguments);
         }
 
+        // TODO:
+        // Test MTP: https://github.com/dotnet/sdk/issues/52383
+
         [Theory]
         [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1" })]
         [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1" })]
         [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1" })]
         [InlineData(new[] { "/bl" }, new[] { "/bl" })]
         [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+        [InlineData(new[] { "--launch-profile", "x" }, new string[0])]
+        [InlineData(new[] { "--no-launch-profile" }, new string[0])]
+        [InlineData(new[] { "--project", "x.csproj" }, new string[0])]
+        [InlineData(new[] { "--verbose" }, new string[0])]
         public void ForwardedBuildOptions_Test(string[] args, string[] commandArgs)
         {
             var isProperty = args[0].Contains("-p") || args[0].Contains("/p");

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -97,6 +97,33 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
         [Theory]
         [CombinatorialData]
+        public void RunOptions_LaunchProfile_NotPassedThrough(bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? ["--launch-profile", "p", "test"] : ["test", "--launch-profile", "p"]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RunOptions_NoLaunchProfile_NotPassedThrough(bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? ["--no-launch-profile", "test"] : ["test", "--no-launch-profile"]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RunOption_Project_NotPassedThrough(bool beforeCommand)
+        {
+            var options = VerifyOptions(beforeCommand ? ["--project", "MyProject.csproj", "test"] : ["test", "--project", "MyProject.csproj"]);
+            Assert.Equal("test", options.Command);
+            AssertEx.SequenceEqual([], options.CommandArguments);
+        }
+
+        [Theory]
+        [CombinatorialData]
         public void WatchOptions_NotPassedThrough(
             [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
             bool beforeCommand)


### PR DESCRIPTION
Only forward options that are supported by the subcommand.

Based on https://github.com/dotnet/sdk/pull/50558 by [ronald-mz](https://github.com/ronald-mz).

Fixes https://github.com/dotnet/sdk/issues/45761, https://github.com/dotnet/sdk/issues/45634