### PR TITLE
Fix build break from concurrent changes w/api breaking change

### DIFF
--- a/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
+++ b/test/dotnet.Tests/CommandTests/Solution/List/GivenDotnetSlnList.cs
@@ -308,7 +308,7 @@ $"{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}" };
                 $"{new string('-', CliCommandStrings.ProjectsHeader.Length)}",
                 $"{Path.Combine("App", "App.csproj")}",
                 $"{Path.Combine("Lib", "Lib.csproj")}" };
-            var projectDirectory = _testAssetsManager
+            var projectDirectory = TestAssetsManager
                 .CopyTestAsset("TestAppWithTrailingCommaSlnf", identifier: "GivenDotnetSlnList-TrailingComma")
                 .WithSource()
                 .Path;
@@ -328,7 +328,7 @@ $"{Path.Combine("NestedSolution", "NestedFolder", "NestedFolder")}" };
             string[] expectedOutput = { $"{CliCommandStrings.ProjectsHeader}",
                 $"{new string('-', CliCommandStrings.ProjectsHeader.Length)}",
                 $"{Path.Combine("App", "App.csproj")}" };
-            var projectDirectory = _testAssetsManager
+            var projectDirectory = TestAssetsManager
                 .CopyTestAsset("TestAppWithTrailingCommaSlnf", identifier: "GivenDotnetSlnList-Comments")
                 .WithSource()
                 .Path;


### PR DESCRIPTION
This was caused by the breaking change in https://github.com/dotnet/sdk/pull/52757 and https://github.com/dotnet/sdk/pull/51962 being merged without updating to latest.