### PR TITLE
Modernize NativeWrapper P/Invoke for Native AOT compatibility

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -12,14 +12,12 @@
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">true</ExcludeFromDotNetBuild>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net472'">
     <!--
       Mark as Native AOT compatible. This will enable relevant analyzers.
       https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
     -->
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net472'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -10,6 +10,16 @@
     <!-- For product build, this project only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass. -->
     <ExcludeFromDotNetBuild Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">true</ExcludeFromDotNetBuild>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net472'">
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.NativeWrapper
 #if NET
                 if (dotnetExeFromPath != null && !Interop.RunningOnWindows)
                 {
-                    // e.g. on Linux the 'dotnet' command from PATH is a symlink so we need to
+                    // e.g. on Linux the 'dotnet' command from PATH may be a symlink so we need to
                     // resolve it to get the actual path to the binary
                     dotnetExeFromPath = Interop.Unix.realpath(dotnetExeFromPath) ?? dotnetExeFromPath;
                 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -70,12 +70,14 @@ namespace Microsoft.DotNet.NativeWrapper
             {
                 string? dotnetExeFromPath = GetCommandPath(Constants.DotNet);
 
+#if NET
                 if (dotnetExeFromPath != null && !Interop.RunningOnWindows)
                 {
                     // e.g. on Linux the 'dotnet' command from PATH is a symlink so we need to
                     // resolve it to get the actual path to the binary
                     dotnetExeFromPath = Interop.Unix.realpath(dotnetExeFromPath) ?? dotnetExeFromPath;
                 }
+#endif
 
                 if (!string.IsNullOrWhiteSpace(dotnetExeFromPath))
                 {

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.NativeWrapper
         ///  Flags that control SDK resolution behavior in <see cref="hostfxr_resolve_sdk2"/>.
         /// </summary>
         [Flags]
-        public enum hostfxr_resolve_sdk2_flags_t : int
+        internal enum hostfxr_resolve_sdk2_flags_t : int
         {
             /// <summary>
             ///  No special flags. Default resolution behavior.
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.NativeWrapper
         ///   comprehensive information about the SDK resolution process.
         ///  </para>
         /// </remarks>
-        public enum hostfxr_resolve_sdk2_result_key_t : int
+        internal enum hostfxr_resolve_sdk2_result_key_t : int
         {
             /// <summary>
             ///  The resolved SDK directory path. Only provided if resolution succeeds.
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.NativeWrapper
         ///  </para>
         /// </remarks>
         [StructLayout(LayoutKind.Sequential)]
-        public struct hostfxr_dotnet_environment_sdk_info
+        internal struct hostfxr_dotnet_environment_sdk_info
         {
             /// <summary>The size of this structure in bytes.</summary>
             public nint size;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -302,12 +302,12 @@ namespace Microsoft.DotNet.NativeWrapper
 #if NET
         [LibraryImport(Constants.HostFxr)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        internal static partial nint hostfxr_set_error_writer(
+        internal static unsafe partial delegate* unmanaged[Cdecl]<PlatformString, void> hostfxr_set_error_writer(
 #else
         [DllImport(Constants.HostFxr, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern nint hostfxr_set_error_writer(
+        internal static extern unsafe delegate* unmanaged[Cdecl]<PlatformString, void>  hostfxr_set_error_writer(
 #endif
-            nint error_writer);
+            delegate* unmanaged[Cdecl]<PlatformString, void> error_writer);
 
         /// <summary>
         ///  Callback delegate for receiving SDK resolution results from <see cref="hostfxr_resolve_sdk2"/>.

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -390,10 +390,9 @@ namespace Microsoft.DotNet.NativeWrapper
             {
                 localResult = new string[sdk_count];
 
-                ReadOnlySpan<PlatformString> dirs = new((void*)sdk_dirs, sdk_count);
                 for (int i = 0; i < sdk_count; i++)
                 {
-                    localResult[i] = dirs[i];
+                    localResult[i] = ((PlatformString*)sdk_dirs)[i];
                 }
             }
         }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.NativeWrapper
 {
     public static partial class Interop
     {
         public static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#if NETCOREAPP
-        private static readonly string? HostFxrPath;
+#if NET
+        private static readonly string? s_hostFxrPath;
 #endif
 
         static Interop()
@@ -18,10 +19,10 @@ namespace Microsoft.DotNet.NativeWrapper
             {
                 PreloadWindowsLibrary(Constants.HostFxr);
             }
-#if NETCOREAPP
+#if NET
             else
             {
-                HostFxrPath = (string)AppContext.GetData(Constants.RuntimeProperty.HostFxrPath)!;
+                s_hostFxrPath = (string)AppContext.GetData(Constants.RuntimeProperty.HostFxrPath)!;
                 System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly())!.ResolvingUnmanagedDll += HostFxrResolver;
             }
 #endif
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.NativeWrapper
         // construction so that subsequent P/Invokes can find it.
         private static void PreloadWindowsLibrary(string dllFileName)
         {
-            string? basePath = Path.GetDirectoryName(typeof(Interop).Assembly.Location);
+            string? basePath = AppContext.BaseDirectory;
             string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
             string dllPath = Path.Combine(basePath ?? string.Empty, architecture, $"{dllFileName}.dll");
 
@@ -49,14 +50,14 @@ namespace Microsoft.DotNet.NativeWrapper
                 return IntPtr.Zero;
             }
 
-            if (string.IsNullOrEmpty(HostFxrPath))
+            if (string.IsNullOrEmpty(s_hostFxrPath))
             {
                 throw new HostFxrRuntimePropertyNotSetException();
             }
 
-            if (!NativeLibrary.TryLoad(HostFxrPath, out var handle))
+            if (!NativeLibrary.TryLoad(s_hostFxrPath, out var handle))
             {
-                throw new HostFxrNotFoundException(HostFxrPath);
+                throw new HostFxrNotFoundException(s_hostFxrPath);
             }
 
             return handle;
@@ -66,140 +67,375 @@ namespace Microsoft.DotNet.NativeWrapper
         // lpFileName passed to LoadLibraryEx must be a full path.
         private const int LOAD_WITH_ALTERED_SEARCH_PATH = 0x8;
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
-        private static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, int dwFlags);
+#if NET
+        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+        private static partial nint LoadLibraryExW(string lpFileName, nint hFile, int dwFlags);
+#else
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern IntPtr LoadLibraryExW(string lpFileName, nint hFile, int dwFlags);
+#endif
 
+        /// <summary>
+        ///  Flags that control SDK resolution behavior in <see cref="hostfxr_resolve_sdk2"/>.
+        /// </summary>
         [Flags]
-        internal enum hostfxr_resolve_sdk2_flags_t : int
+        public enum hostfxr_resolve_sdk2_flags_t : int
         {
-            disallow_prerelease = 0x1,
+            /// <summary>
+            ///  No special flags. Default resolution behavior.
+            /// </summary>
+            none = 0,
+
+            /// <summary>
+            ///  Disallow resolution to return a prerelease SDK version unless a prerelease
+            ///  version was explicitly specified via global.json.
+            /// </summary>
+            disallow_prerelease = 0x1
         }
 
-        internal enum hostfxr_resolve_sdk2_result_key_t : int
+        /// <summary>
+        ///  Identifies the type of result returned through the <see cref="hostfxr_resolve_sdk2"/> callback.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The callback may be invoked multiple times with different keys to provide
+        ///   comprehensive information about the SDK resolution process.
+        ///  </para>
+        /// </remarks>
+        public enum hostfxr_resolve_sdk2_result_key_t : int
         {
+            /// <summary>
+            ///  The resolved SDK directory path. Only provided if resolution succeeds.
+            /// </summary>
             resolved_sdk_dir = 0,
+
+            /// <summary>
+            ///  The path to the global.json file that influenced resolution, if any.
+            ///  Not provided if no global.json was found or if it didn't affect resolution.
+            /// </summary>
             global_json_path = 1,
+
+            /// <summary>
+            ///  The SDK version requested by global.json, if a specific version was specified.
+            ///  Provided for both successful and failed resolutions.
+            /// </summary>
             requested_version = 2,
-            global_json_state = 3,
+
+            /// <summary>
+            ///  The state of global.json processing. One of: "not_found", "valid", "invalid_json", or "invalid_data".
+            /// </summary>
+            global_json_state = 3
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        internal struct hostfxr_dotnet_environment_info
+        /// <summary>
+        ///  Contains comprehensive information about the .NET environment, passed to the
+        ///  <c>hostfxr_get_dotnet_environment_info</c> callback.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This structure provides information about the hostfxr version, all installed SDKs,
+        ///   and all installed shared frameworks.
+        ///  </para>
+        ///  <para>
+        ///   <b>Memory ownership:</b> This structure, the arrays it references, and all strings within those
+        ///   arrays are owned by the native hostfxr library. They are valid only for the duration of the
+        ///   callback invocation. The caller must copy any data it needs to retain. Do not attempt to free
+        ///   any pointers in this structure or the nested structures.
+        ///  </para>
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct hostfxr_dotnet_environment_info
         {
-            public nuint size;
-            public string hostfxr_version;
-            public string hostfxr_commit_hash;
-            public nuint sdk_count;
-            public IntPtr sdks;
-            public nuint framework_count;
-            public IntPtr frameworks;
+            /// <summary>The size of this structure in bytes.</summary>
+            public nint size;
+
+            /// <summary>Pointer to the hostfxr version string.</summary>
+            public PlatformString hostfxr_version;
+
+            /// <summary>Pointer to the hostfxr commit hash string.</summary>
+            public PlatformString hostfxr_commit_hash;
+
+            /// <summary>The number of SDKs in the <see cref="sdks"/> array.</summary>
+            public nint sdk_count;
+
+            /// <summary>Pointer to an array of <see cref="hostfxr_dotnet_environment_sdk_info"/> structures.</summary>
+            public hostfxr_dotnet_environment_sdk_info* sdks;
+
+            /// <summary>The number of frameworks in the <see cref="frameworks"/> array.</summary>
+            public nint framework_count;
+
+            /// <summary>Pointer to an array of <see cref="hostfxr_dotnet_environment_framework_info"/> structures.</summary>
+            public hostfxr_dotnet_environment_framework_info* frameworks;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        /// <summary>
+        ///  Contains information about an installed shared framework, returned by <see cref="hostfxr_get_dotnet_environment_info"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   <b>Memory ownership:</b> This structure and all referenced strings are owned by the native hostfxr
+        ///   library. They are valid only for the duration of the callback invocation. The caller must copy
+        ///   any data it needs to retain. Do not attempt to free any pointers in this structure.
+        ///  </para>
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential)]
         internal struct hostfxr_dotnet_environment_framework_info
         {
-            public nuint size;
-            public string name;
-            public string version;
-            public string path;
+            /// <summary>The size of this structure in bytes.</summary>
+            public nint size;
+
+            /// <summary>Pointer to the framework name (e.g., "Microsoft.NETCore.App").</summary>
+            public PlatformString name;
+
+            /// <summary>Pointer to the framework version string (e.g., "8.0.0").</summary>
+            public PlatformString version;
+
+            /// <summary>Pointer to the full path to the framework directory.</summary>
+            public PlatformString path;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        internal struct hostfxr_dotnet_environment_sdk_info
+        /// <summary>
+        ///  Contains information about an installed SDK, returned by <see cref="hostfxr_dotnet_environment_info"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   <b>Memory ownership:</b> This structure and all referenced strings are owned by the native hostfxr
+        ///   library. They are valid only for the duration of the callback invocation. The caller must copy
+        ///   any data it needs to retain. Do not attempt to free any pointers in this structure.
+        ///  </para>
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct hostfxr_dotnet_environment_sdk_info
         {
-            public nuint size;
-            public string version;
-            public string path;
+            /// <summary>The size of this structure in bytes.</summary>
+            public nint size;
+
+            /// <summary>Pointer to the SDK version string (e.g., "8.0.100").</summary>
+            public PlatformString version;
+
+            /// <summary>Pointer to the full path to the SDK directory.</summary>
+            public PlatformString path;
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        internal delegate void hostfxr_get_dotnet_environment_info_result_fn(
-            IntPtr info,
-            IntPtr result_context);
-
-        [DllImport(Constants.HostFxr, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int hostfxr_get_dotnet_environment_info(
-            string dotnet_root,
-            IntPtr reserved,
-            hostfxr_get_dotnet_environment_info_result_fn result,
-            IntPtr result_context);
-
+        /// <summary>
+        ///  Callback delegate for receiving environment information from <c>hostfxr_get_dotnet_environment_info</c>.
+        /// </summary>
+        /// <param name="info">Pointer to a <see cref="hostfxr_dotnet_environment_info"/> structure.</param>
+        /// <param name="result_context">The context pointer passed to the original function call.</param>
+        /// <remarks>
+        ///  <para>
+        ///   All data referenced by the info structure is valid only for the duration of the callback.
+        ///   Copy any needed data before returning.
+        ///  </para>
+        /// </remarks>
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void hostfxr_error_writer_fn(IntPtr message);
+        internal delegate void hostfxr_get_dotnet_environment_info_result_fn(ref hostfxr_dotnet_environment_info info, nint result_context);
 
-        [DllImport(Constants.HostFxr, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr hostfxr_set_error_writer(IntPtr error_writer);
+        /// <summary>
+        ///  Gets comprehensive information about the .NET environment including installed SDKs and frameworks.
+        /// </summary>
+        /// <param name="dotnetRoot">Path to the .NET installation root, or <c>null</c> to use the default or registered location.</param>
+        /// <param name="reserved">Reserved for future use. Must be zero.</param>
+        /// <param name="result">Callback invoked with environment information.</param>
+        /// <param name="resultContext">Arbitrary context pointer passed through to the callback.</param>
+        /// <returns>
+        ///  <see cref="StatusCode.Success"/> on success, or an error status code.
+        /// </returns>
+        /// <remarks>
+        ///  <para>
+        ///  The callback receives a pointer to a <see cref="hostfxr_dotnet_environment_info"/> structure
+        ///  containing hostfxr version information, installed SDKs, and installed frameworks.
+        ///  All data is valid only for the duration of the callback.
+        ///  </para>
+        /// </remarks>
+#if NET
+        [LibraryImport(Constants.HostFxr, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(PlatformStringMarshaller))]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static partial int hostfxr_get_dotnet_environment_info(
+#else
+        [DllImport(Constants.HostFxr, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int hostfxr_get_dotnet_environment_info(
+#endif
+            string? dotnetRoot,
+            nint reserved,
+            hostfxr_get_dotnet_environment_info_result_fn result,
+            nint resultContext);
 
-        public static class Windows
+        /// <summary>
+        ///  Callback delegate for receiving error messages from the hosting layer.
+        /// </summary>
+        /// <param name="message">The error message text.</param>
+        /// <remarks>
+        ///  <para>
+        ///   Set via <see cref="hostfxr_set_error_writer"/> to receive error messages that would
+        ///   otherwise be written to stderr. Useful for capturing diagnostics in GUI applications
+        ///   or custom logging scenarios.
+        ///  </para>
+        /// </remarks>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void hostfxr_error_writer_fn(PlatformString message);
+
+        /// <summary>
+        ///  Sets a callback for receiving error messages from the hosting layer.
+        /// </summary>
+        /// <param name="error_writer">
+        ///  Callback to receive error messages, or <c>null</c> to restore the default behavior (writing to stderr).
+        /// </param>
+        /// <returns>
+        ///  A pointer to the previously registered error writer callback, or zero if none was set.
+        /// </returns>
+        /// <remarks>
+        ///  <para>
+        ///   Use this to capture error messages in GUI applications or for custom logging scenarios
+        ///   where stderr is not appropriate.
+        ///  </para>
+        /// </remarks>
+#if NET
+        [LibraryImport(Constants.HostFxr)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static partial nint hostfxr_set_error_writer(
+#else
+        [DllImport(Constants.HostFxr, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint hostfxr_set_error_writer(
+#endif
+            nint error_writer);
+
+        /// <summary>
+        ///  Callback delegate for receiving SDK resolution results from <see cref="hostfxr_resolve_sdk2"/>.
+        /// </summary>
+        /// <param name="key">Identifies the type of data being provided.</param>
+        /// <param name="value">The string value associated with the key.</param>
+        /// <remarks>
+        ///  <para>
+        ///   This callback may be invoked multiple times with different keys during a single
+        ///   resolution operation. The string values are valid only for the duration of the callback.
+        ///  </para>
+        /// </remarks>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void hostfxr_resolve_sdk2_result_fn(hostfxr_resolve_sdk2_result_key_t key, PlatformString value);
+
+        /// <summary>
+        ///  Resolves the SDK directory with detailed results provided via callback.
+        /// </summary>
+        /// <param name="exeDir">
+        ///  Directory containing the dotnet executable, or <see langword="null"/>/empty for default search.
+        /// </param>
+        /// <param name="workingDir">
+        ///  Directory to start searching for global.json, or <see langword="null"/>/empty to disable global.json search.
+        /// </param>
+        /// <param name="flags">
+        ///  Resolution flags controlling behavior (e.g., <see cref="hostfxr_resolve_sdk2_flags_t.disallow_prerelease"/>).
+        /// </param>
+        /// <param name="result">Dictionary with resolution results.</param>
+        /// <returns>
+        ///  <see cref="StatusCode.Success"/> if the SDK was resolved, or <see cref="StatusCode.SdkResolveFailure"/> if not found.
+        /// </returns>
+#if NET
+        [LibraryImport(
+            Constants.HostFxr,
+            EntryPoint = "hostfxr_resolve_sdk2",
+            StringMarshalling = StringMarshalling.Custom,
+            StringMarshallingCustomType = typeof(PlatformStringMarshaller))]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static partial StatusCode hostfxr_resolve_sdk2(
+#else
+        [DllImport(
+            Constants.HostFxr,
+            EntryPoint = "hostfxr_resolve_sdk2",
+            CharSet = CharSet.Unicode,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern StatusCode hostfxr_resolve_sdk2(
+#endif
+            string? exeDir,
+            string? workingDir,
+            hostfxr_resolve_sdk2_flags_t flags,
+            hostfxr_resolve_sdk2_result_fn result);
+
+        /// <summary>
+        ///  Callback delegate for receiving available SDK list from <see cref="hostfxr_get_available_sdks"/>.
+        /// </summary>
+        /// <param name="sdk_count">The number of SDKs in the array.</param>
+        /// <param name="sdk_dirs">Pointer to an array of pointers to null-terminated SDK directory path strings.</param>
+        /// <remarks>
+        ///  <para>
+        ///   The SDKs are returned in ascending version order. The array and string data are valid
+        ///   only for the duration of the callback.
+        ///  </para>
+        /// </remarks>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void hostfxr_get_available_sdks_result_fn(int sdk_count, nint sdk_dirs);
+
+        /// <summary>
+        ///  Gets all installed SDKs in ascending version order.
+        /// </summary>
+        /// <param name="exeDir">Path to the dotnet executable directory.</param>
+        /// <param name="result">List of SDK directories.</param>
+        /// <returns>
+        ///  Always returns <see cref="StatusCode.Success"/>.
+        /// </returns>
+        /// <remarks>
+        ///  <para>
+        ///   The SDKs are returned in ascending version order. This is useful for the MSBuild SDK resolver
+        ///   to find a compatible SDK when the latest SDK is incompatible.
+        ///  </para>
+        /// </remarks>
+        internal static StatusCode hostfxr_get_available_sdks(string? exeDir, out string[] result)
         {
-            private const CharSet UTF16 = CharSet.Unicode;
+            string[]? localResult = null;
+            StatusCode status = hostfxr_get_available_sdks_private(exeDir, SdkCallback);
+            result = localResult ?? [];
+            return status;
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = UTF16)]
-            internal delegate void hostfxr_resolve_sdk2_result_fn(
-                hostfxr_resolve_sdk2_result_key_t key,
-                string value);
+            unsafe void SdkCallback(int sdk_count, nint sdk_dirs)
+            {
+                localResult = new string[sdk_count];
 
-            [DllImport(Constants.HostFxr, CharSet = UTF16, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern int hostfxr_resolve_sdk2(
-                string? exe_dir,
-                string? working_dir,
-                hostfxr_resolve_sdk2_flags_t flags,
-                hostfxr_resolve_sdk2_result_fn result);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = UTF16)]
-            internal delegate void hostfxr_get_available_sdks_result_fn(
-                int sdk_count,
-                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
-                string[] sdk_dirs);
-
-            [DllImport(Constants.HostFxr, CharSet = UTF16, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern int hostfxr_get_available_sdks(
-                string? exe_dir,
-                hostfxr_get_available_sdks_result_fn result);
+                ReadOnlySpan<PlatformString> dirs = new((void*)sdk_dirs, sdk_count);
+                for (int i = 0; i < sdk_count; i++)
+                {
+                    localResult[i] = dirs[i];
+                }
+            }
         }
 
-        public static class Unix
+#if NET
+        [LibraryImport(
+            Constants.HostFxr,
+            EntryPoint = "hostfxr_get_available_sdks",
+            StringMarshalling = StringMarshalling.Custom,
+            StringMarshallingCustomType = typeof(PlatformStringMarshaller))]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        private static partial StatusCode hostfxr_get_available_sdks_private(
+#else
+        [DllImport(
+            Constants.HostFxr,
+            EntryPoint = "hostfxr_get_available_sdks",
+            CharSet = CharSet.Unicode,
+            CallingConvention = CallingConvention.Cdecl)]
+        private static extern StatusCode hostfxr_get_available_sdks_private(
+#endif
+            string? exeDir,
+            hostfxr_get_available_sdks_result_fn result);
+
+#if NET
+        public static partial class Unix
         {
-            // Ansi marshaling on Unix is actually UTF8
-            private const CharSet UTF8 = CharSet.Ansi;
-            private static string? PtrToStringUTF8(IntPtr ptr) => Marshal.PtrToStringAnsi(ptr);
+            [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8)]
+            [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+            private static partial nint realpath(string path, nint buffer);
 
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = UTF8)]
-            internal delegate void hostfxr_resolve_sdk2_result_fn(
-                hostfxr_resolve_sdk2_result_key_t key,
-                string value);
-
-            [DllImport(Constants.HostFxr, CharSet = UTF8, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern int hostfxr_resolve_sdk2(
-                string? exe_dir,
-                string? working_dir,
-                hostfxr_resolve_sdk2_flags_t flags,
-                hostfxr_resolve_sdk2_result_fn result);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = UTF8)]
-            internal delegate void hostfxr_get_available_sdks_result_fn(
-                int sdk_count,
-                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
-                string[] sdk_dirs);
-
-            [DllImport(Constants.HostFxr, CharSet = UTF8, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern int hostfxr_get_available_sdks(
-                string? exe_dir,
-                hostfxr_get_available_sdks_result_fn result);
-
-            [DllImport("libc", CharSet = UTF8, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            private static extern IntPtr realpath(string path, IntPtr buffer);
-
-            [DllImport("libc", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            private static extern void free(IntPtr ptr);
+            [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8)]
+            [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+            private static partial void free(nint ptr);
 
             public static string? realpath(string path)
             {
-                var ptr = realpath(path, IntPtr.Zero);
-                var result = PtrToStringUTF8(ptr);
+                nint ptr = realpath(path, nint.Zero);
+                string? result = Marshal.PtrToStringUTF8(ptr);
                 free(ptr);
                 return result;
             }
         }
+#endif
     }
 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Microsoft.DotNet.NativeWrapper.csproj
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Microsoft.DotNet.NativeWrapper.csproj
@@ -2,6 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework);net472</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net472'">
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETBundlesNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETBundlesNativeWrapper.cs
@@ -7,11 +7,11 @@ namespace Microsoft.DotNet.NativeWrapper
     {
         public NetEnvironmentInfo GetDotnetEnvironmentInfo(string dotnetExeDirectory)
         {
-            var info = new NetEnvironmentInfo();
+            NetEnvironmentInfo info = new();
             IntPtr reserved = IntPtr.Zero;
             IntPtr resultContext = IntPtr.Zero;
 
-            int errorCode = Interop.hostfxr_get_dotnet_environment_info(dotnetExeDirectory, reserved, info.Initialize, resultContext);
+            int errorCode = Interop.hostfxr_get_dotnet_environment_info(dotnetExeDirectory, default, info.Initialize, default);
 
             return info;
         }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
@@ -15,9 +15,7 @@ namespace Microsoft.DotNet.NativeWrapper
             var result = new SdkResolutionResult();
             var flags = disallowPrerelease ? Interop.hostfxr_resolve_sdk2_flags_t.disallow_prerelease : 0;
 
-            int errorCode = Interop.RunningOnWindows
-                ? Interop.Windows.hostfxr_resolve_sdk2(dotnetExeDirectory, globalJsonStartDirectory, flags, result.Initialize)
-                : Interop.Unix.hostfxr_resolve_sdk2(dotnetExeDirectory, globalJsonStartDirectory, flags, result.Initialize);
+            StatusCode errorCode = Interop.hostfxr_resolve_sdk2(dotnetExeDirectory, globalJsonStartDirectory, flags, result.Initialize);
 
             Debug.Assert((errorCode == 0) == (result.ResolvedSdkDirectory != null));
             return result;
@@ -29,9 +27,9 @@ namespace Microsoft.DotNet.NativeWrapper
             // so just pass empty string as executable directory for resolution. This means that
             // we expect the call to fail to resolve an SDK. Set up the error writer to avoid
             // output going to stderr. We reset it after the call.
-            var swallowErrors = new Interop.hostfxr_error_writer_fn(message => { });
-            IntPtr errorWriter = Marshal.GetFunctionPointerForDelegate(swallowErrors);
-            IntPtr previousErrorWriter = Interop.hostfxr_set_error_writer(errorWriter);
+            Interop.hostfxr_error_writer_fn swallowErrors = new(message => { });
+            nint errorWriter = Marshal.GetFunctionPointerForDelegate(swallowErrors);
+            nint previousErrorWriter = Interop.hostfxr_set_error_writer(errorWriter);
             try
             {
                 SdkResolutionResult result = ResolveSdk(string.Empty, globalJsonStartDirectory);
@@ -40,30 +38,14 @@ namespace Microsoft.DotNet.NativeWrapper
             finally
             {
                 Interop.hostfxr_set_error_writer(previousErrorWriter);
+                GC.KeepAlive(swallowErrors);
             }
         }
 
-        private sealed class SdkList
+        public static string[] GetAvailableSdks(string? dotnetExeDirectory)
         {
-            public string[]? Entries;
-
-            public void Initialize(int count, string[] entries)
-            {
-                entries = entries ?? Array.Empty<string>();
-                Debug.Assert(count == entries.Length);
-                Entries = entries;
-            }
-        }
-
-        public static string[]? GetAvailableSdks(string? dotnetExeDirectory)
-        {
-            var list = new SdkList();
-
-            int errorCode = Interop.RunningOnWindows
-                ? Interop.Windows.hostfxr_get_available_sdks(dotnetExeDirectory, list.Initialize)
-                : Interop.Unix.hostfxr_get_available_sdks(dotnetExeDirectory, list.Initialize);
-
-            return list.Entries;
+            Interop.hostfxr_get_available_sdks(dotnetExeDirectory, out string[] result);
+            return result;
         }
     }
 }

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETCoreSdkResolverNativeWrapper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.NativeWrapper
             return result;
         }
 
-        public static string? GetGlobalJsonState(string globalJsonStartDirectory)
+        public static unsafe string? GetGlobalJsonState(string globalJsonStartDirectory)
         {
             // We don't care about the actual SDK resolution, just the global.json information,
             // so just pass empty string as executable directory for resolution. This means that
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.NativeWrapper
             // output going to stderr. We reset it after the call.
             Interop.hostfxr_error_writer_fn swallowErrors = new(message => { });
             nint errorWriter = Marshal.GetFunctionPointerForDelegate(swallowErrors);
-            nint previousErrorWriter = Interop.hostfxr_set_error_writer(errorWriter);
+            var previousErrorWriter = Interop.hostfxr_set_error_writer((delegate* unmanaged[Cdecl]<PlatformString, void>)errorWriter);
             try
             {
                 SdkResolutionResult result = ResolveSdk(string.Empty, globalJsonStartDirectory);

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETEnvironmentInfo.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/NETEnvironmentInfo.cs
@@ -62,22 +62,27 @@ namespace Microsoft.DotNet.NativeWrapper
 
         internal unsafe void Initialize(ref hostfxr_dotnet_environment_info info, nint _)
         {
-            ReadOnlySpan<hostfxr_dotnet_environment_framework_info> runtimes = new(info.frameworks, (int)info.framework_count);
-            List<NetRuntimeInfo> runtimeInfo = new(capacity: runtimes.Length);
+            int count = (int)info.framework_count;
+            var framework = info.frameworks;
 
-            for (var i = 0; i < runtimes.Length; i++)
+            List<NetRuntimeInfo> runtimeInfo = new(capacity: count);
+
+            for (var i = 0; i < count; i++)
             {
-                runtimeInfo.Add(new(runtimes[i].name, runtimes[i].version, runtimes[i].path));
+                runtimeInfo.Add(new(framework->name, framework->version, framework->path));
+                framework++;
             }
 
             RuntimeInfo = runtimeInfo;
 
-            ReadOnlySpan<hostfxr_dotnet_environment_sdk_info> sdks = new(info.sdks, (int)info.sdk_count);
-            List<NetSdkInfo> sdkInfo = new(capacity: sdks.Length);
+            count = (int)info.sdk_count;
+            var sdk = info.sdks;
+            List<NetSdkInfo> sdkInfo = new(count);
 
-            for (var i = 0; i < sdks.Length; i++)
+            for (var i = 0; i < count; i++)
             {
-                sdkInfo.Add(new(sdks[i].version, sdks[i].path));
+                sdkInfo.Add(new(sdk->version, sdk->path));
+                sdk++;
             }
 
             SdkInfo = sdkInfo;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformString.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformString.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.NativeWrapper;
+
+/// <summary>
+///  Helper struct for marshalling platform-dependent strings.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is particularly useful for returned strings.
+///  </para>
+/// </remarks>
+public readonly struct PlatformString
+{
+    /// <summary>
+    ///  The native value.
+    /// </summary>
+    public readonly nint Value { get; }
+
+    /// <inheritdoc/>
+    public override readonly string ToString()
+    {
+        if (Value == 0)
+        {
+            return string.Empty;
+        }
+
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return Marshal.PtrToStringUTF8(Value) ?? string.Empty;
+        }
+#endif
+
+        return Marshal.PtrToStringUni(Value) ?? string.Empty;
+    }
+
+    /// <summary>
+    ///  Implicit conversion from <see cref="PlatformString"/> to <see cref="string"/>.
+    /// </summary>
+    public static implicit operator string(PlatformString value) => value.ToString();
+}

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformStringMarshaller.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformStringMarshaller.cs
@@ -16,8 +16,6 @@ namespace Microsoft.DotNet.NativeWrapper;
 ///  </para>
 /// </remarks>
 [CustomMarshaller(typeof(string), MarshalMode.Default, typeof(PlatformStringMarshaller))]
-[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
-[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedOut, typeof(ManagedToUnmanagedOut))]
 public static unsafe class PlatformStringMarshaller
 {
     /// <summary>
@@ -35,23 +33,6 @@ public static unsafe class PlatformStringMarshaller
         return OperatingSystem.IsWindows()
             ? (nint)Utf16StringMarshaller.ConvertToUnmanaged(managed)
             : (nint)Utf8StringMarshaller.ConvertToUnmanaged(managed);
-    }
-
-    private static void PlatformFree(nint unmanaged)
-    {
-        if (unmanaged == 0)
-        {
-            return;
-        }
-
-        if (OperatingSystem.IsWindows())
-        {
-            Utf16StringMarshaller.Free((ushort*)unmanaged);
-        }
-        else
-        {
-            Utf8StringMarshaller.Free((byte*)unmanaged);
-        }
     }
 
     /// <summary>
@@ -75,89 +56,21 @@ public static unsafe class PlatformStringMarshaller
     ///  Frees memory allocated by <see cref="ConvertToUnmanaged"/>.
     /// </summary>
     /// <param name="unmanaged">The unmanaged string pointer to free.</param>
-    public static void Free(nint unmanaged) => PlatformFree(unmanaged);
-
-    /// <summary>
-    ///  Marshaller for managed-to-unmanaged direction (input parameters) with stack allocation support.
-    /// </summary>
-    public ref struct ManagedToUnmanagedIn
+    public static void Free(nint unmanaged)
     {
-        /// <summary>
-        ///  The recommended buffer size for stack allocation.
-        /// </summary>
-        public static int BufferSize => 256;
-
-        private nint _unmanagedValue;
-        private Utf8StringMarshaller.ManagedToUnmanagedIn _utf8Marshaller;
-        private bool _useUtf8;
-
-        /// <summary>
-        ///  Initializes the marshaller with an optional stack-allocated buffer.
-        /// </summary>
-        /// <param name="managed">The managed string to marshal.</param>
-        /// <param name="buffer">A stack-allocated buffer that may be used for small strings.</param>
-        public void FromManaged(string? managed, Span<byte> buffer)
+        if (unmanaged == 0)
         {
-            _useUtf8 = !OperatingSystem.IsWindows();
-            if (_useUtf8)
-            {
-                _utf8Marshaller.FromManaged(managed, buffer);
-                _unmanagedValue = 0;
-                return;
-            }
-
-            _unmanagedValue = (nint)Utf16StringMarshaller.ConvertToUnmanaged(managed);
+            return;
         }
 
-        /// <summary>
-        ///  Returns the unmanaged string pointer.
-        /// </summary>
-        /// <returns>The unmanaged string pointer.</returns>
-        public readonly nint ToUnmanaged() => _useUtf8
-            ? (nint)_utf8Marshaller.ToUnmanaged()
-            : _unmanagedValue;
-
-        /// <summary>
-        ///  Frees any allocated unmanaged memory.
-        /// </summary>
-        public readonly void Free()
+        if (OperatingSystem.IsWindows())
         {
-            if (_useUtf8)
-            {
-                _utf8Marshaller.Free();
-                return;
-            }
-
-            if (_unmanagedValue != 0)
-            {
-                Utf16StringMarshaller.Free((ushort*)_unmanagedValue);
-            }
+            Utf16StringMarshaller.Free((ushort*)unmanaged);
         }
-    }
-
-    /// <summary>
-    ///  Marshaller for managed-to-unmanaged direction (output/return values).
-    /// </summary>
-    public ref struct ManagedToUnmanagedOut
-    {
-        private nint _unmanagedValue;
-
-        /// <summary>
-        ///  Sets the unmanaged value received from native code.
-        /// </summary>
-        /// <param name="unmanaged">The unmanaged string pointer.</param>
-        public void FromUnmanaged(nint unmanaged) => _unmanagedValue = unmanaged;
-
-        /// <summary>
-        ///  Converts the unmanaged string to a managed string.
-        /// </summary>
-        /// <returns>The managed string, or null if the pointer is zero.</returns>
-        public readonly string? ToManaged() => ConvertToManaged(_unmanagedValue);
-
-        /// <summary>
-        ///  Frees the unmanaged string memory.
-        /// </summary>
-        public readonly void Free() => PlatformFree(_unmanagedValue);
+        else
+        {
+            Utf8StringMarshaller.Free((byte*)unmanaged);
+        }
     }
 }
 #endif

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformStringMarshaller.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/PlatformStringMarshaller.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.DotNet.NativeWrapper;
+
+/// <summary>
+///  A platform-aware string marshaller that uses UTF-16 on Windows and UTF-8 on Unix platforms.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This marshaller automatically selects the appropriate string encoding based on the current
+///   operating system.
+///  </para>
+/// </remarks>
+[CustomMarshaller(typeof(string), MarshalMode.Default, typeof(PlatformStringMarshaller))]
+[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
+[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedOut, typeof(ManagedToUnmanagedOut))]
+public static unsafe class PlatformStringMarshaller
+{
+    /// <summary>
+    ///  Converts a managed string to an unmanaged pointer using platform-appropriate encoding.
+    /// </summary>
+    /// <param name="managed">The managed string to convert.</param>
+    /// <returns>A pointer to the unmanaged string, or zero if the input is null.</returns>
+    public static nint ConvertToUnmanaged(string? managed)
+    {
+        if (managed is null)
+        {
+            return 0;
+        }
+
+        return OperatingSystem.IsWindows()
+            ? (nint)Utf16StringMarshaller.ConvertToUnmanaged(managed)
+            : (nint)Utf8StringMarshaller.ConvertToUnmanaged(managed);
+    }
+
+    private static void PlatformFree(nint unmanaged)
+    {
+        if (unmanaged == 0)
+        {
+            return;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            Utf16StringMarshaller.Free((ushort*)unmanaged);
+        }
+        else
+        {
+            Utf8StringMarshaller.Free((byte*)unmanaged);
+        }
+    }
+
+    /// <summary>
+    ///  Converts an unmanaged string pointer to a managed string using platform-appropriate encoding.
+    /// </summary>
+    /// <param name="unmanaged">The unmanaged string pointer.</param>
+    /// <returns>The managed string, or null if the pointer is zero.</returns>
+    public static string? ConvertToManaged(nint unmanaged)
+    {
+        if (unmanaged == 0)
+        {
+            return null;
+        }
+
+        return OperatingSystem.IsWindows()
+            ? Utf16StringMarshaller.ConvertToManaged((ushort*)unmanaged)
+            : Utf8StringMarshaller.ConvertToManaged((byte*)unmanaged);
+    }
+
+    /// <summary>
+    ///  Frees memory allocated by <see cref="ConvertToUnmanaged"/>.
+    /// </summary>
+    /// <param name="unmanaged">The unmanaged string pointer to free.</param>
+    public static void Free(nint unmanaged) => PlatformFree(unmanaged);
+
+    /// <summary>
+    ///  Marshaller for managed-to-unmanaged direction (input parameters) with stack allocation support.
+    /// </summary>
+    public ref struct ManagedToUnmanagedIn
+    {
+        /// <summary>
+        ///  The recommended buffer size for stack allocation.
+        /// </summary>
+        public static int BufferSize => 256;
+
+        private nint _unmanagedValue;
+        private Utf8StringMarshaller.ManagedToUnmanagedIn _utf8Marshaller;
+        private bool _useUtf8;
+
+        /// <summary>
+        ///  Initializes the marshaller with an optional stack-allocated buffer.
+        /// </summary>
+        /// <param name="managed">The managed string to marshal.</param>
+        /// <param name="buffer">A stack-allocated buffer that may be used for small strings.</param>
+        public void FromManaged(string? managed, Span<byte> buffer)
+        {
+            _useUtf8 = !OperatingSystem.IsWindows();
+            if (_useUtf8)
+            {
+                _utf8Marshaller.FromManaged(managed, buffer);
+                _unmanagedValue = 0;
+                return;
+            }
+
+            _unmanagedValue = (nint)Utf16StringMarshaller.ConvertToUnmanaged(managed);
+        }
+
+        /// <summary>
+        ///  Returns the unmanaged string pointer.
+        /// </summary>
+        /// <returns>The unmanaged string pointer.</returns>
+        public readonly nint ToUnmanaged() => _useUtf8
+            ? (nint)_utf8Marshaller.ToUnmanaged()
+            : _unmanagedValue;
+
+        /// <summary>
+        ///  Frees any allocated unmanaged memory.
+        /// </summary>
+        public readonly void Free()
+        {
+            if (_useUtf8)
+            {
+                _utf8Marshaller.Free();
+                return;
+            }
+
+            if (_unmanagedValue != 0)
+            {
+                Utf16StringMarshaller.Free((ushort*)_unmanagedValue);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Marshaller for managed-to-unmanaged direction (output/return values).
+    /// </summary>
+    public ref struct ManagedToUnmanagedOut
+    {
+        private nint _unmanagedValue;
+
+        /// <summary>
+        ///  Sets the unmanaged value received from native code.
+        /// </summary>
+        /// <param name="unmanaged">The unmanaged string pointer.</param>
+        public void FromUnmanaged(nint unmanaged) => _unmanagedValue = unmanaged;
+
+        /// <summary>
+        ///  Converts the unmanaged string to a managed string.
+        /// </summary>
+        /// <returns>The managed string, or null if the pointer is zero.</returns>
+        public readonly string? ToManaged() => ConvertToManaged(_unmanagedValue);
+
+        /// <summary>
+        ///  Frees the unmanaged string memory.
+        /// </summary>
+        public readonly void Free() => PlatformFree(_unmanagedValue);
+    }
+}
+#endif

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/SdkResolutionResult.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.NativeWrapper
         /// </summary>
         public bool FailedToResolveSDKSpecifiedInGlobalJson;
 
-        internal void Initialize(Interop.hostfxr_resolve_sdk2_result_key_t key, string value)
+        internal void Initialize(Interop.hostfxr_resolve_sdk2_result_key_t key, PlatformString value)
         {
             switch (key)
             {

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/StatusCode.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/StatusCode.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.NativeWrapper;
+
+/// <summary>
+///  Common status codes returned by hostfxr APIs.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Success is indicated by 0. Positive values may indicate partial success or informational
+///   status. Negative values (shown as hex) indicate errors. These values match the native
+///   <c>StatusCode</c> enum in the hosting layer.
+///  </para>
+/// </remarks>
+internal enum StatusCode : uint
+{
+    /// <summary>Operation completed successfully.</summary>
+    Success = 0,
+
+    /// <summary>One or more arguments are invalid.</summary>
+    InvalidArgFailure = 0x80008081,
+
+    /// <summary>Failed to load a required native library (coreclr, hostpolicy).</summary>
+    CoreHostLibLoadFailure = 0x80008082,
+
+    /// <summary>A required native library was not found.</summary>
+    CoreHostLibMissingFailure = 0x80008083,
+
+    /// <summary>Failed to find a required entry point in a native library.</summary>
+    CoreHostEntryPointFailure = 0x80008084,
+
+    /// <summary>Failed to determine the path of the current host executable.</summary>
+    CoreHostCurHostFindFailure = 0x80008085,
+
+    /// <summary>Failed to resolve the path to coreclr.</summary>
+    CoreClrResolveFailure = 0x80008087,
+
+    /// <summary>Failed to bind to coreclr.</summary>
+    CoreClrBindFailure = 0x80008088,
+
+    /// <summary>Failed to initialize the CoreCLR runtime.</summary>
+    CoreClrInitFailure = 0x80008089,
+
+    /// <summary>Failed to execute the managed application entry point.</summary>
+    CoreClrExeFailure = 0x8000808a,
+
+    /// <summary>Failed to initialize the dependency resolver.</summary>
+    ResolverInitFailure = 0x8000808b,
+
+    /// <summary>Dependency resolution failed.</summary>
+    ResolverResolveFailure = 0x8000808c,
+
+    /// <summary>Failed to find the current executable path.</summary>
+    LibHostCurExeFindFailure = 0x8000808d,
+
+    /// <summary>Host initialization failed.</summary>
+    LibHostInitFailure = 0x8000808e,
+
+    /// <summary>Failed to find a compatible SDK.</summary>
+    LibHostSdkFindFailure = 0x80008091,
+
+    /// <summary>Invalid arguments passed to the host library.</summary>
+    LibHostInvalidArgs = 0x80008092,
+
+    /// <summary>The runtime configuration file is invalid or malformed.</summary>
+    InvalidConfigFile = 0x80008093,
+
+    /// <summary>The application argument is not runnable.</summary>
+    AppArgNotRunnable = 0x80008094,
+
+    /// <summary>The apphost executable is not bound to an application.</summary>
+    AppHostExeNotBoundFailure = 0x80008095,
+
+    /// <summary>A required framework was not found.</summary>
+    FrameworkMissingFailure = 0x80008096,
+
+    /// <summary>The host API version is not supported.</summary>
+    HostApiUnsupportedVersion = 0x80008097,
+
+    /// <summary>The provided buffer is too small for the result.</summary>
+    HostApiBufferTooSmall = 0x80008098,
+
+    /// <summary>An unknown command was passed to the host library.</summary>
+    LibHostUnknownCommand = 0x80008099,
+
+    /// <summary>SDK resolution failed.</summary>
+    SdkResolveFailure = 0x8000809b,
+
+    /// <summary>Incompatible framework versions were requested.</summary>
+    FrameworkCompatFailure = 0x8000809c,
+
+    /// <summary>Framework resolution should be retried (internal use).</summary>
+    FrameworkCompatRetry = 0x8000809d,
+
+    /// <summary>Failed to extract files from a single-file bundle.</summary>
+    BundleExtractionFailure = 0x8000809e,
+
+    /// <summary>I/O error during bundle extraction.</summary>
+    BundleExtractionIOError = 0x8000809f,
+
+    /// <summary>A duplicate property was specified.</summary>
+    LibHostDuplicateProperty = 0x800080a0,
+
+    /// <summary>The requested API scenario is not supported.</summary>
+    HostApiUnsupportedScenario = 0x800080a1,
+
+    /// <summary>A required host feature is disabled.</summary>
+    HostFeatureDisabled = 0x800080a2,
+
+    /// <summary>Failed to determine the current host path.</summary>
+    CurrentHostFindFailure = 0x800080a3,
+
+    /// <summary>The host is in an invalid state for the requested operation.</summary>
+    HostInvalidState = 0x800080a4,
+
+    /// <summary>The requested runtime property was not found.</summary>
+    HostPropertyNotFound = 0x800080a5
+}


### PR DESCRIPTION
## Summary

Refactor hostfxr interop code to use source-generated P/Invoke (LibraryImport) on .NET and improve string marshalling for cross-platform compatibility.

## Changes

- Add PlatformString struct - Helper for marshalling platform-dependent strings (UTF-16 on Windows, UTF-8 on Unix)
- Add PlatformStringMarshaller - Custom marshaller with stack allocation support for .NET source-generated interop
- Add StatusCode enum - Strongly-typed hostfxr return codes replacing raw int values
- Unify P/Invoke declarations - Remove separate Windows/Unix nested classes; use conditional compilation with LibraryImport (.NET) and DllImport (.NET Framework)
- Improve callback handling - Update delegates to use PlatformString and ref parameters for better memory safety
- Optimize SDK enumeration - Use ReadOnlySpan<T> for parsing native arrays in callbacks
- Enable AOT compatibility - Add IsAotCompatible property and AllowUnsafeBlocks to project file