### PR TITLE
Don't import BundledVersions multiple times

### DIFF
--- a/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -601,7 +601,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <NetCoreRoot Condition="'%24(NetCoreRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\'))</NetCoreRoot>
-    <NetCoreSdkRoot Condition="'%24(NetCoreSdkRoot)' == ''">%24(MSBuildThisFileDirectory)</NetCoreSdkRoot>
+    <NetCoreSdkRoot>%24(MSBuildThisFileDirectory)</NetCoreSdkRoot>
     <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(NetCoreRoot)'))packs</NetCoreTargetingPackRoot>
     <PrunePackageDataRoot Condition="'%24(PrunePackageDataRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(MSBuildThisFileDirectory)'))PrunePackageData</PrunePackageDataRoot>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.BundledVersions.props
@@ -16,6 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="'$(NETCoreSdkBundledVersionsProps)' == ''">
     <NETCoreSdkBundledVersionsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledVersions.props</NETCoreSdkBundledVersionsProps>
   </PropertyGroup>
-  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
+
+  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="'$(NetCoreSdkRoot)' == '' and Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
 
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.props
@@ -15,7 +15,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETCoreSdkBundledVersionsProps>$(MSBuildThisFileDirectory)..\..\..\Microsoft.NETCoreSdk.BundledVersions.props</NETCoreSdkBundledVersionsProps>
   </PropertyGroup>
 
-  <!-- Import bundled version information that needs to be availble before the Common.props / D.B.props import
+  <!-- Import bundled version information that needs to be available before the Common.props / D.B.props import
        in order for users to be able to reference it. -->
   <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="'$(NetCoreSdkRoot)' == '' and Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.props
@@ -17,6 +17,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Import bundled version information that needs to be availble before the Common.props / D.B.props import
        in order for users to be able to reference it. -->
-  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
+  <Import Project="$(NETCoreSdkBundledVersionsProps)" Condition="'$(NetCoreSdkRoot)' == '' and Exists('$(NETCoreSdkBundledVersionsProps)')" /> 
 
 </Project>


### PR DESCRIPTION
Avoids issues when the Sdk.BundledVersions.props file gets manually imported.