### PR TITLE
Keep template_feed/../content/../.gitattributes in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -71,3 +71,8 @@
 *.verified.zsh text eol=lf working-tree-encoding=UTF-8
 *.verified.nu text eol=lf working-tree-encoding=UTF-8
 *.verified.fish text eol=lf working-tree-encoding=UTF-8
+
+###############################################################################
+# Ensure files are included in git archive
+###############################################################################
+/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitattributes/.gitattributes -export-ignore


### PR DESCRIPTION
Some consumers of the VMR source build consume the `git archive` generated source tarball. Without this change, the source tarball doesn't include the content/../.gitattributes file, which makes `dotnet new gitattributes` non-functional.

Fixes: https://github.com/dotnet/sdk/issues/52307