### PR TITLE
Build RPM packages in CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -193,7 +193,7 @@ extends:
               # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true /p:BuildSdkRpm=true
               runTests: false
             - categoryName: glibc
               targetArchitecture: arm64
@@ -201,7 +201,7 @@ extends:
               # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
               publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
               officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true
+              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true /p:BuildSdkRpm=true
               runTests: false
             ### musl ###
             - categoryName: musl

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -30,7 +30,7 @@ parameters:
   - categoryName: ContainerBased
     container: azureLinux30Amd64
     helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
-    osProperties: /p:OSName=linux /p:BuildSdkDeb=true
+    osProperties: /p:OSName=linux /p:BuildSdkDeb=true /p:BuildSdkRpm=true
     # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
     disableJob: true
   - categoryName: TemplateEngine


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/52712

We can now build RPMs on any Linux host or container.