### PR TITLE
Refactor VSHostObject credential extraction for COM compatibility and out-of-process execution

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -85,7 +85,6 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <Compile Remove="Tasks/CreateNewImageToolTask.cs" />
     <Compile Remove="net472Definitions.cs" />
-    <Compile Remove="VSHostObject.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Strings.Designer.cs">

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -63,8 +63,8 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
     /// <returns></returns>
     protected override ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch)
     {
-        VSHostObject hostObj = new(HostObject as System.Collections.Generic.IEnumerable<ITaskItem>);
-        if (hostObj.ExtractCredentials(out string user, out string pass, (string s) => Log.LogWarning(s)))
+        VSHostObject hostObj = new(HostObject, Log);
+        if (hostObj.TryGetCredentials() is (string user, string pass))
         {
             extractionInfo = (true, user, pass);
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/VSHostObject.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/VSHostObject.cs
@@ -1,44 +1,121 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+using System.Text.Json;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Containers.Tasks;
 
-internal sealed class VSHostObject
+internal sealed class VSHostObject(ITaskHost? hostObject, TaskLoggingHelper log)
 {
     private const string CredentialItemSpecName = "MsDeployCredential";
     private const string UserMetaDataName = "UserName";
     private const string PasswordMetaDataName = "Password";
-    IEnumerable<ITaskItem>? _hostObject;
 
-    public VSHostObject(IEnumerable<ITaskItem>? hostObject)
+    private readonly ITaskHost? _hostObject = hostObject;
+    private readonly TaskLoggingHelper _log = log;
+
+    /// <summary>
+    /// Tries to extract credentials from the host object.
+    /// </summary>
+    /// <returns>A tuple of (username, password) if credentials were found with non-empty username, null otherwise.</returns>
+    public (string username, string password)? TryGetCredentials()
     {
-        _hostObject = hostObject;
+        if (_hostObject is null)
+        {
+            return null;
+        }
+
+        IEnumerable<ITaskItem>? taskItems = GetTaskItems();
+        if (taskItems is null)
+        {
+            _log.LogMessage(MessageImportance.Low, "No task items found in host object.");
+            return null;
+        }
+
+        ITaskItem? credentialItem = taskItems.FirstOrDefault(p => p.ItemSpec == CredentialItemSpecName);
+        if (credentialItem is null)
+        {
+            return null;
+        }
+
+        string username = credentialItem.GetMetadata(UserMetaDataName);
+        if (string.IsNullOrEmpty(username))
+        {
+            return null;
+        }
+
+        string password = credentialItem.GetMetadata(PasswordMetaDataName);
+        return (username, password);
     }
 
-    public bool ExtractCredentials(out string username, out string password, Action<string> logMethod)
+    private IEnumerable<ITaskItem>? GetTaskItems()
     {
-        bool retVal = false;
-        username = password = string.Empty;
-        if (_hostObject != null)
+        try
         {
-            ITaskItem credentialItem = _hostObject.FirstOrDefault<ITaskItem>(p => p.ItemSpec == CredentialItemSpecName);
-            if (credentialItem != null)
+            // This call mirrors the behavior of Microsoft.WebTools.Publish.MSDeploy.VSMsDeployTaskHostObject.QueryAllTaskItems.
+            // Expected contract:
+            //   - Instance method on the host object named "QueryAllTaskItems".
+            //   - Signature: string QueryAllTaskItems().
+            //   - Returns a JSON array of objects with the shape:
+            //       [{ "ItemSpec": "<string>", "Metadata": { "<key>": "<value>", ... } }, ...]
+            // The JSON is deserialized into TaskItemDto records and converted to ITaskItem instances.
+            // Only UserName and Password metadata are extracted to avoid conflicts with reserved MSBuild metadata.
+            string? rawTaskItems = (string?)_hostObject!.GetType().InvokeMember(
+                "QueryAllTaskItems",
+                BindingFlags.InvokeMethod,
+                null,
+                _hostObject,
+                null);
+
+            if (!string.IsNullOrEmpty(rawTaskItems))
             {
-                retVal = true;
-                username = credentialItem.GetMetadata(UserMetaDataName);
-                if (!string.IsNullOrEmpty(username))
+                List<TaskItemDto>? dtos = JsonSerializer.Deserialize<List<TaskItemDto>>(rawTaskItems);
+                if (dtos is not null && dtos.Count > 0)
                 {
-                    password = credentialItem.GetMetadata(PasswordMetaDataName);
-                }
-                else
-                {
-                    logMethod("HostObject credentials not detected. Falling back to Docker credential retrieval.");
+                    _log.LogMessage(MessageImportance.Low, "Successfully retrieved task items via QueryAllTaskItems.");
+                    return dtos.Select(ConvertToTaskItem).ToList();
                 }
             }
+
+            _log.LogMessage(MessageImportance.Low, "QueryAllTaskItems returned null or empty result.");
         }
-        return retVal;
+        catch (Exception ex)
+        {
+            _log.LogMessage(MessageImportance.Low, "Exception trying to call QueryAllTaskItems: {0}", ex.Message);
+        }
+
+        // Fallback: try to use the host object directly as IEnumerable<ITaskItem> (legacy behavior).
+        if (_hostObject is IEnumerable<ITaskItem> enumerableHost)
+        {
+            _log.LogMessage(MessageImportance.Low, "Falling back to IEnumerable<ITaskItem> host object.");
+            return enumerableHost;
+        }
+
+        return null;
+
+        static TaskItem ConvertToTaskItem(TaskItemDto dto)
+        {
+            TaskItem taskItem = new(dto.ItemSpec ?? string.Empty);
+            if (dto.Metadata is not null)
+            {
+                if (dto.Metadata.TryGetValue(UserMetaDataName, out string? userName))
+                {
+                    taskItem.SetMetadata(UserMetaDataName, userName);
+                }
+
+                if (dto.Metadata.TryGetValue(PasswordMetaDataName, out string? password))
+                {
+                    taskItem.SetMetadata(PasswordMetaDataName, password);
+                }
+            }
+
+            return taskItem;
+        }
     }
+
+    private readonly record struct TaskItemDto(string? ItemSpec, Dictionary<string, string>? Metadata);
 }
 


### PR DESCRIPTION
This PR refactors the VSHostObject class to improve credential extraction from the Visual Studio host object but still maintains backward compatibility with the existing approach.

This is Step 1 of enabling enhanced container task execution capabilities:

1.	Out-of-process MSBuild execution: Currently, the Container task executes in-proc, collects credentials, and passes them to out-of-process executions. This refactoring enables executing the Container task in MSBuild.exe out-of-proc directly.
2.	COM compatibility for .NET Container task: This change prepares the task to be COM-compatible. While not active yet due to lack of app host support, once integrated into the SDK, it can be enabled by default.