### PR TITLE
Modify suppression file writing settings

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -140,11 +140,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
 
             xmlWriter.WriteComment(DiagnosticIdDocumentationComment);
             CreateXmlSerializer().Serialize(xmlWriter, orderedSuppressions);
-            writer.Flush(); // ensure XML is written
+            xmlWriter.Flush(); // ensure XML is written
 
             // Write a new line character at the end of the file as the suppression file often gets checked-in
             // and many repos configure `insert_final_newline=true` in their .editorconfig.
-            writer.WriteWhitespace(Environment.NewLine);
+            xmlWriter.WriteWhitespace(Environment.NewLine);
 
             // Callback for tests
             AfterWritingSuppressionsCallback(stream);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -144,8 +144,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
 
             // Write a new line character at the end of the file as the suppression file often gets checked-in
             // and many repos configure `insert_final_newline=true` in their .editorconfig.
-            byte[] newlineBytes = settings.Encoding.GetBytes(Environment.NewLine);
-            stream.Write(newlineBytes, 0, newlineBytes.Length);
+            writer.WriteWhitespace(Environment.NewLine);
 
             // Callback for tests
             AfterWritingSuppressionsCallback(stream);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -132,13 +132,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
             using Stream stream = GetWritableStream(suppressionOutputFile);
             XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings()
             {
-                Encoding = Encoding.UTF8,
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) // UTF-8, no BOM
                 ConformanceLevel = ConformanceLevel.Document,
                 Indent = true
             });
 
             xmlWriter.WriteComment(DiagnosticIdDocumentationComment);
             CreateXmlSerializer().Serialize(xmlWriter, orderedSuppressions);
+            writer.Flush(); // ensure XML is written
+
+            // Write a new line character at the end of the file as the suppression file often gets checked-in
+            // and many repos configure `insert_final_newline=true` in their .editorconfig.
+            byte[] newlineBytes = settings.Encoding.GetBytes(Environment.NewLine);
+            stream.Write(newlineBytes, 0, newlineBytes.Length);
+
+            // Callback for tests
             AfterWritingSuppressionsCallback(stream);
 
             return (true, orderedSuppressions);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Logging/SuppressionEngine.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging
             using Stream stream = GetWritableStream(suppressionOutputFile);
             XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings()
             {
-                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) // UTF-8, no BOM
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), // UTF-8, no BOM
                 ConformanceLevel = ConformanceLevel.Document,
                 Indent = true
             });


### PR DESCRIPTION
Updated XML writer settings to use UTF-8 without BOM and ensured a newline is written at the end of the suppression file.

This is due to feedback from @akoeplinger that aspnetcore configures their xml files to insert a final new line: https://github.com/dotnet/aspnetcore/blob/8f0cd0cfe7cc2729c8c7fee997ef53548afdfc17/.editorconfig#L20. Probably many other repos as well.

> According to the XML 1.0 specification, whitespace is permitted before and after the root element, meaning trailing newlines do not break the syntax or validity of the document

@ericstj what do you think?