### PR TITLE
Update documentation on target framework updates

### DIFF
--- a/documentation/general/UpdateToNewTargetFramework.md
+++ b/documentation/general/UpdateToNewTargetFramework.md
@@ -1,4 +1,38 @@
-# This document is to track the list of changes we had to make to enable 7.0 when we branched in 2021. This will hopefully help us when we do this again in the future.
+## Summary of work required to update TFMs
+
+**Large updates**
+- [Branding](https://github.com/dotnet/sdk/blob/main/eng/Versions.props#L6)
+  - Recommend doing in the VMR and fixing tests on backflow
+  - We had to disable a bunch of tests to merge the branding flow
+- [KnownFrameworkReference](https://github.com/dotnet/sdk/blob/main/src/Layout/redist/targets/BundledTemplates.targets) update
+  - Should be wrote but tricky to get right
+  - Can be done at any time
+- Retarget to net11
+  - Can be done before runtime work as you typically pin the new TFM to the N-1 versions before you have a runtime
+  - Likely requires updating tests
+- [Update tests to target the new TFM](https://github.com/dotnet/sdk/blob/main/test/Microsoft.NET.TestFramework/ToolsetInfo.cs#L11)
+  - Use PreviousTargetFramework temporarily if you need to pin any tests to the N-1 runtime
+  - Disable tests if needed
+  - Use a NetTFMUpdate comment to make it easier to track down changes added
+ - Update templates
+   - Should also be possible to do before runtime update as templating targeting "newTFM" will just be pinned to N-1 
+
+**Miscellaneous**
+- Fix versions after the N-1 GA as there should be RC placeholders
+- Likely will need to ping to N-1 templates
+- Will need to update restore-toolset for the N-1 runtime
+- Will need to update global.json for a new SDK
+
+
+Example PRs from net11 update
+[Backflow from VMR](https://github.com/dotnet/sdk/pull/52242)
+[unwind test changes](https://github.com/dotnet/sdk/pull/52512)
+[Branding](https://github.com/dotnet/sdk/pull/50468)
+[BundledVersions](https://github.com/dotnet/sdk/pull/50329)
+
+### Net7 TFM update list
+
+The below is to track the list of changes we had to make to enable 7.0 when we branched in 2021. This will hopefully help us when we do this again in the future.
 
 **Key Maestro PRs**
 

--- a/documentation/general/UpdateToNewTargetFramework.md
+++ b/documentation/general/UpdateToNewTargetFramework.md
@@ -5,7 +5,7 @@
   - Recommend doing in the VMR and fixing tests on backflow
   - We had to disable a bunch of tests to merge the branding flow
 - [KnownFrameworkReference](https://github.com/dotnet/sdk/blob/main/src/Layout/redist/targets/BundledTemplates.targets) update
-  - Should be rote but tricky to get right
+  - Should be straight-forward but tricky to get right
   - Can be done at any time
 - Retarget to net11
   - Can be done before runtime work as you typically pin the new TFM to the N-1 versions before you have a runtime
@@ -19,7 +19,7 @@
 
 **Miscellaneous**
 - Fix versions after the N-1 GA as there should be RC placeholders
-- Likely will need to pin to N-1 templates
+- Likely will need to pin to N-1 templates for any templates outside of the repo (like windows desktop)
 - Will need to update restore-toolset for the N-1 runtime
 - Will need to update global.json for a new SDK
 
@@ -30,9 +30,11 @@
 - [Branding](https://github.com/dotnet/sdk/pull/50468)
 - [BundledVersions](https://github.com/dotnet/sdk/pull/50329)
 
+---
+
 ### Net7 TFM update list
 
-The below is to track the list of changes we had to make to enable 7.0 when we branched in 2021. This will hopefully help us when we do this again in the future.
+The below is to track the list of changes we had to make to enable 7.0 when we branched in 2021. Many of these are not needed anymore or have changed but keeping it in the document for historical purposes as some of the more niche changes could be relevant.
 
 **Key Maestro PRs**
 

--- a/documentation/general/UpdateToNewTargetFramework.md
+++ b/documentation/general/UpdateToNewTargetFramework.md
@@ -5,7 +5,7 @@
   - Recommend doing in the VMR and fixing tests on backflow
   - We had to disable a bunch of tests to merge the branding flow
 - [KnownFrameworkReference](https://github.com/dotnet/sdk/blob/main/src/Layout/redist/targets/BundledTemplates.targets) update
-  - Should be wrote but tricky to get right
+  - Should be rote but tricky to get right
   - Can be done at any time
 - Retarget to net11
   - Can be done before runtime work as you typically pin the new TFM to the N-1 versions before you have a runtime
@@ -19,16 +19,16 @@
 
 **Miscellaneous**
 - Fix versions after the N-1 GA as there should be RC placeholders
-- Likely will need to ping to N-1 templates
+- Likely will need to pin to N-1 templates
 - Will need to update restore-toolset for the N-1 runtime
 - Will need to update global.json for a new SDK
 
 
-Example PRs from net11 update
-[Backflow from VMR](https://github.com/dotnet/sdk/pull/52242)
-[unwind test changes](https://github.com/dotnet/sdk/pull/52512)
-[Branding](https://github.com/dotnet/sdk/pull/50468)
-[BundledVersions](https://github.com/dotnet/sdk/pull/50329)
+### Example PRs from net11 update
+- [Backflow from VMR](https://github.com/dotnet/sdk/pull/52242)
+- [unwind test changes](https://github.com/dotnet/sdk/pull/52512)
+- [Branding](https://github.com/dotnet/sdk/pull/50468)
+- [BundledVersions](https://github.com/dotnet/sdk/pull/50329)
 
 ### Net7 TFM update list
 


### PR DESCRIPTION
Expanded the document to summarize the work required for updating target framework versions, including large updates and miscellaneous tasks. Added example PRs and a section for Net7 TFM updates.