### PR TITLE
Fix dotnet test hang when the test app process exits but a child process of it remains alive

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -83,7 +83,13 @@ internal sealed class TestApplication(
 
             // At this point, process already exited. Allow for 5 seconds to consume stdout/stderr.
             // We might not be able to consume all the output if the test app has exited but left a child process alive.
-            await Task.WhenAll(stdOutTask, stdErrTask).WaitAsync(TimeSpan.FromSeconds(5));
+            try
+            {
+                await Task.WhenAll(stdOutTask, stdErrTask).WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+            }
 
             var exitCode = process.ExitCode;
             _handler.OnTestProcessExited(exitCode, stdOutBuilder.ToString(), stdErrBuilder.ToString());

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -119,6 +119,7 @@ internal sealed class TestApplication(
     private static async Task WaitForExitWithoutOutputAsync(Process process)
     {
         // Mostly copied from WaitForExitAsync from dotnet/runtime, with adjustments to match our needs here.
+        // Basically, we don't want to wait for the output streams, and we also simplify logic around CancellationToken as we don't need to pass one.
         try
         {
             process.EnableRaisingEvents = true;

--- a/test/Microsoft.NET.TestFramework/Commands/SdkCommandSpec.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/SdkCommandSpec.cs
@@ -19,6 +19,8 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public bool RedirectStandardInput { get; set; }
 
+        public bool DisableOutputAndErrorRedirection { get; set; }
+
         private string EscapeArgs()
         {
             //  Note: this doesn't handle invoking .cmd files via "cmd /c" on Windows, which probably won't be necessary here

--- a/test/TestAssets/TestProjects/MTPChildProcessHangTest/MTPChildProcessHangTest.csproj
+++ b/test/TestAssets/TestProjects/MTPChildProcessHangTest/MTPChildProcessHangTest.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/MTPChildProcessHangTest/Program.cs
+++ b/test/TestAssets/TestProjects/MTPChildProcessHangTest/Program.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.TestFramework;

--- a/test/TestAssets/TestProjects/MTPChildProcessHangTest/Program.cs
+++ b/test/TestAssets/TestProjects/MTPChildProcessHangTest/Program.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+if (args.Length == 1 && args[0] == "hang")
+{
+    var @event = new ManualResetEvent(false);
+    @event.WaitOne();
+    return 0;
+}
+
+var builder = await TestApplication.CreateBuilderAsync(args);
+builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, _) => new MyTestFramework());
+using var testApp = await builder.BuildAsync();
+return await testApp.RunAsync();
+
+internal class MyTestFramework : ITestFramework
+{
+    public string Uid => nameof(MyTestFramework);
+    public string Version => "1.0.0";
+    public string DisplayName => nameof(MyTestFramework);
+    public string Description => DisplayName;
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+    {
+        return Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+    }
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        var fileName = Process.GetCurrentProcess().MainModule.FileName;
+        var p = Process.Start(new ProcessStartInfo(fileName, "hang")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        });
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        p.ErrorDataReceived += (sender, e) => { };
+        p.OutputDataReceived += (sender, e) => { };
+        context.Complete();
+        return Task.CompletedTask;
+    }
+    public Task<bool> IsEnabledAsync()
+        => Task.FromResult(true);
+}

--- a/test/TestAssets/TestProjects/MTPChildProcessHangTest/global.json
+++ b/test/TestAssets/TestProjects/MTPChildProcessHangTest/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -601,7 +601,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute(TestCommandDefinition.ConfigurationOption.Name, configuration);
 
-            result.ExitCode.Should().Be(8);
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -594,7 +594,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [Theory(Skip = "Works manually. The test here still hangs because the test infra redirects stdout/stderr and will be waiting for the hanging process.")]
         public void DotnetTest_MTPChildProcessHangTestProject_ShouldNotHang(string configuration)
         {
-            var testInstance = _testAssetsManager.CopyTestAsset("MTPChildProcessHangTest", Guid.NewGuid().ToString())
+            var testInstance = TestAssetsManager.CopyTestAsset("MTPChildProcessHangTest", Guid.NewGuid().ToString())
                 .WithSource();
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -599,7 +599,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testInstance.Path)
-                .Execute(TestCommandDefinition.ConfigurationOption.Name, configuration);
+                .Execute("-c", configuration);
 
             result.ExitCode.Should().Be(ExitCodes.ZeroTests);
         }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -588,5 +588,20 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
+
+        [InlineData(TestingConstants.Debug)]
+        [InlineData(TestingConstants.Release)]
+        [Theory]
+        public void DotnetTest_MTPChildProcessHangTestProject_ShouldNotHang(string configuration)
+        {
+            var testInstance = _testAssetsManager.CopyTestAsset("MTPChildProcessHangTest", Guid.NewGuid().ToString())
+                .WithSource();
+
+            var result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute(TestCommandDefinition.ConfigurationOption.Name, configuration);
+
+            result.ExitCode.Should().Be(8);
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -591,7 +591,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
-        [Theory]
+        [Theory(Skip = "Works manually. The test here still hangs because the test infra redirects stdout/stderr and will be waiting for the hanging process.")]
         public void DotnetTest_MTPChildProcessHangTestProject_ShouldNotHang(string configuration)
         {
             var testInstance = _testAssetsManager.CopyTestAsset("MTPChildProcessHangTest", Guid.NewGuid().ToString())

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -591,7 +591,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
         [InlineData(TestingConstants.Debug)]
         [InlineData(TestingConstants.Release)]
-        [Theory(Skip = "Works manually. The test here still hangs because the test infra redirects stdout/stderr and will be waiting for the hanging process.")]
+        [Theory]
         public void DotnetTest_MTPChildProcessHangTestProject_ShouldNotHang(string configuration)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MTPChildProcessHangTest", Guid.NewGuid().ToString())
@@ -599,6 +599,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testInstance.Path)
+                .WithDisableOutputAndErrorRedirection()
                 .Execute("-c", configuration);
 
             result.ExitCode.Should().Be(ExitCodes.ZeroTests);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -599,6 +599,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .WithWorkingDirectory(testInstance.Path)
+                // We need to disable output and error redirection so that the test infra doesn't
+                // hang because of a hanging child process that keeps out/err open.
                 .WithDisableOutputAndErrorRedirection()
                 .Execute("-c", configuration);
 


### PR DESCRIPTION
Fixes #51507