### PR TITLE
Remove SourceBuild patches from inter-branch merge into 10.0

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -29,7 +29,7 @@
         "release/10.0.1xx":{
             "MergeToBranch": "release/10.0.2xx",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*,src/SourceBuild/*"
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*;src/SourceBuild/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.2xx to release/10.0.3xx
         "release/10.0.2xx":{

--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -23,13 +23,13 @@
         "release/9.0.3xx":{
             "MergeToBranch": "release/10.0.1xx",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*;src/SourceBuild/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.1xx to release/10.0.2xx
         "release/10.0.1xx":{
             "MergeToBranch": "release/10.0.2xx",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*;src/SourceBuild/*"
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.2xx to release/10.0.3xx
         "release/10.0.2xx":{

--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -29,7 +29,7 @@
         "release/10.0.1xx":{
             "MergeToBranch": "release/10.0.2xx",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*,src/SourceBuild/*"
         },
         // Automate opening PRs to merge sdk repos from release/10.0.2xx to release/10.0.3xx
         "release/10.0.2xx":{


### PR DESCRIPTION
These patches only apply to 9.0 and earlier. Needs https://github.com/dotnet/arcade/pull/16466