### PR TITLE
Fix trusted root test layout

### DIFF
--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(ToolsetTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <CanRunTestAsTool>false</CanRunTestAsTool>
-    <OutputPath>$(TestHostFolder)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Trusted root was being built in the root folder with all it's dependencies leading to the zip layout to include things like xunit