### PR TITLE
Add --format <json|text> option to `dotnet solution list` command

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2574,6 +2574,9 @@ To display a value, specify the corresponding command-line option without provid
   <data name="SolutionAddReferencedProjectsOptionDescription" xml:space="preserve">
     <value>Recursively add projects' ReferencedProjects to solution</value>
   </data>
+  <data name="SolutionListFormatOptionDescription" xml:space="preserve">
+    <value>The output format for the list of projects in the solution.</value>
+  </data>
   <data name="ToolExecuteCommandDescription" xml:space="preserve">
     <value>Executes a tool from source without permanently installing it.</value>
   </data>

--- a/src/Cli/dotnet/Commands/Solution/List/SolutionListCommandDefinition.cs
+++ b/src/Cli/dotnet/Commands/Solution/List/SolutionListCommandDefinition.cs
@@ -15,10 +15,18 @@ public static class SolutionListCommandDefinition
         Arity = ArgumentArity.Zero
     };
 
+    public static readonly Option<SolutionListOutputFormat> SolutionListFormatOption = new("--format")
+    {
+        Arity = ArgumentArity.ZeroOrOne,
+        DefaultValueFactory = _ => SolutionListOutputFormat.text,
+        Description = CliCommandStrings.SolutionListFormatOptionDescription
+    };
+
     public static Command Create()
     {
         Command command = new(Name, CliCommandStrings.ListAppFullName);
         command.Options.Add(SolutionFolderOption);
+        command.Options.Add(SolutionListFormatOption);
         return command;
     }
 }

--- a/src/Cli/dotnet/Commands/Solution/List/SolutionListCommandDefinition.cs
+++ b/src/Cli/dotnet/Commands/Solution/List/SolutionListCommandDefinition.cs
@@ -5,7 +5,7 @@ using System.CommandLine;
 
 namespace Microsoft.DotNet.Cli.Commands.Solution.List;
 
-public static class SolutionListCommandDefinition
+internal static class SolutionListCommandDefinition
 {
     public const string Name = "list";
 

--- a/src/Cli/dotnet/Commands/Solution/List/SolutionListJsonHelper.cs
+++ b/src/Cli/dotnet/Commands/Solution/List/SolutionListJsonHelper.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
 using System.Text.Json;
 
 namespace Microsoft.DotNet.Cli.Commands.Solution.List;
 
-
-public enum SolutionListOutputFormat
+internal enum SolutionListOutputFormat
 {
     text = 0,
     json = 1

--- a/src/Cli/dotnet/Commands/Solution/List/SolutionListJsonHelper.cs
+++ b/src/Cli/dotnet/Commands/Solution/List/SolutionListJsonHelper.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.DotNet.Cli.Commands.Solution.List;
+
+
+public enum SolutionListOutputFormat
+{
+    text = 0,
+    json = 1
+}
+
+internal static class JsonHelper
+{
+    public static readonly JsonSerializerOptions NoEscapeSerializerOptions = new()
+    {
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+}

--- a/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
+++ b/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
@@ -348,7 +348,6 @@ $"{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}" };
         public void WhenProjectsPresentInTheReadonlySolutionItListsThemInJsonFormatWhenJsonFormattingIsSpecified(string solutionCommand, string solutionExtension)
         {
             var expectedOutput = $"""["{Path.Combine("App", "App.csproj")}", "{Path.Combine("Lib", "Lib.csproj")}"]""";
-            // var expectedOutput = $"""["{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}"]""";
 
             var projectDirectory = _testAssetsManager
                 .CopyTestAsset("TestAppWithSlnAndExistingCsprojReferences", identifier: $"GivenDotnetSlnList-Readonly-{solutionCommand}{solutionExtension}")

--- a/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
+++ b/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
@@ -409,7 +409,7 @@ $"{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}" };
         [InlineData("solution")]
         public void WhenSolutionFilterOriginalPathContainsSpecialCharactersTheyAreUnescapedJsonFormatWhenJsonFormattingIsSpecified(string solutionCommand)
         {
-            var expectedOutput = $"""["{Path.Combine("App", "App.csproj")}", "{Path.Combine("Lib", "Lib.csproj")}"]""";
+            var expectedOutput = $"""["{Path.Combine("src", "App", "App.csproj")}"]""";
 
             var projectDirectory = _testAssetsManager
                 .CopyTestAsset("TestAppWithSlnAndSlnfWithSpecialCharactersInPath", identifier: "GivenDotnetSlnList-Filter-Unescape")
@@ -420,6 +420,7 @@ $"{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}" };
                 .Execute(solutionCommand, "App.slnf", "list", "--format", "json");
 
             cmd.Should().Pass();
+            cmd.StdOut.Should().Be(expectedOutput);
         }
     }
 }


### PR DESCRIPTION
Hi team,

I've come across a use case which requires parsing solution files to extract projects for CI workflows.
The current system runs regex on `.sln` files, but does not currently support `.slnx`. Instead of having to write tooling to handle the different solution formats I would it would be nice if `dotnet solution list` could support a json output format: ```dotnet solution list --format json```

This PR has the bare minimum required to make this work, it takes some influence from [ToolListLocalCommand](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Tool/List/ToolListLocalCommand.cs) / [ToolListCommandDefinition](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Tool/List/ToolListCommandDefinition.cs). `ToolListLocalCommand` serializes the output to a [VersionedDataContract<TContract>](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Tool/List/ToolListJsonHelper.cs#L23) type which wraps the data and has a `version` property.

```csharp
internal sealed class VersionedDataContract<TContract>
{
    /// <summary>
    /// The version of the JSON format for dotnet tool list.
    /// </summary>
    [JsonPropertyName("version")]
    public int Version { get; init; } = 1;
    
    [JsonPropertyName("data")]
    public required TContract Data { get; init; }
}
```
This implementation does not follow this, it will just output a raw json array ```["src/App/App.csproj"]``` for initial simplicity, however if it would be preferable to enable versioning then the `VersionedDataContract<TContract>` approach could be followed.

`en` localisation has added, but I have excluded the other automatically generated localisations as I am unsure how this process is handled.

Tests have been added to validate json format output, the set of existing output verification tests have been copied and modified to handle new formatting. To support output consistency, the operation of the command has been slightly modified, if no projects exist within the solution, and json formatting is chosen, the result will be an empty json array, instead of the usual message.

When modifying the tests to support the json output, I came across an existing test case [WhenProjectsInSolutionFoldersPresentInTheSolutionItListsSolutionFolderPaths](https://github.com/dotnet/sdk/blob/701f7951f86c4e4d79ee9be0c22fd929961f61ff/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs#L260) which does not appear to actually test what its name implies rather it just checks that the output contains a subset of the desired paths. It does not actually verify the solution folder paths are listed. I have not updated this yet, but was raising it for guidance/feedback, as I may just be misinterpreting the test.

Feedback / thoughts would be appreciated if this is something that could be supported.