### PR TITLE
Enforce license header (IDE0073) for C#/VB files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -274,6 +274,8 @@ dotnet_diagnostic.IDE0041.severity = warning
 dotnet_diagnostic.IDE0043.severity = warning
 # MakeLocalFunctionStatic
 dotnet_diagnostic.IDE0062.severity = warning
+# FileHeaderMismatch
+dotnet_diagnostic.IDE0073.severity = warning
 # ConvertTypeOfToNameOf
 dotnet_diagnostic.IDE0082.severity = warning
 # Remove unnecessary lambda expression
@@ -341,8 +343,6 @@ dotnet_diagnostic.CA5394.severity = warning
 dotnet_diagnostic.IDE0005.severity = warning
 # Fix formating
 dotnet_diagnostic.IDE0055.severity = warning
-# FileHeaderMismatch
-dotnet_diagnostic.IDE0073.severity = warning
 # Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = none
 # Opening parenthesis should not be preceded by a space
@@ -471,6 +471,14 @@ dotnet_diagnostic.SA1201.severity = none
 dotnet_diagnostic.SA1202.severity = none
 # Static elements should appear before instance elements
 dotnet_diagnostic.SA1204.severity = none
+
+# Generated build output
+[artifacts/**.cs]
+dotnet_diagnostic.IDE0073.severity = none
+
+# Imported code with different license headers
+[{src/Microsoft.CodeAnalysis.NetAnalyzers,src/BuiltInTools/dotnet-format,test/dotnet-format.UnitTests}/**.cs]
+dotnet_diagnostic.IDE0073.severity = none
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/Utilities/CompilerFeatureRequiredAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs

--- a/src/BuiltInTools/DotNetWatchTasks/Utilities/RequiredMemberAttribute.cs
+++ b/src/BuiltInTools/DotNetWatchTasks/Utilities/RequiredMemberAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Copied from:
 // https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs

--- a/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
+++ b/src/BuiltInTools/HotReloadAgent.PipeRpc/StreamExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 

--- a/src/BuiltInTools/HotReloadClient/Web/SharedSecretProvider.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/SharedSecretProvider.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
 

--- a/src/BuiltInTools/Watch.Aspire/Program.cs
+++ b/src/BuiltInTools/Watch.Aspire/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Build.Locator;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Locator;
 using Microsoft.DotNet.Watch;
 
 if (!DotNetWatchOptions.TryParse(args, out var options))

--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/ForwardedOptionExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/ForwardedOptionExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 

--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/OptionBuilderExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/OptionBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.CommandLine;
 using System.CommandLine.Completions;
 

--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/ResultNavigationExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/ResultNavigationExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 

--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/SpanParsableExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/SpanParsableExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Parsing;

--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/SymbolDocumentationExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/SymbolDocumentationExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.CommandLine;
 
 namespace Microsoft.DotNet.Cli.CommandLine;

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/VerbosityOptions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/VerbosityOptions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.DotNet.Cli.Utils;
 
 /// <summary>

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiCodes.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiCodes.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiDetector.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiDetector.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 // Portions of the code in this file were ported from the spectre.console by Patrik Svensson, Phil Scott, Nils Andresen
 // https://github.com/spectreconsole/spectre.console/blob/main/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ErrorMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ErrorMessage.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ExceptionFlattener.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ExceptionFlattener.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/FileUtilities.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/FileUtilities.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IColor.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IConsole.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IConsole.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IProgressMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IProgressMessage.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IStopwatch.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IStopwatch.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ITerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ITerminal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/NativeMethods.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/NativeMethods.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/NonAnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/NonAnsiTerminal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleAnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleAnsiTerminal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 using Microsoft.DotNet.Cli.Commands;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsole.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsole.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsoleColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsoleColor.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemStopwatch.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemStopwatch.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TargetFrameworkParser.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TargetFrameworkParser.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalColor.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -1,4 +1,5 @@
-﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
 using System.Diagnostics;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestDetailState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestDetailState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
 using System.Globalization;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestOutcome.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestOutcome.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using TestNodeInfoEntry = (int Passed, int Skipped, int Failed, int LastAttemptNumber);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressStateAwareTerminal.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestRunArtifact.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestRunArtifact.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/WarningMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/WarningMessage.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadResolverFactory.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadResolverFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloader.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/Common/Polyfills.cs
+++ b/src/Common/Polyfills.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace System.Linq
 {
     public static class CustomEnumerableExtensions

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/FileOutputDiffGenerator.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/IMethodSymbolExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/IMethodSymbolExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;

--- a/src/Containers/Microsoft.NET.Build.Containers/Exceptions/RepositoryNotFoundException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Exceptions/RepositoryNotFoundException.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToAccessRepositoryException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToAccessRepositoryException.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToDownloadFromRepositoryException.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Exceptions/UnableToDownloadFromRepositoryException.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobOperations.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using System.Net;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobUploadOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultBlobUploadOperations.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
 using System.Net.Http.Headers;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
 using System.Net.Http.Headers;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultRegistryAPI.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/FinalizeUploadInformation.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/FinalizeUploadInformation.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/HttpExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IBlobOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IBlobOperations.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IBlobUploadOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IBlobUploadOperations.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IRegistryAPI.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IRegistryAPI.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/NextChunkUploadInformation.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/NextChunkUploadInformation.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistryConstants.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistryConstants.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistrySettings.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/RegistrySettings.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Utils;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/SchemaTypes.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/StartUploadInformation.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/StartUploadInformation.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.NET.Build.Containers;
 

--- a/src/Microsoft.Extensions.Logging.MSBuild/MSBuildLogger.cs
+++ b/src/Microsoft.Extensions.Logging.MSBuild/MSBuildLogger.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.Extensions.Logging.MSBuild/MSBuildLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.MSBuild/MSBuildLoggerProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Utilities;
 

--- a/src/System.CommandLine.StaticCompletions/DynamicSymbolExtensions.cs
+++ b/src/System.CommandLine.StaticCompletions/DynamicSymbolExtensions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace System.CommandLine.StaticCompletions;
 
 /// <summary>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/AddPackageType.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/AddPackageType.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.Build.Framework;
 using Task = Microsoft.Build.Utilities.Task;
 using System;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net5.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net5.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net6.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net6.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net7.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net7.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net8.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net8.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net9.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.net9.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.2.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp2.2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 #nullable disable

--- a/test/EndToEnd.Tests/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd.Tests/GivenFrameworkDependentApps.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 

--- a/test/EndToEnd.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/test/EndToEnd.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 

--- a/test/EndToEnd.Tests/GivenWindowsApp.cs
+++ b/test/EndToEnd.Tests/GivenWindowsApp.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 

--- a/test/EndToEnd.Tests/ProjectBuildTests.cs
+++ b/test/EndToEnd.Tests/ProjectBuildTests.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/ScriptInjectingStreamTests.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/ScriptInjectingStreamTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Watch.BrowserRefresh;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh;
 
 public class ScriptInjectingStreamTests
 {

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -1,6 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Compression;
 

--- a/test/Microsoft.NET.TestFramework/InMemoryLoggerProvider.cs
+++ b/test/Microsoft.NET.TestFramework/InMemoryLoggerProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 

--- a/test/Microsoft.NET.TestFramework/TestLoggerFactory.cs
+++ b/test/Microsoft.NET.TestFramework/TestLoggerFactory.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 

--- a/test/Microsoft.NET.TestFramework/XunitLoggerProvider.cs
+++ b/test/Microsoft.NET.TestFramework/XunitLoggerProvider.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 using ILogger = Microsoft.Extensions.Logging.ILogger;

--- a/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/Mocks/IAspireServerEventsMock.cs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Moq;
 using Moq.Language.Flow;

--- a/test/dotnet-watch-test-browser/Program.cs
+++ b/test/dotnet-watch-test-browser/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Buffers;
 using System.Linq;
 using System.Net.Http;

--- a/test/dotnet.Tests/CommandTests/Test/NamedPipeClient.cs
+++ b/test/dotnet.Tests/CommandTests/Test/NamedPipeClient.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace dotnet.Tests.CommandTests.Test;
 

--- a/test/sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.DotNet.Build.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests
 {

--- a/test/sdk-tasks.Tests/GenerateDefaultRuntimeFrameworkVersionTests.cs
+++ b/test/sdk-tasks.Tests/GenerateDefaultRuntimeFrameworkVersionTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.DotNet.Build.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests
 {


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/issues/52775

- Enable IDE0073 (FileHeaderMismatch) for all [*.{cs,vb}] files
- Add exclusions for imported code with different valid headers:
  - src/Microsoft.CodeAnalysis.NetAnalyzers (Roslyn analyzers)
  - src/BuiltInTools/dotnet-format (dotnet-format source)
  - test/dotnet-format.UnitTests (dotnet-format tests)
- Fix license headers in SDK-owned files
  - Add headers where missing
  - Updated headers where inconsistent