### PR TITLE
Adjust MTP exit code logic

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -85,7 +85,13 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         actionQueue.EnqueueCompleted();
         // Don't inline exitCode variable. We want to always call WaitAllActions first.
         var exitCode = actionQueue.WaitAllActions();
-        exitCode = _output.HasHandshakeFailure && exitCode == ExitCode.Success ? ExitCode.GenericFailure : exitCode;
+
+        // If all test apps exited with 0 exit code, but we detected that handshake didn't happen correctly, map that to generic failure.
+        if (exitCode == ExitCode.Success && _output.HasHandshakeFailure)
+        {
+            exitCode = ExitCode.GenericFailure;
+        }
+
         if (exitCode == ExitCode.Success &&
             parseResult.HasOption(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption) &&
             parseResult.GetValue(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption) is { } minimumExpectedTests &&

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -85,7 +85,7 @@ internal partial class MicrosoftTestingPlatformTestCommand : Command, ICustomHel
         actionQueue.EnqueueCompleted();
         // Don't inline exitCode variable. We want to always call WaitAllActions first.
         var exitCode = actionQueue.WaitAllActions();
-        exitCode = _output.HasHandshakeFailure ? ExitCode.GenericFailure : exitCode;
+        exitCode = _output.HasHandshakeFailure && exitCode == ExitCode.Success ? ExitCode.GenericFailure : exitCode;
         if (exitCode == ExitCode.Success &&
             parseResult.HasOption(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption) &&
             parseResult.GetValue(MicrosoftTestingPlatformOptions.MinimumExpectedTestsOption) is { } minimumExpectedTests &&


### PR DESCRIPTION
Related to #52107

But this won't change the behavior described there. This PR will only cause exit code to be transformed to generic failure only in case it would have been a success otherwise.

But if all test apps exited with the same non-success exit code, we will preserve that.