### PR TITLE
[backport to release/10.0.3xx]Add warnings for newer tool versions during dotnet tool restore

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -919,6 +919,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   <data name="RestoreSuccessful" xml:space="preserve">
     <value>Tool '{0}' (version '{1}') was restored. Available commands: {2}</value>
   </data>
+  <data name="RestoreNewVersionAvailable" xml:space="preserve">
+    <value>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</value>
+  </data>
   <data name="RollbackDefinitionContainsExtraneousManifestIds" xml:space="preserve">
     <value>Invalid rollback definition. The manifest IDs in rollback definition {0} do not match installed manifest IDs {1}.</value>
   </data>

--- a/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
@@ -83,6 +83,9 @@ internal class ToolPackageRestorer
                         toolPackage.Command.Name));
             }
 
+            // Check for newer versions and prepare warning message
+            string warning = CheckForNewerVersion(package, configFile);
+
             return ToolRestoreResult.Success(
                 saveToCache:
                     (new RestoredCommandIdentifier(
@@ -96,7 +99,8 @@ internal class ToolPackageRestorer
                     CliCommandStrings.RestoreSuccessful,
                     package.PackageId,
                     package.Version.ToNormalizedString(),
-                    string.Join(" ", package.CommandNames)));
+                    string.Join(" ", package.CommandNames)),
+                warning: warning);
         }
         catch (ToolPackageException e)
         {
@@ -127,6 +131,44 @@ internal class ToolPackageRestorer
                    sampleRestoredCommandIdentifierOfThePackage,
                    out var toolCommand)
                && _fileSystem.File.Exists(toolCommand.Executable.Value);
+    }
+
+    private string CheckForNewerVersion(ToolManifestPackage package, FilePath? configFile)
+    {
+        try
+        {
+            // Use wildcard version range to get the latest version
+            var latestVersionRange = VersionRange.Parse("*");
+            
+            var (latestVersion, _) = _toolPackageDownloader.GetNuGetVersion(
+                new PackageLocation(
+                    nugetConfig: configFile,
+                    additionalFeeds: _additionalSources,
+                    sourceFeedOverrides: _overrideSources,
+                    rootConfigDirectory: package.FirstEffectDirectory),
+                package.PackageId,
+                _verbosity,
+                latestVersionRange,
+                _restoreActionConfig);
+
+            // Compare versions - only warn if there's a newer stable version or if the manifest uses prerelease
+            if (latestVersion != null && latestVersion > package.Version)
+            {
+                // If the current version is prerelease, show warning for any newer version
+                // If the current version is stable, only show warning for newer stable versions
+                if (package.Version.IsPrerelease || !latestVersion.IsPrerelease)
+                {
+                    return string.Format(CliCommandStrings.RestoreNewVersionAvailable, package.PackageId, latestVersion.ToNormalizedString());
+                }
+            }
+        }
+        catch
+        {
+            // If we can't check for newer versions, don't show a warning
+            // This could happen due to network issues, package source problems, etc.
+        }
+
+        return string.Empty;
     }
 
     private static string JoinBySpaceWithQuote(IEnumerable<object> objects)

--- a/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
@@ -100,7 +100,7 @@ internal class ToolPackageRestorer
                     package.PackageId,
                     package.Version.ToNormalizedString(),
                     string.Join(" ", package.CommandNames)),
-                    warning: warning);
+                warning: warning);
         }
         catch (ToolPackageException e)
         {

--- a/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
+++ b/src/Cli/dotnet/Commands/Tool/Restore/ToolPackageRestorer.cs
@@ -100,7 +100,7 @@ internal class ToolPackageRestorer
                     package.PackageId,
                     package.Version.ToNormalizedString(),
                     string.Join(" ", package.CommandNames)),
-                warning: warning);
+                    warning: warning);
         }
         catch (ToolPackageException e)
         {

--- a/src/Cli/dotnet/Commands/Tool/Restore/ToolRestoreCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Restore/ToolRestoreCommand.cs
@@ -140,7 +140,14 @@ internal class ToolRestoreCommand : CommandBase<ToolRestoreCommandDefinition>
             {
                 _reporter.WriteLine();
                 _reporter.WriteLine(string.Join(Environment.NewLine, successMessage));
-
+                
+                // Display warnings for successful restorations even in partial failure case
+                var warnings = toolRestoreResults.Where(r => r.IsSuccess && !string.IsNullOrEmpty(r.Warning)).Select(r => r.Warning);
+                if (warnings.Any())
+                {
+                    _reporter.WriteLine();
+                    _reporter.WriteLine(string.Join(Environment.NewLine, warnings).Yellow());
+                }
             }
 
             _errorReporter.WriteLine(Environment.NewLine +
@@ -154,6 +161,15 @@ internal class ToolRestoreCommand : CommandBase<ToolRestoreCommandDefinition>
         {
             _reporter.WriteLine(string.Join(Environment.NewLine,
                 toolRestoreResults.Where(r => r.IsSuccess).Select(r => r.Message)));
+            
+            // Display warnings for newer versions available
+            var warnings = toolRestoreResults.Where(r => r.IsSuccess && !string.IsNullOrEmpty(r.Warning)).Select(r => r.Warning);
+            if (warnings.Any())
+            {
+                _reporter.WriteLine();
+                _reporter.WriteLine(string.Join(Environment.NewLine, warnings).Yellow());
+            }
+            
             _reporter.WriteLine();
             _reporter.WriteLine(CliCommandStrings.LocalToolsRestoreWasSuccessful.Green());
 
@@ -203,10 +219,11 @@ internal class ToolRestoreCommand : CommandBase<ToolRestoreCommandDefinition>
         public (RestoredCommandIdentifier restoredCommandIdentifier, ToolCommand toolCommand)? SaveToCache { get; }
         public bool IsSuccess { get; }
         public string Message { get; }
+        public string Warning { get; }
 
         private ToolRestoreResult(
             (RestoredCommandIdentifier, ToolCommand)? saveToCache,
-            bool isSuccess, string message)
+            bool isSuccess, string message, string warning = null)
         {
             if (string.IsNullOrWhiteSpace(message))
             {
@@ -216,18 +233,20 @@ internal class ToolRestoreCommand : CommandBase<ToolRestoreCommandDefinition>
             SaveToCache = saveToCache;
             IsSuccess = isSuccess;
             Message = message;
+            Warning = warning;
         }
 
         public static ToolRestoreResult Success(
             (RestoredCommandIdentifier, ToolCommand)? saveToCache,
-            string message)
+            string message,
+            string warning = null)
         {
-            return new ToolRestoreResult(saveToCache, true, message);
+            return new ToolRestoreResult(saveToCache, true, message, warning);
         }
 
         public static ToolRestoreResult Failure(string message)
         {
-            return new ToolRestoreResult(null, false, message);
+            return new ToolRestoreResult(null, false, message, null);
         }
 
         public static ToolRestoreResult Failure(
@@ -236,7 +255,7 @@ internal class ToolRestoreCommand : CommandBase<ToolRestoreCommandDefinition>
         {
             return new ToolRestoreResult(null, false,
                 string.Format(CliCommandStrings.PackageFailedToRestore,
-                    packageId.ToString(), toolPackageException.ToString()));
+                    packageId.ToString(), toolPackageException.ToString()), null);
         }
     }
 }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -1337,6 +1337,11 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="translated">Obnovení selhalo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Obnovení bylo částečně neúspěšné.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -1337,6 +1337,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="translated">Fehler beim Wiederherstellen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Die Wiederherstellung war nur teilweise möglich.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -1337,6 +1337,11 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="translated">Error en la restauración.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Error parcial de restauración.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -1337,6 +1337,11 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="translated">Échec de la restauration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Échec partiel de la restauration.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -1337,6 +1337,11 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="translated">Il ripristino non è riuscito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Il ripristino non è riuscito parzialmente.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">復元に失敗しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">復元が部分的に失敗しました。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">복원하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">부분적으로 복원하지 못했습니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -1337,6 +1337,11 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="translated">Przywracanie nie powiodło się.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Przywracanie częściowo nie powiodło się.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -1337,6 +1337,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="translated">Falha na restauração.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Falha parcial na restauração.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">Сбой восстановления.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Восстановление частично не выполнено.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">Geri yükleme başarısız oldu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">Geri yükleme kısmen başarısız oldu.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">还原失败。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">还原部分失败。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -1337,6 +1337,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">還原失敗。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreNewVersionAvailable">
+        <source>A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</source>
+        <target state="new">A newer version of tool '{0}' is available (version '{1}'). Consider updating your manifest file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
         <source>Restore partially failed.</source>
         <target state="translated">還原部分失敗。</target>


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/sdk/pull/51011 because the backport bot failed