### PR TITLE
Improve `dotnetup` Muxer Handling, In-Use Muxer + Perf

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -129,7 +129,12 @@ internal class DotnetArchiveExtractor : IDisposable
     /// <returns>The resolved destination path.</returns>
     private static string ResolveEntryDestPath(string entryName, string targetDir, MuxerHandler? muxerHandler)
     {
-        if (muxerHandler != null && entryName == muxerHandler.MuxerEntryName)
+        // Normalize entry name by stripping leading "./" prefix (common in tar archives)
+        string normalizedName = entryName.StartsWith("./", StringComparison.Ordinal)
+            ? entryName.Substring(2)
+            : entryName;
+
+        if (muxerHandler != null && normalizedName == muxerHandler.MuxerEntryName)
         {
             return muxerHandler.GetMuxerExtractionPath();
         }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -103,7 +103,7 @@ internal class DotnetArchiveExtractor : IDisposable
         Directory.CreateDirectory(targetDir);
 
         // Set up muxer handling - muxer will be extracted to temp path during main extraction
-        var muxerHandler = new MuxerHandler(targetDir);
+        var muxerHandler = new MuxerHandler(targetDir, _request.Options.RequireMuxerUpdate);
         muxerHandler.RecordPreExtractionState();
 
         // Extract everything, redirecting muxer to temp path

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -21,7 +21,7 @@ internal class DotnetArchiveExtractor : IDisposable
     private readonly IProgressTarget _progressTarget;
     private readonly IArchiveDownloader _archiveDownloader;
     private readonly bool _shouldDisposeDownloader;
-    private readonly MuxerHandler? _muxerHandler;
+    private MuxerHandler? _muxerHandler;
     private string scratchDownloadDirectory;
     private string? _archivePath;
     private IProgressReporter? _progressReporter;
@@ -47,13 +47,6 @@ internal class DotnetArchiveExtractor : IDisposable
         {
             _archiveDownloader = new DotnetArchiveDownloader(releaseManifest);
             _shouldDisposeDownloader = true;
-        }
-
-        // Create MuxerHandler early so that when requireMuxerUpdate is true,
-        // a locked muxer is detected before the expensive download in Prepare().
-        if (_request.InstallRoot.Path is not null)
-        {
-            _muxerHandler = new MuxerHandler(_request.InstallRoot.Path, _request.Options.RequireMuxerUpdate);
         }
     }
 
@@ -109,6 +102,13 @@ internal class DotnetArchiveExtractor : IDisposable
     private void ExtractArchiveDirectlyToTarget(string archivePath, string targetDir, IProgressTask? installTask)
     {
         Directory.CreateDirectory(targetDir);
+
+        // Capture pre-extraction muxer/runtime state right before extraction so
+        // the snapshot is as accurate as possible (caller holds the mutex here).
+        if (_muxerHandler is null && _request.InstallRoot.Path is not null)
+        {
+            _muxerHandler = new MuxerHandler(_request.InstallRoot.Path, _request.Options.RequireMuxerUpdate);
+        }
 
         // Extract everything, redirecting muxer to temp path
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -21,6 +21,7 @@ internal class DotnetArchiveExtractor : IDisposable
     private readonly IProgressTarget _progressTarget;
     private readonly IArchiveDownloader _archiveDownloader;
     private readonly bool _shouldDisposeDownloader;
+    private readonly MuxerHandler? _muxerHandler;
     private string scratchDownloadDirectory;
     private string? _archivePath;
     private IProgressReporter? _progressReporter;
@@ -46,6 +47,13 @@ internal class DotnetArchiveExtractor : IDisposable
         {
             _archiveDownloader = new DotnetArchiveDownloader(releaseManifest);
             _shouldDisposeDownloader = true;
+        }
+
+        // Create MuxerHandler early so that when requireMuxerUpdate is true,
+        // a locked muxer is detected before the expensive download in Prepare().
+        if (_request.InstallRoot.Path is not null)
+        {
+            _muxerHandler = new MuxerHandler(_request.InstallRoot.Path, _request.Options.RequireMuxerUpdate);
         }
     }
 
@@ -102,22 +110,18 @@ internal class DotnetArchiveExtractor : IDisposable
     {
         Directory.CreateDirectory(targetDir);
 
-        // Set up muxer handling - muxer will be extracted to temp path during main extraction
-        var muxerHandler = new MuxerHandler(targetDir, _request.Options.RequireMuxerUpdate);
-        muxerHandler.RecordPreExtractionState();
-
         // Extract everything, redirecting muxer to temp path
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            ExtractTarArchive(archivePath, targetDir, installTask, muxerHandler);
+            ExtractTarArchive(archivePath, targetDir, installTask, _muxerHandler);
         }
         else
         {
-            ExtractZipArchive(archivePath, targetDir, installTask, muxerHandler);
+            ExtractZipArchive(archivePath, targetDir, installTask, _muxerHandler);
         }
 
         // After extraction, decide whether to keep or discard the temp muxer
-        muxerHandler.FinalizeAfterExtraction();
+        _muxerHandler?.FinalizeAfterExtraction();
     }
 
     /// <summary>
@@ -136,7 +140,8 @@ internal class DotnetArchiveExtractor : IDisposable
 
         if (muxerHandler != null && normalizedName == muxerHandler.MuxerEntryName)
         {
-            return muxerHandler.GetMuxerExtractionPath();
+            muxerHandler.MuxerWasExtracted = true;
+            return muxerHandler.TempMuxerPath;
         }
 
         return Path.Combine(targetDir, entryName);

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstall.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstall.cs
@@ -29,4 +29,10 @@ internal record InstallRequestOptions()
 {
     // Include options such as the custom feed, manifest path, etc.
     public string? ManifestPath { get; init; }
+
+    /// <summary>
+    /// If true, the installation will fail if the muxer (dotnet executable) cannot be updated.
+    /// If false (default), a warning is displayed but installation continues.
+    /// </summary>
+    public bool RequireMuxerUpdate { get; init; }
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetupUtilities.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetupUtilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -75,6 +76,35 @@ internal static class DotnetupUtilities
         else
         {
             return ".tar.gz"; // Unix-like systems use tar.gz
+        }
+    }
+
+    /// <summary>
+    /// Attempts to find running dotnet processes and returns a formatted string with their PIDs.
+    /// Returns an empty string if no processes are found or an error occurs.
+    /// </summary>
+    public static string GetDotnetProcessPidInfo()
+    {
+        try
+        {
+            var processes = Process.GetProcessesByName("dotnet");
+            if (processes.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var pids = new int[processes.Length];
+            for (int i = 0; i < processes.Length; i++)
+            {
+                pids[i] = processes[i].Id;
+                processes[i].Dispose();
+            }
+
+            return $" (dotnet process PIDs: {string.Join(", ", pids)})";
+        }
+        catch
+        {
+            return string.Empty;
         }
     }
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Deployment.DotNet.Releases;
 
 namespace Microsoft.Dotnet.Installation.Internal;
 
@@ -25,7 +26,7 @@ internal class MuxerHandler
     private readonly string _existingMuxerBackupPath;
     private readonly bool _requireMuxerUpdate;
 
-    private Version? _preExtractionHighestRuntimeVersion;
+    private ReleaseVersion? _preExtractionHighestRuntimeVersion;
     private bool _hadExistingMuxer;
     private bool _extractedNewMuxer;
     private bool _movedExistingMuxer;
@@ -176,8 +177,9 @@ internal class MuxerHandler
 
     /// <summary>
     /// Gets the latest runtime version from the install root by checking the shared/Microsoft.NETCore.App directory.
+    /// Uses <see cref="ReleaseVersion"/> for proper semver comparison, including pre-release labels.
     /// </summary>
-    private static Version? GetLatestRuntimeVersionFromInstallRoot(string installRoot)
+    internal static ReleaseVersion? GetLatestRuntimeVersionFromInstallRoot(string installRoot)
     {
         var runtimePath = Path.Combine(installRoot, "shared", "Microsoft.NETCore.App");
         if (!Directory.Exists(runtimePath))
@@ -185,11 +187,11 @@ internal class MuxerHandler
             return null;
         }
 
-        Version? highestVersion = null;
+        ReleaseVersion? highestVersion = null;
         foreach (var dir in Directory.GetDirectories(runtimePath))
         {
             var versionString = Path.GetFileName(dir);
-            if (Version.TryParse(versionString, out Version? dirVersion))
+            if (ReleaseVersion.TryParse(versionString, out ReleaseVersion? dirVersion))
             {
                 if (highestVersion == null || dirVersion > highestVersion)
                 {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Dotnet.Installation.Internal;
+
+/// <summary>
+/// Handles muxer (dotnet executable) replacement logic during archive extraction.
+/// The muxer should only be replaced when installing a newer core runtime version.
+/// 
+/// Workflow:
+/// 1. Before extraction: record the highest existing runtime version
+/// 2. Extract everything, but redirect the muxer to a temp file
+/// 3. After extraction: check if a higher runtime version now exists
+/// 4. If yes, move the temp muxer to the real location; otherwise delete it
+/// </summary>
+internal class MuxerHandler
+{
+    private readonly string _targetDir;
+    private readonly string _muxerName;
+    private readonly string _muxerTargetPath;
+    private readonly string _tempMuxerPath;
+    private readonly string _existingMuxerBackupPath;
+
+    private Version? _preExtractionHighestRuntimeVersion;
+    private bool _hadExistingMuxer;
+    private bool _extractedNewMuxer;
+    private bool _movedExistingMuxer;
+
+    public MuxerHandler(string targetDir)
+    {
+        _targetDir = targetDir;
+        _muxerName = DotnetupUtilities.GetDotnetExeName();
+        _muxerTargetPath = Path.Combine(targetDir, _muxerName);
+        _tempMuxerPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.new";
+        _existingMuxerBackupPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.old";
+    }
+
+    /// <summary>
+    /// Gets the muxer entry name to detect during extraction.
+    /// </summary>
+    public string MuxerEntryName => _muxerName;
+
+    /// <summary>
+    /// Gets the path where the muxer should be extracted to during the main extraction pass.
+    /// This is a temp path - the muxer will be moved to its final location after extraction.
+    /// </summary>
+    public string TempMuxerPath => _tempMuxerPath;
+
+    /// <summary>
+    /// Records the state before extraction begins.
+    /// Call this before extracting the archive.
+    /// </summary>
+    public void RecordPreExtractionState()
+    {
+        _preExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
+        _hadExistingMuxer = File.Exists(_muxerTargetPath);
+    }
+
+    /// <summary>
+    /// Called by the extractor when the muxer entry is being extracted.
+    /// Returns the path where the muxer should be written.
+    /// </summary>
+    public string GetMuxerExtractionPath()
+    {
+        _extractedNewMuxer = true;
+        return _tempMuxerPath;
+    }
+
+    /// <summary>
+    /// After extraction completes, determines if the muxer should be updated
+    /// and moves/deletes the temp muxer accordingly.
+    /// </summary>
+    public void FinalizeAfterExtraction()
+    {
+        // If no muxer was extracted (e.g., WindowsDesktop), nothing to do
+        if (!_extractedNewMuxer || !File.Exists(_tempMuxerPath))
+        {
+            return;
+        }
+
+        var postExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
+
+        // If no runtime exists after extraction, something is wrong - but keep the muxer
+        if (postExtractionHighestRuntimeVersion == null)
+        {
+            // Clean up temp file since we can't determine what to do
+            TryDeleteTempMuxer();
+            return;
+        }
+
+        // Determine if we should update the muxer
+        bool shouldUpdateMuxer;
+        if (_preExtractionHighestRuntimeVersion == null)
+        {
+            // No runtime existed before - we need the muxer
+            shouldUpdateMuxer = true;
+        }
+        else if (postExtractionHighestRuntimeVersion > _preExtractionHighestRuntimeVersion)
+        {
+            // A higher runtime version was installed - update the muxer
+            shouldUpdateMuxer = true;
+        }
+        else
+        {
+            // Existing runtime is same or higher - keep existing muxer
+            shouldUpdateMuxer = false;
+        }
+
+        if (!shouldUpdateMuxer)
+        {
+            TryDeleteTempMuxer();
+            return;
+        }
+
+        // Move the existing muxer out of the way if it exists
+        if (_hadExistingMuxer)
+        {
+            try
+            {
+                File.Move(_muxerTargetPath, _existingMuxerBackupPath);
+                _movedExistingMuxer = true;
+            }
+            catch (Exception ex) when (IsFileInUseException(ex))
+            {
+                Console.WriteLine($"Warning: Could not update dotnet executable - it is currently in use by another process. " +
+                    $"The existing muxer will be retained. This may cause issues if the new runtime requires a newer muxer.");
+                TryDeleteTempMuxer();
+                return;
+            }
+        }
+
+        try
+        {
+            // Move the new muxer into place
+            File.Move(_tempMuxerPath, _muxerTargetPath);
+
+            // Clean up the backup
+            if (_movedExistingMuxer && File.Exists(_existingMuxerBackupPath))
+            {
+                try { File.Delete(_existingMuxerBackupPath); } catch { }
+            }
+        }
+        catch
+        {
+            // Restore the original muxer if we moved it
+            if (_movedExistingMuxer && File.Exists(_existingMuxerBackupPath) && !File.Exists(_muxerTargetPath))
+            {
+                try { File.Move(_existingMuxerBackupPath, _muxerTargetPath); } catch { }
+            }
+            throw;
+        }
+    }
+
+    private void TryDeleteTempMuxer()
+    {
+        if (File.Exists(_tempMuxerPath))
+        {
+            try { File.Delete(_tempMuxerPath); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Gets the latest runtime version from the install root by checking the shared/Microsoft.NETCore.App directory.
+    /// </summary>
+    private static Version? GetLatestRuntimeVersionFromInstallRoot(string installRoot)
+    {
+        var runtimePath = Path.Combine(installRoot, "shared", "Microsoft.NETCore.App");
+        if (!Directory.Exists(runtimePath))
+        {
+            return null;
+        }
+
+        Version? highestVersion = null;
+        foreach (var dir in Directory.GetDirectories(runtimePath))
+        {
+            var versionString = Path.GetFileName(dir);
+            if (Version.TryParse(versionString, out Version? dirVersion))
+            {
+                if (highestVersion == null || dirVersion > highestVersion)
+                {
+                    highestVersion = dirVersion;
+                }
+            }
+        }
+
+        return highestVersion;
+    }
+
+    private static bool IsFileInUseException(Exception ex)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return ex is UnauthorizedAccessException || ex is IOException;
+        }
+        return false;
+    }
+}

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
@@ -41,12 +41,32 @@ internal class MuxerHandler
 
         _preExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
         _hadExistingMuxer = File.Exists(_muxerTargetPath);
+    }
 
-        // Fail fast: if the muxer must be updated and the existing one is locked,
-        // throw before the caller does expensive download/extraction work.
-        if (_requireMuxerUpdate && _hadExistingMuxer)
+    /// <summary>
+    /// Checks whether the muxer at the given install root is writable.
+    /// Throws <see cref="InvalidOperationException"/> if it is locked by another process.
+    /// Callers should invoke this while holding the installation-state mutex to
+    /// avoid racing with other processes that modify the same hive.
+    /// </summary>
+    public static void EnsureMuxerIsWritable(string installRoot)
+    {
+        var muxerPath = Path.Combine(installRoot, DotnetupUtilities.GetDotnetExeName());
+        if (!File.Exists(muxerPath))
         {
-            ThrowIfMuxerInUse();
+            return;
+        }
+
+        try
+        {
+            // Probe with FileShare.None to detect sharing/lock violations
+            using var fs = new FileStream(muxerPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (Exception ex) when (IsFileMoveBlockedException(ex))
+        {
+            string reason = GetMoveBlockedReason(ex);
+            throw new InvalidOperationException(
+                $"Cannot update dotnet executable at '{muxerPath}' - {reason}.", ex);
         }
     }
 
@@ -61,25 +81,6 @@ internal class MuxerHandler
     /// Otherwise, it returns a temp path so the muxer can be moved into place after extraction.
     /// </summary>
     public string TempMuxerPath => _hadExistingMuxer ? _tempMuxerPath : _muxerTargetPath;
-
-    /// <summary>
-    /// Checks whether the existing muxer file is locked by another process.
-    /// Throws <see cref="InvalidOperationException"/> if it cannot be moved.
-    /// </summary>
-    private void ThrowIfMuxerInUse()
-    {
-        try
-        {
-            // Probe with FileShare.None to detect sharing/lock violations
-            using var fs = new FileStream(_muxerTargetPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-        }
-        catch (Exception ex) when (IsFileMoveBlockedException(ex))
-        {
-            string reason = GetMoveBlockedReason(ex);
-            throw new InvalidOperationException(
-                $"Cannot update dotnet executable at '{_muxerTargetPath}' - {reason}.", ex);
-        }
-    }
 
     /// <summary>
     /// Set to true by the caller when the muxer entry has been extracted.

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Dotnet.Installation.Internal;
 internal class MuxerHandler
 {
     private readonly string _targetDir;
-    private readonly string _muxerName;
     private readonly string _muxerTargetPath;
     private readonly string _tempMuxerPath;
     private readonly string _existingMuxerBackupPath;
@@ -28,49 +27,64 @@ internal class MuxerHandler
 
     private ReleaseVersion? _preExtractionHighestRuntimeVersion;
     private bool _hadExistingMuxer;
-    private bool _extractedNewMuxer;
     private bool _movedExistingMuxer;
 
     public MuxerHandler(string targetDir, bool requireMuxerUpdate = false)
     {
         _targetDir = targetDir;
         _requireMuxerUpdate = requireMuxerUpdate;
-        _muxerName = DotnetupUtilities.GetDotnetExeName();
-        _muxerTargetPath = Path.Combine(targetDir, _muxerName);
-        _tempMuxerPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.new";
-        _existingMuxerBackupPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.old";
+        var muxerName = DotnetupUtilities.GetDotnetExeName();
+        _muxerTargetPath = Path.Combine(targetDir, muxerName);
+        var guid = Guid.NewGuid();
+        _tempMuxerPath = $"{_muxerTargetPath}.{guid}.new";
+        _existingMuxerBackupPath = $"{_muxerTargetPath}.{guid}.old";
+
+        _preExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
+        _hadExistingMuxer = File.Exists(_muxerTargetPath);
+
+        // Fail fast: if the muxer must be updated and the existing one is locked,
+        // throw before the caller does expensive download/extraction work.
+        if (_requireMuxerUpdate && _hadExistingMuxer)
+        {
+            ThrowIfMuxerInUse();
+        }
     }
 
     /// <summary>
     /// Gets the muxer entry name to detect during extraction.
     /// </summary>
-    public string MuxerEntryName => _muxerName;
+    public string MuxerEntryName => DotnetupUtilities.GetDotnetExeName();
 
     /// <summary>
     /// Gets the path where the muxer should be extracted to during the main extraction pass.
-    /// This is a temp path - the muxer will be moved to its final location after extraction.
+    /// If there is no existing muxer, this returns the final target path directly.
+    /// Otherwise, it returns a temp path so the muxer can be moved into place after extraction.
     /// </summary>
-    public string TempMuxerPath => _tempMuxerPath;
+    public string TempMuxerPath => _hadExistingMuxer ? _tempMuxerPath : _muxerTargetPath;
 
     /// <summary>
-    /// Records the state before extraction begins.
-    /// Call this before extracting the archive.
+    /// Checks whether the existing muxer file is locked by another process.
+    /// Throws <see cref="InvalidOperationException"/> if it cannot be moved.
     /// </summary>
-    public void RecordPreExtractionState()
+    private void ThrowIfMuxerInUse()
     {
-        _preExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
-        _hadExistingMuxer = File.Exists(_muxerTargetPath);
+        try
+        {
+            // Probe with FileShare.None to detect sharing/lock violations
+            using var fs = new FileStream(_muxerTargetPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (Exception ex) when (IsFileMoveBlockedException(ex))
+        {
+            string reason = GetMoveBlockedReason(ex);
+            throw new InvalidOperationException(
+                $"Cannot update dotnet executable at '{_muxerTargetPath}' - {reason}.", ex);
+        }
     }
 
     /// <summary>
-    /// Called by the extractor when the muxer entry is being extracted.
-    /// Returns the path where the muxer should be written.
+    /// Set to true by the caller when the muxer entry has been extracted.
     /// </summary>
-    public string GetMuxerExtractionPath()
-    {
-        _extractedNewMuxer = true;
-        return _tempMuxerPath;
-    }
+    public bool MuxerWasExtracted { get; set; }
 
     /// <summary>
     /// After extraction completes, determines if the muxer should be updated
@@ -79,7 +93,21 @@ internal class MuxerHandler
     public void FinalizeAfterExtraction()
     {
         // If no muxer was extracted (e.g., WindowsDesktop), nothing to do
-        if (!_extractedNewMuxer || !File.Exists(_tempMuxerPath))
+        if (!MuxerWasExtracted)
+        {
+            return;
+        }
+
+        // If there was no existing muxer, the new muxer was extracted directly
+        // to its final location - nothing more to do.
+        if (!_hadExistingMuxer)
+        {
+            return;
+        }
+
+        // From here on, the muxer was extracted to a temp path and we need to
+        // decide whether to replace the existing one.
+        if (!File.Exists(_tempMuxerPath))
         {
             return;
         }
@@ -224,7 +252,8 @@ internal class MuxerHandler
 
             if (ioEx.HResult == ERROR_SHARING_VIOLATION || ioEx.HResult == ERROR_LOCK_VIOLATION)
             {
-                return "it is currently in use by another process. Close all running .NET applications and try again";
+                string pidInfo = DotnetupUtilities.GetDotnetProcessPidInfo();
+                return $"it is currently in use by another process.{pidInfo} Close all running .NET applications and try again";
             }
 
             return $"an I/O error occurred (HRESULT 0x{ioEx.HResult:X8}): {ioEx.Message}";
@@ -242,4 +271,5 @@ internal class MuxerHandler
 
         return ex.Message;
     }
+
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -23,6 +23,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
-    <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 </Project>

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -23,5 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
+    <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 </Project>

--- a/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
+++ b/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
@@ -70,14 +70,9 @@ internal class RuntimeInstallCommand(ParseResult result) : CommandBase(result)
             _manifestPath,
             _interactive,
             _noProgress,
-<<<<<<< HEAD
-            runtimeInfo.Component,
-            runtimeInfo.Description,
-            RequireMuxerUpdate: _requireMuxerUpdate);
-=======
             component,
-            componentDescription);
->>>>>>> origin/release/dnup
+            componentDescription,
+            RequireMuxerUpdate: _requireMuxerUpdate);
 
         InstallWorkflow.InstallWorkflowResult workflowResult = workflow.Execute(options);
         return workflowResult.ExitCode;

--- a/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
+++ b/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
@@ -16,6 +16,7 @@ internal class RuntimeInstallCommand(ParseResult result) : CommandBase(result)
     private readonly string? _manifestPath = result.GetValue(RuntimeInstallCommandParser.ManifestPathOption);
     private readonly bool _interactive = result.GetValue(RuntimeInstallCommandParser.InteractiveOption);
     private readonly bool _noProgress = result.GetValue(RuntimeInstallCommandParser.NoProgressOption);
+    private readonly bool _requireMuxerUpdate = result.GetValue(RuntimeInstallCommandParser.RequireMuxerUpdateOption);
 
     private readonly IDotnetInstallManager _dotnetInstaller = new DotnetInstallManager();
     private readonly ChannelVersionResolver _channelVersionResolver = new ChannelVersionResolver();
@@ -64,7 +65,8 @@ internal class RuntimeInstallCommand(ParseResult result) : CommandBase(result)
             _interactive,
             _noProgress,
             runtimeInfo.Component,
-            runtimeInfo.Description);
+            runtimeInfo.Description,
+            RequireMuxerUpdate: _requireMuxerUpdate);
 
         InstallWorkflow.InstallWorkflowResult workflowResult = workflow.Execute(options);
         return workflowResult.ExitCode;

--- a/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommandParser.cs
+++ b/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommandParser.cs
@@ -34,6 +34,7 @@ internal static class RuntimeInstallCommandParser
     public static readonly Option<string> ManifestPathOption = CommonOptions.ManifestPathOption;
     public static readonly Option<bool> InteractiveOption = CommonOptions.InteractiveOption;
     public static readonly Option<bool> NoProgressOption = CommonOptions.NoProgressOption;
+    public static readonly Option<bool> RequireMuxerUpdateOption = CommonOptions.RequireMuxerUpdateOption;
 
     private static readonly Command RuntimeInstallCommand = ConstructCommand();
 
@@ -55,6 +56,7 @@ internal static class RuntimeInstallCommandParser
 
         command.Options.Add(InteractiveOption);
         command.Options.Add(NoProgressOption);
+        command.Options.Add(RequireMuxerUpdateOption);
 
         command.SetAction(parseResult => new RuntimeInstallCommand(parseResult).Execute());
 

--- a/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -17,6 +17,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
     private readonly string? _manifestPath = result.GetValue(SdkInstallCommandParser.ManifestPathOption);
     private readonly bool _interactive = result.GetValue(SdkInstallCommandParser.InteractiveOption);
     private readonly bool _noProgress = result.GetValue(SdkInstallCommandParser.NoProgressOption);
+    private readonly bool _requireMuxerUpdate = result.GetValue(SdkInstallCommandParser.RequireMuxerUpdateOption);
 
     private readonly IDotnetInstallManager _dotnetInstaller = new DotnetInstallManager();
     private readonly ChannelVersionResolver _channelVersionResolver = new ChannelVersionResolver();
@@ -35,7 +36,8 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
             InstallComponent.SDK,
             ".NET SDK",
             _updateGlobalJson,
-            ResolveChannelFromGlobalJson);
+            ResolveChannelFromGlobalJson,
+            _requireMuxerUpdate);
 
         var result = workflow.Execute(options);
         return result.ExitCode;

--- a/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommandParser.cs
+++ b/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommandParser.cs
@@ -19,6 +19,7 @@ internal static class SdkInstallCommandParser
     public static readonly Option<string> ManifestPathOption = CommonOptions.ManifestPathOption;
     public static readonly Option<bool> InteractiveOption = CommonOptions.InteractiveOption;
     public static readonly Option<bool> NoProgressOption = CommonOptions.NoProgressOption;
+    public static readonly Option<bool> RequireMuxerUpdateOption = CommonOptions.RequireMuxerUpdateOption;
 
     public static readonly Option<bool?> UpdateGlobalJsonOption = new("--update-global-json")
     {
@@ -57,6 +58,7 @@ internal static class SdkInstallCommandParser
 
         command.Options.Add(InteractiveOption);
         command.Options.Add(NoProgressOption);
+        command.Options.Add(RequireMuxerUpdateOption);
 
         command.SetAction(parseResult => new SdkInstallCommand(parseResult).Execute());
 

--- a/src/Installer/dotnetup/Commands/Shared/InstallExecutor.cs
+++ b/src/Installer/dotnetup/Commands/Shared/InstallExecutor.cs
@@ -30,13 +30,15 @@ internal class InstallExecutor
     /// <param name="component">The component type (SDK, Runtime, ASPNETCore, WindowsDesktop).</param>
     /// <param name="manifestPath">Optional manifest path for tracking installations.</param>
     /// <param name="channelVersionResolver">The resolver to use for version resolution.</param>
+    /// <param name="requireMuxerUpdate">If true, fail when the muxer cannot be updated.</param>
     /// <returns>The resolved install request with version information.</returns>
     public static ResolvedInstallRequest CreateAndResolveRequest(
         string installPath,
         string channel,
         InstallComponent component,
         string? manifestPath,
-        ChannelVersionResolver channelVersionResolver)
+        ChannelVersionResolver channelVersionResolver,
+        bool requireMuxerUpdate = false)
     {
         var installRoot = new DotnetInstallRoot(installPath, InstallerUtilities.GetDefaultInstallArchitecture());
 
@@ -46,7 +48,8 @@ internal class InstallExecutor
             component,
             new InstallRequestOptions
             {
-                ManifestPath = manifestPath
+                ManifestPath = manifestPath,
+                RequireMuxerUpdate = requireMuxerUpdate
             });
 
         var resolvedVersion = channelVersionResolver.Resolve(request);
@@ -90,6 +93,7 @@ internal class InstallExecutor
     /// <param name="componentDescription">Description of the component for display.</param>
     /// <param name="manifestPath">Optional manifest path.</param>
     /// <param name="noProgress">Whether to suppress progress display.</param>
+    /// <param name="requireMuxerUpdate">If true, fail when the muxer cannot be updated.</param>
     /// <returns>True if all installations succeeded, false if any failed.</returns>
     public static bool ExecuteAdditionalInstalls(
         IEnumerable<string> additionalVersions,
@@ -97,7 +101,8 @@ internal class InstallExecutor
         InstallComponent component,
         string componentDescription,
         string? manifestPath,
-        bool noProgress)
+        bool noProgress,
+        bool requireMuxerUpdate = false)
     {
         bool allSucceeded = true;
 
@@ -109,7 +114,8 @@ internal class InstallExecutor
                 component,
                 new InstallRequestOptions
                 {
-                    ManifestPath = manifestPath
+                    ManifestPath = manifestPath,
+                    RequireMuxerUpdate = requireMuxerUpdate
                 });
 
             var additionalInstall = InstallerOrchestratorSingleton.Instance.Install(additionalRequest, noProgress);

--- a/src/Installer/dotnetup/Commands/Shared/InstallPathResolver.cs
+++ b/src/Installer/dotnetup/Commands/Shared/InstallPathResolver.cs
@@ -58,15 +58,16 @@ internal class InstallPathResolver
         {
             installPathFromGlobalJson = globalJsonInfo.SdkPath;
 
-            if (installPathFromGlobalJson is not null && explicitInstallPath is not null &&
-                !DotnetupUtilities.PathsEqual(installPathFromGlobalJson, explicitInstallPath))
+            // If explicit path is provided, use it (it takes precedence over global.json)
+            // If no explicit path, fall back to global.json path
+            if (explicitInstallPath is not null)
             {
-                //  TODO: Add parameter to override error
-                error = $"Error: The install path specified in global.json ({installPathFromGlobalJson}) does not match the install path provided ({explicitInstallPath}).";
-                return null;
+                resolvedInstallPath = explicitInstallPath;
             }
-
-            resolvedInstallPath = installPathFromGlobalJson;
+            else
+            {
+                resolvedInstallPath = installPathFromGlobalJson;
+            }
         }
 
         if (resolvedInstallPath == null)

--- a/src/Installer/dotnetup/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup/Commands/Shared/InstallWorkflow.cs
@@ -31,7 +31,8 @@ internal class InstallWorkflow
         InstallComponent Component,
         string ComponentDescription,
         bool? UpdateGlobalJson = null,
-        Func<string, string?>? ResolveChannelFromGlobalJson = null);
+        Func<string, string?>? ResolveChannelFromGlobalJson = null,
+        bool RequireMuxerUpdate = false);
 
     public record InstallWorkflowResult(int ExitCode, InstallExecutor.ResolvedInstallRequest? ResolvedRequest);
 
@@ -125,7 +126,8 @@ internal class InstallWorkflow
             context.Channel,
             context.Options.Component,
             context.Options.ManifestPath,
-            _channelVersionResolver);
+            _channelVersionResolver,
+            context.Options.RequireMuxerUpdate);
     }
 
     private bool ExecuteInstallations(WorkflowContext context, InstallExecutor.ResolvedInstallRequest resolved)
@@ -152,7 +154,8 @@ internal class InstallWorkflow
             context.Options.Component,
             context.Options.ComponentDescription,
             context.Options.ManifestPath,
-            context.Options.NoProgress);
+            context.Options.NoProgress,
+            context.Options.RequireMuxerUpdate);
 
         return true;
     }

--- a/src/Installer/dotnetup/CommonOptions.cs
+++ b/src/Installer/dotnetup/CommonOptions.cs
@@ -42,6 +42,12 @@ internal class CommonOptions
         Description = "Custom path to the manifest file for tracking .NET installations",
     };
 
+    public static Option<bool> RequireMuxerUpdateOption = new("--require-muxer-update")
+    {
+        Description = "Fail if the muxer (dotnet executable) cannot be updated. By default, a warning is displayed but installation continues.",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+
     private static bool IsCIEnvironmentOrRedirected() =>
         new Cli.Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment() || Console.IsOutputRedirected;
 }

--- a/src/Installer/dotnetup/CommonOptions.cs
+++ b/src/Installer/dotnetup/CommonOptions.cs
@@ -66,7 +66,7 @@ internal class CommonOptions
 
     public static Option<bool> RequireMuxerUpdateOption = new("--require-muxer-update")
     {
-        Description = "Fail if the muxer (dotnet executable) cannot be updated. By default, a warning is displayed but installation continues.",
+        Description = "Fail if the dotnet executable cannot be updated. By default, a warning is displayed but installation continues.",
         Arity = ArgumentArity.ZeroOrOne
     };
 

--- a/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
@@ -44,7 +44,6 @@ internal class InstallerOrchestratorSingleton
         string componentDescription = installRequest.Component.GetDisplayName();
 
         // Check if the install already exists and we don't need to do anything
-        // read write mutex only for manifest?
         using (var finalizeLock = modifyInstallStateMutex())
         {
             if (InstallAlreadyExists(install, customManifestPath))
@@ -61,6 +60,14 @@ internal class InstallerOrchestratorSingleton
                 DotnetupSharedManifest manifestManager = new(customManifestPath);
                 manifestManager.AddInstalledVersion(install);
                 return install;
+            }
+
+            // Fail fast: if the muxer must be updated and it is currently locked,
+            // throw before the expensive download.  The check is inside the mutex
+            // so it does not race with other dotnetup processes.
+            if (installRequest.Options.RequireMuxerUpdate && installRequest.InstallRoot.Path is not null)
+            {
+                MuxerHandler.EnsureMuxerIsWritable(installRequest.InstallRoot.Path);
             }
         }
 

--- a/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
@@ -250,8 +250,8 @@ public class DotnetArchiveExtractorTests
             var readmeMode = File.GetUnixFileMode(readmePath);
 #pragma warning restore CA1416
 
-            _log.WriteLine($"dotnet mode: {dotnetMode} ({(int)dotnetMode:o})");
-            _log.WriteLine($"readme mode: {readmeMode} ({(int)readmeMode:o})");
+            _log.WriteLine($"dotnet mode: {dotnetMode} ({Convert.ToString((int)dotnetMode, 8)})");
+            _log.WriteLine($"readme mode: {readmeMode} ({Convert.ToString((int)readmeMode, 8)})");
 
             dotnetMode.Should().HaveFlag(UnixFileMode.UserExecute, "executable entry should preserve UserExecute");
             readmeMode.Should().NotHaveFlag(UnixFileMode.UserExecute, "non-executable entry should not have UserExecute");
@@ -291,7 +291,7 @@ public class DotnetArchiveExtractorTests
 #pragma warning disable CA1416 // Validate platform compatibility — test is gated by PlatformSpecificFact
             var actualMode = File.GetUnixFileMode(dirPath);
 #pragma warning restore CA1416
-            _log.WriteLine($"directory mode: {actualMode} ({(int)actualMode:o})");
+            _log.WriteLine($"directory mode: {actualMode} ({Convert.ToString((int)actualMode, 8)})");
 
             actualMode.Should().HaveFlag(UnixFileMode.UserExecute, "directory should preserve UserExecute");
             actualMode.Should().HaveFlag(UnixFileMode.UserRead);

--- a/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Formats.Tar;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Deployment.DotNet.Releases;
@@ -9,6 +10,7 @@ using Microsoft.Dotnet.Installation;
 using Microsoft.Dotnet.Installation.Internal;
 using Microsoft.DotNet.Tools.Dotnetup.Tests.Mocks;
 using Microsoft.DotNet.Tools.Dotnetup.Tests.Utilities;
+using Microsoft.NET.TestFramework;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -179,6 +181,164 @@ public class DotnetArchiveExtractorTests
         call.DestinationPath.Should().EndWith(DotnetupUtilities.GetArchiveFileExtensionForPlatform());
 
         _log.WriteLine($"Download was called with version {call.Version} to {call.DestinationPath}");
+    }
+
+    /// <summary>
+    /// Creates a tar file with entries having specified Unix permissions.
+    /// </summary>
+    private static void CreateTarWithPermissions(string tarPath, params (string name, UnixFileMode mode, bool isDirectory)[] entries)
+    {
+        using var fs = File.Create(tarPath);
+        using var writer = new TarWriter(fs);
+
+        foreach (var (name, mode, isDirectory) in entries)
+        {
+            TarEntry entry;
+            if (isDirectory)
+            {
+                entry = new PaxTarEntry(TarEntryType.Directory, name) { Mode = mode };
+            }
+            else
+            {
+                entry = new PaxTarEntry(TarEntryType.RegularFile, name)
+                {
+                    Mode = mode,
+                    DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"content-of-{name}"))
+                };
+            }
+
+            writer.WriteEntry(entry);
+        }
+    }
+
+    [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX)]
+    public void ExtractTarContents_PreservesExecutePermission()
+    {
+        // Arrange — create a tar with an executable (755) and a non-executable (644) entry
+        var testDir = Path.Combine(Path.GetTempPath(), $"tar-perm-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(testDir);
+
+        try
+        {
+            var tarPath = Path.Combine(testDir, "test.tar");
+            var extractDir = Path.Combine(testDir, "extracted");
+            Directory.CreateDirectory(extractDir);
+
+            var executableMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                               | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                               | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
+            var readOnlyMode = UnixFileMode.UserRead | UnixFileMode.UserWrite
+                             | UnixFileMode.GroupRead
+                             | UnixFileMode.OtherRead; // 644
+
+            CreateTarWithPermissions(tarPath,
+                ("bin/dotnet", executableMode, isDirectory: false),
+                ("shared/readme.txt", readOnlyMode, isDirectory: false));
+
+            // Act — ExtractToFile should apply Mode via UnixCreateMode
+            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+
+            // Assert
+            var dotnetPath = Path.Combine(extractDir, "bin", "dotnet");
+            var readmePath = Path.Combine(extractDir, "shared", "readme.txt");
+
+            File.Exists(dotnetPath).Should().BeTrue();
+            File.Exists(readmePath).Should().BeTrue();
+
+#pragma warning disable CA1416 // Validate platform compatibility — test is gated by PlatformSpecificFact
+            var dotnetMode = File.GetUnixFileMode(dotnetPath);
+            var readmeMode = File.GetUnixFileMode(readmePath);
+#pragma warning restore CA1416
+
+            _log.WriteLine($"dotnet mode: {dotnetMode} ({(int)dotnetMode:o})");
+            _log.WriteLine($"readme mode: {readmeMode} ({(int)readmeMode:o})");
+
+            dotnetMode.Should().HaveFlag(UnixFileMode.UserExecute, "executable entry should preserve UserExecute");
+            readmeMode.Should().NotHaveFlag(UnixFileMode.UserExecute, "non-executable entry should not have UserExecute");
+        }
+        finally
+        {
+            Directory.Delete(testDir, recursive: true);
+        }
+    }
+
+    [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX)]
+    public void ExtractTarContents_PreservesDirectoryPermissions()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), $"tar-dir-perm-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(testDir);
+
+        try
+        {
+            var tarPath = Path.Combine(testDir, "test.tar");
+            var extractDir = Path.Combine(testDir, "extracted");
+            Directory.CreateDirectory(extractDir);
+
+            var dirMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                        | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                        | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
+
+            CreateTarWithPermissions(tarPath,
+                ("mydir/", dirMode, isDirectory: true));
+
+            // Act
+            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+
+            // Assert
+            var dirPath = Path.Combine(extractDir, "mydir");
+            Directory.Exists(dirPath).Should().BeTrue();
+
+#pragma warning disable CA1416 // Validate platform compatibility — test is gated by PlatformSpecificFact
+            var actualMode = File.GetUnixFileMode(dirPath);
+#pragma warning restore CA1416
+            _log.WriteLine($"directory mode: {actualMode} ({(int)actualMode:o})");
+
+            actualMode.Should().HaveFlag(UnixFileMode.UserExecute, "directory should preserve UserExecute");
+            actualMode.Should().HaveFlag(UnixFileMode.UserRead);
+            actualMode.Should().HaveFlag(UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            Directory.Delete(testDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExtractTarContents_ExtractsContentCorrectly()
+    {
+        // Cross-platform test for content correctness
+        var testDir = Path.Combine(Path.GetTempPath(), $"tar-content-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(testDir);
+
+        try
+        {
+            var tarPath = Path.Combine(testDir, "test.tar");
+            var extractDir = Path.Combine(testDir, "extracted");
+            Directory.CreateDirectory(extractDir);
+
+            var defaultMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
+            CreateTarWithPermissions(tarPath,
+                ("hello.txt", defaultMode, isDirectory: false),
+                ("sub/nested.txt", defaultMode, isDirectory: false));
+
+            // Act
+            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+
+            // Assert
+            var helloPath = Path.Combine(extractDir, "hello.txt");
+            var nestedPath = Path.Combine(extractDir, "sub", "nested.txt");
+
+            File.Exists(helloPath).Should().BeTrue();
+            File.ReadAllText(helloPath).Should().Be("content-of-hello.txt");
+
+            File.Exists(nestedPath).Should().BeTrue();
+            File.ReadAllText(nestedPath).Should().Be("content-of-sub/nested.txt");
+        }
+        finally
+        {
+            Directory.Delete(testDir, recursive: true);
+        }
     }
 }
 

--- a/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveExtractorTests.cs
@@ -215,130 +215,106 @@ public class DotnetArchiveExtractorTests
     public void ExtractTarContents_PreservesExecutePermission()
     {
         // Arrange — create a tar with an executable (755) and a non-executable (644) entry
-        var testDir = Path.Combine(Path.GetTempPath(), $"tar-perm-test-{Guid.NewGuid()}");
-        Directory.CreateDirectory(testDir);
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
 
-        try
-        {
-            var tarPath = Path.Combine(testDir, "test.tar");
-            var extractDir = Path.Combine(testDir, "extracted");
-            Directory.CreateDirectory(extractDir);
+        var tarPath = Path.Combine(testEnv.TempRoot, "test.tar");
+        var extractDir = Path.Combine(testEnv.TempRoot, "extracted");
+        Directory.CreateDirectory(extractDir);
 
-            var executableMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                               | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                               | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
-            var readOnlyMode = UnixFileMode.UserRead | UnixFileMode.UserWrite
-                             | UnixFileMode.GroupRead
-                             | UnixFileMode.OtherRead; // 644
+        var executableMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                           | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                           | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
+        var readOnlyMode = UnixFileMode.UserRead | UnixFileMode.UserWrite
+                         | UnixFileMode.GroupRead
+                         | UnixFileMode.OtherRead; // 644
 
-            CreateTarWithPermissions(tarPath,
-                ("bin/dotnet", executableMode, isDirectory: false),
-                ("shared/readme.txt", readOnlyMode, isDirectory: false));
+        CreateTarWithPermissions(tarPath,
+            ("bin/dotnet", executableMode, isDirectory: false),
+            ("shared/readme.txt", readOnlyMode, isDirectory: false));
 
-            // Act — ExtractToFile should apply Mode via UnixCreateMode
-            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+        // Act — ExtractToFile should apply Mode via UnixCreateMode
+        DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
 
-            // Assert
-            var dotnetPath = Path.Combine(extractDir, "bin", "dotnet");
-            var readmePath = Path.Combine(extractDir, "shared", "readme.txt");
+        // Assert
+        var dotnetPath = Path.Combine(extractDir, "bin", "dotnet");
+        var readmePath = Path.Combine(extractDir, "shared", "readme.txt");
 
-            File.Exists(dotnetPath).Should().BeTrue();
-            File.Exists(readmePath).Should().BeTrue();
+        File.Exists(dotnetPath).Should().BeTrue();
+        File.Exists(readmePath).Should().BeTrue();
 
 #pragma warning disable CA1416 // Validate platform compatibility — test is gated by PlatformSpecificFact
-            var dotnetMode = File.GetUnixFileMode(dotnetPath);
-            var readmeMode = File.GetUnixFileMode(readmePath);
+        var dotnetMode = File.GetUnixFileMode(dotnetPath);
+        var readmeMode = File.GetUnixFileMode(readmePath);
 #pragma warning restore CA1416
 
-            _log.WriteLine($"dotnet mode: {dotnetMode} ({Convert.ToString((int)dotnetMode, 8)})");
-            _log.WriteLine($"readme mode: {readmeMode} ({Convert.ToString((int)readmeMode, 8)})");
+        _log.WriteLine($"dotnet mode: {dotnetMode} ({Convert.ToString((int)dotnetMode, 8)})");
+        _log.WriteLine($"readme mode: {readmeMode} ({Convert.ToString((int)readmeMode, 8)})");
 
-            dotnetMode.Should().HaveFlag(UnixFileMode.UserExecute, "executable entry should preserve UserExecute");
-            readmeMode.Should().NotHaveFlag(UnixFileMode.UserExecute, "non-executable entry should not have UserExecute");
-        }
-        finally
-        {
-            Directory.Delete(testDir, recursive: true);
-        }
+        dotnetMode.Should().HaveFlag(UnixFileMode.UserExecute, "executable entry should preserve UserExecute");
+        readmeMode.Should().NotHaveFlag(UnixFileMode.UserExecute, "non-executable entry should not have UserExecute");
     }
 
     [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX)]
     public void ExtractTarContents_PreservesDirectoryPermissions()
     {
-        var testDir = Path.Combine(Path.GetTempPath(), $"tar-dir-perm-test-{Guid.NewGuid()}");
-        Directory.CreateDirectory(testDir);
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
 
-        try
-        {
-            var tarPath = Path.Combine(testDir, "test.tar");
-            var extractDir = Path.Combine(testDir, "extracted");
-            Directory.CreateDirectory(extractDir);
+        var tarPath = Path.Combine(testEnv.TempRoot, "test.tar");
+        var extractDir = Path.Combine(testEnv.TempRoot, "extracted");
+        Directory.CreateDirectory(extractDir);
 
-            var dirMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                        | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                        | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
+        var dirMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute; // 755
 
-            CreateTarWithPermissions(tarPath,
-                ("mydir/", dirMode, isDirectory: true));
+        CreateTarWithPermissions(tarPath,
+            ("mydir/", dirMode, isDirectory: true));
 
-            // Act
-            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+        // Act
+        DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
 
-            // Assert
-            var dirPath = Path.Combine(extractDir, "mydir");
-            Directory.Exists(dirPath).Should().BeTrue();
+        // Assert
+        var dirPath = Path.Combine(extractDir, "mydir");
+        Directory.Exists(dirPath).Should().BeTrue();
 
 #pragma warning disable CA1416 // Validate platform compatibility — test is gated by PlatformSpecificFact
-            var actualMode = File.GetUnixFileMode(dirPath);
+        var actualMode = File.GetUnixFileMode(dirPath);
 #pragma warning restore CA1416
-            _log.WriteLine($"directory mode: {actualMode} ({Convert.ToString((int)actualMode, 8)})");
+        _log.WriteLine($"directory mode: {actualMode} ({Convert.ToString((int)actualMode, 8)})");
 
-            actualMode.Should().HaveFlag(UnixFileMode.UserExecute, "directory should preserve UserExecute");
-            actualMode.Should().HaveFlag(UnixFileMode.UserRead);
-            actualMode.Should().HaveFlag(UnixFileMode.UserWrite);
-        }
-        finally
-        {
-            Directory.Delete(testDir, recursive: true);
-        }
+        actualMode.Should().HaveFlag(UnixFileMode.UserExecute, "directory should preserve UserExecute");
+        actualMode.Should().HaveFlag(UnixFileMode.UserRead);
+        actualMode.Should().HaveFlag(UnixFileMode.UserWrite);
     }
 
     [Fact]
     public void ExtractTarContents_ExtractsContentCorrectly()
     {
         // Cross-platform test for content correctness
-        var testDir = Path.Combine(Path.GetTempPath(), $"tar-content-test-{Guid.NewGuid()}");
-        Directory.CreateDirectory(testDir);
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
 
-        try
-        {
-            var tarPath = Path.Combine(testDir, "test.tar");
-            var extractDir = Path.Combine(testDir, "extracted");
-            Directory.CreateDirectory(extractDir);
+        var tarPath = Path.Combine(testEnv.TempRoot, "test.tar");
+        var extractDir = Path.Combine(testEnv.TempRoot, "extracted");
+        Directory.CreateDirectory(extractDir);
 
-            var defaultMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+        var defaultMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
 
-            CreateTarWithPermissions(tarPath,
-                ("hello.txt", defaultMode, isDirectory: false),
-                ("sub/nested.txt", defaultMode, isDirectory: false));
+        CreateTarWithPermissions(tarPath,
+            ("hello.txt", defaultMode, isDirectory: false),
+            ("sub/nested.txt", defaultMode, isDirectory: false));
 
-            // Act
-            DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
+        // Act
+        DotnetArchiveExtractor.ExtractTarContents(tarPath, extractDir, installTask: null);
 
-            // Assert
-            var helloPath = Path.Combine(extractDir, "hello.txt");
-            var nestedPath = Path.Combine(extractDir, "sub", "nested.txt");
+        // Assert
+        var helloPath = Path.Combine(extractDir, "hello.txt");
+        var nestedPath = Path.Combine(extractDir, "sub", "nested.txt");
 
-            File.Exists(helloPath).Should().BeTrue();
-            File.ReadAllText(helloPath).Should().Be("content-of-hello.txt");
+        File.Exists(helloPath).Should().BeTrue();
+        File.ReadAllText(helloPath).Should().Be("content-of-hello.txt");
 
-            File.Exists(nestedPath).Should().BeTrue();
-            File.ReadAllText(nestedPath).Should().Be("content-of-sub/nested.txt");
-        }
-        finally
-        {
-            Directory.Delete(testDir, recursive: true);
-        }
+        File.Exists(nestedPath).Should().BeTrue();
+        File.ReadAllText(nestedPath).Should().Be("content-of-sub/nested.txt");
     }
 }
 

--- a/test/dotnetup.Tests/InstallPathResolverTests.cs
+++ b/test/dotnetup.Tests/InstallPathResolverTests.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.Dotnet.Installation;
+using Microsoft.Dotnet.Installation.Internal;
+using Microsoft.DotNet.Tools.Bootstrapper;
+using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
+
+/// <summary>
+/// Unit tests for InstallPathResolver.
+/// </summary>
+public class InstallPathResolverTests(ITestOutputHelper output)
+{
+    private readonly InstallPathResolver _resolver = new(new DotnetInstallManager());
+    
+    // Use platform-appropriate temp paths for test data
+    private static readonly string TempDir = Path.GetTempPath();
+    private static readonly string ExplicitPath = Path.Combine(TempDir, "explicit-dotnet");
+    private static readonly string GlobalJsonPath = Path.Combine(TempDir, "globaljson-dotnet");
+    private static readonly string SamePath = Path.Combine(TempDir, "same-dotnet");
+
+    /// <summary>
+    /// Tests that explicit --install-path takes precedence over global.json's sdk-path,
+    /// even when they differ. This is the key behavior change being tested.
+    /// </summary>
+    [Fact]
+    public void Resolve_ExplicitPathOverridesGlobalJson()
+    {
+        var globalJsonInfo = CreateGlobalJsonInfo(GlobalJsonPath);
+
+        var result = _resolver.Resolve(
+            explicitInstallPath: ExplicitPath,
+            globalJsonInfo: globalJsonInfo,
+            currentDotnetInstallRoot: null,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        output.WriteLine($"Error: {error ?? "(none)"}, Result: {result?.ResolvedInstallPath ?? "(null)"}");
+
+        error.Should().BeNull("explicit install path should override global.json without error");
+        result.Should().NotBeNull();
+        result!.ResolvedInstallPath.Should().Be(ExplicitPath);
+    }
+
+    [Fact]
+    public void Resolve_UsesGlobalJsonPath_WhenNoExplicitPath()
+    {
+        var globalJsonInfo = CreateGlobalJsonInfo(GlobalJsonPath);
+
+        var result = _resolver.Resolve(
+            explicitInstallPath: null,
+            globalJsonInfo: globalJsonInfo,
+            currentDotnetInstallRoot: null,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        error.Should().BeNull();
+        result.Should().NotBeNull();
+        result!.ResolvedInstallPath.Should().Be(GlobalJsonPath);
+    }
+
+    [Fact]
+    public void Resolve_MatchingPathsSucceed()
+    {
+        var globalJsonInfo = CreateGlobalJsonInfo(SamePath);
+
+        var result = _resolver.Resolve(
+            explicitInstallPath: SamePath,
+            globalJsonInfo: globalJsonInfo,
+            currentDotnetInstallRoot: null,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        error.Should().BeNull();
+        result!.ResolvedInstallPath.Should().Be(SamePath);
+    }
+
+    [Fact]
+    public void Resolve_UsesExplicitPath_WhenNoGlobalJson()
+    {
+        var result = _resolver.Resolve(
+            explicitInstallPath: ExplicitPath,
+            globalJsonInfo: null,
+            currentDotnetInstallRoot: null,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        error.Should().BeNull();
+        result!.ResolvedInstallPath.Should().Be(ExplicitPath);
+    }
+
+    [Fact]
+    public void Resolve_UsesDefaultPath_WhenNothingSpecified()
+    {
+        var installManager = new DotnetInstallManager();
+        var result = _resolver.Resolve(
+            explicitInstallPath: null,
+            globalJsonInfo: null,
+            currentDotnetInstallRoot: null,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        error.Should().BeNull();
+        result.Should().NotBeNull();
+        result!.ResolvedInstallPath.Should().Be(installManager.GetDefaultDotnetInstallPath());
+    }
+
+    [Fact]
+    public void Resolve_UsesCurrentUserInstall_WhenNoExplicitOrGlobalJson()
+    {
+        var installRoot = new DotnetInstallRoot("/user/dotnet", InstallerUtilities.GetDefaultInstallArchitecture());
+        var currentInstall = new DotnetInstallRootConfiguration(installRoot, InstallType.User, IsFullyConfigured: true);
+
+        var result = _resolver.Resolve(
+            explicitInstallPath: null,
+            globalJsonInfo: null,
+            currentDotnetInstallRoot: currentInstall,
+            interactive: false,
+            componentDescription: ".NET SDK",
+            out string? error);
+
+        error.Should().BeNull();
+        result!.ResolvedInstallPath.Should().Be("/user/dotnet");
+    }
+
+    private static GlobalJsonInfo CreateGlobalJsonInfo(string sdkPath)
+    {
+        // GlobalJsonInfo.SdkPath is computed from GlobalJsonContents.Sdk.Paths relative to GlobalJsonPath
+        // We need a fully qualified path for the global.json directory
+        string tempDir = Path.GetTempPath();
+        string globalJsonPath = Path.Combine(tempDir, "global.json");
+
+        return new GlobalJsonInfo
+        {
+            GlobalJsonPath = globalJsonPath,
+            GlobalJsonContents = new GlobalJsonContents
+            {
+                Sdk = new GlobalJsonContents.SdkSection
+                {
+                    // Use the absolute path directly since it will be resolved relative to tempDir
+                    Paths = [sdkPath]
+                }
+            }
+        };
+    }
+}

--- a/test/dotnetup.Tests/MuxerHandlerTests.cs
+++ b/test/dotnetup.Tests/MuxerHandlerTests.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.Dotnet.Installation.Internal;
+using Xunit;
+
+namespace Microsoft.Dotnet.Installation.Tests;
+
+public class MuxerHandlerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _muxerPath;
+    private readonly MuxerHandler _handler;
+
+    public MuxerHandlerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"muxer-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDir);
+        _muxerPath = Path.Combine(_testDir, DotnetupUtilities.GetDotnetExeName());
+        _handler = new MuxerHandler(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    private void CreateRuntime(string version)
+    {
+        var runtimeDir = Path.Combine(_testDir, "shared", "Microsoft.NETCore.App", version);
+        Directory.CreateDirectory(runtimeDir);
+        File.WriteAllText(Path.Combine(runtimeDir, "marker.txt"), "test");
+    }
+
+    private void CreateExistingMuxer(string content = "existing")
+    {
+        File.WriteAllText(_muxerPath, content);
+    }
+
+    /// <summary>
+    /// Simulates what the archive extractor does: calls GetMuxerExtractionPath() when 
+    /// it encounters the muxer entry, then writes to that path.
+    /// </summary>
+    private void SimulateMuxerExtraction(string content = "new")
+    {
+        var tempPath = _handler.GetMuxerExtractionPath();
+        File.WriteAllText(tempPath, content);
+    }
+
+    [Fact]
+    public void NoExistingMuxer_ExtractsNewMuxer()
+    {
+        // Arrange
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert
+        File.Exists(_muxerPath).Should().BeTrue();
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExistingMuxer_NewerRuntime_ReplacesMuxer()
+    {
+        // Arrange
+        CreateRuntime("7.0.0");
+        CreateExistingMuxer("old-7.0");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExistingMuxer_SameOrOlderRuntime_KeepsExisting()
+    {
+        // Arrange
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("7.0.0"); // Older runtime
+        SimulateMuxerExtraction("new-7.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged, temp deleted
+        File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NoRuntimeExtracted_DeletesTempMuxer()
+    {
+        // Arrange - simulates WindowsDesktop which has no core runtime
+        CreateExistingMuxer("existing");
+        _handler.RecordPreExtractionState();
+        // Muxer extracted but no runtime created
+        SimulateMuxerExtraction("new");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged, temp deleted
+        File.ReadAllText(_muxerPath).Should().Be("existing");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NoTempMuxerExtracted_NoOp()
+    {
+        // Arrange - archive didn't contain a muxer (GetMuxerExtractionPath never called)
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("9.0.0"); // New runtime but muxer not extracted
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged
+        File.ReadAllText(_muxerPath).Should().Be("existing");
+    }
+
+    [Fact]
+    public void MultipleRuntimes_UsesHighestForComparison()
+    {
+        // Arrange - multiple existing runtimes, highest is 8.0.0
+        CreateRuntime("6.0.0");
+        CreateRuntime("7.0.0");
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+        _handler.RecordPreExtractionState();
+        
+        // Install 9.0.0 (higher than existing highest)
+        CreateRuntime("9.0.0");
+        SimulateMuxerExtraction("new-9.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - should replace since 9.0.0 > 8.0.0
+        File.ReadAllText(_muxerPath).Should().Be("new-9.0");
+    }
+
+    [Fact]
+    public void NoPreExistingRuntime_ExtractsMuxer()
+    {
+        // Edge case: no runtime directories exist yet
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - should install new muxer
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+    }
+}

--- a/test/dotnetup.Tests/MuxerHandlerTests.cs
+++ b/test/dotnetup.Tests/MuxerHandlerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Deployment.DotNet.Releases;
@@ -14,14 +15,12 @@ public class MuxerHandlerTests : IDisposable
 {
     private readonly string _testDir;
     private readonly string _muxerPath;
-    private readonly MuxerHandler _handler;
 
     public MuxerHandlerTests()
     {
         _testDir = Path.Combine(Path.GetTempPath(), $"muxer-test-{Guid.NewGuid()}");
         Directory.CreateDirectory(_testDir);
         _muxerPath = Path.Combine(_testDir, DotnetupUtilities.GetDotnetExeName());
-        _handler = new MuxerHandler(_testDir);
     }
 
     public void Dispose()
@@ -45,30 +44,34 @@ public class MuxerHandlerTests : IDisposable
     }
 
     /// <summary>
-    /// Simulates what the archive extractor does: calls GetMuxerExtractionPath() when
-    /// it encounters the muxer entry, then writes to that path.
+    /// Simulates what the archive extractor does: sets MuxerWasExtracted and writes
+    /// to TempMuxerPath when it encounters the muxer entry.
     /// </summary>
-    private void SimulateMuxerExtraction(string content = "new")
+    private static void SimulateMuxerExtraction(MuxerHandler handler, string content = "new")
     {
-        var tempPath = _handler.GetMuxerExtractionPath();
-        File.WriteAllText(tempPath, content);
+        handler.MuxerWasExtracted = true;
+        File.WriteAllText(handler.TempMuxerPath, content);
+    }
+
+    private MuxerHandler CreateHandler(bool requireMuxerUpdate = false)
+    {
+        return new MuxerHandler(_testDir, requireMuxerUpdate);
     }
 
     [Fact]
     public void NoExistingMuxer_ExtractsNewMuxer()
     {
         // Arrange
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         CreateRuntime("8.0.0");
-        SimulateMuxerExtraction("new-8.0");
+        SimulateMuxerExtraction(handler, "new-8.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
-        // Assert
+        // Assert — when no existing muxer, TempMuxerPath == final path, so muxer is already in place
         File.Exists(_muxerPath).Should().BeTrue();
         File.ReadAllText(_muxerPath).Should().Be("new-8.0");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
@@ -77,16 +80,16 @@ public class MuxerHandlerTests : IDisposable
         // Arrange
         CreateRuntime("7.0.0");
         CreateExistingMuxer("old-7.0");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         CreateRuntime("8.0.0");
-        SimulateMuxerExtraction("new-8.0");
+        SimulateMuxerExtraction(handler, "new-8.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert
         File.ReadAllText(_muxerPath).Should().Be("new-8.0");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+        File.Exists(handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
@@ -95,16 +98,16 @@ public class MuxerHandlerTests : IDisposable
         // Arrange
         CreateRuntime("8.0.0");
         CreateExistingMuxer("existing-8.0");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         CreateRuntime("7.0.0"); // Older runtime
-        SimulateMuxerExtraction("new-7.0");
+        SimulateMuxerExtraction(handler, "new-7.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - existing muxer unchanged, temp deleted
         File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+        File.Exists(handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
@@ -112,29 +115,29 @@ public class MuxerHandlerTests : IDisposable
     {
         // Arrange - simulates WindowsDesktop which has no core runtime
         CreateExistingMuxer("existing");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         // Muxer extracted but no runtime created
-        SimulateMuxerExtraction("new");
+        SimulateMuxerExtraction(handler, "new");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - existing muxer unchanged, temp deleted
         File.ReadAllText(_muxerPath).Should().Be("existing");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+        File.Exists(handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
     public void NoTempMuxerExtracted_NoOp()
     {
-        // Arrange - archive didn't contain a muxer (GetMuxerExtractionPath never called)
+        // Arrange - archive didn't contain a muxer (MuxerWasExtracted never set)
         CreateRuntime("8.0.0");
         CreateExistingMuxer("existing");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         CreateRuntime("9.0.0"); // New runtime but muxer not extracted
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - existing muxer unchanged
         File.ReadAllText(_muxerPath).Should().Be("existing");
@@ -148,14 +151,14 @@ public class MuxerHandlerTests : IDisposable
         CreateRuntime("7.0.0");
         CreateRuntime("8.0.0");
         CreateExistingMuxer("existing-8.0");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install 9.0.0 (higher than existing highest)
         CreateRuntime("9.0.0");
-        SimulateMuxerExtraction("new-9.0");
+        SimulateMuxerExtraction(handler, "new-9.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - should replace since 9.0.0 > 8.0.0
         File.ReadAllText(_muxerPath).Should().Be("new-9.0");
@@ -165,12 +168,12 @@ public class MuxerHandlerTests : IDisposable
     public void NoPreExistingRuntime_ExtractsMuxer()
     {
         // Edge case: no runtime directories exist yet
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
         CreateRuntime("8.0.0");
-        SimulateMuxerExtraction("new-8.0");
+        SimulateMuxerExtraction(handler, "new-8.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - should install new muxer
         File.ReadAllText(_muxerPath).Should().Be("new-8.0");
@@ -182,18 +185,18 @@ public class MuxerHandlerTests : IDisposable
         // Arrange - only a preview runtime exists
         CreateRuntime("10.0.0-preview.5.25280.5");
         CreateExistingMuxer("existing-10.0-preview");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install 9.0.x (lower major version)
         CreateRuntime("9.0.32");
-        SimulateMuxerExtraction("new-9.0");
+        SimulateMuxerExtraction(handler, "new-9.0");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - muxer should NOT be downgraded since 10.0.0 > 9.0.32
         File.ReadAllText(_muxerPath).Should().Be("existing-10.0-preview");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+        File.Exists(handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
@@ -202,14 +205,14 @@ public class MuxerHandlerTests : IDisposable
         // Arrange - release 9.0 runtime exists
         CreateRuntime("9.0.32");
         CreateExistingMuxer("existing-9.0");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install 10.0 preview (higher major version)
         CreateRuntime("10.0.0-preview.5.25280.5");
-        SimulateMuxerExtraction("new-10.0-preview");
+        SimulateMuxerExtraction(handler, "new-10.0-preview");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - muxer SHOULD be upgraded since 10.0.0 > 9.0.32
         File.ReadAllText(_muxerPath).Should().Be("new-10.0-preview");
@@ -240,18 +243,18 @@ public class MuxerHandlerTests : IDisposable
         // Arrange - preview 6 already installed
         CreateRuntime("10.0.0-preview.6.25300.1");
         CreateExistingMuxer("existing-preview6");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install preview 5 (older preview)
         CreateRuntime("10.0.0-preview.5.25280.5");
-        SimulateMuxerExtraction("new-preview5");
+        SimulateMuxerExtraction(handler, "new-preview5");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - muxer should NOT be downgraded
         File.ReadAllText(_muxerPath).Should().Be("existing-preview6");
-        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+        File.Exists(handler.TempMuxerPath).Should().BeFalse();
     }
 
     [Fact]
@@ -260,14 +263,14 @@ public class MuxerHandlerTests : IDisposable
         // Arrange - preview 5 already installed
         CreateRuntime("10.0.0-preview.5.25280.5");
         CreateExistingMuxer("existing-preview5");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install preview 6 (newer preview)
         CreateRuntime("10.0.0-preview.6.25300.1");
-        SimulateMuxerExtraction("new-preview6");
+        SimulateMuxerExtraction(handler, "new-preview6");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - muxer SHOULD be upgraded
         File.ReadAllText(_muxerPath).Should().Be("new-preview6");
@@ -279,14 +282,14 @@ public class MuxerHandlerTests : IDisposable
         // Arrange - preview runtime exists
         CreateRuntime("10.0.0-preview.5.25280.5");
         CreateExistingMuxer("existing-preview");
-        _handler.RecordPreExtractionState();
+        var handler = CreateHandler();
 
         // Install GA release 10.0.0 (same major.minor.patch, no prerelease = higher precedence)
         CreateRuntime("10.0.0");
-        SimulateMuxerExtraction("new-ga");
+        SimulateMuxerExtraction(handler, "new-ga");
 
         // Act
-        _handler.FinalizeAfterExtraction();
+        handler.FinalizeAfterExtraction();
 
         // Assert - GA > preview per semver, so muxer should be upgraded
         File.ReadAllText(_muxerPath).Should().Be("new-ga");
@@ -300,56 +303,116 @@ public class MuxerHandlerTests : IDisposable
     }
 
     [PlatformSpecificFact(TestPlatforms.Windows)] // File locking simulation only works on Windows; actual error handling is cross-platform
-    public void MuxerInUse_RequireMuxerUpdateFalse_WarnsAndKeepsExisting()
+    public void MuxerInUse_RequireMuxerUpdateTrue_FailsFastAtConstruction()
     {
         // Arrange
         CreateRuntime("8.0.0");
         CreateExistingMuxer("existing-8.0");
 
-        var handler = new MuxerHandler(_testDir, requireMuxerUpdate: false);
-        handler.RecordPreExtractionState();
+        // Lock the existing muxer BEFORE creating the handler
+        using var fileLock = new FileStream(_muxerPath, FileMode.Open, FileAccess.Read, FileShare.None);
 
+        // Act & Assert - should throw at construction time, before any extraction work
+        var ex = Assert.Throws<InvalidOperationException>(() => new MuxerHandler(_testDir, requireMuxerUpdate: true));
+        ex.Message.Should().Contain(_muxerPath);
+        ex.Message.Should().Contain("in use");
+
+        // Existing muxer is untouched
+        fileLock.Close();
+        File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
+    }
+
+    [PlatformSpecificFact(TestPlatforms.Windows)]
+    public void MuxerBecomesInUseDuringExtraction_RequireUpdate_ThrowsAtFinalize()
+    {
+        // Arrange - muxer is NOT locked at construction time (passes the early check)
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+
+        var handler = new MuxerHandler(_testDir, requireMuxerUpdate: true);
+
+        // Simulate extraction
         CreateRuntime("9.0.0");
-        var tempPath = handler.GetMuxerExtractionPath();
-        File.WriteAllText(tempPath, "new-9.0");
+        handler.MuxerWasExtracted = true;
+        File.WriteAllText(handler.TempMuxerPath, "new-9.0");
 
-        // Lock the existing muxer to simulate it being in use
+        // Lock the muxer AFTER construction (simulates another process starting during download/extraction)
+        using var fileLock = new FileStream(_muxerPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        // Act & Assert - should throw at FinalizeAfterExtraction, not silently succeed
+        var ex = Assert.Throws<InvalidOperationException>(() => handler.FinalizeAfterExtraction());
+        ex.Message.Should().Contain(_muxerPath);
+        ex.Message.Should().Contain("in use");
+
+        // Existing muxer is untouched, temp cleaned up
+        fileLock.Close();
+        File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
+        File.Exists(handler.TempMuxerPath).Should().BeFalse("temp muxer should be cleaned up");
+    }
+
+    [PlatformSpecificFact(TestPlatforms.Windows)]
+    public void MuxerBecomesInUseDuringExtraction_NoRequireUpdate_WarnsAndKeepsExisting()
+    {
+        // Arrange - muxer is NOT locked at construction time
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+
+        var handler = new MuxerHandler(_testDir, requireMuxerUpdate: false);
+
+        // Simulate extraction
+        CreateRuntime("9.0.0");
+        handler.MuxerWasExtracted = true;
+        File.WriteAllText(handler.TempMuxerPath, "new-9.0");
+
+        // Lock the muxer AFTER construction
         using var fileLock = new FileStream(_muxerPath, FileMode.Open, FileAccess.Read, FileShare.None);
 
         // Act - should not throw, should warn
         handler.FinalizeAfterExtraction();
 
-        // Assert - existing muxer kept, warning emitted to stderr
+        // Assert - existing muxer kept
         fileLock.Close();
         File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
-        File.Exists(tempPath).Should().BeFalse("temp muxer should be cleaned up");
+        File.Exists(handler.TempMuxerPath).Should().BeFalse("temp muxer should be cleaned up");
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows)] // File locking simulation only works on Windows; actual error handling is cross-platform
-    public void MuxerInUse_RequireMuxerUpdateTrue_ThrowsWithPath()
+    [Fact]
+    public void GetDotnetProcessPidInfo_DoesNotKillProcess()
     {
-        // Arrange
-        CreateRuntime("8.0.0");
-        CreateExistingMuxer("existing-8.0");
+        // Start a dotnet process we can look up by name.
+        var proc = new Process();
+        proc.StartInfo.FileName = "dotnet";
+        proc.StartInfo.Arguments = "help";
+        proc.StartInfo.UseShellExecute = false;
+        proc.StartInfo.CreateNoWindow = true;
+        proc.StartInfo.RedirectStandardOutput = true;
+        proc.StartInfo.RedirectStandardError = true;
+        proc.Start();
 
-        var handler = new MuxerHandler(_testDir, requireMuxerUpdate: true);
-        handler.RecordPreExtractionState();
+        try
+        {
+            int pid = proc.Id;
 
-        CreateRuntime("9.0.0");
-        var tempPath = handler.GetMuxerExtractionPath();
-        File.WriteAllText(tempPath, "new-9.0");
+            // Call the utility — this enumerates processes without disposing them
+            string pidInfo = DotnetupUtilities.GetDotnetProcessPidInfo();
+            pidInfo.Should().Contain(pid.ToString(), "our started process should appear in the PID list");
 
-        // Lock the existing muxer to simulate it being in use
-        using var fileLock = new FileStream(_muxerPath, FileMode.Open, FileAccess.Read, FileShare.None);
-
-        // Act & Assert - should throw with path in message
-        var ex = Assert.Throws<InvalidOperationException>(() => handler.FinalizeAfterExtraction());
-        ex.Message.Should().Contain(_muxerPath);
-        ex.Message.Should().Contain("in use");
-
-        // Cleanup
-        fileLock.Close();
-        File.ReadAllText(_muxerPath).Should().Be("existing-8.0", "existing muxer should be preserved");
-        File.Exists(tempPath).Should().BeFalse("temp muxer should be cleaned up even on failure");
+            // The actual process should still be running
+            proc.HasExited.Should().BeFalse(
+                "GetDotnetProcessPidInfo must not kill running dotnet processes");
+        }
+        finally
+        {
+            try
+            {
+                if (!proc.HasExited)
+                {
+                    proc.Kill();
+                    proc.WaitForExit(5000);
+                }
+            }
+            catch { }
+            proc.Dispose();
+        }
     }
 }

--- a/test/dotnetup.Tests/MuxerHandlerTests.cs
+++ b/test/dotnetup.Tests/MuxerHandlerTests.cs
@@ -303,23 +303,40 @@ public class MuxerHandlerTests : IDisposable
     }
 
     [PlatformSpecificFact(TestPlatforms.Windows)] // File locking simulation only works on Windows; actual error handling is cross-platform
-    public void MuxerInUse_RequireMuxerUpdateTrue_FailsFastAtConstruction()
+    public void EnsureMuxerIsWritable_ThrowsWhenMuxerIsLocked()
     {
         // Arrange
         CreateRuntime("8.0.0");
         CreateExistingMuxer("existing-8.0");
 
-        // Lock the existing muxer BEFORE creating the handler
+        // Lock the existing muxer
         using var fileLock = new FileStream(_muxerPath, FileMode.Open, FileAccess.Read, FileShare.None);
 
-        // Act & Assert - should throw at construction time, before any extraction work
-        var ex = Assert.Throws<InvalidOperationException>(() => new MuxerHandler(_testDir, requireMuxerUpdate: true));
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => MuxerHandler.EnsureMuxerIsWritable(_testDir));
         ex.Message.Should().Contain(_muxerPath);
         ex.Message.Should().Contain("in use");
 
         // Existing muxer is untouched
         fileLock.Close();
         File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
+    }
+
+    [PlatformSpecificFact(TestPlatforms.Windows)]
+    public void EnsureMuxerIsWritable_SucceedsWhenMuxerIsNotLocked()
+    {
+        // Arrange
+        CreateExistingMuxer("existing");
+
+        // Act & Assert — should not throw
+        MuxerHandler.EnsureMuxerIsWritable(_testDir);
+    }
+
+    [Fact]
+    public void EnsureMuxerIsWritable_NoOpWhenNoMuxer()
+    {
+        // No muxer exists — should not throw
+        MuxerHandler.EnsureMuxerIsWritable(_testDir);
     }
 
     [PlatformSpecificFact(TestPlatforms.Windows)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/51691
This also addresses the exception raised in this issue https://github.com/dotnet/sdk/issues/51689 

When moving the .NET SDK build to use `dotnetup` in https://github.com/nagilson/sdk/pull/8, I hit several issues. The main issue is that the dotnet muxer may be in use when dotnetup tries to replace it, which would cause a failure.

I don't think we want to fail in this case and instead we want to emit a warning. I've added an option to fail instead, however.

What I also realized is that the approach of renaming the muxer even if it doesn't need to be replaced would cause the warning message to appear even if we didn't need to replace the muxer.  Then I realized, we can do something clever. The windowsdesktop runtime has no runtime so we can skip muxer logic there. The other runtimes versions are the deciding factor for the muxer version since the muxer doesn't have its own version, so we can skip the resolution to find the version there.

For the SDK, what we can do to avoid an extra rename of the existing muxer if it doesn't need to be replaced, is to extract out the new muxer to a different name temporarily, and then look and see if the latest runtime in the dotnet install root target changed after that install. If so then the runtime that came with  the SDK is newer so the new muxer should be used. This lets us gracefully handle when  the muxer is in use as well as avoid any extra work we don't need to do.

https://github.com/dotnet/sdk/pull/52696 this will fail quite often until this other PR is merged due to a dotnetup bug.