### PR TITLE
Add Sdk.BundledVersions.props

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
@@ -1,0 +1,21 @@
+<!--
+***********************************************************************************************
+Sdk.BundledVersions.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Imported by components that need the BundledVerisons.props information but don't import the entire Microsoft.NET.Sdk -->
+
+  <PropertyGroup Condition="'$(NETCoreSdkBundledVersionsProps)' == ''">
+    <NETCoreSdkBundledVersionsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledVersions.props</NETCoreSdkBundledVersionsProps>
+  </PropertyGroup>
+  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
+
+</Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
@@ -11,7 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Imported by components that need the BundledVerisons.props information but don't import the entire Microsoft.NET.Sdk -->
+  <!-- Imported by components that need the BundledVersions.props information but don't import the entire Microsoft.NET.Sdk -->
 
   <PropertyGroup Condition="'$(NETCoreSdkBundledVersionsProps)' == ''">
     <NETCoreSdkBundledVersionsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledVersions.props</NETCoreSdkBundledVersionsProps>


### PR DESCRIPTION
Needed to unblock https://github.com/dotnet/arcade/pull/16413 to workaround https://github.com/dotnet/msbuild/issues/12895 but in general offers a way to import BundledVersions.props information from projects that don't import the Microsoft.NET.Sdk.

---

The Arcade.Sdk will import this file conditionally:

```xml
<!-- Import the BundledVersions.props file from SDK to light-up Runtime="NET" task support. Remove when https://github.com/dotnet/msbuild/issues/12895 is implemented. -->
<Sdk Import="Microsoft.NET.Sdk" Project="Sdk.BundledVersions.props" Condition="'$(NETCoreSdkBundledVersionsProps)' == ''" />
```