### PR TITLE
Fix content publish path calculation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -850,8 +850,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- Preserve existing TargetPath if already set, otherwise compute it -->
         <TargetPath Condition="'%(Content.TargetPath)' != ''">%(Content.TargetPath)</TargetPath>
         <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' != ''">%(Content.Link)</TargetPath>
-        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == '' and '%(Content.DefiningProjectDirectory)' != '' and '%(Content.DefiningProjectFullPath)' != ''">$([MSBuild]::MakeRelative(%(Content.DefiningProjectDirectory), %(Content.FullPath)))</TargetPath>
-        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == '' and ('%(Content.DefiningProjectDirectory)' == '' or '%(Content.DefiningProjectFullPath)' == '')">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
+        <!-- Use MSBuildProjectDirectory as the base for relative path computation. DefiningProjectDirectory can point to sdk targets folder and lead to unexpected paths. -->
+        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == ''">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
       </_ContentWithPublishMetadata>
       
       <ContentWithTargetPath Include="@(_ContentWithPublishMetadata)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/65247

Thanks to @rainersigwald and @baronfel for quick analysis and rootcausing of the issue!

### Context

The path was incorrecftly calculated from `DefiningProjectDirectory` - which can point to sdk targets. The relative paths should be allways based on `MSBuildProjectDirectory` which points to the user project file.


### Testing

Was done manualy offline.

```
wsl -d Ubuntu -- bash -c "mkdir -p /home/jan/MVCFS && cd /home/jan/MVCFS && ~/dotnet10-200/dotnet new mvc -lang F# --no-restore"

wsl -d Ubuntu -- bash -c "cd /home/jan/MVCFS ; ~/dotnet10-200/dotnet publish"
```

To repro the behavior, you need project with `CopyToPublishDirectory` items, while it is being placed to more shallow folder nesting than the sdk that is being tested.