### PR TITLE
Add escape hatch for not setting a default PublishRuntimeIdentifier value.

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
@@ -127,7 +127,8 @@ Copyright (c) .NET Foundation. All rights reserved.
        then set a default value for PublishRuntimeIdentifier if RuntimeIdentifier isn't set.
        However, don't do this if we are packing a PackAsTool project, as the "outer" build should still be
        without a RuntimeIdentifier -->
-  <PropertyGroup Condition="'$(PublishRuntimeIdentifier)' == '' And
+  <PropertyGroup Condition="'$(UseDefaultPublishRuntimeIdentifier)' == '' And
+                            '$(PublishRuntimeIdentifier)' == '' And
                             '$(RuntimeIdentifier)' == '' And
                             '$(_IsExecutable)' == 'true' And
                             (
@@ -138,6 +139,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                               '$(PublishAot)' == 'true'
                             ) And
                             !('$(PackAsTool)' == 'true' And '$(_IsPacking)' == 'true')">
+    <UseDefaultPublishRuntimeIdentifier>true</UseDefaultPublishRuntimeIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseDefaultPublishRuntimeIdentifier)' == 'true'">
     <PublishRuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier)</PublishRuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
This adds an escape hatch (setting 'UseDefaultPublishRuntimeIdentifier=false') when trying to set a default PublishRuntimeIdentifier value.

This is necessary when publishing with RuntimeIdentifiers (plural), but without a RuntimeIdentifier, which is valid when building universal apps for macOS and Mac Catalyst (the netX-macos and netX-maccatalyst target frameworks).

When building such an app, the project file will set RuntimeIdentifiers (plural):

```xml
<TargetFramework>net11.0-macos</TargetFramework>
<RuntimeIdentifiers>osx-x64;osx-arm</RuntimeIdentifiers>
```

and then during build/publish, the macOS SDK will run two inner builds, with RuntimeIdentifiers unset, and RuntimeIdentifier set to each of the rids (and at the end merge the result into a single app).

The problem is that the outer build, where RuntimeIdentifiers is set, but RuntimeIdentifier isn't, PublishRuntimeIdentifier will now get a default value (after PR #51765), and that will set RuntimeIdentifier, which will confuse our outer build.

Also note that we can't set PublishRuntimeIdentifier to the desired runtime identifiers (plural), because PublishRuntimeIdentifier is only valid for a single runtime identifier.