### PR TITLE
Ignore trailing/leading whitespace when validating sarif files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -516,6 +516,9 @@ dotnet_diagnostic.IDE0040.severity = warning
 [*.txt]
 insert_final_newline = false
 
+[*.sarif]
+insert_final_newline = false
+
 # Verify settings
 [*.{received,verified}.{txt,xml,json,sh,zsh,nu,fish,ps1}]
 charset = "utf-8-bom"

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -270,7 +270,7 @@ namespace GenerateDocumentationAndConfigFiles
                     fileContents =
                         $"""
                         <Project>
-                          <!-- 
+                          <!--
                             PropertyGroup to disable built-in analyzers from .NET SDK that have the identical CA rules to those implemented in this package.
                             This props file should only be present in the analyzer NuGet package, it should **not** be inserted into the .NET SDK.
                           -->
@@ -292,7 +292,7 @@ namespace GenerateDocumentationAndConfigFiles
                     {
                         return $"""
 
-                              <!-- 
+                              <!--
                                 This import includes an additional props file that disables built-in analyzers from .NET SDK that have the identical CA rules to those implemented in this package.
                                 This additional props file should only be present in the analyzer NuGet package, it should **not** be inserted into the .NET SDK.
                               -->
@@ -318,7 +318,7 @@ namespace GenerateDocumentationAndConfigFiles
                 var allRuleIds = string.Join(';', allRulesById.Keys);
                 return $"""
 
-                      <!-- 
+                      <!--
                         This property group handles 'CodeAnalysisTreatWarningsAsErrors = false' for the CA rule ids implemented in this package.
                       -->
                       <PropertyGroup>
@@ -1153,7 +1153,7 @@ namespace GenerateDocumentationAndConfigFiles
         private static void Validate(string fileWithPath, string fileContents, List<string> fileNamesWithValidationFailures)
         {
             string actual = File.ReadAllText(fileWithPath);
-            if (actual != fileContents)
+            if (actual.Trim() != fileContents.Trim())
             {
                 fileNamesWithValidationFailures.Add(fileWithPath);
             }
@@ -1560,7 +1560,7 @@ namespace GenerateDocumentationAndConfigFiles
                 {
                     builder.AppendLine($"""
 
-                          <!-- MSBuild properties to thread to the analyzers as options --> 
+                          <!-- MSBuild properties to thread to the analyzers as options -->
                           <ItemGroup>
                         """);
                     foreach (var compilerVisibleProperty in compilerVisibleProperties)


### PR DESCRIPTION
Some editor configs will automatically insert a newline on save. The sarif generator does not insert such a newline. This a meaningless difference in comparison, so ignore it to avoid failures in PR.