### PR TITLE
[draft] Implement ProcessFrameworkReferences in pure MSBuild

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -356,29 +356,49 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownCrossgen2PackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
     </ItemGroup>
 
-    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="$(NETCoreSdkRuntimeIdentifier)"
-                 SupportedRids="%(_ApplicableCrossgen2Pack.Crossgen2RuntimeIdentifiers)"
-                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                           '$(PublishReadyToRun)' == 'true' AND
-                           '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
-                           '@(_ApplicableCrossgen2Pack)' != ''">
-      <Output TaskParameter="MatchingRid" ItemName="_Crossgen2HostRid" />
-    </PickBestRid>
-
-    <!-- Prepare Crossgen2 pack intermediate data -->
+    <!-- Create candidate items with RuntimeIdentifier metadata for each supported RID -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishReadyToRun)' == 'true' AND
                           '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
-                          '@(_Crossgen2HostRid)' != ''">
-      <_Crossgen2Pack Include="@(_ApplicableCrossgen2Pack->'%(Crossgen2PackNamePattern)'.Replace('**RID**', '%(_Crossgen2HostRid.Identity)'))">
-        <NuGetPackageId>%(_Crossgen2Pack.Identity)</NuGetPackageId>
-        <NuGetPackageVersion>%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</NuGetPackageVersion>
-        <RuntimeIdentifier>%(_Crossgen2HostRid.Identity)</RuntimeIdentifier>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)')">$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</PackageDirectory>
+                          '@(_ApplicableCrossgen2Pack)' != ''">
+      <_Crossgen2Candidate Include="%(_ApplicableCrossgen2Pack.Crossgen2RuntimeIdentifiers)">
+        <Crossgen2PackNamePattern>%(_ApplicableCrossgen2Pack.Crossgen2PackNamePattern)</Crossgen2PackNamePattern>
+        <Crossgen2PackVersion>%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</Crossgen2PackVersion>
+      </_Crossgen2Candidate>
+    </ItemGroup>
+
+    <!-- Select compatible Crossgen2 pack -->
+    <SelectRuntimeIdentifierSpecificItems RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                                          TargetRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
+                                          Items="@(_Crossgen2Candidate)"
+                                          RuntimeIdentifierItemMetadata="Identity"
+                                          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                                    '$(PublishReadyToRun)' == 'true' AND
+                                                    '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                                                    '@(_Crossgen2Candidate)' != ''">
+      <Output TaskParameter="SelectedItems" ItemName="_SelectedCrossgen2Candidate" />
+    </SelectRuntimeIdentifierSpecificItems>
+
+    <!-- Prepare Crossgen2 pack intermediate data -->
+    <!-- First create the items with substituted RID -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishReadyToRun)' == 'true' AND
+                          '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                          '@(_SelectedCrossgen2Candidate)' != ''">
+      <_Crossgen2Pack Include="$([System.String]::Copy('%(_SelectedCrossgen2Candidate.Crossgen2PackNamePattern)').Replace('**RID**', '%(_SelectedCrossgen2Candidate.Identity)'))">
+        <NuGetPackageVersion>%(_SelectedCrossgen2Candidate.Crossgen2PackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_SelectedCrossgen2Candidate.Identity)</RuntimeIdentifier>
       </_Crossgen2Pack>
+    </ItemGroup>
+
+    <!-- Then add metadata that depends on Identity -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishReadyToRun)' == 'true' AND
+                          '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                          '@(_Crossgen2Pack)' != ''">
       <_Crossgen2Pack>
-        <Path>%(_Crossgen2Pack.PackageDirectory)</Path>
+        <NuGetPackageId>%(_Crossgen2Pack.Identity)</NuGetPackageId>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_Crossgen2Pack.NuGetPackageVersion)')">$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_Crossgen2Pack.NuGetPackageVersion)</PackageDirectory>
       </_Crossgen2Pack>
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -260,37 +260,42 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->
-    <!-- Create scenario items for PickBestRid batching: one per runtime pack -->
+    <!-- Create candidate items where Identity is the RID -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
-                          '$(_EffectiveRuntimeIdentifier)' != ''">
-      <_PrimaryRidScenario Include="@(_MatchedRuntimePack)" KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;FrameworkReferenceName;LatestRuntimeFrameworkVersion;IsTrimmable;RuntimePackAlwaysCopyLocal">
-        <TargetRid>$(_EffectiveRuntimeIdentifier)</TargetRid>
-        <SupportedRids>%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)</SupportedRids>
-      </_PrimaryRidScenario>
+                          '$(_EffectiveRuntimeIdentifier)' != '' AND
+                          '@(_MatchedRuntimePack)' != ''">
+      <_PrimaryRuntimePackCandidate Include="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)">
+        <RuntimePackNamePatterns>%(_MatchedRuntimePack.RuntimePackNamePatterns)</RuntimePackNamePatterns>
+        <FrameworkReferenceName>%(_MatchedRuntimePack.FrameworkReferenceName)</FrameworkReferenceName>
+        <LatestRuntimeFrameworkVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestRuntimeFrameworkVersion>
+        <IsTrimmable>%(_MatchedRuntimePack.IsTrimmable)</IsTrimmable>
+        <RuntimePackAlwaysCopyLocal>%(_MatchedRuntimePack.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
+      </_PrimaryRuntimePackCandidate>
     </ItemGroup>
 
-    <!-- Batch PickBestRid across each runtime pack scenario - metadata is preserved from batched items -->
-    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="%(_PrimaryRidScenario.TargetRid)"
-                 SupportedRids="%(_PrimaryRidScenario.SupportedRids)"
-                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
-                           '$(_EffectiveRuntimeIdentifier)' != '' AND
-                           '@(_PrimaryRidScenario)' != ''">
-      <Output TaskParameter="MatchingRid" ItemName="_PrimaryMatchedRid" />
-    </PickBestRid>
+    <!-- Select compatible runtime pack for primary RID -->
+    <SelectRuntimeIdentifierSpecificItems RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                                          TargetRuntimeIdentifier="$(_EffectiveRuntimeIdentifier)"
+                                          Items="@(_PrimaryRuntimePackCandidate)"
+                                          RuntimeIdentifierItemMetadata="Identity"
+                                          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                                    '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                                                    '$(_EffectiveRuntimeIdentifier)' != '' AND
+                                                    '@(_PrimaryRuntimePackCandidate)' != ''">
+      <Output TaskParameter="SelectedItems" ItemName="_PrimaryMatchedRuntimePackCandidate" />
+    </SelectRuntimeIdentifierSpecificItems>
 
     <!-- Prepare intermediate runtime pack data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                           '$(_EffectiveRuntimeIdentifier)' != ''">
-      <_RuntimePackWithRid Include="@(_PrimaryMatchedRid->'%(RuntimePackNamePatterns)')">
-        <MatchedRid>%(_PrimaryMatchedRid.Identity)</MatchedRid>
-        <FrameworkName>%(_PrimaryMatchedRid.FrameworkReferenceName)</FrameworkName>
-        <LatestVersion>%(_PrimaryMatchedRid.LatestRuntimeFrameworkVersion)</LatestVersion>
-        <IsTrimmable>%(_PrimaryMatchedRid.IsTrimmable)</IsTrimmable>
-        <RuntimePackAlwaysCopyLocal>%(_PrimaryMatchedRid.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
+      <_RuntimePackWithRid Include="@(_PrimaryMatchedRuntimePackCandidate->'%(RuntimePackNamePatterns)')">
+        <MatchedRid>%(_PrimaryMatchedRuntimePackCandidate.Identity)</MatchedRid>
+        <FrameworkName>%(_PrimaryMatchedRuntimePackCandidate.FrameworkReferenceName)</FrameworkName>
+        <LatestVersion>%(_PrimaryMatchedRuntimePackCandidate.LatestRuntimeFrameworkVersion)</LatestVersion>
+        <IsTrimmable>%(_PrimaryMatchedRuntimePackCandidate.IsTrimmable)</IsTrimmable>
+        <RuntimePackAlwaysCopyLocal>%(_PrimaryMatchedRuntimePackCandidate.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
       </_RuntimePackWithRid>
     </ItemGroup>
 
@@ -588,18 +593,25 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Prepare runtime pack intermediate data with complete metadata -->
+    <!-- First create items with substituted RID -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                           '$(_EffectiveRuntimeIdentifier)' != ''">
-      <!-- Substitute **RID** placeholder -->
-      <_RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
-        <NuGetPackageId>%(_RuntimePack.Identity)</NuGetPackageId>
+      <_RuntimePack Include="$([System.String]::Copy('%(_RuntimePackWithRid.Identity)').Replace('**RID**', '%(_RuntimePackWithRid.MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
         <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
         <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
         <RuntimePackAlwaysCopyLocal Condition="'%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)' == 'true'">true</RuntimePackAlwaysCopyLocal>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)')">$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)</PackageDirectory>
       </_RuntimePack>
+    </ItemGroup>
+
+    <!-- Then add metadata that depends on Identity -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                          '$(_EffectiveRuntimeIdentifier)' != '' AND
+                          '@(_RuntimePack)' != ''">
       <_RuntimePack>
+        <NuGetPackageId>%(_RuntimePack.Identity)</NuGetPackageId>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePack.NuGetPackageVersion)')">$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePack.NuGetPackageVersion)</PackageDirectory>
         <Path>%(_RuntimePack.PackageDirectory)</Path>
       </_RuntimePack>
     </ItemGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -188,14 +188,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_JoinedFrameworkReference>
         <WasReferencedDirectly>true</WasReferencedDirectly>
       </_JoinedFrameworkReference>
-
-      <!-- Filter _ApplicableKnownFrameworkReference to only those with matching FrameworkReference -->
-      <_FilteredApplicableKnownFrameworkReference Include="@(_ApplicableKnownFrameworkReference)"
-        Condition="'%(_ApplicableKnownFrameworkReference.Identity)' == '%(_JoinedFrameworkReference.Identity)'" />
-
-      <!-- Replace _ApplicableKnownFrameworkReference with filtered version -->
-      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)" />
-      <_ApplicableKnownFrameworkReference Include="@(_FilteredApplicableKnownFrameworkReference)" />
     </ItemGroup>
 
     <!-- Validate Windows-only frameworks from _ValidateWindowsOnlyFrameworks -->
@@ -219,20 +211,36 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Select runtime packs by labels from _SelectRuntimePacksByLabels -->
-     <!-- TODO: this is broken - no _candidateruntimepack items are created. -->
+    <!-- Build up candidate runtime packs incrementally, one framework reference at a time -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- For each runtime pack, check if it matches any framework reference's RuntimeFrameworkName -->
+      <!-- For each framework reference, find runtime packs matching its RuntimeFrameworkName -->
       <_CandidateRuntimePack Include="@(_ApplicableKnownRuntimePack)"
-        Condition="@(_JoinedFrameworkReference->AnyHaveMetadataValue('RuntimeFrameworkName', '%(_ApplicableKnownRuntimePack.Identity)'))"
+        Condition="'%(_ApplicableKnownRuntimePack.Identity)' == '%(_JoinedFrameworkReference.RuntimeFrameworkName)'"
         KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
         <FrameworkReferenceName>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceName>
         <RequiredRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</RequiredRuntimePackLabels>
       </_CandidateRuntimePack>
+    </ItemGroup>
 
-      <!-- Filter to runtime packs where labels match exactly (or both are empty) -->
+    <!-- Filter to runtime packs where labels match (set-based equality) -->
+    <!-- Add normalized sorted labels for comparison -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_CandidateRuntimePack>
+        <NormalizedRuntimePackLabels Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' != ''">$([MSBuild]::ValueOrDefault('%(_CandidateRuntimePack.RuntimePackLabels)', '').Replace(';', '|').Split('|').OrderBy().Aggregate((x,y) => x + ';' + y))</NormalizedRuntimePackLabels>
+        <NormalizedRequiredLabels Condition="'%(_CandidateRuntimePack.RequiredRuntimePackLabels)' != ''">$([MSBuild]::ValueOrDefault('%(_CandidateRuntimePack.RequiredRuntimePackLabels)', '').Replace(';', '|').Split('|').OrderBy().Aggregate((x,y) => x + ';' + y))</NormalizedRequiredLabels>
+      </_CandidateRuntimePack>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <!-- Case 1: Both have no labels (empty strings) -->
       <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
-        Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' == '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' OR
-                   ('%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == '')" />
+        Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == ''" />
+
+      <!-- Case 2: Both have labels - compare normalized sorted strings -->
+      <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
+        Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' != '' AND
+                   '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' != '' AND
+                   '%(_CandidateRuntimePack.NormalizedRuntimePackLabels)' == '%(_CandidateRuntimePack.NormalizedRequiredLabels)'" />
     </ItemGroup>
 
     <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -260,13 +260,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->
+    <!-- Create scenario items for PickBestRid batching: one per runtime pack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                          '$(_EffectiveRuntimeIdentifier)' != ''">
+      <_PrimaryRidScenario Include="@(_MatchedRuntimePack)" KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;FrameworkReferenceName;LatestRuntimeFrameworkVersion;IsTrimmable;RuntimePackAlwaysCopyLocal">
+        <TargetRid>$(_EffectiveRuntimeIdentifier)</TargetRid>
+        <SupportedRids>%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)</SupportedRids>
+      </_PrimaryRidScenario>
+    </ItemGroup>
+
+    <!-- Batch PickBestRid across each runtime pack scenario - metadata is preserved from batched items -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="$(_EffectiveRuntimeIdentifier)"
-                 SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
+                 TargetRid="%(_PrimaryRidScenario.TargetRid)"
+                 SupportedRids="%(_PrimaryRidScenario.SupportedRids)"
                  Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                            '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                            '$(_EffectiveRuntimeIdentifier)' != '' AND
-                           '@(_MatchedRuntimePack)' != ''">
+                           '@(_PrimaryRidScenario)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_PrimaryMatchedRid" />
     </PickBestRid>
 
@@ -274,12 +285,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                           '$(_EffectiveRuntimeIdentifier)' != ''">
-      <_RuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
+      <_RuntimePackWithRid Include="@(_PrimaryMatchedRid->'%(RuntimePackNamePatterns)')">
         <MatchedRid>%(_PrimaryMatchedRid.Identity)</MatchedRid>
-        <FrameworkName>%(_MatchedRuntimePack.FrameworkReferenceName)</FrameworkName>
-        <LatestVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestVersion>
-        <IsTrimmable>%(_MatchedRuntimePack.IsTrimmable)</IsTrimmable>
-        <RuntimePackAlwaysCopyLocal>%(_MatchedRuntimePack.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
+        <FrameworkName>%(_PrimaryMatchedRid.FrameworkReferenceName)</FrameworkName>
+        <LatestVersion>%(_PrimaryMatchedRid.LatestRuntimeFrameworkVersion)</LatestVersion>
+        <IsTrimmable>%(_PrimaryMatchedRid.IsTrimmable)</IsTrimmable>
+        <RuntimePackAlwaysCopyLocal>%(_PrimaryMatchedRid.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
       </_RuntimePackWithRid>
     </ItemGroup>
 
@@ -293,37 +304,45 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_AdditionalRuntimeIdentifier Remove="any" />
     </ItemGroup>
 
-    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="%(_AdditionalRuntimeIdentifier.Identity)"
-                 SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
-                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                           '$(EnableRuntimePackDownload)' == 'true' AND
-                           '@(_AdditionalRuntimeIdentifier)' != '' AND
-                           '@(_MatchedRuntimePack)' != ''">
-      <Output TaskParameter="MatchingRid" ItemName="_AdditionalMatchedRid" />
-    </PickBestRid>
-
-    <!-- Deduplicate matched RIDs -->
-    <RemoveDuplicates Inputs="@(_AdditionalMatchedRid)"
-                      Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                                '$(EnableRuntimePackDownload)' == 'true' AND
-                                '@(_AdditionalMatchedRid)' != ''">
-      <Output TaskParameter="Filtered" ItemName="_UniqueAdditionalMatchedRid" />
-    </RemoveDuplicates>
-
-    <!-- Create download items for additional RIDs -->
+    <!-- Create candidate items with RuntimeIdentifier metadata for each supported RID -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(EnableRuntimePackDownload)' == 'true' AND
-                          '@(_UniqueAdditionalMatchedRid)' != ''">
-      <_AdditionalRuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
-        <MatchedRid>%(_UniqueAdditionalMatchedRid.Identity)</MatchedRid>
-        <LatestVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestVersion>
-      </_AdditionalRuntimePackWithRid>
+                          '@(_AdditionalRuntimeIdentifier)' != '' AND
+                          '@(_MatchedRuntimePack)' != ''">
+      <!-- For each runtime pack, create items for each of its supported RIDs -->
+      <_RuntimePackCandidate Include="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)">
+        <RuntimePackNamePatterns>%(_MatchedRuntimePack.RuntimePackNamePatterns)</RuntimePackNamePatterns>
+        <LatestRuntimeFrameworkVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestRuntimeFrameworkVersion>
+      </_RuntimePackCandidate>
+    </ItemGroup>
 
-      <!-- Substitute **RID** and add to download list -->
-      <_PackageToDownload Include="@(_AdditionalRuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))">
-        <Version>%(_AdditionalRuntimePackWithRid.LatestVersion)</Version>
-      </_PackageToDownload>
+    <!-- For each additional RID, select compatible runtime pack candidates -->
+    <SelectRuntimeIdentifierSpecificItems RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                                          TargetRuntimeIdentifier="%(_AdditionalRuntimeIdentifier.Identity)"
+                                          Items="@(_RuntimePackCandidate)"
+                                          RuntimeIdentifierItemMetadata="Identity"
+                                          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                                    '$(EnableRuntimePackDownload)' == 'true' AND
+                                                    '@(_AdditionalRuntimeIdentifier)' != '' AND
+                                                    '@(_RuntimePackCandidate)' != ''">
+      <Output TaskParameter="SelectedItems" ItemName="_AdditionalMatchedRuntimePackCandidate" />
+    </SelectRuntimeIdentifierSpecificItems>
+
+    <!-- Create download items for additional RIDs -->
+    <!-- First, create intermediate items with RID substituted -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(EnableRuntimePackDownload)' == 'true' AND
+                          '@(_AdditionalMatchedRuntimePackCandidate)' != ''">
+      <_AdditionalRuntimePackWithRidSubstituted Include="$([System.String]::Copy('%(RuntimePackNamePatterns)').Replace('**RID**', '%(Identity)'))">
+        <Version>%(_AdditionalMatchedRuntimePackCandidate.LatestRuntimeFrameworkVersion)</Version>
+      </_AdditionalRuntimePackWithRidSubstituted>
+    </ItemGroup>
+
+    <!-- Add to download list -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(EnableRuntimePackDownload)' == 'true' AND
+                          '@(_AdditionalRuntimePackWithRidSubstituted)' != ''">
+      <_PackageToDownload Include="@(_AdditionalRuntimePackWithRidSubstituted)" />
     </ItemGroup>
 
     <!-- Resolve Crossgen2 packs from _ResolveCrossgen2Packs -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -187,7 +187,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <JoinItems Left="@(_ApplicableKnownFrameworkReference)"
                Right="@(FrameworkReference)"
                LeftMetadata="*"
-               RightMetadata="TargetingPackVersion;RuntimeFrameworkVersion;RuntimePackLabels;TargetLatestRuntimePatch"
+               RightMetadata="IsImplicitlyDefined;PrivateAssets;Pack"
                ItemSpecToUse="Left">
       <Output TaskParameter="JoinResult" ItemName="_JoinedFrameworkReference" />
     </JoinItems>
@@ -237,29 +237,28 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CreateTargetingPackItems"
           DependsOnTargets="_SelectRuntimePacksByLabels">
     <ItemGroup>
-      <_TargetingPack Include="@(_JoinedFrameworkReference)">
-        <NuGetPackageId>%(_JoinedFrameworkReference.TargetingPackName)</NuGetPackageId>
-        <NuGetPackageVersion>%(_JoinedFrameworkReference.TargetingPackVersion)</NuGetPackageVersion>
-        <TargetingPackFormat>%(_JoinedFrameworkReference.TargetingPackFormat)</TargetingPackFormat>
-        <TargetFramework>%(_JoinedFrameworkReference.TargetFramework)</TargetFramework>
-        <RuntimeFrameworkName>%(_JoinedFrameworkReference.RuntimeFrameworkName)</RuntimeFrameworkName>
-        <Profile>%(_JoinedFrameworkReference.Profile)</Profile>
-        <!-- Check if pack exists locally in any pack root -->
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_JoinedFrameworkReference.TargetingPackName)\%(_JoinedFrameworkReference.TargetingPackVersion)')">$(NetCoreTargetingPackRoot)\%(_JoinedFrameworkReference.TargetingPackName)\%(_JoinedFrameworkReference.TargetingPackVersion)</PackageDirectory>
+      <_TargetingPack Include="@(_JoinedFrameworkReference)" KeepMetadata="Profile;WasReferencedDirectly;TargetFramework;TargetingPackFormat;RuntimeFrameworkName;TargetingPackName;TargetingPackVersion" />
+      <_TargetingPack>
+        <NuGetPackageId>%(_TargetingPack.TargetingPackName)</NuGetPackageId>
+        <NuGetPackageVersion>%(_TargetingPack.TargetingPackVersion)</NuGetPackageVersion>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)</PackageDirectory>
       </_TargetingPack>
       <_TargetingPack>
         <Path>%(_TargetingPack.PackageDirectory)</Path>
       </_TargetingPack>
       <TargetingPack Include="@(_TargetingPack)" />
+      <_TargetingPack Remove="@(_TargetingPack)" />
     </ItemGroup>
 
     <!-- Add targeting packs to download list if not found locally and downloads enabled -->
     <ItemGroup Condition="'$(EnableTargetingPackDownload)' == 'true'">
-      <_PackageToDownload Include="@(TargetingPack->'%(TargetingPackName)')"
-        Condition="'%(TargetingPack.PackageDirectory)' == '' AND
-                   ('%(TargetingPack.WasReferencedDirectly)' == 'true' OR '$(DisableTransitiveFrameworkReferenceDownloads)' != 'true')">
-        <Version>%(TargetingPack.NuGetPackageVersion)</Version>
-      </_PackageToDownload>
+      <_TargetingPackPackage
+        Include="@(TargetingPack->'%(NuGetPackageId)')"
+        KeepDuplicates="false"
+        KeepMetadata="NuGetPackageVersion;WasReferencedDirectly"
+        Version="%(TargetingPack.NuGetPackageVersion)"
+        Condition= "'%(TargetingPack.WasReferencedDirectly)' == 'true' OR '$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'"/>
+      <_PackageToDownload Include="@(_TargetingPackPackage)" KeepMetadata="Version" />
     </ItemGroup>
 
     <!-- Build PackageConflictPreferredPackages list -->
@@ -276,6 +275,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <TargetingPack>
         <PackageConflictPreferredPackages>$(_PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
       </TargetingPack>
+      <_PreferredPackage Remove="@(_PreferredPackage)" />
     </ItemGroup>
   </Target>
 
@@ -307,14 +307,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       </_RuntimePackWithRid>
 
       <!-- Substitute **RID** placeholder -->
-      <RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))">
-        <NuGetPackageId>%(RuntimePack.Identity)</NuGetPackageId>
+      <_RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
+        <NuGetPackageId>%(_RuntimePack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
-        <FrameworkName>%(_RuntimePackWithRid.FrameworkName)</FrameworkName>
         <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
-        <IsTrimmable>%(_RuntimePackWithRid.IsTrimmable)</IsTrimmable>
-        <RuntimePackAlwaysCopyLocal>%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
-      </RuntimePack>
+        <RuntimePackAlwaysCopyLocal Condition="'%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)' == 'true'">true</RuntimePackAlwaysCopyLocal>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)')">$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)</PackageDirectory>
+      </_RuntimePack>
+      <_RuntimePack>
+        <Path>%(_RuntimePack.PackageDirectory)</Path>
+      </_RuntimePack>
+      <RuntimePack Include="@(_RuntimePack)" />
+      <_RuntimePack Remove="@(_RuntimePack)" />
     </ItemGroup>
 
     <!-- Add to download list if not found locally -->
@@ -396,11 +400,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Create Crossgen2Pack item -->
     <ItemGroup Condition="'@(_Crossgen2HostRid)' != ''">
-      <Crossgen2Pack Include="@(_ApplicableCrossgen2Pack->'%(Crossgen2PackNamePattern)'.Replace('**RID**', '%(_Crossgen2HostRid.Identity)'))">
-        <NuGetPackageId>%(Crossgen2Pack.Identity)</NuGetPackageId>
+      <_Crossgen2Pack Include="@(_ApplicableCrossgen2Pack->'%(Crossgen2PackNamePattern)'.Replace('**RID**', '%(_Crossgen2HostRid.Identity)'))">
+        <NuGetPackageId>%(_Crossgen2Pack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</NuGetPackageVersion>
         <RuntimeIdentifier>%(_Crossgen2HostRid.Identity)</RuntimeIdentifier>
-      </Crossgen2Pack>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)')">$(NetCoreTargetingPackRoot)\%(_Crossgen2Pack.Identity)\%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</PackageDirectory>
+      </_Crossgen2Pack>
+      <_Crossgen2Pack>
+        <Path>%(_Crossgen2Pack.PackageDirectory)</Path>
+      </_Crossgen2Pack>
+      <Crossgen2Pack Include="@(_Crossgen2Pack)" />
+      <_Crossgen2Pack Remove="@(_Crossgen2Pack)" />
     </ItemGroup>
 
     <!-- Add to download list if needed -->
@@ -438,11 +448,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Create host ILCompiler pack -->
     <ItemGroup Condition="'@(_ILCompilerHostRid)' != ''">
-      <HostILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_ILCompilerHostRid.Identity)'))">
-        <NuGetPackageId>%(HostILCompilerPack.Identity)</NuGetPackageId>
+      <_HostILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_ILCompilerHostRid.Identity)'))">
+        <NuGetPackageId>%(_HostILCompilerPack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
         <RuntimeIdentifier>%(_ILCompilerHostRid.Identity)</RuntimeIdentifier>
-      </HostILCompilerPack>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)</PackageDirectory>
+      </_HostILCompilerPack>
+      <_HostILCompilerPack>
+        <Pack>%(_HostILCompilerPack.Identity)</Pack>
+      </_HostILCompilerPack>
+      <HostILCompilerPack Include="@(_HostILCompilerPack)" />
+      <_HostILCompilerPack Remove="@(_HostILCompilerPack)" />
     </ItemGroup>
 
     <!-- Find best target RID(s) for cross-compilation -->
@@ -473,11 +489,17 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Create target ILCompiler packs for cross-compilation scenarios -->
     <ItemGroup Condition="'@(_DistinctILCompilerTargetRid)' != ''">
-      <TargetILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_DistinctILCompilerTargetRid.Identity)'))">
-        <NuGetPackageId>%(TargetILCompilerPack.Identity)</NuGetPackageId>
+      <_TargetILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_DistinctILCompilerTargetRid.Identity)'))">
+        <NuGetPackageId>%(_TargetILCompilerPack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
         <RuntimeIdentifier>%(_DistinctILCompilerTargetRid.Identity)</RuntimeIdentifier>
-      </TargetILCompilerPack>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)</PackageDirectory>
+      </_TargetILCompilerPack>
+      <_TargetILCompilerPack>
+        <Pack>%(_TargetILCompilerPack.Identity)</Pack>
+      </_TargetILCompilerPack>
+      <TargetILCompilerPack Include="@(_TargetILCompilerPack)" />
+      <_TargetILCompilerPack Remove="@(_TargetILCompilerPack)" />
     </ItemGroup>
 
     <!-- Add to download list if needed -->
@@ -570,11 +592,58 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Only create RuntimeFramework items for frameworks that aren't always copy-local -->
       <RuntimeFramework Include="@(_JoinedFrameworkReference)"
         Condition="'%(_JoinedFrameworkReference.RuntimePackAlwaysCopyLocal)' != 'true' AND
-                   '%(_JoinedFrameworkReference.RuntimeFrameworkName)' != ''">
-        <Version>%(_JoinedFrameworkReference.RuntimeFrameworkVersion)</Version>
+                   '%(_JoinedFrameworkReference.RuntimeFrameworkName)' != ''"
+        KeepMetadata="Profile">
+        <Version>%(_JoinedFrameworkReference.DefaultRuntimeFrameworkVersion)</Version>
         <FrameworkName>%(_JoinedFrameworkReference.Identity)</FrameworkName>
-        <Profile>%(_JoinedFrameworkReference.Profile)</Profile>
       </RuntimeFramework>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Extract known runtime identifier platforms from Microsoft.NETCore.App runtime packs.
+    Used for validating runtime assets in .NET 8+.
+    -->
+  <Target Name="_CreateKnownRuntimeIdentifierPlatforms"
+          DependsOnTargets="_FilterApplicableFrameworkReferences">
+    <ItemGroup>
+      <!-- Get all Microsoft.NETCore.App runtime packs and framework references for this target framework -->
+      <_NetCoreAppRuntimePack Include="@(_ApplicableKnownFrameworkReference);@(_ApplicableKnownRuntimePack)"
+        Condition="'%(Identity)' == 'Microsoft.NETCore.App'" />
+
+      <!-- Split RuntimePackRuntimeIdentifiers by semicolon to create individual RID items -->
+      <_RuntimePackRid Include="%(_NetCoreAppRuntimePack.RuntimePackRuntimeIdentifiers)" />
+    </ItemGroup>
+    <!-- Remove duplicates to get unique rids -->
+    <RemoveDuplicates Inputs="@(_RuntimePackRid)">
+      <Output TaskParameter="Filtered" ItemName="_DeduplicatedRuntimePackRid" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <_DeduplicatedRuntimePackRid>
+        <Platform Condition="$([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).LastIndexOf('-')) &gt; 0">$([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).Substring(0, $([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).LastIndexOf('-'))))</Platform>
+      </_DeduplicatedRuntimePackRid>
+
+      <!-- Extract platform from each RID (everything before last '-') -->
+      <!-- For RIDs like 'win-x64', extract 'win'. For 'linux-x64', extract 'linux' -->
+      <_RuntimeIdentifierPlatform
+        Include="@(_DeduplicatedRuntimePackRid->'%(Platform)')" />
+
+      <!-- For RIDs without '-', use the whole RID as platform -->
+      <_RuntimeIdentifierPlatform Include="%(_DeduplicatedRuntimePackRid.Identity)"
+        Condition="$([System.String]::Copy('%(_DeduplicatedRuntimePackRid.Identity)').LastIndexOf('-')) &lt; 0" />
+    </ItemGroup>
+
+    <!-- Remove duplicates to get unique platforms -->
+    <RemoveDuplicates Inputs="@(_RuntimeIdentifierPlatform)">
+      <Output TaskParameter="Filtered" ItemName="_KnownRuntimeIdentifierPlatformsForTargetFramework" />
+    </RemoveDuplicates>
+
+    <!-- Clean up intermediate items -->
+    <ItemGroup>
+      <_NetCoreAppRuntimePack Remove="@(_NetCoreAppRuntimePack)" />
+      <_RuntimePackRid Remove="@(_RuntimePackRid)" />
+      <_RuntimeIdentifierPlatform Remove="@(_RuntimeIdentifierPlatform)" />
     </ItemGroup>
   </Target>
 
@@ -633,7 +702,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                            _ResolveILLinkPack;
                            _ResolveWebAssemblySdkPack;
                            _ResolveAspNetCorePack;
-                           _CreateRuntimeFrameworkItems">
+                           _CreateRuntimeFrameworkItems;
+                           _CreateKnownRuntimeIdentifierPlatforms">
     <!-- All work done in dependencies -->
   </Target>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -579,7 +579,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Build PackageConflictPreferredPackages property -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_PreferredPackage Include="%(_TargetingPack.NuGetPackageId)" />
-      <_PreferredPackage Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')" />
+      <!-- Expand runtime pack patterns for all supported RIDs -->
+      <_RuntimePackPatternWithRid Include="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)">
+        <Pattern>%(_MatchedRuntimePack.RuntimePackNamePatterns)</Pattern>
+      </_RuntimePackPatternWithRid>
+    </ItemGroup>
+
+    <!-- Substitute RID in each pattern -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PreferredPackage Include="$([System.String]::Copy('%(_RuntimePackPatternWithRid.Pattern)').Replace('**RID**', '%(_RuntimePackPatternWithRid.Identity)'))" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -219,10 +219,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Select runtime packs by labels from _SelectRuntimePacksByLabels -->
+     <!-- TODO: this is broken - no _candidateruntimepack items are created. -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- For each joined framework reference, find matching runtime packs -->
+      <!-- For each runtime pack, check if it matches any framework reference's RuntimeFrameworkName -->
       <_CandidateRuntimePack Include="@(_ApplicableKnownRuntimePack)"
-        Condition="'%(_ApplicableKnownRuntimePack.Identity)' == '%(_JoinedFrameworkReference.RuntimeFrameworkName)'"
+        Condition="@(_JoinedFrameworkReference->AnyHaveMetadataValue('RuntimeFrameworkName', '%(_ApplicableKnownRuntimePack.Identity)'))"
         KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
         <FrameworkReferenceName>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceName>
         <RequiredRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</RequiredRuntimePackLabels>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -597,7 +597,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                           '$(_EffectiveRuntimeIdentifier)' != ''">
-      <_RuntimePack Include="$([System.String]::Copy('%(_RuntimePackWithRid.Identity)').Replace('**RID**', '%(_RuntimePackWithRid.MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
+      <_RuntimePack Include="$([System.String]::Copy('%(_RuntimePackWithRid.Identity)').Replace('**RID**', '%(_RuntimePackWithRid.MatchedRid)'))">
+        <FrameworkName>%(_RuntimePackWithRid.FrameworkName)</FrameworkName>
+        <IsTrimmable>%(_RuntimePackWithRid.IsTrimmable)</IsTrimmable>
         <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
         <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
         <RuntimePackAlwaysCopyLocal Condition="'%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)' == 'true'">true</RuntimePackAlwaysCopyLocal>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -246,24 +246,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Filter to runtime packs where labels match (set-based equality) -->
-    <!-- Add normalized sorted labels for comparison -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <_CandidateRuntimePack>
-        <NormalizedRuntimePackLabels Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' != ''">$([MSBuild]::ValueOrDefault('%(_CandidateRuntimePack.RuntimePackLabels)', '').Replace(';', '|').Split('|').OrderBy().Aggregate((x,y) => x + ';' + y))</NormalizedRuntimePackLabels>
-        <NormalizedRequiredLabels Condition="'%(_CandidateRuntimePack.RequiredRuntimePackLabels)' != ''">$([MSBuild]::ValueOrDefault('%(_CandidateRuntimePack.RequiredRuntimePackLabels)', '').Replace(';', '|').Split('|').OrderBy().Aggregate((x,y) => x + ';' + y))</NormalizedRequiredLabels>
-      </_CandidateRuntimePack>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- Case 1: Both have no labels (empty strings) -->
+      <!-- Both have no labels (empty strings) - these match -->
       <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
         Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == ''" />
 
-      <!-- Case 2: Both have labels - compare normalized sorted strings -->
+      <!-- Both have labels - TODO: implement proper set equality (order-independent comparison) -->
+      <!-- For now, use simple string equality (assumes labels are in same order in SDK data) -->
       <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
         Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' != '' AND
                    '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' != '' AND
-                   '%(_CandidateRuntimePack.NormalizedRuntimePackLabels)' == '%(_CandidateRuntimePack.NormalizedRequiredLabels)'" />
+                   '%(_CandidateRuntimePack.RuntimePackLabels)' == '%(_CandidateRuntimePack.RequiredRuntimePackLabels)'" />
     </ItemGroup>
 
     <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -51,7 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     </CreateWindowsSdkKnownFrameworkReferences>
   </Target>
-  
+
   <!-- TODO: https://github.com/dotnet/sdk/issues/49917 Remove the framework based condition when the data for netcoreapp2.1 and below is fixed-->
   <!-- Package pruning is expected to be enable for all TFMs for multi-targeted projects, so still generate the pruning data when RestoreEnablePackagePruning is '' which implies a multi-targeted project. -->
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
@@ -63,7 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AllowMissingPrunePackageData Condition="'$(AllowMissingPrunePackageData)' == ''">false</AllowMissingPrunePackageData>
       <LoadPrunePackageDataFromNearestFramework Condition="'$(LoadPrunePackageDataFromNearestFramework)' == ''">false</LoadPrunePackageDataFromNearestFramework>
     </PropertyGroup>
-    
+
     <GetPackagesToPrune TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                         TargetFrameworkVersion="$(_TargetFrameworkVersionWithoutV)"
                         FrameworkReferences="@(FrameworkReference)"
@@ -74,25 +74,525 @@ Copyright (c) .NET Foundation. All rights reserved.
                         LoadPrunePackageDataFromNearestFramework="$(LoadPrunePackageDataFromNearestFramework)">
       <Output TaskParameter="PackagesToPrune" ItemName="PrunePackageReference" />
     </GetPackagesToPrune>
-    
+
   </Target>
-  
+
   <!--
     ============================================================
-                                        ProcessFrameworkReferences
+                                        ProcessFrameworkReferences (Refactored)
+
+    The following targets break down framework reference resolution into logical steps.
+    Set UseRefactoredFrameworkReferenceResolution=false to use the original monolithic task.
+    ============================================================
+    -->
+
+  <!--
+    Compute settings that determine which packs are needed based on deployment model.
+    -->
+  <Target Name="_ComputeFrameworkReferenceSettings">
+    <!-- Determine if deployment model requires runtime-specific components -->
+    <PropertyGroup>
+      <_DeploymentRequiresRuntimeComponents>false</_DeploymentRequiresRuntimeComponents>
+      <_DeploymentRequiresRuntimeComponents Condition="'$(SelfContained)' == 'true'">true</_DeploymentRequiresRuntimeComponents>
+      <_DeploymentRequiresRuntimeComponents Condition="'$(PublishReadyToRun)' == 'true'">true</_DeploymentRequiresRuntimeComponents>
+      <_DeploymentRequiresRuntimeComponents Condition="'$(_RequiresILLinkPack)' == 'true'">true</_DeploymentRequiresRuntimeComponents>
+
+      <!-- Normalize RuntimeIdentifier: treat 'any' as null for platform-agnostic builds -->
+      <_EffectiveRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != 'any'">$(RuntimeIdentifier)</_EffectiveRuntimeIdentifier>
+
+      <!-- Determine if project is platform-specific -->
+      <_ProjectIsPlatformSpecific Condition="'$(_EffectiveRuntimeIdentifier)' != ''">true</_ProjectIsPlatformSpecific>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Filter KnownFrameworkReferences and KnownRuntimePacks by target framework.
+    Parses TargetFramework metadata (e.g., "net9.0-windows10.0") into components.
+    Uses VersionEquals for proper version normalization (5.0.0.0 == 5.0).
+    -->
+  <Target Name="_FilterApplicableFrameworkReferences"
+          DependsOnTargets="_ComputeFrameworkReferenceSettings">
+    <ItemGroup>
+      <!-- Parse TargetFramework into components and filter KnownFrameworkReferences -->
+      <!-- MSBuild functions: GetTargetFrameworkIdentifier, GetTargetFrameworkVersion, GetTargetPlatformIdentifier, GetTargetPlatformVersion -->
+      <_KnownFrameworkReferenceMatchingTFI Include="@(KnownFrameworkReference)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <!-- Filter by TFM version using VersionEquals for normalization -->
+      <_ApplicableKnownFrameworkReference Include="@(_KnownFrameworkReferenceMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownFrameworkReferenceMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+
+      <!-- Parse platform identifier from TargetFramework and filter if both are specified -->
+      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
+        Condition="'$(TargetPlatformIdentifier)' != '' AND
+                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownFrameworkReference.TargetFramework)')) != '' AND
+                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownFrameworkReference.TargetFramework)')) != '$(TargetPlatformIdentifier)'" />
+
+      <!-- Parse platform version from TargetFramework and filter if both are specified (using VersionEquals) -->
+      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
+        Condition="'$(TargetPlatformVersion)' != '' AND
+                   $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)) != '' AND
+                   !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Same filtering for KnownRuntimePacks -->
+      <_KnownRuntimePackMatchingTFI Include="@(KnownRuntimePack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownRuntimePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableKnownRuntimePack Include="@(_KnownRuntimePackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownRuntimePackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+
+      <_ApplicableKnownRuntimePack Remove="@(_ApplicableKnownRuntimePack)"
+        Condition="'$(TargetPlatformIdentifier)' != '' AND
+                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownRuntimePack.TargetFramework)')) != '' AND
+                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownRuntimePack.TargetFramework)')) != '$(TargetPlatformIdentifier)'" />
+
+      <_ApplicableKnownRuntimePack Remove="@(_ApplicableKnownRuntimePack)"
+        Condition="'$(TargetPlatformVersion)' != '' AND
+                   $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)) != '' AND
+                   !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Validate that Windows-only frameworks aren't referenced on non-Windows platforms.
+    -->
+  <Target Name="_ValidateWindowsOnlyFrameworks"
+          DependsOnTargets="_JoinFrameworkReferencesWithKnownData">
+    <ItemGroup>
+      <_WindowsOnlyFrameworkReference Include="@(_JoinedFrameworkReference)"
+        Condition="'%(_JoinedFrameworkReference.IsWindowsOnly)' == 'true'" />
+    </ItemGroup>
+
+    <NetSdkError Condition="'@(_WindowsOnlyFrameworkReference)' != '' AND
+                            '$(OS)' != 'Windows_NT' AND
+                            '$(EnableWindowsTargeting)' != 'true'"
+                 ResourceName="WindowsDesktopFrameworkRequiresWindows" />
+
+    <!-- Remove Windows-only frameworks from processing on non-Windows -->
+    <ItemGroup Condition="'$(OS)' != 'Windows_NT' AND '$(EnableWindowsTargeting)' != 'true'">
+      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
+        Condition="'%(_ApplicableKnownFrameworkReference.IsWindowsOnly)' == 'true'" />
+      <_JoinedFrameworkReference Remove="@(_JoinedFrameworkReference)"
+        Condition="'%(_JoinedFrameworkReference.IsWindowsOnly)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Join user FrameworkReferences with KnownFrameworkReferences to combine metadata.
+    -->
+  <Target Name="_JoinFrameworkReferencesWithKnownData"
+          DependsOnTargets="_FilterApplicableFrameworkReferences">
+    <JoinItems Left="@(_ApplicableKnownFrameworkReference)"
+               Right="@(FrameworkReference)"
+               LeftMetadata="*"
+               RightMetadata="TargetingPackVersion;RuntimeFrameworkVersion;RuntimePackLabels;TargetLatestRuntimePatch"
+               ItemSpecToUse="Left">
+      <Output TaskParameter="JoinResult" ItemName="_JoinedFrameworkReference" />
+    </JoinItems>
+
+    <ItemGroup>
+      <!-- All of the newly-joined framework references are directly referenced -->
+      <_JoinedFrameworkReference>
+        <WasReferencedDirectly>true</WasReferencedDirectly>
+      </_JoinedFrameworkReference>
+    </ItemGroup>
+
+    <!-- Also include framework references without user reference if not disabling transitive -->
+    <ItemGroup Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'">
+      <_UnreferencedKnownFrameworkReference Include="@(_ApplicableKnownFrameworkReference)"
+        Exclude="@(_JoinedFrameworkReference)" />
+      <_JoinedFrameworkReference Include="@(_UnreferencedKnownFrameworkReference)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Select the appropriate runtime pack for each framework reference based on RuntimePackLabels.
+    -->
+  <Target Name="_SelectRuntimePacksByLabels"
+          DependsOnTargets="_JoinFrameworkReferencesWithKnownData">
+    <ItemGroup>
+      <!-- For each joined framework reference, find matching runtime packs -->
+      <!-- Cross-join: For each framework reference, create items for all runtime packs with matching name -->
+      <_CandidateRuntimePack Include="@(_ApplicableKnownRuntimePack)"
+        Condition="'%(_ApplicableKnownRuntimePack.Identity)' == '%(_JoinedFrameworkReference.RuntimeFrameworkName)'"
+        KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
+        <FrameworkReferenceName>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceName>
+        <RequiredRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</RequiredRuntimePackLabels>
+      </_CandidateRuntimePack>
+    </ItemGroup>
+
+    <!-- Filter to runtime packs where labels match exactly (or both are empty) -->
+    <ItemGroup>
+      <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
+        Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' == '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' OR
+                   ('%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == '')" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Create TargetingPack items for compilation.
+    -->
+  <Target Name="_CreateTargetingPackItems"
+          DependsOnTargets="_SelectRuntimePacksByLabels">
+    <ItemGroup>
+      <_TargetingPack Include="@(_JoinedFrameworkReference)">
+        <NuGetPackageId>%(_JoinedFrameworkReference.TargetingPackName)</NuGetPackageId>
+        <NuGetPackageVersion>%(_JoinedFrameworkReference.TargetingPackVersion)</NuGetPackageVersion>
+        <TargetingPackFormat>%(_JoinedFrameworkReference.TargetingPackFormat)</TargetingPackFormat>
+        <TargetFramework>%(_JoinedFrameworkReference.TargetFramework)</TargetFramework>
+        <RuntimeFrameworkName>%(_JoinedFrameworkReference.RuntimeFrameworkName)</RuntimeFrameworkName>
+        <Profile>%(_JoinedFrameworkReference.Profile)</Profile>
+        <!-- Check if pack exists locally in any pack root -->
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_JoinedFrameworkReference.TargetingPackName)\%(_JoinedFrameworkReference.TargetingPackVersion)')">$(NetCoreTargetingPackRoot)\%(_JoinedFrameworkReference.TargetingPackName)\%(_JoinedFrameworkReference.TargetingPackVersion)</PackageDirectory>
+      </_TargetingPack>
+      <_TargetingPack>
+        <Path>%(_TargetingPack.PackageDirectory)</Path>
+      </_TargetingPack>
+      <TargetingPack Include="@(_TargetingPack)" />
+    </ItemGroup>
+
+    <!-- Add targeting packs to download list if not found locally and downloads enabled -->
+    <ItemGroup Condition="'$(EnableTargetingPackDownload)' == 'true'">
+      <_PackageToDownload Include="@(TargetingPack->'%(TargetingPackName)')"
+        Condition="'%(TargetingPack.PackageDirectory)' == '' AND
+                   ('%(TargetingPack.WasReferencedDirectly)' == 'true' OR '$(DisableTransitiveFrameworkReferenceDownloads)' != 'true')">
+        <Version>%(TargetingPack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- Build PackageConflictPreferredPackages list -->
+    <ItemGroup>
+      <_PreferredPackage Include="%(TargetingPack.NuGetPackageId)" />
+      <_PreferredPackage Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_PackageConflictPreferredPackages>@(_PreferredPackage, ';')</_PackageConflictPreferredPackages>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TargetingPack>
+        <PackageConflictPreferredPackages>$(_PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
+      </TargetingPack>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve runtime packs for the primary RuntimeIdentifier.
+    -->
+  <Target Name="_ResolveRuntimePacksForPrimaryRID"
+          DependsOnTargets="_CreateTargetingPackItems"
+          Condition="'$(_DeploymentRequiresRuntimeComponents)' == 'true' AND '$(_EffectiveRuntimeIdentifier)' != ''">
+
+    <!-- For each matched runtime pack, find best matching RID -->
+    <!-- Output MatchingRid as Item (not Property) so batching accumulates results -->
+    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
+                 TargetRid="$(_EffectiveRuntimeIdentifier)"
+                 SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
+                 Condition="'@(_MatchedRuntimePack)' != ''">
+      <Output TaskParameter="MatchingRid" ItemName="_PrimaryMatchedRid" />
+    </PickBestRid>
+
+    <!-- Create RuntimePack items by substituting **RID** in pattern with matched RID -->
+    <!-- Cross-join pattern: Each _MatchedRuntimePack × each _PrimaryMatchedRid creates runtime pack items -->
+    <ItemGroup>
+      <_RuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
+        <MatchedRid>%(_PrimaryMatchedRid.Identity)</MatchedRid>
+        <FrameworkName>%(_MatchedRuntimePack.FrameworkReferenceName)</FrameworkName>
+        <LatestVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestVersion>
+        <IsTrimmable>%(_MatchedRuntimePack.IsTrimmable)</IsTrimmable>
+        <RuntimePackAlwaysCopyLocal>%(_MatchedRuntimePack.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
+      </_RuntimePackWithRid>
+
+      <!-- Substitute **RID** placeholder -->
+      <RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))">
+        <NuGetPackageId>%(RuntimePack.Identity)</NuGetPackageId>
+        <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
+        <FrameworkName>%(_RuntimePackWithRid.FrameworkName)</FrameworkName>
+        <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
+        <IsTrimmable>%(_RuntimePackWithRid.IsTrimmable)</IsTrimmable>
+        <RuntimePackAlwaysCopyLocal>%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
+      </RuntimePack>
+    </ItemGroup>
+
+    <!-- Add to download list if not found locally -->
+    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true'">
+      <_PackageToDownload Include="@(RuntimePack)"
+        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(RuntimePack.NuGetPackageId)\%(RuntimePack.NuGetPackageVersion)')">
+        <Version>%(RuntimePack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve runtime packs for additional RuntimeIdentifiers (for multi-RID publish scenarios).
+    These are downloaded but not added to RuntimePack output.
+    -->
+  <Target Name="_ResolveRuntimePacksForAdditionalRIDs"
+          DependsOnTargets="_ResolveRuntimePacksForPrimaryRID"
+          Condition="'$(EnableRuntimePackDownload)' == 'true' AND '$(RuntimeIdentifiers)' != ''">
+
+    <!-- Split RuntimeIdentifiers into items -->
+    <ItemGroup>
+      <_AdditionalRuntimeIdentifier Include="$(RuntimeIdentifiers)" />
+      <!-- Remove primary RID if it's already processed -->
+      <_AdditionalRuntimeIdentifier Remove="$(_EffectiveRuntimeIdentifier)" />
+      <_AdditionalRuntimeIdentifier Remove="any" />
+    </ItemGroup>
+
+    <!-- Batch PickBestRid for each additional RID - outputs accumulate as Items -->
+    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
+                 TargetRid="%(_AdditionalRuntimeIdentifier.Identity)"
+                 SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
+                 Condition="'@(_AdditionalRuntimeIdentifier)' != '' AND '@(_MatchedRuntimePack)' != ''">
+      <Output TaskParameter="MatchingRid" ItemName="_AdditionalMatchedRid" />
+    </PickBestRid>
+
+    <!-- Deduplicate matched RIDs -->
+    <RemoveDuplicates Inputs="@(_AdditionalMatchedRid)" Condition="'@(_AdditionalMatchedRid)' != ''">
+      <Output TaskParameter="Filtered" ItemName="_UniqueAdditionalMatchedRid" />
+    </RemoveDuplicates>
+
+    <!-- Create download items for additional RIDs -->
+    <!-- Cross-join: Each runtime pack pattern × each unique additional RID -->
+    <ItemGroup Condition="'@(_UniqueAdditionalMatchedRid)' != ''">
+      <_AdditionalRuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
+        <MatchedRid>%(_UniqueAdditionalMatchedRid.Identity)</MatchedRid>
+        <LatestVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestVersion>
+      </_AdditionalRuntimePackWithRid>
+
+      <!-- Substitute **RID** and add to download list -->
+      <_PackageToDownload Include="@(_AdditionalRuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))">
+        <Version>%(_AdditionalRuntimePackWithRid.LatestVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve Crossgen2 packs for ReadyToRun compilation.
+    -->
+  <Target Name="_ResolveCrossgen2Packs"
+          DependsOnTargets="_FilterApplicableFrameworkReferences"
+          Condition="'$(PublishReadyToRun)' == 'true' AND '$(PublishReadyToRunUseCrossgen2)' == 'true'">
+
+    <!-- Filter Crossgen2 packs by TFM (parse TargetFramework) -->
+    <ItemGroup>
+      <_KnownCrossgen2PackMatchingTFI Include="@(KnownCrossgen2Pack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownCrossgen2Pack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableCrossgen2Pack Include="@(_KnownCrossgen2PackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownCrossgen2PackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+    </ItemGroup>
+
+    <!-- Find best host RID for the SDK -->
+    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
+                 TargetRid="$(NETCoreSdkRuntimeIdentifier)"
+                 SupportedRids="%(_ApplicableCrossgen2Pack.Crossgen2RuntimeIdentifiers)"
+                 Condition="'@(_ApplicableCrossgen2Pack)' != ''">
+      <Output TaskParameter="MatchingRid" ItemName="_Crossgen2HostRid" />
+    </PickBestRid>
+
+    <!-- Create Crossgen2Pack item -->
+    <ItemGroup Condition="'@(_Crossgen2HostRid)' != ''">
+      <Crossgen2Pack Include="@(_ApplicableCrossgen2Pack->'%(Crossgen2PackNamePattern)'.Replace('**RID**', '%(_Crossgen2HostRid.Identity)'))">
+        <NuGetPackageId>%(Crossgen2Pack.Identity)</NuGetPackageId>
+        <NuGetPackageVersion>%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_Crossgen2HostRid.Identity)</RuntimeIdentifier>
+      </Crossgen2Pack>
+    </ItemGroup>
+
+    <!-- Add to download list if needed -->
+    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true' AND '@(Crossgen2Pack)' != ''">
+      <_PackageToDownload Include="@(Crossgen2Pack)"
+        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(Crossgen2Pack.NuGetPackageId)\%(Crossgen2Pack.NuGetPackageVersion)')">
+        <Version>%(Crossgen2Pack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve ILCompiler packs for Native AOT compilation (both host and target).
+    -->
+  <Target Name="_ResolveILCompilerPacks"
+          DependsOnTargets="_FilterApplicableFrameworkReferences"
+          Condition="'$(PublishAot)' == 'true'">
+
+    <!-- Filter ILCompiler packs by TFM (parse TargetFramework) -->
+    <ItemGroup>
+      <_KnownILCompilerPackMatchingTFI Include="@(KnownILCompilerPack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownILCompilerPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableILCompilerPack Include="@(_KnownILCompilerPackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILCompilerPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+    </ItemGroup>
+
+    <!-- Find best host RID for the SDK -->
+    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
+                 TargetRid="$(NETCoreSdkRuntimeIdentifier)"
+                 SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
+                 Condition="'@(_ApplicableILCompilerPack)' != ''">
+      <Output TaskParameter="MatchingRid" ItemName="_ILCompilerHostRid" />
+    </PickBestRid>
+
+    <!-- Create host ILCompiler pack -->
+    <ItemGroup Condition="'@(_ILCompilerHostRid)' != ''">
+      <HostILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_ILCompilerHostRid.Identity)'))">
+        <NuGetPackageId>%(HostILCompilerPack.Identity)</NuGetPackageId>
+        <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_ILCompilerHostRid.Identity)</RuntimeIdentifier>
+      </HostILCompilerPack>
+    </ItemGroup>
+
+    <!-- Find best target RID(s) for cross-compilation -->
+    <ItemGroup>
+      <_ILCompilerTargetRidToResolve Include="$(_EffectiveRuntimeIdentifier)" Condition="'$(_EffectiveRuntimeIdentifier)' != ''" />
+      <_ILCompilerTargetRidToResolve Include="$(RuntimeIdentifiers)" />
+      <_ILCompilerTargetRidToResolve Remove="any" />
+    </ItemGroup>
+
+    <!-- Batch PickBestRid for each target RID -->
+    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
+                 TargetRid="%(_ILCompilerTargetRidToResolve.Identity)"
+                 SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
+                 Condition="'@(_ILCompilerTargetRidToResolve)' != '' AND '@(_ApplicableILCompilerPack)' != ''">
+      <Output TaskParameter="MatchingRid" ItemName="_ILCompilerTargetRid" />
+    </PickBestRid>
+
+    <!-- Deduplicate target RIDs -->
+    <RemoveDuplicates Inputs="@(_ILCompilerTargetRid)" Condition="'@(_ILCompilerTargetRid)' != ''">
+      <Output TaskParameter="Filtered" ItemName="_UniqueILCompilerTargetRid" />
+    </RemoveDuplicates>
+
+    <!-- Filter out target RIDs that match host RID -->
+    <ItemGroup>
+      <_DistinctILCompilerTargetRid Include="@(_UniqueILCompilerTargetRid)"
+        Condition="'%(_UniqueILCompilerTargetRid.Identity)' != '%(_ILCompilerHostRid.Identity)'" />
+    </ItemGroup>
+
+    <!-- Create target ILCompiler packs for cross-compilation scenarios -->
+    <ItemGroup Condition="'@(_DistinctILCompilerTargetRid)' != ''">
+      <TargetILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_DistinctILCompilerTargetRid.Identity)'))">
+        <NuGetPackageId>%(TargetILCompilerPack.Identity)</NuGetPackageId>
+        <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_DistinctILCompilerTargetRid.Identity)</RuntimeIdentifier>
+      </TargetILCompilerPack>
+    </ItemGroup>
+
+    <!-- Add to download list if needed -->
+    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true'">
+      <_PackageToDownload Include="@(HostILCompilerPack);@(TargetILCompilerPack)"
+        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(NuGetPackageId)\%(NuGetPackageVersion)')">
+        <Version>%(NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve ILLink pack for trimming support.
+    -->
+  <Target Name="_ResolveILLinkPack"
+          DependsOnTargets="_FilterApplicableFrameworkReferences"
+          Condition="'$(_RequiresILLinkPack)' == 'true'">
+
+    <!-- Filter ILLink packs by TFM (parse TargetFramework) -->
+    <ItemGroup>
+      <_KnownILLinkPackMatchingTFI Include="@(KnownILLinkPack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownILLinkPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableILLinkPack Include="@(_KnownILLinkPackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILLinkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+    </ItemGroup>
+
+    <!-- Add ILLink pack as implicit package reference -->
+    <ItemGroup Condition="'@(_ApplicableILLinkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
+      <_ImplicitPackageReference Include="@(_ApplicableILLinkPack)">
+        <Version>%(ILLinkPackVersion)</Version>
+      </_ImplicitPackageReference>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve WebAssembly SDK pack.
+    -->
+  <Target Name="_ResolveWebAssemblySdkPack"
+          DependsOnTargets="_FilterApplicableFrameworkReferences"
+          Condition="'$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">
+
+    <!-- Filter WebAssembly SDK packs by TFM (parse TargetFramework) -->
+    <ItemGroup>
+      <_KnownWebAssemblySdkPackMatchingTFI Include="@(KnownWebAssemblySdkPack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownWebAssemblySdkPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableWebAssemblySdkPack Include="@(_KnownWebAssemblySdkPackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownWebAssemblySdkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+    </ItemGroup>
+
+    <!-- Add as package download -->
+    <ItemGroup Condition="'@(_ApplicableWebAssemblySdkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
+      <_PackageToDownload Include="@(_ApplicableWebAssemblySdkPack)">
+        <Version>%(WebAssemblySdkPackVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Resolve ASP.NET Core pack for .NET 10+ projects requiring web assets.
+    -->
+  <Target Name="_ResolveAspNetCorePack"
+          DependsOnTargets="_FilterApplicableFrameworkReferences"
+          Condition="'$(RequiresAspNetWebAssets)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">
+
+    <!-- Filter ASP.NET Core packs by TFM (parse TargetFramework) -->
+    <ItemGroup>
+      <_KnownAspNetCorePackMatchingTFI Include="@(KnownAspNetCorePack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownAspNetCorePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+
+      <_ApplicableAspNetCorePack Include="@(_KnownAspNetCorePackMatchingTFI)"
+        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownAspNetCorePackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
+    </ItemGroup>
+
+    <!-- Add as package download -->
+    <ItemGroup Condition="'@(_ApplicableAspNetCorePack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
+      <_PackageToDownload Include="@(_ApplicableAspNetCorePack)">
+        <Version>%(_ApplicableAspNetCorePack.AspNetCorePackVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Create RuntimeFramework items for runtimeconfig.json.
+    -->
+  <Target Name="_CreateRuntimeFrameworkItems"
+          DependsOnTargets="_SelectRuntimePacksByLabels">
+    <ItemGroup>
+      <!-- Only create RuntimeFramework items for frameworks that aren't always copy-local -->
+      <RuntimeFramework Include="@(_JoinedFrameworkReference)"
+        Condition="'%(_JoinedFrameworkReference.RuntimePackAlwaysCopyLocal)' != 'true' AND
+                   '%(_JoinedFrameworkReference.RuntimeFrameworkName)' != ''">
+        <Version>%(_JoinedFrameworkReference.RuntimeFrameworkVersion)</Version>
+        <FrameworkName>%(_JoinedFrameworkReference.Identity)</FrameworkName>
+        <Profile>%(_JoinedFrameworkReference.Profile)</Profile>
+      </RuntimeFramework>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
+    ProcessFrameworkReferences
 
     Matches FrameworkReference items with KnownFrameworkReference items to determine the corresponding
     targeting pack and if necessary the runtime pack.  If the packs aren't available in the NetCoreTargetingPackRoot
     folder, then generate PackageDownload items in order to download the packs during restore.
 
     Also resolves app host packs in a similar fashion, and checks for duplicate FrameworkReference items.
+
+    Set UseRefactoredFrameworkReferenceResolution=false to use the original monolithic task implementation.
     ============================================================
     -->
 
-  <Target Name="ProcessFrameworkReferences" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
-          DependsOnTargets="_ComputeTargetLatestRuntimePatch;AddWindowsSdkKnownFrameworkReferences"
-          Condition="'@(FrameworkReference)' != '' Or '$(_RequiresILLinkPack)' == 'true'">
-
+  <Target Name="_ProcessFrameworkReferencesComputeProperties">
     <CheckForDuplicateFrameworkReferences
         FrameworkReferences="@(FrameworkReference)"
         MoreInformationLink="https://aka.ms/sdkimplicitrefs">
@@ -118,7 +618,29 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
     </ItemGroup>
+  </Target>
 
+  <!--
+    Refactored implementation that calls sub-targets.
+    -->
+  <Target Name="_ProcessFrameworkReferencesRefactored"
+          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'"
+          DependsOnTargets="_ValidateWindowsOnlyFrameworks;
+                           _CreateTargetingPackItems;
+                           _ResolveRuntimePacksForAdditionalRIDs;
+                           _ResolveCrossgen2Packs;
+                           _ResolveILCompilerPacks;
+                           _ResolveILLinkPack;
+                           _ResolveWebAssemblySdkPack;
+                           _ResolveAspNetCorePack;
+                           _CreateRuntimeFrameworkItems">
+    <!-- All work done in dependencies -->
+  </Target>
+
+  <!--
+    Original monolithic task implementation (fallback).
+    -->
+  <Target Name="_ProcessFrameworkReferencesOriginal" Condition="'$(UseRefactoredFrameworkReferenceResolution)' == 'false'" >
     <ProcessFrameworkReferences FrameworkReferences="@(FrameworkReference)"
                                 KnownFrameworkReferences="@(KnownFrameworkReference)"
                                 KnownRuntimePacks="@(KnownRuntimePack)"
@@ -182,7 +704,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="KnownRuntimeIdentifierPlatforms" ItemName="_KnownRuntimeIdentifierPlatformsForTargetFramework" />
 
     </ProcessFrameworkReferences>
+  </Target>
 
+  <Target Name="_ResolveAppHosts">
     <PropertyGroup Condition="'$(AppHostRuntimeIdentifier)' == '' And
                               ('$(UseAppHost)' == 'true' Or '$(EnableComHosting)' == 'true' Or '$(UseIJWHost)' == 'true')">
       <AppHostRuntimeIdentifier>$(RuntimeIdentifier)</AppHostRuntimeIdentifier>
@@ -212,8 +736,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ComHost" ItemName="ComHostPack" />
       <Output TaskParameter="IjwHost" ItemName="IjwHostPack" />
       <Output TaskParameter="PackAsToolShimAppHostPacks" ItemName="PackAsToolShimAppHostPack" />
-
     </ResolveAppHosts>
+  </Target>
+
+  <Target Name="ProcessFrameworkReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
+          DependsOnTargets="_ComputeTargetLatestRuntimePatch;AddWindowsSdkKnownFrameworkReferences;_ProcessFrameworkReferencesComputeProperties;_ProcessFrameworkReferencesRefactored;_ProcessFrameworkReferencesOriginal;_ResolveAppHosts;"
+          Condition="'@(FrameworkReference)' != '' Or '$(_RequiresILLinkPack)' == 'true'">
 
     <PropertyGroup Condition="'$(UsePackageDownload)' == ''">
       <UsePackageDownload Condition="'$(MSBuildRuntimeType)' == 'Core'">true</UsePackageDownload>
@@ -487,10 +1016,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Set the namespaces emitted by the ValidationsGenerator for interception when applicable (.NET 10 and above). -->
     <InterceptorsPreviewNamespaces Condition="'$(_TargetFrameworkVersionWithoutV)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Validation.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
-  
+
   <Target Name="ResolveOffByDefaultAnalyzers" AfterTargets="ResolveTargetingPackAssets"
           Condition="'@(FrameworkReference)' != ''">
-    
+
     <ItemGroup>
       <OffByDefaultAnalyzer Include="Microsoft.AspNetCore.Http.RequestDelegateGenerator.dll"
                             IsEnabled="$(EnableRequestDelegateGenerator)"/>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -392,27 +392,36 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILCompilerPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
     </ItemGroup>
 
-    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="$(NETCoreSdkRuntimeIdentifier)"
-                 SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
-                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                           '$(PublishAot)' == 'true' AND
-                           '@(_ApplicableILCompilerPack)' != ''">
-      <Output TaskParameter="MatchingRid" ItemName="_ILCompilerHostRid" />
-    </PickBestRid>
+    <!-- Create candidate items with RuntimeIdentifier metadata for each supported RID -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true' AND
+                          '@(_ApplicableILCompilerPack)' != ''">
+      <_ILCompilerCandidate Include="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)">
+        <ILCompilerPackNamePattern>%(_ApplicableILCompilerPack.ILCompilerPackNamePattern)</ILCompilerPackNamePattern>
+        <ILCompilerPackVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</ILCompilerPackVersion>
+      </_ILCompilerCandidate>
+    </ItemGroup>
+
+    <!-- Select compatible host ILCompiler pack -->
+    <SelectRuntimeIdentifierSpecificItems RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                                          TargetRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
+                                          Items="@(_ILCompilerCandidate)"
+                                          RuntimeIdentifierItemMetadata="Identity"
+                                          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                                    '$(PublishAot)' == 'true' AND
+                                                    '@(_ILCompilerCandidate)' != ''">
+      <Output TaskParameter="SelectedItems" ItemName="_SelectedILCompilerHostCandidate" />
+    </SelectRuntimeIdentifierSpecificItems>
 
     <!-- Prepare host ILCompiler pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishAot)' == 'true' AND
-                          '@(_ILCompilerHostRid)' != ''">
-      <_HostILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_ILCompilerHostRid.Identity)'))">
+                          '@(_SelectedILCompilerHostCandidate)' != ''">
+      <_HostILCompilerPack Include="$([System.String]::Copy('%(_SelectedILCompilerHostCandidate.ILCompilerPackNamePattern)').Replace('**RID**', '%(_SelectedILCompilerHostCandidate.Identity)'))">
         <NuGetPackageId>%(_HostILCompilerPack.Identity)</NuGetPackageId>
-        <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
-        <RuntimeIdentifier>%(_ILCompilerHostRid.Identity)</RuntimeIdentifier>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)</PackageDirectory>
-      </_HostILCompilerPack>
-      <_HostILCompilerPack>
-        <Pack>%(_HostILCompilerPack.Identity)</Pack>
+        <NuGetPackageVersion>%(_SelectedILCompilerHostCandidate.ILCompilerPackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_SelectedILCompilerHostCandidate.Identity)</RuntimeIdentifier>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_SelectedILCompilerHostCandidate.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_HostILCompilerPack.Identity)\%(_SelectedILCompilerHostCandidate.ILCompilerPackVersion)</PackageDirectory>
       </_HostILCompilerPack>
     </ItemGroup>
 
@@ -420,44 +429,47 @@ Copyright (c) .NET Foundation. All rights reserved.
                           '$(PublishAot)' == 'true'">
       <_ILCompilerTargetRidToResolve Include="$(_EffectiveRuntimeIdentifier)" Condition="'$(_EffectiveRuntimeIdentifier)' != ''" />
       <_ILCompilerTargetRidToResolve Include="$(RuntimeIdentifiers)" />
+      <_ILCompilerTargetRidToResolve Remove="$(NETCoreSdkRuntimeIdentifier)" /> <!-- just resolved this for the 'host', don't want duplicates -->
       <_ILCompilerTargetRidToResolve Remove="any" />
     </ItemGroup>
 
-    <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
-                 TargetRid="%(_ILCompilerTargetRidToResolve.Identity)"
-                 SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
-                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                           '$(PublishAot)' == 'true' AND
-                           '@(_ILCompilerTargetRidToResolve)' != '' AND
-                           '@(_ApplicableILCompilerPack)' != ''">
-      <Output TaskParameter="MatchingRid" ItemName="_ILCompilerTargetRid" />
-    </PickBestRid>
+    <!-- Create candidate items (reuse _ILCompilerHostCandidate if already created) -->
 
-    <RemoveDuplicates Inputs="@(_ILCompilerTargetRid)"
+    <!-- Select compatible target ILCompiler packs for each target RID -->
+    <SelectRuntimeIdentifierSpecificItems RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
+                                          TargetRuntimeIdentifier="%(_ILCompilerTargetRidToResolve.Identity)"
+                                          Items="@(_ILCompilerCandidate)"
+                                          RuntimeIdentifierItemMetadata="Identity"
+                                          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                                    '$(PublishAot)' == 'true' AND
+                                                    '@(_ILCompilerTargetRidToResolve)' != '' AND
+                                                    '@(_ILCompilerCandidate)' != ''">
+      <Output TaskParameter="SelectedItems" ItemName="_SelectedILCompilerTargetCandidate" />
+    </SelectRuntimeIdentifierSpecificItems>
+
+    <!-- Remove duplicates and exclude host RID -->
+    <RemoveDuplicates Inputs="@(_SelectedILCompilerTargetCandidate)"
                       Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                                 '$(PublishAot)' == 'true' AND
-                                '@(_ILCompilerTargetRid)' != ''">
-      <Output TaskParameter="Filtered" ItemName="_UniqueILCompilerTargetRid" />
+                                '@(_SelectedILCompilerTargetCandidate)' != ''">
+      <Output TaskParameter="Filtered" ItemName="_UniqueILCompilerTargetCandidate" />
     </RemoveDuplicates>
 
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishAot)' == 'true'">
-      <_DistinctILCompilerTargetRid Include="@(_UniqueILCompilerTargetRid)"
-        Condition="'%(_UniqueILCompilerTargetRid.Identity)' != '%(_ILCompilerHostRid.Identity)'" />
+      <_DistinctILCompilerTargetCandidate Include="@(_UniqueILCompilerTargetCandidate)"
+        Condition="'%(_UniqueILCompilerTargetCandidate.Identity)' != '%(_SelectedILCompilerHostCandidate.Identity)'" />
     </ItemGroup>
 
     <!-- Prepare target ILCompiler pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishAot)' == 'true' AND
-                          '@(_DistinctILCompilerTargetRid)' != ''">
-      <_TargetILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_DistinctILCompilerTargetRid.Identity)'))">
+                          '@(_DistinctILCompilerTargetCandidate)' != ''">
+      <_TargetILCompilerPack Include="$([System.String]::Copy('%(_DistinctILCompilerTargetCandidate.ILCompilerPackNamePattern)').Replace('**RID**', '%(_DistinctILCompilerTargetCandidate.Identity)'))">
         <NuGetPackageId>%(_TargetILCompilerPack.Identity)</NuGetPackageId>
-        <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
-        <RuntimeIdentifier>%(_DistinctILCompilerTargetRid.Identity)</RuntimeIdentifier>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_ApplicableILCompilerPack.ILCompilerPackVersion)</PackageDirectory>
-      </_TargetILCompilerPack>
-      <_TargetILCompilerPack>
-        <Pack>%(_TargetILCompilerPack.Identity)</Pack>
+        <NuGetPackageVersion>%(_DistinctILCompilerTargetCandidate.ILCompilerPackVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_DistinctILCompilerTargetCandidate.Identity)</RuntimeIdentifier>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_DistinctILCompilerTargetCandidate.ILCompilerPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetILCompilerPack.Identity)\%(_DistinctILCompilerTargetCandidate.ILCompilerPackVersion)</PackageDirectory>
       </_TargetILCompilerPack>
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -79,19 +79,61 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ProcessFrameworkReferences (Refactored)
+    ProcessFrameworkReferences
 
-    The following targets break down framework reference resolution into logical steps.
-    Set UseRefactoredFrameworkReferenceResolution=false to use the original monolithic task.
+    Matches FrameworkReference items with KnownFrameworkReference items to determine the corresponding
+    targeting pack and if necessary the runtime pack.  If the packs aren't available in the NetCoreTargetingPackRoot
+    folder, then generate PackageDownload items in order to download the packs during restore.
+
+    Also resolves app host packs in a similar fashion, and checks for duplicate FrameworkReference items.
+
+    Set UseRefactoredFrameworkReferenceResolution=false to use the original monolithic task implementation.
     ============================================================
     -->
 
-  <!--
-    Compute settings that determine which packs are needed based on deployment model.
+  <Target Name="ProcessFrameworkReferences"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
+          DependsOnTargets="_ComputeTargetLatestRuntimePatch;AddWindowsSdkKnownFrameworkReferences"
+          Condition="'@(FrameworkReference)' != '' Or '$(_RequiresILLinkPack)' == 'true'">
+
+    <!--
+      Check for duplicate framework references and normalize.
+      This runs AFTER BeforeTargets hooks, so properties set by external hooks are visible.
     -->
-  <Target Name="_ComputeFrameworkReferenceSettings">
-    <!-- Determine if deployment model requires runtime-specific components -->
+    <CheckForDuplicateFrameworkReferences
+        FrameworkReferences="@(FrameworkReference)"
+        MoreInformationLink="https://aka.ms/sdkimplicitrefs">
+      <Output TaskParameter="ItemsToRemove" ItemName="_FrameworkReferenceToRemove" />
+      <Output TaskParameter="ItemsToAdd" ItemName="_FrameworkReferenceToAdd" />
+    </CheckForDuplicateFrameworkReferences>
+
+    <ItemGroup>
+      <FrameworkReference Remove="@(_FrameworkReferenceToRemove)" />
+      <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
+    </ItemGroup>
+
+    <!-- Set default property values -->
     <PropertyGroup>
+      <EnableTargetingPackDownload Condition="'$(EnableTargetingPackDownload)' == ''">true</EnableTargetingPackDownload>
+      <EnableRuntimePackDownload Condition="'$(EnableRuntimePackDownload)' == ''">true</EnableRuntimePackDownload>
+      <RequiresAspNetWebAssets Condition="'$(RequiresAspNetWebAssets)' == ''">false</RequiresAspNetWebAssets>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_NuGetRestoreSupported Condition="('$(Language)' == 'C++' and '$(_EnablePackageReferencesInVCProjects)' != 'true')">false</_NuGetRestoreSupported>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
+    </ItemGroup>
+
+    <!-- ============================================================
+         BEGIN INLINED REFACTORED IMPLEMENTATION
+         All logic from _ProcessFrameworkReferencesRefactored and dependencies inlined here
+         so it executes AFTER BeforeTargets hooks.
+         ============================================================ -->
+    <PropertyGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <!-- Compute framework reference settings from _ComputeFrameworkReferenceSettings -->
       <_DeploymentRequiresRuntimeComponents>false</_DeploymentRequiresRuntimeComponents>
       <_DeploymentRequiresRuntimeComponents Condition="'$(SelfContained)' == 'true'">true</_DeploymentRequiresRuntimeComponents>
       <_DeploymentRequiresRuntimeComponents Condition="'$(PublishReadyToRun)' == 'true'">true</_DeploymentRequiresRuntimeComponents>
@@ -103,18 +145,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Determine if project is platform-specific -->
       <_ProjectIsPlatformSpecific Condition="'$(_EffectiveRuntimeIdentifier)' != ''">true</_ProjectIsPlatformSpecific>
     </PropertyGroup>
-  </Target>
 
-  <!--
-    Filter KnownFrameworkReferences and KnownRuntimePacks by target framework.
-    Parses TargetFramework metadata (e.g., "net9.0-windows10.0") into components.
-    Uses VersionEquals for proper version normalization (5.0.0.0 == 5.0).
-    -->
-  <Target Name="_FilterApplicableFrameworkReferences"
-          DependsOnTargets="_ComputeFrameworkReferenceSettings">
-    <ItemGroup>
+    <!-- Filter applicable framework references from _FilterApplicableFrameworkReferences -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <!-- Parse TargetFramework into components and filter KnownFrameworkReferences -->
-      <!-- MSBuild functions: GetTargetFrameworkIdentifier, GetTargetFrameworkVersion, GetTargetPlatformIdentifier, GetTargetPlatformVersion -->
       <_KnownFrameworkReferenceMatchingTFI Include="@(KnownFrameworkReference)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
@@ -133,9 +167,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'$(TargetPlatformVersion)' != '' AND
                    $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)) != '' AND
                    !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
-    </ItemGroup>
 
-    <ItemGroup>
       <!-- Same filtering for KnownRuntimePacks -->
       <_KnownRuntimePackMatchingTFI Include="@(KnownRuntimePack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownRuntimePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
@@ -153,90 +185,67 @@ Copyright (c) .NET Foundation. All rights reserved.
                    $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)) != '' AND
                    !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
     </ItemGroup>
-  </Target>
 
-  <!--
-    Validate that Windows-only frameworks aren't referenced on non-Windows platforms.
-    -->
-  <Target Name="_ValidateWindowsOnlyFrameworks"
-          DependsOnTargets="_JoinFrameworkReferencesWithKnownData">
-    <ItemGroup>
+    <!-- Join framework references with known data from _JoinFrameworkReferencesWithKnownData -->
+    <JoinItems Left="@(_ApplicableKnownFrameworkReference)"
+               Right="@(FrameworkReference)"
+               LeftMetadata="*"
+               RightMetadata="IsImplicitlyDefined;PrivateAssets;Pack"
+               ItemSpecToUse="Left"
+               Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <Output TaskParameter="JoinResult" ItemName="_JoinedFrameworkReference" />
+    </JoinItems>
+
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <!-- All of the newly-joined framework references are directly referenced -->
+      <_JoinedFrameworkReference>
+        <WasReferencedDirectly>true</WasReferencedDirectly>
+      </_JoinedFrameworkReference>
+
+      <!-- Also include framework references without user reference if not disabling transitive -->
+      <_UnreferencedKnownFrameworkReference Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'" Include="@(_ApplicableKnownFrameworkReference)"
+        Exclude="@(_JoinedFrameworkReference)" />
+      <_JoinedFrameworkReference Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'" Include="@(_UnreferencedKnownFrameworkReference)" />
+    </ItemGroup>
+
+    <!-- Validate Windows-only frameworks from _ValidateWindowsOnlyFrameworks -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_WindowsOnlyFrameworkReference Include="@(_JoinedFrameworkReference)"
         Condition="'%(_JoinedFrameworkReference.IsWindowsOnly)' == 'true'" />
     </ItemGroup>
 
-    <NetSdkError Condition="'@(_WindowsOnlyFrameworkReference)' != '' AND
+    <NetSdkError Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                            '@(_WindowsOnlyFrameworkReference)' != '' AND
                             '$(OS)' != 'Windows_NT' AND
                             '$(EnableWindowsTargeting)' != 'true'"
                  ResourceName="WindowsDesktopFrameworkRequiresWindows" />
 
     <!-- Remove Windows-only frameworks from processing on non-Windows -->
-    <ItemGroup Condition="'$(OS)' != 'Windows_NT' AND '$(EnableWindowsTargeting)' != 'true'">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND '$(OS)' != 'Windows_NT' AND '$(EnableWindowsTargeting)' != 'true'">
       <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
         Condition="'%(_ApplicableKnownFrameworkReference.IsWindowsOnly)' == 'true'" />
       <_JoinedFrameworkReference Remove="@(_JoinedFrameworkReference)"
         Condition="'%(_JoinedFrameworkReference.IsWindowsOnly)' == 'true'" />
     </ItemGroup>
-  </Target>
 
-  <!--
-    Join user FrameworkReferences with KnownFrameworkReferences to combine metadata.
-    -->
-  <Target Name="_JoinFrameworkReferencesWithKnownData"
-          DependsOnTargets="_FilterApplicableFrameworkReferences">
-    <JoinItems Left="@(_ApplicableKnownFrameworkReference)"
-               Right="@(FrameworkReference)"
-               LeftMetadata="*"
-               RightMetadata="IsImplicitlyDefined;PrivateAssets;Pack"
-               ItemSpecToUse="Left">
-      <Output TaskParameter="JoinResult" ItemName="_JoinedFrameworkReference" />
-    </JoinItems>
-
-    <ItemGroup>
-      <!-- All of the newly-joined framework references are directly referenced -->
-      <_JoinedFrameworkReference>
-        <WasReferencedDirectly>true</WasReferencedDirectly>
-      </_JoinedFrameworkReference>
-    </ItemGroup>
-
-    <!-- Also include framework references without user reference if not disabling transitive -->
-    <ItemGroup Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'">
-      <_UnreferencedKnownFrameworkReference Include="@(_ApplicableKnownFrameworkReference)"
-        Exclude="@(_JoinedFrameworkReference)" />
-      <_JoinedFrameworkReference Include="@(_UnreferencedKnownFrameworkReference)" />
-    </ItemGroup>
-  </Target>
-
-  <!--
-    Select the appropriate runtime pack for each framework reference based on RuntimePackLabels.
-    -->
-  <Target Name="_SelectRuntimePacksByLabels"
-          DependsOnTargets="_JoinFrameworkReferencesWithKnownData">
-    <ItemGroup>
+    <!-- Select runtime packs by labels from _SelectRuntimePacksByLabels -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <!-- For each joined framework reference, find matching runtime packs -->
-      <!-- Cross-join: For each framework reference, create items for all runtime packs with matching name -->
       <_CandidateRuntimePack Include="@(_ApplicableKnownRuntimePack)"
         Condition="'%(_ApplicableKnownRuntimePack.Identity)' == '%(_JoinedFrameworkReference.RuntimeFrameworkName)'"
         KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
         <FrameworkReferenceName>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceName>
         <RequiredRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</RequiredRuntimePackLabels>
       </_CandidateRuntimePack>
-    </ItemGroup>
 
-    <!-- Filter to runtime packs where labels match exactly (or both are empty) -->
-    <ItemGroup>
+      <!-- Filter to runtime packs where labels match exactly (or both are empty) -->
       <_MatchedRuntimePack Include="@(_CandidateRuntimePack)"
         Condition="'%(_CandidateRuntimePack.RuntimePackLabels)' == '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' OR
                    ('%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == '')" />
     </ItemGroup>
-  </Target>
 
-  <!--
-    Create TargetingPack items for compilation.
-    -->
-  <Target Name="_CreateTargetingPackItems"
-          DependsOnTargets="_SelectRuntimePacksByLabels">
-    <ItemGroup>
+    <!-- Create targeting pack items from _CreateTargetingPackItems -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_TargetingPack Include="@(_JoinedFrameworkReference)" KeepMetadata="Profile;WasReferencedDirectly;TargetFramework;TargetingPackFormat;RuntimeFrameworkName;TargetingPackName;TargetingPackVersion" />
       <_TargetingPack>
         <NuGetPackageId>%(_TargetingPack.TargetingPackName)</NuGetPackageId>
@@ -251,7 +260,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Add targeting packs to download list if not found locally and downloads enabled -->
-    <ItemGroup Condition="'$(EnableTargetingPackDownload)' == 'true'">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND '$(EnableTargetingPackDownload)' == 'true'">
       <_TargetingPackPackage
         Include="@(TargetingPack->'%(NuGetPackageId)')"
         KeepDuplicates="false"
@@ -262,42 +271,37 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Build PackageConflictPreferredPackages list -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_PreferredPackage Include="%(TargetingPack.NuGetPackageId)" />
       <_PreferredPackage Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')" />
     </ItemGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_PackageConflictPreferredPackages>@(_PreferredPackage, ';')</_PackageConflictPreferredPackages>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <TargetingPack>
         <PackageConflictPreferredPackages>$(_PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
       </TargetingPack>
       <_PreferredPackage Remove="@(_PreferredPackage)" />
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve runtime packs for the primary RuntimeIdentifier.
-    -->
-  <Target Name="_ResolveRuntimePacksForPrimaryRID"
-          DependsOnTargets="_CreateTargetingPackItems"
-          Condition="'$(_DeploymentRequiresRuntimeComponents)' == 'true' AND '$(_EffectiveRuntimeIdentifier)' != ''">
-
-    <!-- For each matched runtime pack, find best matching RID -->
-    <!-- Output MatchingRid as Item (not Property) so batching accumulates results -->
+    <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="$(_EffectiveRuntimeIdentifier)"
                  SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
-                 Condition="'@(_MatchedRuntimePack)' != ''">
+                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                           '$(_EffectiveRuntimeIdentifier)' != '' AND
+                           '@(_MatchedRuntimePack)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_PrimaryMatchedRid" />
     </PickBestRid>
 
     <!-- Create RuntimePack items by substituting **RID** in pattern with matched RID -->
-    <!-- Cross-join pattern: Each _MatchedRuntimePack × each _PrimaryMatchedRid creates runtime pack items -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                          '$(_EffectiveRuntimeIdentifier)' != ''">
       <_RuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
         <MatchedRid>%(_PrimaryMatchedRid.Identity)</MatchedRid>
         <FrameworkName>%(_MatchedRuntimePack.FrameworkReferenceName)</FrameworkName>
@@ -322,46 +326,48 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Add to download list if not found locally -->
-    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true'">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                          '$(_EffectiveRuntimeIdentifier)' != '' AND
+                          '$(EnableRuntimePackDownload)' == 'true'">
       <_PackageToDownload Include="@(RuntimePack)"
         Condition="!Exists('$(NetCoreTargetingPackRoot)\%(RuntimePack.NuGetPackageId)\%(RuntimePack.NuGetPackageVersion)')">
         <Version>%(RuntimePack.NuGetPackageVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve runtime packs for additional RuntimeIdentifiers (for multi-RID publish scenarios).
-    These are downloaded but not added to RuntimePack output.
-    -->
-  <Target Name="_ResolveRuntimePacksForAdditionalRIDs"
-          DependsOnTargets="_ResolveRuntimePacksForPrimaryRID"
-          Condition="'$(EnableRuntimePackDownload)' == 'true' AND '$(RuntimeIdentifiers)' != ''">
-
-    <!-- Split RuntimeIdentifiers into items -->
-    <ItemGroup>
+    <!-- Resolve runtime packs for additional RIDs from _ResolveRuntimePacksForAdditionalRIDs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(EnableRuntimePackDownload)' == 'true' AND
+                          '$(RuntimeIdentifiers)' != ''">
       <_AdditionalRuntimeIdentifier Include="$(RuntimeIdentifiers)" />
       <!-- Remove primary RID if it's already processed -->
       <_AdditionalRuntimeIdentifier Remove="$(_EffectiveRuntimeIdentifier)" />
       <_AdditionalRuntimeIdentifier Remove="any" />
     </ItemGroup>
 
-    <!-- Batch PickBestRid for each additional RID - outputs accumulate as Items -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="%(_AdditionalRuntimeIdentifier.Identity)"
                  SupportedRids="%(_MatchedRuntimePack.RuntimePackRuntimeIdentifiers)"
-                 Condition="'@(_AdditionalRuntimeIdentifier)' != '' AND '@(_MatchedRuntimePack)' != ''">
+                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                           '$(EnableRuntimePackDownload)' == 'true' AND
+                           '@(_AdditionalRuntimeIdentifier)' != '' AND
+                           '@(_MatchedRuntimePack)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_AdditionalMatchedRid" />
     </PickBestRid>
 
     <!-- Deduplicate matched RIDs -->
-    <RemoveDuplicates Inputs="@(_AdditionalMatchedRid)" Condition="'@(_AdditionalMatchedRid)' != ''">
+    <RemoveDuplicates Inputs="@(_AdditionalMatchedRid)"
+                      Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                '$(EnableRuntimePackDownload)' == 'true' AND
+                                '@(_AdditionalMatchedRid)' != ''">
       <Output TaskParameter="Filtered" ItemName="_UniqueAdditionalMatchedRid" />
     </RemoveDuplicates>
 
     <!-- Create download items for additional RIDs -->
-    <!-- Cross-join: Each runtime pack pattern × each unique additional RID -->
-    <ItemGroup Condition="'@(_UniqueAdditionalMatchedRid)' != ''">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(EnableRuntimePackDownload)' == 'true' AND
+                          '@(_UniqueAdditionalMatchedRid)' != ''">
       <_AdditionalRuntimePackWithRid Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')">
         <MatchedRid>%(_UniqueAdditionalMatchedRid.Identity)</MatchedRid>
         <LatestVersion>%(_MatchedRuntimePack.LatestRuntimeFrameworkVersion)</LatestVersion>
@@ -372,17 +378,11 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Version>%(_AdditionalRuntimePackWithRid.LatestVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve Crossgen2 packs for ReadyToRun compilation.
-    -->
-  <Target Name="_ResolveCrossgen2Packs"
-          DependsOnTargets="_FilterApplicableFrameworkReferences"
-          Condition="'$(PublishReadyToRun)' == 'true' AND '$(PublishReadyToRunUseCrossgen2)' == 'true'">
-
-    <!-- Filter Crossgen2 packs by TFM (parse TargetFramework) -->
-    <ItemGroup>
+    <!-- Resolve Crossgen2 packs from _ResolveCrossgen2Packs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishReadyToRun)' == 'true' AND
+                          '$(PublishReadyToRunUseCrossgen2)' == 'true'">
       <_KnownCrossgen2PackMatchingTFI Include="@(KnownCrossgen2Pack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownCrossgen2Pack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
@@ -390,16 +390,20 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownCrossgen2PackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
     </ItemGroup>
 
-    <!-- Find best host RID for the SDK -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="$(NETCoreSdkRuntimeIdentifier)"
                  SupportedRids="%(_ApplicableCrossgen2Pack.Crossgen2RuntimeIdentifiers)"
-                 Condition="'@(_ApplicableCrossgen2Pack)' != ''">
+                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                           '$(PublishReadyToRun)' == 'true' AND
+                           '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                           '@(_ApplicableCrossgen2Pack)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_Crossgen2HostRid" />
     </PickBestRid>
 
-    <!-- Create Crossgen2Pack item -->
-    <ItemGroup Condition="'@(_Crossgen2HostRid)' != ''">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishReadyToRun)' == 'true' AND
+                          '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                          '@(_Crossgen2HostRid)' != ''">
       <_Crossgen2Pack Include="@(_ApplicableCrossgen2Pack->'%(Crossgen2PackNamePattern)'.Replace('**RID**', '%(_Crossgen2HostRid.Identity)'))">
         <NuGetPackageId>%(_Crossgen2Pack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableCrossgen2Pack.Crossgen2PackVersion)</NuGetPackageVersion>
@@ -413,24 +417,20 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_Crossgen2Pack Remove="@(_Crossgen2Pack)" />
     </ItemGroup>
 
-    <!-- Add to download list if needed -->
-    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true' AND '@(Crossgen2Pack)' != ''">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishReadyToRun)' == 'true' AND
+                          '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                          '$(EnableRuntimePackDownload)' == 'true' AND
+                          '@(Crossgen2Pack)' != ''">
       <_PackageToDownload Include="@(Crossgen2Pack)"
         Condition="!Exists('$(NetCoreTargetingPackRoot)\%(Crossgen2Pack.NuGetPackageId)\%(Crossgen2Pack.NuGetPackageVersion)')">
         <Version>%(Crossgen2Pack.NuGetPackageVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve ILCompiler packs for Native AOT compilation (both host and target).
-    -->
-  <Target Name="_ResolveILCompilerPacks"
-          DependsOnTargets="_FilterApplicableFrameworkReferences"
-          Condition="'$(PublishAot)' == 'true'">
-
-    <!-- Filter ILCompiler packs by TFM (parse TargetFramework) -->
-    <ItemGroup>
+    <!-- Resolve ILCompiler packs from _ResolveILCompilerPacks -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true'">
       <_KnownILCompilerPackMatchingTFI Include="@(KnownILCompilerPack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownILCompilerPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
@@ -438,16 +438,18 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILCompilerPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
     </ItemGroup>
 
-    <!-- Find best host RID for the SDK -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="$(NETCoreSdkRuntimeIdentifier)"
                  SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
-                 Condition="'@(_ApplicableILCompilerPack)' != ''">
+                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                           '$(PublishAot)' == 'true' AND
+                           '@(_ApplicableILCompilerPack)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_ILCompilerHostRid" />
     </PickBestRid>
 
-    <!-- Create host ILCompiler pack -->
-    <ItemGroup Condition="'@(_ILCompilerHostRid)' != ''">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true' AND
+                          '@(_ILCompilerHostRid)' != ''">
       <_HostILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_ILCompilerHostRid.Identity)'))">
         <NuGetPackageId>%(_HostILCompilerPack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
@@ -461,34 +463,39 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_HostILCompilerPack Remove="@(_HostILCompilerPack)" />
     </ItemGroup>
 
-    <!-- Find best target RID(s) for cross-compilation -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true'">
       <_ILCompilerTargetRidToResolve Include="$(_EffectiveRuntimeIdentifier)" Condition="'$(_EffectiveRuntimeIdentifier)' != ''" />
       <_ILCompilerTargetRidToResolve Include="$(RuntimeIdentifiers)" />
       <_ILCompilerTargetRidToResolve Remove="any" />
     </ItemGroup>
 
-    <!-- Batch PickBestRid for each target RID -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="%(_ILCompilerTargetRidToResolve.Identity)"
                  SupportedRids="%(_ApplicableILCompilerPack.ILCompilerRuntimeIdentifiers)"
-                 Condition="'@(_ILCompilerTargetRidToResolve)' != '' AND '@(_ApplicableILCompilerPack)' != ''">
+                 Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                           '$(PublishAot)' == 'true' AND
+                           '@(_ILCompilerTargetRidToResolve)' != '' AND
+                           '@(_ApplicableILCompilerPack)' != ''">
       <Output TaskParameter="MatchingRid" ItemName="_ILCompilerTargetRid" />
     </PickBestRid>
 
-    <!-- Deduplicate target RIDs -->
-    <RemoveDuplicates Inputs="@(_ILCompilerTargetRid)" Condition="'@(_ILCompilerTargetRid)' != ''">
+    <RemoveDuplicates Inputs="@(_ILCompilerTargetRid)"
+                      Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                                '$(PublishAot)' == 'true' AND
+                                '@(_ILCompilerTargetRid)' != ''">
       <Output TaskParameter="Filtered" ItemName="_UniqueILCompilerTargetRid" />
     </RemoveDuplicates>
 
-    <!-- Filter out target RIDs that match host RID -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true'">
       <_DistinctILCompilerTargetRid Include="@(_UniqueILCompilerTargetRid)"
         Condition="'%(_UniqueILCompilerTargetRid.Identity)' != '%(_ILCompilerHostRid.Identity)'" />
     </ItemGroup>
 
-    <!-- Create target ILCompiler packs for cross-compilation scenarios -->
-    <ItemGroup Condition="'@(_DistinctILCompilerTargetRid)' != ''">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true' AND
+                          '@(_DistinctILCompilerTargetRid)' != ''">
       <_TargetILCompilerPack Include="@(_ApplicableILCompilerPack->'%(ILCompilerPackNamePattern)'.Replace('**RID**', '%(_DistinctILCompilerTargetRid.Identity)'))">
         <NuGetPackageId>%(_TargetILCompilerPack.Identity)</NuGetPackageId>
         <NuGetPackageVersion>%(_ApplicableILCompilerPack.ILCompilerPackVersion)</NuGetPackageVersion>
@@ -502,93 +509,60 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_TargetILCompilerPack Remove="@(_TargetILCompilerPack)" />
     </ItemGroup>
 
-    <!-- Add to download list if needed -->
-    <ItemGroup Condition="'$(EnableRuntimePackDownload)' == 'true'">
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(PublishAot)' == 'true' AND
+                          '$(EnableRuntimePackDownload)' == 'true'">
       <_PackageToDownload Include="@(HostILCompilerPack);@(TargetILCompilerPack)"
         Condition="!Exists('$(NetCoreTargetingPackRoot)\%(NuGetPackageId)\%(NuGetPackageVersion)')">
         <Version>%(NuGetPackageVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve ILLink pack for trimming support.
-    -->
-  <Target Name="_ResolveILLinkPack"
-          DependsOnTargets="_FilterApplicableFrameworkReferences"
-          Condition="'$(_RequiresILLinkPack)' == 'true'">
-
-    <!-- Filter ILLink packs by TFM (parse TargetFramework) -->
-    <ItemGroup>
+    <!-- Resolve ILLink pack from _ResolveILLinkPack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_RequiresILLinkPack)' == 'true'">
       <_KnownILLinkPackMatchingTFI Include="@(KnownILLinkPack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownILLinkPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
       <_ApplicableILLinkPack Include="@(_KnownILLinkPackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILLinkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-    </ItemGroup>
 
-    <!-- Add ILLink pack as implicit package reference -->
-    <ItemGroup Condition="'@(_ApplicableILLinkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
-      <_ImplicitPackageReference Include="@(_ApplicableILLinkPack)">
+      <_ImplicitPackageReference Condition="'@(_ApplicableILLinkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableILLinkPack)">
         <Version>%(ILLinkPackVersion)</Version>
       </_ImplicitPackageReference>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve WebAssembly SDK pack.
-    -->
-  <Target Name="_ResolveWebAssemblySdkPack"
-          DependsOnTargets="_FilterApplicableFrameworkReferences"
-          Condition="'$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">
-
-    <!-- Filter WebAssembly SDK packs by TFM (parse TargetFramework) -->
-    <ItemGroup>
+    <!-- Resolve WebAssembly SDK pack from _ResolveWebAssemblySdkPack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">
       <_KnownWebAssemblySdkPackMatchingTFI Include="@(KnownWebAssemblySdkPack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownWebAssemblySdkPack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
       <_ApplicableWebAssemblySdkPack Include="@(_KnownWebAssemblySdkPackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownWebAssemblySdkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-    </ItemGroup>
 
-    <!-- Add as package download -->
-    <ItemGroup Condition="'@(_ApplicableWebAssemblySdkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
-      <_PackageToDownload Include="@(_ApplicableWebAssemblySdkPack)">
+      <_PackageToDownload Condition="'@(_ApplicableWebAssemblySdkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableWebAssemblySdkPack)">
         <Version>%(WebAssemblySdkPackVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Resolve ASP.NET Core pack for .NET 10+ projects requiring web assets.
-    -->
-  <Target Name="_ResolveAspNetCorePack"
-          DependsOnTargets="_FilterApplicableFrameworkReferences"
-          Condition="'$(RequiresAspNetWebAssets)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">
-
-    <!-- Filter ASP.NET Core packs by TFM (parse TargetFramework) -->
-    <ItemGroup>
+    <!-- Resolve ASP.NET Core pack from _ResolveAspNetCorePack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(RequiresAspNetWebAssets)' == 'true' AND
+                          $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0'))">
       <_KnownAspNetCorePackMatchingTFI Include="@(KnownAspNetCorePack)"
         Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownAspNetCorePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
 
       <_ApplicableAspNetCorePack Include="@(_KnownAspNetCorePackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownAspNetCorePackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-    </ItemGroup>
 
-    <!-- Add as package download -->
-    <ItemGroup Condition="'@(_ApplicableAspNetCorePack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'">
-      <_PackageToDownload Include="@(_ApplicableAspNetCorePack)">
+      <_PackageToDownload Condition="'@(_ApplicableAspNetCorePack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableAspNetCorePack)">
         <Version>%(_ApplicableAspNetCorePack.AspNetCorePackVersion)</Version>
       </_PackageToDownload>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Create RuntimeFramework items for runtimeconfig.json.
-    -->
-  <Target Name="_CreateRuntimeFrameworkItems"
-          DependsOnTargets="_SelectRuntimePacksByLabels">
-    <ItemGroup>
+    <!-- Create RuntimeFramework items from _CreateRuntimeFrameworkItems -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <!-- Only create RuntimeFramework items for frameworks that aren't always copy-local -->
       <RuntimeFramework Include="@(_JoinedFrameworkReference)"
         Condition="'%(_JoinedFrameworkReference.RuntimePackAlwaysCopyLocal)' != 'true' AND
@@ -598,15 +572,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <FrameworkName>%(_JoinedFrameworkReference.Identity)</FrameworkName>
       </RuntimeFramework>
     </ItemGroup>
-  </Target>
 
-  <!--
-    Extract known runtime identifier platforms from Microsoft.NETCore.App runtime packs.
-    Used for validating runtime assets in .NET 8+.
-    -->
-  <Target Name="_CreateKnownRuntimeIdentifierPlatforms"
-          DependsOnTargets="_FilterApplicableFrameworkReferences">
-    <ItemGroup>
+    <!-- Create known runtime identifier platforms from _CreateKnownRuntimeIdentifierPlatforms -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <!-- Get all Microsoft.NETCore.App runtime packs and framework references for this target framework -->
       <_NetCoreAppRuntimePack Include="@(_ApplicableKnownFrameworkReference);@(_ApplicableKnownRuntimePack)"
         Condition="'%(Identity)' == 'Microsoft.NETCore.App'" />
@@ -614,18 +582,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Split RuntimePackRuntimeIdentifiers by semicolon to create individual RID items -->
       <_RuntimePackRid Include="%(_NetCoreAppRuntimePack.RuntimePackRuntimeIdentifiers)" />
     </ItemGroup>
-    <!-- Remove duplicates to get unique rids -->
-    <RemoveDuplicates Inputs="@(_RuntimePackRid)">
+
+    <RemoveDuplicates Inputs="@(_RuntimePackRid)"
+                      Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <Output TaskParameter="Filtered" ItemName="_DeduplicatedRuntimePackRid" />
     </RemoveDuplicates>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_DeduplicatedRuntimePackRid>
         <Platform Condition="$([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).LastIndexOf('-')) &gt; 0">$([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).Substring(0, $([System.String]::Copy(%(_DeduplicatedRuntimePackRid.Identity)).LastIndexOf('-'))))</Platform>
       </_DeduplicatedRuntimePackRid>
 
       <!-- Extract platform from each RID (everything before last '-') -->
-      <!-- For RIDs like 'win-x64', extract 'win'. For 'linux-x64', extract 'linux' -->
       <_RuntimeIdentifierPlatform
         Include="@(_DeduplicatedRuntimePackRid->'%(Platform)')" />
 
@@ -634,83 +602,25 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="$([System.String]::Copy('%(_DeduplicatedRuntimePackRid.Identity)').LastIndexOf('-')) &lt; 0" />
     </ItemGroup>
 
-    <!-- Remove duplicates to get unique platforms -->
-    <RemoveDuplicates Inputs="@(_RuntimeIdentifierPlatform)">
+    <RemoveDuplicates Inputs="@(_RuntimeIdentifierPlatform)"
+                      Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <Output TaskParameter="Filtered" ItemName="_KnownRuntimeIdentifierPlatformsForTargetFramework" />
     </RemoveDuplicates>
 
     <!-- Clean up intermediate items -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <_NetCoreAppRuntimePack Remove="@(_NetCoreAppRuntimePack)" />
       <_RuntimePackRid Remove="@(_RuntimePackRid)" />
       <_RuntimeIdentifierPlatform Remove="@(_RuntimeIdentifierPlatform)" />
     </ItemGroup>
-  </Target>
 
-  <!--
-    ============================================================
-    ProcessFrameworkReferences
+    <!-- ============================================================
+         END INLINED REFACTORED IMPLEMENTATION
+         ============================================================ -->
 
-    Matches FrameworkReference items with KnownFrameworkReference items to determine the corresponding
-    targeting pack and if necessary the runtime pack.  If the packs aren't available in the NetCoreTargetingPackRoot
-    folder, then generate PackageDownload items in order to download the packs during restore.
-
-    Also resolves app host packs in a similar fashion, and checks for duplicate FrameworkReference items.
-
-    Set UseRefactoredFrameworkReferenceResolution=false to use the original monolithic task implementation.
-    ============================================================
-    -->
-
-  <Target Name="_ProcessFrameworkReferencesComputeProperties">
-    <CheckForDuplicateFrameworkReferences
-        FrameworkReferences="@(FrameworkReference)"
-        MoreInformationLink="https://aka.ms/sdkimplicitrefs">
-      <Output TaskParameter="ItemsToRemove" ItemName="_FrameworkReferenceToRemove" />
-      <Output TaskParameter="ItemsToAdd" ItemName="_FrameworkReferenceToAdd" />
-    </CheckForDuplicateFrameworkReferences>
-
-    <ItemGroup>
-      <FrameworkReference Remove="@(_FrameworkReferenceToRemove)" />
-      <FrameworkReference Include="@(_FrameworkReferenceToAdd)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <EnableTargetingPackDownload Condition="'$(EnableTargetingPackDownload)' == ''">true</EnableTargetingPackDownload>
-      <EnableRuntimePackDownload Condition="'$(EnableRuntimePackDownload)' == ''">true</EnableRuntimePackDownload>
-      <RequiresAspNetWebAssets Condition="'$(RequiresAspNetWebAssets)' == ''">false</RequiresAspNetWebAssets>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_NuGetRestoreSupported Condition="('$(Language)' == 'C++' and '$(_EnablePackageReferencesInVCProjects)' != 'true')">false</_NuGetRestoreSupported>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_PackAsToolShimRuntimeIdentifiers Condition="@(_PackAsToolShimRuntimeIdentifiers) ==''" Include="$(PackAsToolShimRuntimeIdentifiers)"/>
-    </ItemGroup>
-  </Target>
-
-  <!--
-    Refactored implementation that calls sub-targets.
-    -->
-  <Target Name="_ProcessFrameworkReferencesRefactored"
-          Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'"
-          DependsOnTargets="_ValidateWindowsOnlyFrameworks;
-                           _CreateTargetingPackItems;
-                           _ResolveRuntimePacksForAdditionalRIDs;
-                           _ResolveCrossgen2Packs;
-                           _ResolveILCompilerPacks;
-                           _ResolveILLinkPack;
-                           _ResolveWebAssemblySdkPack;
-                           _ResolveAspNetCorePack;
-                           _CreateRuntimeFrameworkItems;
-                           _CreateKnownRuntimeIdentifierPlatforms">
-    <!-- All work done in dependencies -->
-  </Target>
-
-  <!--
-    Original monolithic task implementation (fallback).
-    -->
-  <Target Name="_ProcessFrameworkReferencesOriginal" Condition="'$(UseRefactoredFrameworkReferenceResolution)' == 'false'" >
+    <!-- ============================================================
+         BEGIN ORIGINAL TASK IMPLEMENTATION
+         ============================================================ -->
     <ProcessFrameworkReferences FrameworkReferences="@(FrameworkReference)"
                                 KnownFrameworkReferences="@(KnownFrameworkReference)"
                                 KnownRuntimePacks="@(KnownRuntimePack)"
@@ -760,7 +670,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 NETCoreSdkPortableRuntimeIdentifier="$(NETCoreSdkPortableRuntimeIdentifier)"
                                 NetCoreRoot="$(NetCoreRoot)"
-                                NETCoreSdkVersion="$(NETCoreSdkVersion)">
+                                NETCoreSdkVersion="$(NETCoreSdkVersion)"
+                                Condition="'$(UseRefactoredFrameworkReferenceResolution)' == 'false'">
 
       <Output TaskParameter="PackagesToDownload" ItemName="_PackageToDownload" />
       <Output TaskParameter="RuntimeFrameworks" ItemName="RuntimeFramework" />
@@ -774,9 +685,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="KnownRuntimeIdentifierPlatforms" ItemName="_KnownRuntimeIdentifierPlatformsForTargetFramework" />
 
     </ProcessFrameworkReferences>
-  </Target>
+    <!-- ============================================================
+         END ORIGINAL TASK IMPLEMENTATION
+         ============================================================ -->
 
-  <Target Name="_ResolveAppHosts">
+    <!-- ============================================================
+         BEGIN INLINED _ResolveAppHosts
+         ============================================================ -->
     <PropertyGroup Condition="'$(AppHostRuntimeIdentifier)' == '' And
                               ('$(UseAppHost)' == 'true' Or '$(EnableComHosting)' == 'true' Or '$(UseIJWHost)' == 'true')">
       <AppHostRuntimeIdentifier>$(RuntimeIdentifier)</AppHostRuntimeIdentifier>
@@ -807,12 +722,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="IjwHost" ItemName="IjwHostPack" />
       <Output TaskParameter="PackAsToolShimAppHostPacks" ItemName="PackAsToolShimAppHostPack" />
     </ResolveAppHosts>
-  </Target>
-
-  <Target Name="ProcessFrameworkReferences"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CollectPackageReferences;CollectPackageDownloads"
-          DependsOnTargets="_ComputeTargetLatestRuntimePatch;AddWindowsSdkKnownFrameworkReferences;_ProcessFrameworkReferencesComputeProperties;_ProcessFrameworkReferencesRefactored;_ProcessFrameworkReferencesOriginal;_ResolveAppHosts;"
-          Condition="'@(FrameworkReference)' != '' Or '$(_RequiresILLinkPack)' == 'true'">
+    <!-- ============================================================
+         END INLINED _ResolveAppHosts
+         ============================================================ -->
 
     <PropertyGroup Condition="'$(UsePackageDownload)' == ''">
       <UsePackageDownload Condition="'$(MSBuildRuntimeType)' == 'Core'">true</UsePackageDownload>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -148,47 +148,34 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Filter applicable framework references from _FilterApplicableFrameworkReferences -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- Parse TargetFramework into components and filter KnownFrameworkReferences -->
-      <_KnownFrameworkReferenceMatchingTFI Include="@(KnownFrameworkReference)"
-        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
+      <!-- Filter by TFM and platform - name filtering happens in subsequent JoinItems -->
+      <_ApplicableKnownFrameworkReference Include="@(KnownFrameworkReference)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '$(TargetFrameworkIdentifier)' AND
+                   $([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(KnownFrameworkReference.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)')) AND
+                   ('$(TargetPlatformIdentifier)' == '' OR
+                    $([MSBuild]::GetTargetPlatformIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '' OR
+                    $([MSBuild]::GetTargetPlatformIdentifier('%(KnownFrameworkReference.TargetFramework)')) == '$(TargetPlatformIdentifier)') AND
+                   ('$(TargetPlatformVersion)' == '' OR
+                    $([MSBuild]::GetTargetPlatformVersion('%(KnownFrameworkReference.TargetFramework)', 2)) == '' OR
+                    $([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(KnownFrameworkReference.TargetFramework)', 2)), '$(TargetPlatformVersion)')))" />
 
-      <!-- Filter by TFM version using VersionEquals for normalization -->
-      <_ApplicableKnownFrameworkReference Include="@(_KnownFrameworkReferenceMatchingTFI)"
-        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownFrameworkReferenceMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-
-      <!-- Parse platform identifier from TargetFramework and filter if both are specified -->
-      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
-        Condition="'$(TargetPlatformIdentifier)' != '' AND
-                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownFrameworkReference.TargetFramework)')) != '' AND
-                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownFrameworkReference.TargetFramework)')) != '$(TargetPlatformIdentifier)'" />
-
-      <!-- Parse platform version from TargetFramework and filter if both are specified (using VersionEquals) -->
-      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)"
-        Condition="'$(TargetPlatformVersion)' != '' AND
-                   $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)) != '' AND
-                   !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownFrameworkReference.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
-
-      <!-- Same filtering for KnownRuntimePacks -->
-      <_KnownRuntimePackMatchingTFI Include="@(KnownRuntimePack)"
-        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownRuntimePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)'" />
-
-      <_ApplicableKnownRuntimePack Include="@(_KnownRuntimePackMatchingTFI)"
-        Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownRuntimePackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-
-      <_ApplicableKnownRuntimePack Remove="@(_ApplicableKnownRuntimePack)"
-        Condition="'$(TargetPlatformIdentifier)' != '' AND
-                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownRuntimePack.TargetFramework)')) != '' AND
-                   $([MSBuild]::GetTargetPlatformIdentifier('%(_ApplicableKnownRuntimePack.TargetFramework)')) != '$(TargetPlatformIdentifier)'" />
-
-      <_ApplicableKnownRuntimePack Remove="@(_ApplicableKnownRuntimePack)"
-        Condition="'$(TargetPlatformVersion)' != '' AND
-                   $([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)) != '' AND
-                   !$([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(_ApplicableKnownRuntimePack.TargetFramework)', 2)), '$(TargetPlatformVersion)'))" />
+      <!-- Filter by TFM and platform - name filtering happens in subsequent JoinItems -->
+      <_ApplicableKnownRuntimePack Include="@(KnownRuntimePack)"
+        Condition="$([MSBuild]::GetTargetFrameworkIdentifier('%(KnownRuntimePack.TargetFramework)')) == '$(TargetFrameworkIdentifier)' AND
+                   $([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(KnownRuntimePack.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)')) AND
+                   ('$(TargetPlatformIdentifier)' == '' OR
+                    $([MSBuild]::GetTargetPlatformIdentifier('%(KnownRuntimePack.TargetFramework)')) == '' OR
+                    $([MSBuild]::GetTargetPlatformIdentifier('%(KnownRuntimePack.TargetFramework)')) == '$(TargetPlatformIdentifier)') AND
+                   ('$(TargetPlatformVersion)' == '' OR
+                    $([MSBuild]::GetTargetPlatformVersion('%(KnownRuntimePack.TargetFramework)', 2)) == '' OR
+                    $([MSBuild]::VersionEquals($([MSBuild]::GetTargetPlatformVersion('%(KnownRuntimePack.TargetFramework)', 2)), '$(TargetPlatformVersion)')))" />
     </ItemGroup>
 
-    <!-- Join framework references with known data from _JoinFrameworkReferencesWithKnownData -->
+    <!-- Join framework references with known data - joins on Identity to filter by framework name -->
     <JoinItems Left="@(_ApplicableKnownFrameworkReference)"
                Right="@(FrameworkReference)"
+               LeftKey="Identity"
+               RightKey="Identity"
                LeftMetadata="*"
                RightMetadata="IsImplicitlyDefined;PrivateAssets;Pack"
                ItemSpecToUse="Left"
@@ -202,10 +189,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         <WasReferencedDirectly>true</WasReferencedDirectly>
       </_JoinedFrameworkReference>
 
-      <!-- Also include framework references without user reference if not disabling transitive -->
-      <_UnreferencedKnownFrameworkReference Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'" Include="@(_ApplicableKnownFrameworkReference)"
-        Exclude="@(_JoinedFrameworkReference)" />
-      <_JoinedFrameworkReference Condition="'$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'" Include="@(_UnreferencedKnownFrameworkReference)" />
+      <!-- Filter _ApplicableKnownFrameworkReference to only those with matching FrameworkReference -->
+      <_FilteredApplicableKnownFrameworkReference Include="@(_ApplicableKnownFrameworkReference)"
+        Condition="'%(_ApplicableKnownFrameworkReference.Identity)' == '%(_JoinedFrameworkReference.Identity)'" />
+
+      <!-- Replace _ApplicableKnownFrameworkReference with filtered version -->
+      <_ApplicableKnownFrameworkReference Remove="@(_ApplicableKnownFrameworkReference)" />
+      <_ApplicableKnownFrameworkReference Include="@(_FilteredApplicableKnownFrameworkReference)" />
     </ItemGroup>
 
     <!-- Validate Windows-only frameworks from _ValidateWindowsOnlyFrameworks -->
@@ -244,49 +234,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                    ('%(_CandidateRuntimePack.RuntimePackLabels)' == '' AND '%(_CandidateRuntimePack.RequiredRuntimePackLabels)' == '')" />
     </ItemGroup>
 
-    <!-- Create targeting pack items from _CreateTargetingPackItems -->
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <_TargetingPack Include="@(_JoinedFrameworkReference)" KeepMetadata="Profile;WasReferencedDirectly;TargetFramework;TargetingPackFormat;RuntimeFrameworkName;TargetingPackName;TargetingPackVersion" />
-      <_TargetingPack>
-        <NuGetPackageId>%(_TargetingPack.TargetingPackName)</NuGetPackageId>
-        <NuGetPackageVersion>%(_TargetingPack.TargetingPackVersion)</NuGetPackageVersion>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)</PackageDirectory>
-      </_TargetingPack>
-      <_TargetingPack>
-        <Path>%(_TargetingPack.PackageDirectory)</Path>
-      </_TargetingPack>
-      <TargetingPack Include="@(_TargetingPack)" />
-      <_TargetingPack Remove="@(_TargetingPack)" />
-    </ItemGroup>
-
-    <!-- Add targeting packs to download list if not found locally and downloads enabled -->
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND '$(EnableTargetingPackDownload)' == 'true'">
-      <_TargetingPackPackage
-        Include="@(TargetingPack->'%(NuGetPackageId)')"
-        KeepDuplicates="false"
-        KeepMetadata="NuGetPackageVersion;WasReferencedDirectly"
-        Version="%(TargetingPack.NuGetPackageVersion)"
-        Condition= "'%(TargetingPack.WasReferencedDirectly)' == 'true' OR '$(DisableTransitiveFrameworkReferenceDownloads)' != 'true'"/>
-      <_PackageToDownload Include="@(_TargetingPackPackage)" KeepMetadata="Version" />
-    </ItemGroup>
-
-    <!-- Build PackageConflictPreferredPackages list -->
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <_PreferredPackage Include="%(TargetingPack.NuGetPackageId)" />
-      <_PreferredPackage Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <_PackageConflictPreferredPackages>@(_PreferredPackage, ';')</_PackageConflictPreferredPackages>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <TargetingPack>
-        <PackageConflictPreferredPackages>$(_PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
-      </TargetingPack>
-      <_PreferredPackage Remove="@(_PreferredPackage)" />
-    </ItemGroup>
-
     <!-- Resolve runtime packs for primary RID from _ResolveRuntimePacksForPrimaryRID -->
     <PickBestRid RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                  TargetRid="$(_EffectiveRuntimeIdentifier)"
@@ -298,7 +245,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="MatchingRid" ItemName="_PrimaryMatchedRid" />
     </PickBestRid>
 
-    <!-- Create RuntimePack items by substituting **RID** in pattern with matched RID -->
+    <!-- Prepare intermediate runtime pack data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
                           '$(_EffectiveRuntimeIdentifier)' != ''">
@@ -309,31 +256,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <IsTrimmable>%(_MatchedRuntimePack.IsTrimmable)</IsTrimmable>
         <RuntimePackAlwaysCopyLocal>%(_MatchedRuntimePack.RuntimePackAlwaysCopyLocal)</RuntimePackAlwaysCopyLocal>
       </_RuntimePackWithRid>
-
-      <!-- Substitute **RID** placeholder -->
-      <_RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
-        <NuGetPackageId>%(_RuntimePack.Identity)</NuGetPackageId>
-        <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
-        <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
-        <RuntimePackAlwaysCopyLocal Condition="'%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)' == 'true'">true</RuntimePackAlwaysCopyLocal>
-        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)')">$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)</PackageDirectory>
-      </_RuntimePack>
-      <_RuntimePack>
-        <Path>%(_RuntimePack.PackageDirectory)</Path>
-      </_RuntimePack>
-      <RuntimePack Include="@(_RuntimePack)" />
-      <_RuntimePack Remove="@(_RuntimePack)" />
-    </ItemGroup>
-
-    <!-- Add to download list if not found locally -->
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
-                          '$(_EffectiveRuntimeIdentifier)' != '' AND
-                          '$(EnableRuntimePackDownload)' == 'true'">
-      <_PackageToDownload Include="@(RuntimePack)"
-        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(RuntimePack.NuGetPackageId)\%(RuntimePack.NuGetPackageVersion)')">
-        <Version>%(RuntimePack.NuGetPackageVersion)</Version>
-      </_PackageToDownload>
     </ItemGroup>
 
     <!-- Resolve runtime packs for additional RIDs from _ResolveRuntimePacksForAdditionalRIDs -->
@@ -400,6 +322,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="MatchingRid" ItemName="_Crossgen2HostRid" />
     </PickBestRid>
 
+    <!-- Prepare Crossgen2 pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishReadyToRun)' == 'true' AND
                           '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
@@ -413,19 +336,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_Crossgen2Pack>
         <Path>%(_Crossgen2Pack.PackageDirectory)</Path>
       </_Crossgen2Pack>
-      <Crossgen2Pack Include="@(_Crossgen2Pack)" />
-      <_Crossgen2Pack Remove="@(_Crossgen2Pack)" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                          '$(PublishReadyToRun)' == 'true' AND
-                          '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
-                          '$(EnableRuntimePackDownload)' == 'true' AND
-                          '@(Crossgen2Pack)' != ''">
-      <_PackageToDownload Include="@(Crossgen2Pack)"
-        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(Crossgen2Pack.NuGetPackageId)\%(Crossgen2Pack.NuGetPackageVersion)')">
-        <Version>%(Crossgen2Pack.NuGetPackageVersion)</Version>
-      </_PackageToDownload>
     </ItemGroup>
 
     <!-- Resolve ILCompiler packs from _ResolveILCompilerPacks -->
@@ -447,6 +357,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="MatchingRid" ItemName="_ILCompilerHostRid" />
     </PickBestRid>
 
+    <!-- Prepare host ILCompiler pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishAot)' == 'true' AND
                           '@(_ILCompilerHostRid)' != ''">
@@ -459,8 +370,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_HostILCompilerPack>
         <Pack>%(_HostILCompilerPack.Identity)</Pack>
       </_HostILCompilerPack>
-      <HostILCompilerPack Include="@(_HostILCompilerPack)" />
-      <_HostILCompilerPack Remove="@(_HostILCompilerPack)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
@@ -493,6 +402,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         Condition="'%(_UniqueILCompilerTargetRid.Identity)' != '%(_ILCompilerHostRid.Identity)'" />
     </ItemGroup>
 
+    <!-- Prepare target ILCompiler pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
                           '$(PublishAot)' == 'true' AND
                           '@(_DistinctILCompilerTargetRid)' != ''">
@@ -505,17 +415,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_TargetILCompilerPack>
         <Pack>%(_TargetILCompilerPack.Identity)</Pack>
       </_TargetILCompilerPack>
-      <TargetILCompilerPack Include="@(_TargetILCompilerPack)" />
-      <_TargetILCompilerPack Remove="@(_TargetILCompilerPack)" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
-                          '$(PublishAot)' == 'true' AND
-                          '$(EnableRuntimePackDownload)' == 'true'">
-      <_PackageToDownload Include="@(HostILCompilerPack);@(TargetILCompilerPack)"
-        Condition="!Exists('$(NetCoreTargetingPackRoot)\%(NuGetPackageId)\%(NuGetPackageVersion)')">
-        <Version>%(NuGetPackageVersion)</Version>
-      </_PackageToDownload>
     </ItemGroup>
 
     <!-- Resolve ILLink pack from _ResolveILLinkPack -->
@@ -526,10 +425,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ApplicableILLinkPack Include="@(_KnownILLinkPackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownILLinkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-
-      <_ImplicitPackageReference Condition="'@(_ApplicableILLinkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableILLinkPack)">
-        <Version>%(ILLinkPackVersion)</Version>
-      </_ImplicitPackageReference>
     </ItemGroup>
 
     <!-- Resolve WebAssembly SDK pack from _ResolveWebAssemblySdkPack -->
@@ -540,10 +435,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ApplicableWebAssemblySdkPack Include="@(_KnownWebAssemblySdkPackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownWebAssemblySdkPackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-
-      <_PackageToDownload Condition="'@(_ApplicableWebAssemblySdkPack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableWebAssemblySdkPack)">
-        <Version>%(WebAssemblySdkPackVersion)</Version>
-      </_PackageToDownload>
     </ItemGroup>
 
     <!-- Resolve ASP.NET Core pack from _ResolveAspNetCorePack -->
@@ -555,25 +446,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_ApplicableAspNetCorePack Include="@(_KnownAspNetCorePackMatchingTFI)"
         Condition="$([MSBuild]::VersionEquals($([MSBuild]::GetTargetFrameworkVersion('%(_KnownAspNetCorePackMatchingTFI.TargetFramework)', 2)), '$(_TargetFrameworkVersionWithoutV)'))" />
-
-      <_PackageToDownload Condition="'@(_ApplicableAspNetCorePack)' != '' AND '$(EnableRuntimePackDownload)' == 'true'" Include="@(_ApplicableAspNetCorePack)">
-        <Version>%(_ApplicableAspNetCorePack.AspNetCorePackVersion)</Version>
-      </_PackageToDownload>
     </ItemGroup>
 
-    <!-- Create RuntimeFramework items from _CreateRuntimeFrameworkItems -->
-    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- Only create RuntimeFramework items for frameworks that aren't always copy-local -->
-      <RuntimeFramework Include="@(_JoinedFrameworkReference)"
-        Condition="'%(_JoinedFrameworkReference.RuntimePackAlwaysCopyLocal)' != 'true' AND
-                   '%(_JoinedFrameworkReference.RuntimeFrameworkName)' != ''"
-        KeepMetadata="Profile">
-        <Version>%(_JoinedFrameworkReference.DefaultRuntimeFrameworkVersion)</Version>
-        <FrameworkName>%(_JoinedFrameworkReference.Identity)</FrameworkName>
-      </RuntimeFramework>
-    </ItemGroup>
-
-    <!-- Create known runtime identifier platforms from _CreateKnownRuntimeIdentifierPlatforms -->
+    <!-- Compute known runtime identifier platforms from _CreateKnownRuntimeIdentifierPlatforms -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
       <!-- Get all Microsoft.NETCore.App runtime packs and framework references for this target framework -->
       <_NetCoreAppRuntimePack Include="@(_ApplicableKnownFrameworkReference);@(_ApplicableKnownRuntimePack)"
@@ -604,14 +479,223 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <RemoveDuplicates Inputs="@(_RuntimeIdentifierPlatform)"
                       Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <Output TaskParameter="Filtered" ItemName="_KnownRuntimeIdentifierPlatformsForTargetFramework" />
+      <Output TaskParameter="Filtered" ItemName="_KnownRuntimeIdentifierPlatformsTemp" />
     </RemoveDuplicates>
 
-    <!-- Clean up intermediate items -->
+    <!-- Prepare targeting pack intermediate data -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_TargetingPack Include="@(_JoinedFrameworkReference)" KeepMetadata="Profile;WasReferencedDirectly;TargetFramework;TargetingPackFormat;RuntimeFrameworkName;TargetingPackName;TargetingPackVersion" />
+      <_TargetingPack>
+        <NuGetPackageId>%(_TargetingPack.TargetingPackName)</NuGetPackageId>
+        <NuGetPackageVersion>%(_TargetingPack.TargetingPackVersion)</NuGetPackageVersion>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)')">$(NetCoreTargetingPackRoot)\%(_TargetingPack.TargetingPackName)\%(_TargetingPack.TargetingPackVersion)</PackageDirectory>
+      </_TargetingPack>
+      <_TargetingPack>
+        <Path>%(_TargetingPack.PackageDirectory)</Path>
+      </_TargetingPack>
+    </ItemGroup>
+
+    <!-- Build PackageConflictPreferredPackages property -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PreferredPackage Include="%(_TargetingPack.NuGetPackageId)" />
+      <_PreferredPackage Include="@(_MatchedRuntimePack->'%(RuntimePackNamePatterns)')" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageConflictPreferredPackages>@(_PreferredPackage, ';')</_PackageConflictPreferredPackages>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_TargetingPack>
+        <PackageConflictPreferredPackages>$(_PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
+      </_TargetingPack>
+    </ItemGroup>
+
+    <!-- Prepare runtime pack intermediate data with complete metadata -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                          '$(_EffectiveRuntimeIdentifier)' != ''">
+      <!-- Substitute **RID** placeholder -->
+      <_RuntimePack Include="@(_RuntimePackWithRid->'%(Identity)'.Replace('**RID**', '%(MatchedRid)'))" KeepMetadata="FrameworkName;IsTrimmable">
+        <NuGetPackageId>%(_RuntimePack.Identity)</NuGetPackageId>
+        <NuGetPackageVersion>%(_RuntimePackWithRid.LatestVersion)</NuGetPackageVersion>
+        <RuntimeIdentifier>%(_RuntimePackWithRid.MatchedRid)</RuntimeIdentifier>
+        <RuntimePackAlwaysCopyLocal Condition="'%(_RuntimePackWithRid.RuntimePackAlwaysCopyLocal)' == 'true'">true</RuntimePackAlwaysCopyLocal>
+        <PackageDirectory Condition="Exists('$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)')">$(NetCoreTargetingPackRoot)\%(_RuntimePack.Identity)\%(_RuntimePackWithRid.LatestVersion)</PackageDirectory>
+      </_RuntimePack>
+      <_RuntimePack>
+        <Path>%(_RuntimePack.PackageDirectory)</Path>
+      </_RuntimePack>
+    </ItemGroup>
+
+    <!-- ============================================================
+         FINAL OUTPUT ITEMS CREATION
+         All outputs that match ProcessFrameworkReferences task outputs
+         ============================================================ -->
+
+    <!-- Output: RuntimeFramework -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <RuntimeFramework Include="@(_JoinedFrameworkReference)"
+        Condition="'%(_JoinedFrameworkReference.RuntimePackAlwaysCopyLocal)' != 'true' AND
+                   '%(_JoinedFrameworkReference.RuntimeFrameworkName)' != ''"
+        KeepMetadata="Profile">
+        <Version>%(_JoinedFrameworkReference.DefaultRuntimeFrameworkVersion)</Version>
+        <FrameworkName>%(_JoinedFrameworkReference.Identity)</FrameworkName>
+      </RuntimeFramework>
+    </ItemGroup>
+
+    <!-- Output: TargetingPack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <TargetingPack Include="@(_TargetingPack)" />
+    </ItemGroup>
+
+    <!-- Output: RuntimePack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <RuntimePack Include="@(_RuntimePack)" />
+    </ItemGroup>
+
+    <!-- Output: Crossgen2Pack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <Crossgen2Pack Include="@(_Crossgen2Pack)" />
+    </ItemGroup>
+
+    <!-- Output: HostILCompilerPack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <HostILCompilerPack Include="@(_HostILCompilerPack)" />
+    </ItemGroup>
+
+    <!-- Output: TargetILCompilerPack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <TargetILCompilerPack Include="@(_TargetILCompilerPack)" />
+    </ItemGroup>
+
+    <!-- Output: _ImplicitPackageReference (for ILLink pack) -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false' AND
+                          '@(_ApplicableILLinkPack)' != '' AND
+                          '$(EnableRuntimePackDownload)' == 'true'">
+      <_ImplicitPackageReference Include="@(_ApplicableILLinkPack)">
+        <Version>%(ILLinkPackVersion)</Version>
+      </_ImplicitPackageReference>
+    </ItemGroup>
+
+    <!-- Output: _KnownRuntimeIdentifierPlatformsForTargetFramework -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_KnownRuntimeIdentifierPlatformsForTargetFramework Include="@(_KnownRuntimeIdentifierPlatformsTemp)" />
+    </ItemGroup>
+
+    <!-- Output: _PackageToDownload (consolidated from all sources) -->
+
+    <!-- Targeting packs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_TargetingPackPackage
+        Include="@(TargetingPack->'%(NuGetPackageId)')"
+        KeepDuplicates="false"
+        KeepMetadata="NuGetPackageVersion;WasReferencedDirectly;NuGetPackageId"
+        Version="%(TargetingPack.NuGetPackageVersion)"
+        Condition="'$(EnableTargetingPackDownload)' == 'true' AND ('%(TargetingPack.WasReferencedDirectly)' == 'true' OR '$(DisableTransitiveFrameworkReferenceDownloads)' != 'true')"/>
+      <_PackageToDownload Include="@(_TargetingPackPackage)" KeepMetadata="Version" />
+    </ItemGroup>
+
+    <!-- Runtime packs for primary RID -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(RuntimePack)"
+        Condition="'$(_DeploymentRequiresRuntimeComponents)' == 'true' AND
+                   '$(_EffectiveRuntimeIdentifier)' != '' AND
+                   '$(EnableRuntimePackDownload)' == 'true' AND
+                   !Exists('$(NetCoreTargetingPackRoot)\%(RuntimePack.NuGetPackageId)\%(RuntimePack.NuGetPackageVersion)')">
+        <Version>%(RuntimePack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- Runtime packs for additional RIDs (already added at lines 295-297) -->
+
+    <!-- Crossgen2 packs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(Crossgen2Pack)"
+        Condition="'$(PublishReadyToRun)' == 'true' AND
+                   '$(PublishReadyToRunUseCrossgen2)' == 'true' AND
+                   '$(EnableRuntimePackDownload)' == 'true' AND
+                   '@(Crossgen2Pack)' != '' AND
+                   !Exists('$(NetCoreTargetingPackRoot)\%(Crossgen2Pack.NuGetPackageId)\%(Crossgen2Pack.NuGetPackageVersion)')">
+        <Version>%(Crossgen2Pack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- Host ILCompiler packs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(HostILCompilerPack)"
+        Condition="'$(PublishAot)' == 'true' AND
+                   '$(EnableRuntimePackDownload)' == 'true' AND
+                   !Exists('$(NetCoreTargetingPackRoot)\%(HostILCompilerPack.NuGetPackageId)\%(HostILCompilerPack.NuGetPackageVersion)')">
+        <Version>%(HostILCompilerPack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- Target ILCompiler packs -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(TargetILCompilerPack)"
+        Condition="'$(PublishAot)' == 'true' AND
+                   '$(EnableRuntimePackDownload)' == 'true' AND
+                   !Exists('$(NetCoreTargetingPackRoot)\%(TargetILCompilerPack.NuGetPackageId)\%(TargetILCompilerPack.NuGetPackageVersion)')">
+        <Version>%(TargetILCompilerPack.NuGetPackageVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- WebAssembly SDK pack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(_ApplicableWebAssemblySdkPack)"
+        Condition="'$(UsingMicrosoftNETSdkWebAssembly)' == 'true' AND
+                   '@(_ApplicableWebAssemblySdkPack)' != '' AND
+                   '$(EnableRuntimePackDownload)' == 'true'">
+        <Version>%(_ApplicableWebAssemblySdkPack.WebAssemblySdkPackVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- ASP.NET Core pack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_PackageToDownload
+        Include="@(_ApplicableAspNetCorePack)"
+        Condition="'$(RequiresAspNetWebAssets)' == 'true' AND
+                   $([MSBuild]::VersionGreaterThanOrEquals('$(_TargetFrameworkVersionWithoutV)', '10.0')) AND
+                   '@(_ApplicableAspNetCorePack)' != '' AND
+                   '$(EnableRuntimePackDownload)' == 'true'">
+        <Version>%(_ApplicableAspNetCorePack.AspNetCorePackVersion)</Version>
+      </_PackageToDownload>
+    </ItemGroup>
+
+    <!-- ============================================================
+         CLEANUP OF INTERMEDIATE ITEMS
+         ============================================================ -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <!-- Filtering intermediate items -->
+      <_KnownFrameworkReferenceMatchingTFI Remove="@(_KnownFrameworkReferenceMatchingTFI)" />
+      <_KnownFrameworkReferenceMatchingTFV Remove="@(_KnownFrameworkReferenceMatchingTFV)" />
+      <_KnownFrameworkReferenceMatchingPlatformId Remove="@(_KnownFrameworkReferenceMatchingPlatformId)" />
+      <_KnownFrameworkReferenceMatchingTFM Remove="@(_KnownFrameworkReferenceMatchingTFM)" />
+      <_KnownRuntimePackMatchingTFI Remove="@(_KnownRuntimePackMatchingTFI)" />
+      <_KnownRuntimePackMatchingTFV Remove="@(_KnownRuntimePackMatchingTFV)" />
+      <_KnownRuntimePackMatchingPlatformId Remove="@(_KnownRuntimePackMatchingPlatformId)" />
+      <_KnownRuntimePackMatchingTFM Remove="@(_KnownRuntimePackMatchingTFM)" />
+
+      <!-- Other intermediate items -->
+      <_TargetingPack Remove="@(_TargetingPack)" />
+      <_TargetingPackPackage Remove="@(_TargetingPackPackage)" />
+      <_PreferredPackage Remove="@(_PreferredPackage)" />
+      <_RuntimePack Remove="@(_RuntimePack)" />
+      <_RuntimePackWithRid Remove="@(_RuntimePackWithRid)" />
+      <_Crossgen2Pack Remove="@(_Crossgen2Pack)" />
+      <_HostILCompilerPack Remove="@(_HostILCompilerPack)" />
+      <_TargetILCompilerPack Remove="@(_TargetILCompilerPack)" />
       <_NetCoreAppRuntimePack Remove="@(_NetCoreAppRuntimePack)" />
       <_RuntimePackRid Remove="@(_RuntimePackRid)" />
       <_RuntimeIdentifierPlatform Remove="@(_RuntimeIdentifierPlatform)" />
+      <_DeduplicatedRuntimePackRid Remove="@(_DeduplicatedRuntimePackRid)" />
+      <_KnownRuntimeIdentifierPlatformsTemp Remove="@(_KnownRuntimeIdentifierPlatformsTemp)" />
     </ItemGroup>
 
     <!-- ============================================================

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -211,14 +211,37 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Select runtime packs by labels from _SelectRuntimePacksByLabels -->
-    <!-- Build up candidate runtime packs incrementally, one framework reference at a time -->
     <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
-      <!-- For each framework reference, find runtime packs matching its RuntimeFrameworkName -->
-      <_CandidateRuntimePack Include="@(_ApplicableKnownRuntimePack)"
-        Condition="'%(_ApplicableKnownRuntimePack.Identity)' == '%(_JoinedFrameworkReference.RuntimeFrameworkName)'"
-        KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
+      <!-- Add base runtime pack from framework reference itself (for unlabeled variants) -->
+      <_CandidateRuntimePack Include="@(_JoinedFrameworkReference)" KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
         <FrameworkReferenceName>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceName>
         <RequiredRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</RequiredRuntimePackLabels>
+      </_CandidateRuntimePack>
+    </ItemGroup>
+
+    <!-- Add labeled runtime pack variants from KnownRuntimePack -->
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_JoinedFrameworkReference>
+        <FrameworkReferenceIdentity>%(_JoinedFrameworkReference.Identity)</FrameworkReferenceIdentity>
+        <FrameworkReferenceRuntimePackLabels>%(_JoinedFrameworkReference.RuntimePackLabels)</FrameworkReferenceRuntimePackLabels>
+      </_JoinedFrameworkReference>
+    </ItemGroup>
+
+    <JoinItems Left="@(_ApplicableKnownRuntimePack)"
+               Right="@(_JoinedFrameworkReference)"
+               LeftKey="Identity"
+               RightKey="RuntimeFrameworkName"
+               LeftMetadata="*"
+               RightMetadata="FrameworkReferenceIdentity;FrameworkReferenceRuntimePackLabels"
+               ItemSpecToUse="Left"
+               Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <Output TaskParameter="JoinResult" ItemName="_CandidateRuntimePackRaw" />
+    </JoinItems>
+
+    <ItemGroup Condition="'$(UseRefactoredFrameworkReferenceResolution)' != 'false'">
+      <_CandidateRuntimePack Include="@(_CandidateRuntimePackRaw)" KeepMetadata="RuntimePackNamePatterns;RuntimePackRuntimeIdentifiers;RuntimePackExcludedRuntimeIdentifiers;LatestRuntimeFrameworkVersion;RuntimePackLabels;IsTrimmable;RuntimePackAlwaysCopyLocal">
+        <FrameworkReferenceName>%(_CandidateRuntimePackRaw.FrameworkReferenceIdentity)</FrameworkReferenceName>
+        <RequiredRuntimePackLabels>%(_CandidateRuntimePackRaw.FrameworkReferenceRuntimePackLabels)</RequiredRuntimePackLabels>
       </_CandidateRuntimePack>
     </ItemGroup>
 


### PR DESCRIPTION
This is an experiment to reimplement PFR in more MSBuild logic to help the debuggability of the Target.  At this point I believe I have parity, so I kicked this off to get CI feedback. Both mechanisms are implemented, so a simple boolean property swaps between them for comparison.

This does all of the things that the current PFR does, _and_ it fixes a bug where targeting packs and RID-specific runtime packs were downloaded for _every_ KnownFrameworkReference that matched the current TFM, not just the FrameworkReference items that the project actually _has_.

This can also be faster than the current PFR - in my binlogs comparing the new version to the old, it's common to have the old PFR be ~50ms and the new ~5ms.

