### PR TITLE
Add .code-workspace files for all solutions

### DIFF
--- a/TemplateEngine.code-workspace
+++ b/TemplateEngine.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "TemplateEngine.slnf"
+    }
+  }

--- a/cli.code-workspace
+++ b/cli.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "cli.slnf"
+    }
+  }

--- a/containers.code-workspace
+++ b/containers.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "containers.slnf"
+    }
+  }

--- a/sdk.code-workspace
+++ b/sdk.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "sdk.slnx"
+    }
+  }

--- a/source-build.code-workspace
+++ b/source-build.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "source-build.slnf"
+    }
+  }

--- a/tasks.code-workspace
+++ b/tasks.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+      {
+        "path": "."
+      }
+    ],
+    "settings": {
+      "dotnet.defaultSolution": "tasks.slnf"
+    }
+  }


### PR DESCRIPTION
Allows to open a solution in VS Code from command line and Windows File Explorer: e.g. `code sdk.code-workspace`.
Workaround for VS Code not supporting opening sln(x|f) files directly.