### PR TITLE
Fix OmniSharp test failure

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -74,9 +74,6 @@ public class OmniSharpTests : SdkTests
 
             Directory.CreateDirectory(OmniSharpDirectory);
             Utilities.ExtractTarball(omniSharpTarballFile, OmniSharpDirectory, OutputHelper);
-
-            // Ensure the run script is executable (see https://github.com/OmniSharp/omnisharp-roslyn/issues/2547)
-            File.SetUnixFileMode($"{OmniSharpDirectory}/run", UnixFileMode.UserRead | UnixFileMode.UserExecute);
         }
     }
 }


### PR DESCRIPTION
OmniSharp tests fail with this error:

`System.IO.FileNotFoundException : Could not find file '/vmr/test/Microsoft.DotNet.SourceBuild.SmokeTests/bin/Release/net9.0/OmniSharpTests/run'.`

That's because I missed removing this code from the changes in https://github.com/dotnet/sdk/pull/52435.