### PR TITLE
Don't use the portable RIDs for older runtimes if it's empty

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -840,6 +840,8 @@ namespace Microsoft.NET.Build.Tasks
                 var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
                 var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 var packSupportedPortableRuntimeIdentifiers = knownPack.GetMetadata(packName + "PortableRuntimeIdentifiers").Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                // Use the non-portable RIDs if there are no portable RIDs defined.
+                packSupportedPortableRuntimeIdentifiers = packSupportedPortableRuntimeIdentifiers.Length > 0 ? packSupportedPortableRuntimeIdentifiers : packSupportedRuntimeIdentifiers;
 
                 // When publishing for a non-portable RID, prefer NETCoreSdkRuntimeIdentifier for the host.
                 // Otherwise prefer the NETCoreSdkPortableRuntimeIdentifier.
@@ -858,7 +860,6 @@ namespace Microsoft.NET.Build.Tasks
                 string? supportedPortableTargetRid = NuGetUtils.GetBestMatchingRid(runtimeGraph, runtimeIdentifier, packSupportedPortableRuntimeIdentifiers, out _);
 
                 bool usePortable = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier)
-                                    && packSupportedPortableRuntimeIdentifiers.Length > 0
                                     && supportedTargetRid == supportedPortableTargetRid;
 
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -838,8 +838,8 @@ namespace Microsoft.NET.Build.Tasks
             if (toolPackType is ToolPackType.Crossgen2 or ToolPackType.ILCompiler)
             {
                 var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
-                var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(';');
-                var packSupportedPortableRuntimeIdentifiers = knownPack.GetMetadata(packName + "PortableRuntimeIdentifiers").Split(';');
+                var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                var packSupportedPortableRuntimeIdentifiers = knownPack.GetMetadata(packName + "PortableRuntimeIdentifiers").Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
                 // When publishing for a non-portable RID, prefer NETCoreSdkRuntimeIdentifier for the host.
                 // Otherwise prefer the NETCoreSdkPortableRuntimeIdentifier.
@@ -853,14 +853,17 @@ namespace Microsoft.NET.Build.Tasks
                 // This also ensures that targeting common RIDs doesn't require any non-portable assets that aren't packaged in the SDK by default.
                 // Due to size concerns, the non-portable ILCompiler and Crossgen2 aren't included by default in non-portable SDK distributions.
                 var runtimeIdentifier = RuntimeIdentifier ?? RuntimeIdentifierForPlatformAgnosticComponents;
+
                 string? supportedTargetRid = NuGetUtils.GetBestMatchingRid(runtimeGraph, runtimeIdentifier, packSupportedRuntimeIdentifiers, out _);
                 string? supportedPortableTargetRid = NuGetUtils.GetBestMatchingRid(runtimeGraph, runtimeIdentifier, packSupportedPortableRuntimeIdentifiers, out _);
 
                 bool usePortable = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier)
+                                    && packSupportedPortableRuntimeIdentifiers.Length > 0
                                     && supportedTargetRid == supportedPortableTargetRid;
 
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
                 Log.LogMessage(MessageImportance.Low, $"Determining best RID for '{knownPack.ItemSpec}@{packVersion}' from among '{knownPack.GetMetadata(packName + "RuntimeIdentifiers")}'");
+
                 string? hostRuntimeIdentifier = usePortable
                     ? NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkPortableRuntimeIdentifier!, packSupportedPortableRuntimeIdentifiers, out _)
                     : NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkRuntimeIdentifier!, packSupportedRuntimeIdentifiers, out _);


### PR DESCRIPTION
Fixes #52565

NuGet Package Explorer is an unusual application where even when you publish with a RID set, it doesn't pass that RID into ProcessFrameworkReferences. In that case we default to `any`. Prior to #52407, we had a check that if our list of supported target rids came back empty, we'd default to non-portable but that doesn't work for source build publishing.

Portable rids were added into GenerateBundledVersions.targets starting in net10 known crossgen packs so if you target an older runtime and don't pass a RID into PFR, we'll end up trying to use the empty portable rid list. This is the simplest fix of going back to non-portable if we don't have that list. Alternatively, we could add portable rids to GBV.targets for all/most downlevel pack definitions but I don't know the impact that'll have.

CC @tmds @agocke 

@baronfel @dsplaisted we cannot take the backport of #52407 as is as it'll break scenarios like NPE. Do you know why the portable rid list and the non-portable RID list for 10+ are identical (trying to understand the point of separating them if they're the same)? Are they different in source built SDKs?