### PR TITLE
Simplify XLF update workflow by removing fork check

### DIFF
--- a/.github/workflows/update-xlf-on-comment.yml
+++ b/.github/workflows/update-xlf-on-comment.yml
@@ -121,11 +121,6 @@ jobs:
               return;
             }
 
-            if (pr.data.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
-              core.setFailed('Pull request head branch is in a fork. Cannot update XLF files automatically.');
-              return;
-            }
-
             core.setOutput('head_ref', pr.data.head.ref);
 
   generate:


### PR DESCRIPTION
Removes the check for pull request head repo being a fork - we already check whether the commenter is an authorized contributor. Most of the time the branch should be on a fork. Also, only the main version of the action will run, so a fork can't try to do something malicious such as use the token from main on dotnet/sdk with a malicious workflow.