### PR TITLE
`dotnetup dotnet` experiment design doc

### DIFF
--- a/documentation/general/dotnetup/designs/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/designs/dotnetup-dotnet.md
@@ -2,7 +2,7 @@
 
 # Motivation
 
-Manipulating the `PATH` environment variable can be tricky when Visual Studio and other installers. These applications are automatically run with updates. They override the system level path on a regular basis which blocks `dotnetup` installs from being used.
+Manipulating the `PATH` environment variable can be tricky when Visual Studio and other installers are involved. These applications are automatically run with updates. They override the system level path on a regular basis which blocks `dotnetup` installs from being used.
 
 To provide an experience during the prototype of `dotnetup` before any official product is changed to work well with `dotnetup`, we propose 'aliasing' or 'shadowing' dotnet commands via `dotnetup` as one option.
 

--- a/documentation/general/dotnetup/designs/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/designs/dotnetup-dotnet.md
@@ -1,0 +1,53 @@
+# `dotnetup dotnet`
+
+# Motivation
+
+Manipulating the `PATH` environment variable can be tricky when Visual Studio and other installers. These applications are automatically run with updates. They override the system level path on a regular basis which blocks `dotnetup` installs from being used.
+
+To provide an experience during the prototype of `dotnetup` before any official product is changed to work well with `dotnetup`, we propose 'aliasing' or 'shadowing' dotnet commands via `dotnetup` as one option.
+
+One downside to this is that IDE components which processes calling `dotnet` would still be broken by a change to the `PATH`. However, this prevents user interactions with terminals and scripts from being broken.
+
+Another downside is that this requires scripts to be updated to call `dotnetup dotnet` instead of `dotnet`. For many individuals, this is a no-go.
+This also adds the overhead of an additional process call.
+
+Yet, until the `dotnet` muxer itself or .NET Installer can be modified, this provides a consistent way for the user to enforce their intended install of `dotnet` when running commands.
+
+This also enables the `PATH` to have the admin install and for the two install types to co-exist to some degree - such that `dotnetup` based installs can still be used by the local user. This also gives `dotnetup` full control over the process call, such that environment variables like `DOTNET_ROOT` can be set.
+
+# Commands
+
+`dotnetup dotnet <>`
+`dotnetup do <>` (alias for the same thing)
+
+Arguments in `<>` are forwarded transparently to `dotnet.exe` in the determined location which limits our ability to configure the command itself.
+The `dotnet.exe` hive used will follow the logic `dotnetup` uses for installation location. (e.g. `global.json` vs `dotnetup hive` priority.)
+
+# Technical Details
+
+### Permissions
+
+We should avoid unintended consequences where an elevated terminal or admin prompt running `dotnetup` runs a `user` executable with elevation.
+One approach would be to sign check dotnet every single time before hand. This is very expensive.
+So alternatively, when we spawn `dotnet`, we should attempt to revoke privileges if `dotnetup` is running under elevation.
+
+On Unix, it is rare to have a 'shell' that's running as admin - instead, users deliberately run under `sudo` or `su`.
+
+For Windows,
+
+The standard approach for this on windows is surprisingly to have explorer.exe launch the process, because explorer.exe is unelevated.
+This implementation can serve as reference for doing so, which we would do if and only if `dotnetup` is currently running under `elevation` (using the workloads check `Microsoft.DotNet.Cli.Installer.Windows.WindowsUtils.IsAdministrator()`): https://github.com/microsoft/nodejstools/blob/main/Nodejs/Product/Nodejs/SharedProject/SystemUtilities.cs#L18
+
+We could provide `dotnetup -a dotnet` as a way to allow running the `dotnet` command with the admin rights, assuming it is needed (e.g. working in a protected folder.)
+
+### Return values
+
+We should return with the return value of `dotnet` and mimic that behavior.
+
+### Environment Settings
+
+The spawned process should modify the `PATH` and set `DOTNET_ROOT` to the value of the determined `dotnet.exe` location, so that `runtime` based interactions (debug, test, run) can work as expected. This would override any custom `DOTNET_ROOT` to ensure the hive is used, for scenarios like when an admin install is side by side with `dotnetup` installs. It should also preserve the `cwd` of the shell and the other environment variables contained within, which need to be expanded (`ExpandEnvironmentVariables`) to run without the overhead of an additional shell.
+
+Using `shell=false` does mean that shell redirection techniques such as `<<` may not work as intended, which could be a point we revisit.
+
+When cross-architecture support is added, we should consider setting variables such as `DOTNET_ROOT_x64`.

--- a/documentation/general/dotnetup/designs/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/designs/dotnetup-dotnet.md
@@ -6,7 +6,7 @@ Manipulating the `PATH` environment variable can be tricky when Visual Studio an
 
 To provide an experience during the prototype of `dotnetup` before any official product is changed to work well with `dotnetup`, we propose 'aliasing' or 'shadowing' dotnet commands via `dotnetup` as one option.
 
-One downside to this is that IDE components which processes calling `dotnet` would still be broken by a change to the `PATH`. However, this prevents user interactions with terminals and scripts from being broken.
+One downside to this is that IDE components whose processes call `dotnet` would still be broken by a change to the `PATH`. However, this prevents user interactions with terminals and scripts from being broken.
 
 Another downside is that this requires scripts to be updated to call `dotnetup dotnet` instead of `dotnet`. For many individuals, this is a no-go.
 This also adds the overhead of an additional process call.

--- a/documentation/general/dotnetup/designs/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/designs/dotnetup-dotnet.md
@@ -35,7 +35,7 @@ On Unix, it is rare to have a 'shell' that's running as admin - instead, users d
 
 For Windows,
 
-The standard approach for this on windows is surprisingly to have explorer.exe launch the process, because explorer.exe is unelevated.
+The standard approach for this on Windows is surprisingly to have explorer.exe launch the process, because explorer.exe is unelevated.
 This implementation can serve as reference for doing so, which we would do if and only if `dotnetup` is currently running under `elevation` (using the workloads check `Microsoft.DotNet.Cli.Installer.Windows.WindowsUtils.IsAdministrator()`): https://github.com/microsoft/nodejstools/blob/main/Nodejs/Product/Nodejs/SharedProject/SystemUtilities.cs#L18
 
 We could provide `dotnetup -a dotnet` as a way to allow running the `dotnet` command with the admin rights, assuming it is needed (e.g. working in a protected folder.)

--- a/documentation/general/dotnetup/designs/dotnetup-multi-architecture.md
+++ b/documentation/general/dotnetup/designs/dotnetup-multi-architecture.md
@@ -1,0 +1,6 @@
+### Cross Architecture Considerations
+
+One scenario our admin installers support is installing the x64 .NET SDK on an ARM64 device.
+We should consider how to handle these hives in `dotnetup`.
+
+When making this implementation, please also consider whether we should set `DOTNET_ROOT_x64` with `dotnetup dotnet <>` as defined by [`the dotnetup dotnet command design`](./dotnetup-dotnet.md).


### PR DESCRIPTION
related https://github.com/dotnet/sdk/issues/52122 

We talked about  'shadowing' `dotnet` commands to allow users to ensure `dotnetup` always works until the product is fully integrated with `dotnet.exe` itself - such that the installers and visual studio are not able to break scenarios that rely on `dotnetup`.

I think that is important for us to provide.

This document is a first-pass on what it'd be like to actually implement that. The security portion in particular is interesting, and I'm less compelled by the proposal after trying to write it all out. Nonetheless, I wanted to see where it would take us were we to implement it. Which, I had to do some of the partial implementation so I could reason with how this would work, but that's not included here. That's in the branch `nagilson-shadow-dotnet`.

I'd appreciate having our team chat about this doc and whether we still want to do this or not, or whether there are changes that need to be made at a higher level. I've reduced the scope of reviewers to a small group, then I'll go larger if we still decide to consider this.