### PR TITLE
[wasm] Remove "UsingBlazorOrWasmSdk" condition from emscripten workload detection

### DIFF
--- a/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' != 'true'">
-    <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or !('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true')" >true</UsingBrowserRuntimeWorkload>
+    <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == '' and '$(RunAOTCompilation)' == 'true'">true</UsingBrowserRuntimeWorkload>
     <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
   </PropertyGroup>
 

--- a/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -34,7 +34,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
-    <SelfContained>true</SelfContained>
     <WasmNativeWorkloadAvailable Condition="'$(TargetsCurrent)' == 'true'">$(WasmNativeWorkload11)</WasmNativeWorkloadAvailable>
     <WasmNativeWorkloadAvailable Condition="'$(TargetsNet10)' == 'true'">$(WasmNativeWorkload10)</WasmNativeWorkloadAvailable>
     <WasmNativeWorkloadAvailable Condition="'$(TargetsNet9)' == 'true'">$(WasmNativeWorkload9)</WasmNativeWorkloadAvailable>


### PR DESCRIPTION
- Similar change to https://github.com/dotnet/sdk/pull/52250. Syncs workload manifest logic with dotnet/runtime#122607 and https://github.com/dotnet/runtime/pull/122607#issuecomment-3671806251, which enables browser-wasm library mode without requiring the workload.
- Remove `SelfContained=true` from WorkloadManifest. We set it for WasmSDK in https://github.com/dotnet/sdk/blob/main/src/WasmSdk/Sdk/Sdk.props#L19 and there is no requirement to have it set just for `RID=browser-wasm` lib
