### PR TITLE
Don't ignore .e2e/ directories in gitignore template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -128,6 +128,8 @@ ipch/
 
 # Visual Studio Trace Files
 *.e2e
+# but not directories ending in .e2e
+!*.e2e/
 
 # TFS 2012 Local Workspace
 $tf/

--- a/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -128,6 +128,8 @@ ipch/
 
 # Visual Studio Trace Files
 *.e2e
+# but not directories ending in .e2e
+!*.e2e/
 
 # TFS 2012 Local Workspace
 $tf/


### PR DESCRIPTION
Add a negation to avoid gitignore-ing *.e2e/ directories, as that's a common suffix for end-to-end test frameworks. Here's some in-the-wild examples today that would be impacted without this fix: https://github.com/search?q=path%3A.e2e%2F&type=code