### PR TITLE
Fix COMException when VS setup configuration is not registered

### DIFF
--- a/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
@@ -108,7 +108,16 @@ internal static class VisualStudioWorkloads
         SdkFeatureBand? sdkFeatureBand = null,
         ISetupConfiguration2? setupConfiguration = null)
     {
-        setupConfiguration ??= GetSetupConfiguration();
+        try
+        {
+            setupConfiguration ??= GetSetupConfiguration();
+        }
+        catch (COMException e) when (e.ErrorCode == REGDB_E_CLASSNOTREG)
+        {
+            // Query API not registered, good indication there are no VS installations of 15.0 or later.
+            return;
+        }
+
         Dictionary<string, string> visualStudioWorkloadIds = GetAvailableVisualStudioWorkloads(workloadResolver);
         HashSet<string> installedWorkloadComponents = [];
 


### PR DESCRIPTION
The refactoring in #52438 moved the SetupConfiguration instantiation outside of the try/catch block that handled REGDB_E_CLASSNOTREG errors. This caused dotnet --info to fail on machines without Visual Studio.

Wrap GetSetupConfiguration() call in a try/catch to handle the case where VS COM classes are not registered.

Added unit tests to verify COMException handling for both REGDB_E_CLASSNOTREG (which should be handled gracefully) and other COM exceptions (which should propagate).