### PR TITLE
Pin hot reaload wasm browser package version

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj
+++ b/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
+  <Import Project="..\Watch\TargetFrameworks.props"/>
 
   <PropertyGroup>
-    <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <!--
+      This code may be injected into a .NET 10.0+ WebAssembly app.
+      Multi-target to ensure compatibility with both .NET 10 and .NET 11 runtimes.
+    -->
+    <TargetFrameworks>$(AgentTargetFrameworkV10);$(AgentTargetFrameworkV11)</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <LangVersion>preview</LangVersion>

--- a/src/BuiltInTools/Watch/TargetFrameworks.props
+++ b/src/BuiltInTools/Watch/TargetFrameworks.props
@@ -6,8 +6,11 @@
     <!-- Used for assemblies injected to apps targeting .NET 6.0 - .NET 9.0. -->
     <AgentTargetFrameworkV6>net6.0</AgentTargetFrameworkV6>
 
-    <!-- Used for assemblies injected to apps targeting .NET 10.0+ -->
+    <!-- Used for assemblies injected to apps targeting .NET 10.0 -->
     <AgentTargetFrameworkV10>net10.0</AgentTargetFrameworkV10>
+
+    <!-- Used for assemblies injected to apps targeting .NET 11.0+ -->
+    <AgentTargetFrameworkV11>net11.0</AgentTargetFrameworkV11>
 
     <!-- Used for assemblies injected to web apps targeting .NET 6.0+ -->
     <MiddlewareTargetFrameworkV6>net6.0</MiddlewareTargetFrameworkV6>


### PR DESCRIPTION
Similar to https://github.com/dotnet/sdk/pull/52517 but fixes https://github.com/dotnet/aspnetcore/issues/65261.

Testing:
- build sdk
- run `dotnet pack ".\src\BuiltInTools\HotReloadAgent.WebAssembly.Browser\Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj" -c Debug -o ".\artifacts\packages\Debug\Shipping" /p:Version=11.0.100-preview.1.26078.107` to create the missing net11 package
- take it and copy it to local net11 nuget cache `Expand-Archive -Path $nupkg -DestinationPath "C:\Nuget\microsoft.dotnet.hotreload.webassembly.browser\11.0.100-preview.1.26078.107" -Force`
- Rerun the steps from the issue and see the problem is gone