### PR TITLE
[HotReloadAgent] Handle unsupported platform for `PosixSignalRegistration`

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.Host/StartupHook.cs
+++ b/src/BuiltInTools/HotReloadAgent.Host/StartupHook.cs
@@ -26,6 +26,7 @@ internal sealed class StartupHook
                                                        && !OperatingSystem.IsIOS()
                                                        && !OperatingSystem.IsTvOS()
                                                        && !OperatingSystem.IsBrowser();
+    private static readonly bool s_supportsPosixSignals = s_supportsConsoleColor;
 
 #if NET10_0_OR_GREATER
     private static PosixSignalRegistration? s_signalRegistration;
@@ -125,7 +126,7 @@ internal sealed class StartupHook
             [DllImport("kernel32.dll", SetLastError = true)]
             static extern bool SetConsoleCtrlHandler(Delegate? handler, bool add);
         }
-        else
+        else if (s_supportsPosixSignals)
         {
 #if NET10_0_OR_GREATER
             // Register a handler for SIGTERM to allow graceful shutdown of the application on Unix.


### PR DESCRIPTION
If running on Android, for example, you can get the following exception:

    01-14 10:46:37.635 28537 28537 F mono-rt : [ERROR] FATAL UNHANDLED EXCEPTION: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    01-14 10:46:37.635 28537 28537 F mono-rt :  ---> System.PlatformNotSupportedException: Operation is not supported on this platform.
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Runtime.InteropServices.PosixSignalRegistration.Register(PosixSignal signal, Action`1 handler)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Runtime.InteropServices.PosixSignalRegistration.Create(PosixSignal signal, Action`1 handler)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at StartupHook.RegisterSignalHandlers()
    01-14 10:46:37.635 28537 28537 F mono-rt :    at StartupHook.InitializeWithHttp(String processDir)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at StartupHook.Initialize()
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    01-14 10:46:37.635 28537 28537 F mono-rt :    --- End of inner exception stack trace ---
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.StartupHookProvider.CallStartupHook(StartupHookNameOrPath startupHook)
    01-14 10:46:37.635 28537 28537 F mono-rt :    at System.StartupHookProvider.ProcessStartupHooks(String diagnosticStartupHooks)

Just like in 79e5fa63a, `PosixSignalRegistration` APIs are decorated with:

    [UnsupportedOSPlatform("android")]
    [UnsupportedOSPlatform("browser")]
    [UnsupportedOSPlatform("ios")]
    [UnsupportedOSPlatform("tvos")]
    public static PosixSignalRegistration Create(PosixSignal signal, Action<PosixSignalContext> handler);

This is used for handling Ctrl+C, for example, which we'll likely implement a different way for mobile platforms.

For now, let's not run the `PlatformNotSupportedException`-throwing code on unsupported platforms.