### PR TITLE
[MTP dotnet test]: Allow specifying project, solution, directory, or test modules as positional argument

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -101,6 +101,8 @@ internal static class MSBuildUtility
     {
         LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
 
+        var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(otherArgs);
+
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(TestCommandParser.GetCommand())
             .Concat(binLogArgs);
 
@@ -122,9 +124,19 @@ internal static class MSBuildUtility
             diagnosticOutputDirectory = Path.GetFullPath(diagnosticOutputDirectory);
         }
 
+        var projectOrSolutionOptionValue = parseResult.GetValue(MicrosoftTestingPlatformOptions.ProjectOrSolutionOption);
+        var testModulesFilterOptionValue = parseResult.GetValue(MicrosoftTestingPlatformOptions.TestModulesFilterOption);
+
+        if ((projectOrSolutionOptionValue is not null && positionalProjectOrSolution is not null) ||
+            testModulesFilterOptionValue is not null && positionalTestModules is not null)
+        {
+            throw new GracefulException(CliCommandStrings.CmdMultipleBuildPathOptionsErrorDescription);
+        }
+
         PathOptions pathOptions = new(
-            parseResult.GetValue(MicrosoftTestingPlatformOptions.ProjectOrSolutionOption),
+            positionalProjectOrSolution ?? parseResult.GetValue(MicrosoftTestingPlatformOptions.ProjectOrSolutionOption),
             parseResult.GetValue(MicrosoftTestingPlatformOptions.SolutionOption),
+            positionalTestModules ?? parseResult.GetValue(MicrosoftTestingPlatformOptions.TestModulesFilterOption),
             resultsDirectory,
             configFile,
             diagnosticOutputDirectory);
@@ -139,6 +151,82 @@ internal static class MSBuildUtility
             otherArgs,
             msbuildArgs);
     }
+
+    private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(List<string> otherArgs)
+    {
+        string? positionalProjectOrSolution = null;
+        string? positionalTestModules = null;
+
+        // In case there is a valid case, users can opt-out.
+        // Note that the validation here is added to have a "better" error message for scenarios that will already fail.
+        // So, disabling validation is okay if the user scenario is valid.
+        bool throwOnUnexpectedFilePassedAsNonFirstPositionalArgument = Environment.GetEnvironmentVariable("DOTNET_TEST_DISABLE_SWITCH_VALIDATION") is not ("true" or "1");
+
+        for (int i = 0; i < otherArgs.Count; i++)
+        {
+            var token = otherArgs[i];
+            if ((token.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+                token.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
+            {
+                if (i == 0)
+                {
+                    positionalProjectOrSolution = token;
+                    otherArgs.RemoveAt(0);
+                    break;
+                }
+                else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
+                {
+                    throw new GracefulException(CliCommandStrings.TestCommandUseSolution);
+                }
+            }
+            else if ((token.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
+                     token.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase) ||
+                     token.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
+            {
+                if (i == 0)
+                {
+                    positionalProjectOrSolution = token;
+                    otherArgs.RemoveAt(0);
+                    break;
+                }
+                else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
+                {
+                    throw new GracefulException(CliCommandStrings.TestCommandUseProject);
+                }
+            }
+            else if ((token.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
+                      token.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) &&
+                     File.Exists(token))
+            {
+                if (i == 0)
+                {
+                    positionalTestModules = token;
+                    otherArgs.RemoveAt(0);
+                    break;
+                }
+                else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
+                {
+                    throw new GracefulException(CliCommandStrings.TestCommandUseTestModules);
+                }
+            }
+            else if (Directory.Exists(token))
+            {
+                if (i == 0)
+                {
+                    positionalTestModules = token;
+                    otherArgs.RemoveAt(0);
+                    break;
+                }
+                else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
+                {
+                    throw new GracefulException(CliCommandStrings.TestCommandUseDirectoryWithSwitch);
+                }
+            }
+        }
+
+        return (positionalProjectOrSolution, positionalTestModules);
+    }
+
 
     private static bool BuildOrRestoreProjectOrSolution(string filePath, BuildOptions buildOptions)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -166,6 +166,7 @@ internal static class MSBuildUtility
         {
             var token = otherArgs[i];
             if ((token.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+                token.EndsWith(".slnf", StringComparison.OrdinalIgnoreCase) ||
                 token.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
             {
                 if (i == 0)

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal record TestOptions(bool IsHelp, bool IsDiscovery, IReadOnlyDictionary<string, string> EnvironmentVariables);
 
-internal record PathOptions(string? ProjectOrSolutionPath, string? SolutionPath, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
+internal record PathOptions(string? ProjectOrSolutionPath, string? SolutionPath, string? TestModules, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 
 internal record BuildOptions(
     PathOptions PathOptions,
@@ -14,5 +14,5 @@ internal record BuildOptions(
     Utils.VerbosityOptions? Verbosity,
     bool NoLaunchProfile,
     bool NoLaunchProfileArguments,
-    List<string> UnmatchedTokens,
+    List<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs);

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -168,7 +168,7 @@ internal sealed class TestApplication(
             builder.Append($" {MicrosoftTestingPlatformOptions.DiagnosticOutputDirectoryOption.Name} {ArgumentEscaper.EscapeSingleArg(diagnosticOutputDirectoryPath)}");
         }
 
-        foreach (var arg in _buildOptions.UnmatchedTokens)
+        foreach (var arg in _buildOptions.TestApplicationArguments)
         {
             builder.Append($" {ArgumentEscaper.EscapeSingleArg(arg)}");
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
@@ -16,11 +16,9 @@ internal sealed class TestModulesFilterHandler(TestApplicationActionQueue action
     private readonly TestApplicationActionQueue _actionQueue = actionQueue;
     private readonly TerminalTestReporter _output = output;
 
-    public bool RunWithTestModulesFilter(ParseResult parseResult)
+    public bool RunWithTestModulesFilter(ParseResult parseResult, string testModules)
     {
         // If the module path pattern(s) was provided, we will use that to filter the test modules
-        string testModules = parseResult.GetValue(MicrosoftTestingPlatformOptions.TestModulesFilterOption)!;
-
         // If the root directory was provided, we will use that to search for the test modules
         // Otherwise, we will use the current directory
         string? rootDirectory = Directory.GetCurrentDirectory();

--- a/src/Cli/dotnet/Commands/Test/MTP/ValidationUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ValidationUtility.cs
@@ -11,30 +11,31 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal static class ValidationUtility
 {
-    public static void ValidateMutuallyExclusiveOptions(ParseResult parseResult)
+    public static void ValidateMutuallyExclusiveOptions(ParseResult parseResult, PathOptions pathOptions)
     {
-        ValidatePathOptions(parseResult);
-        ValidateOptionsIrrelevantToModulesFilter(parseResult);
+        ValidatePathOptions(parseResult, pathOptions);
 
-        static void ValidatePathOptions(ParseResult parseResult)
+        ValidateOptionsIrrelevantToModulesFilter(parseResult, pathOptions.TestModules);
+
+        static void ValidatePathOptions(ParseResult parseResult, PathOptions pathOptions)
         {
             var count = 0;
-            if (parseResult.HasOption(MicrosoftTestingPlatformOptions.TestModulesFilterOption))
+            if (pathOptions.TestModules is not null)
                 count++;
 
-            if (parseResult.HasOption(MicrosoftTestingPlatformOptions.SolutionOption))
+            if (pathOptions.SolutionPath is not null)
                 count++;
 
-            if (parseResult.HasOption(MicrosoftTestingPlatformOptions.ProjectOrSolutionOption))
+            if (pathOptions.ProjectOrSolutionPath is not null)
                 count++;
 
             if (count > 1)
                 throw new GracefulException(CliCommandStrings.CmdMultipleBuildPathOptionsErrorDescription);
         }
 
-        static void ValidateOptionsIrrelevantToModulesFilter(ParseResult parseResult)
+        static void ValidateOptionsIrrelevantToModulesFilter(ParseResult parseResult, string? testModules)
         {
-            if (!parseResult.HasOption(MicrosoftTestingPlatformOptions.TestModulesFilterOption))
+            if (testModules is null)
             {
                 return;
             }
@@ -93,47 +94,6 @@ internal static class ValidationUtility
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Validates that arguments requiring specific command-line switches are used correctly for Microsoft.Testing.Platform.
-    /// Provides helpful error messages when users provide file/directory arguments without proper switches.
-    /// </summary>
-    public static void ValidateSolutionOrProjectOrDirectoryOrModulesArePassedCorrectly(ParseResult parseResult)
-    {
-        if (Environment.GetEnvironmentVariable("DOTNET_TEST_DISABLE_SWITCH_VALIDATION") is "true" or "1")
-        {
-            // In case there is a valid case, users can opt-out.
-            // Note that the validation here is added to have a "better" error message for scenarios that will already fail.
-            // So, disabling validation is okay if the user scenario is valid.
-            return;
-        }
-
-        foreach (string token in parseResult.UnmatchedTokens)
-        {
-            // Check for .sln files
-            if ((token.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
-                token.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
-            {
-                throw new GracefulException(CliCommandStrings.TestCommandUseSolution);
-            }
-            else if ((token.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
-                     token.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase) ||
-                     token.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
-            {
-                throw new GracefulException(CliCommandStrings.TestCommandUseProject);
-            }
-            else if ((token.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
-                      token.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) &&
-                     File.Exists(token))
-            {
-                throw new GracefulException(CliCommandStrings.TestCommandUseTestModules);
-            }
-            else if (Directory.Exists(token))
-            {
-                throw new GracefulException(CliCommandStrings.TestCommandUseDirectoryWithSwitch);
-            }
-        }
     }
 
     private static bool ValidateSolutionPath(string solutionFileOrDirectory, [NotNullWhen(true)] out string? solutionFile)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -592,6 +592,25 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
         [Theory]
+        public void RunWithSolutionFilterAsFirstUnmatchedToken_ShouldWork(string configuration)
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithSharedProject", Guid.NewGuid().ToString()).WithSource();
+
+            string testSolutionFilterPath = "TestProjectsWithShared.slnf";
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute(testSolutionFilterPath,
+                                    TestCommandDefinition.ConfigurationOption.Name, configuration);
+
+            result.StdOut.Should().Contain("TestProject.dll");
+            result.StdOut.Should().NotContain("OtherTestProject.dll");
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
+        }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
         public void RunWithSolutionAndPlatformConfiguration_ShouldRespectPlatform(string configuration)
         {
             TestAsset testInstance = _testAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithPlatforms", Guid.NewGuid().ToString()).WithSource();

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testDir.Path)
-                .Execute(filename);
+                .Execute("--my-arg", filename);
 
             result.ExitCode.Should().NotBe(0);
             if (!TestContext.IsLocalized())
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testDir.Path)
-                .Execute("test_directory");
+                .Execute("--myarg", "test_directory");
 
             result.ExitCode.Should().NotBe(0);
             if (!TestContext.IsLocalized())
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testDir.Path)
-                .Execute("test.dll");
+                .Execute("--my-arg", "test.dll");
 
             result.ExitCode.Should().NotBe(0);
             if (!TestContext.IsLocalized())


### PR DESCRIPTION
This brings back the same behavior that was with VSTest, where we don't require `--project` and similar options for specifying what to test.

To limit the impact of this change, we only consider the first unmatched token.

This helps AI agents that always get confused and call MTP incorrectly.