### PR TITLE
Issue 13073 task migration nontrivial 3

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/CreateComHost.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CreateComHost.cs
@@ -8,8 +8,14 @@ using Microsoft.NET.HostModel.ComHost;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class CreateComHost : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class CreateComHost : TaskBase, IMultiThreadableTask
     {
+        /// <summary>
+        /// Gets or sets the task environment for thread-safe operations.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         [Required]
         public string ComHostSourcePath { get; set; }
 
@@ -37,10 +43,14 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
 
+                string comHostSourcePath = TaskEnvironment?.GetAbsolutePath(ComHostSourcePath) ?? ComHostSourcePath;
+                string comHostDestinationPath = TaskEnvironment?.GetAbsolutePath(ComHostDestinationPath) ?? ComHostDestinationPath;
+                string clsidMapPath = TaskEnvironment?.GetAbsolutePath(ClsidMapPath) ?? ClsidMapPath;
+
                 ComHost.Create(
-                    ComHostSourcePath,
-                    ComHostDestinationPath,
-                    ClsidMapPath,
+                    comHostSourcePath,
+                    comHostDestinationPath,
+                    clsidMapPath,
                     typeLibIdMap);
             }
             catch (TypeLibraryDoesNotExistException ex)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -13,8 +13,14 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Filters out the assemblies from the list based on a given package closure.
     /// </summary>
-    public class FilterResolvedFiles : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class FilterResolvedFiles : TaskBase, IMultiThreadableTask
     {
+        /// <summary>
+        /// Gets or sets the task environment for thread-safe operations.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         private readonly List<ITaskItem> _assembliesToPublish = new();
         private readonly List<ITaskItem> _packagesResolved = new();
 
@@ -52,7 +58,8 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             var lockFileCache = new LockFileCache(this);
-            LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
+            string assetsFilePath = TaskEnvironment?.GetAbsolutePath(AssetsFilePath) ?? AssetsFilePath;
+            LockFile lockFile = lockFileCache.GetLockFile(assetsFilePath);
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 TargetFramework,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRegFreeComManifest.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRegFreeComManifest.cs
@@ -8,8 +8,14 @@ using Microsoft.NET.HostModel.ComHost;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GenerateRegFreeComManifest : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GenerateRegFreeComManifest : TaskBase, IMultiThreadableTask
     {
+        /// <summary>
+        /// Gets or sets the task environment for thread-safe operations.
+        /// </summary>
+        public TaskEnvironment? TaskEnvironment { get; set; }
+
         [Required]
         public string IntermediateAssembly { get; set; }
 
@@ -40,12 +46,16 @@ namespace Microsoft.NET.Build.Tasks
                     return;
                 }
 
+                string intermediateAssemblyPath = TaskEnvironment?.GetAbsolutePath(IntermediateAssembly) ?? IntermediateAssembly;
+                string clsidMapPath = TaskEnvironment?.GetAbsolutePath(ClsidMapPath) ?? ClsidMapPath;
+                string comManifestPath = TaskEnvironment?.GetAbsolutePath(ComManifestPath) ?? ComManifestPath;
+
                 RegFreeComManifest.CreateManifestFromClsidmap(
                     Path.GetFileNameWithoutExtension(IntermediateAssembly),
                     ComHostName,
-                    FileUtilities.TryGetAssemblyVersion(IntermediateAssembly).ToString(),
-                    ClsidMapPath,
-                    ComManifestPath);
+                    FileUtilities.TryGetAssemblyVersion(intermediateAssemblyPath).ToString(),
+                    clsidMapPath,
+                    comManifestPath);
             }
             catch (TypeLibraryDoesNotExistException ex)
             {


### PR DESCRIPTION
for these tasks, path manipulation through TaskEnvironment should be enough

starting from updated main to avoid piling too many commits on top of each other. merging the previous ones still recommended to avoid overlaying the polyfill and other temporary dependencies.