### PR TITLE
Update version numbers for features 80, 90, and 100 for Jan release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,9 +33,9 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>22</VersionFeature80>
-    <VersionFeature90>11</VersionFeature90>
-    <VersionFeature100>1</VersionFeature100>
+    <VersionFeature80>23</VersionFeature80>
+    <VersionFeature90>12</VersionFeature90>
+    <VersionFeature100>2</VersionFeature100>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
We should update this ahead of the fork for preview 1.

Post fork, we'll need preview 1 to target the latest workload version for 10 but we don't do that in main.