### PR TITLE
Enable AOT compatibility analyzers and fix issues

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
+++ b/src/Cli/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
@@ -5,10 +5,16 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">true</PublicSign>
+    <PublicSign Condition="'$([MSBuild]::IsOSPlatform(`Windows`))' == 'false'">true</PublicSign>
     <RepositoryType>git</RepositoryType>
     <DefineConstants Condition="'$(IncludeAspNetCoreRuntime)' == 'false'">$(DefineConstants);EXCLUDE_ASPNETCORE</DefineConstants>
     <IsPackable>true</IsPackable>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.csproj
+++ b/src/Cli/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.csproj
@@ -7,9 +7,15 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">true</PublicSign>
+    <PublicSign Condition="'$([MSBuild]::IsOSPlatform(`Windows`))' == 'false'">true</PublicSign>
     <RepositoryType>git</RepositoryType>
     <IsPackable>true</IsPackable>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net472'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Cli
                           .SetMinimumLevel(logLevel)
                           .AddConsole(config => config.FormatterName = nameof(CliConsoleFormatter));
                       builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, CliConsoleFormatter>());
-                      builder.Services.Configure<ConsoleFormatterOptions>(nameof(CliConsoleFormatter), config =>
+                      builder.Services.Configure<ConsoleFormatterOptions>(config =>
                       {
                           config.IncludeScopes = true;
                           config.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff";

--- a/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.TemplateEngine.Abstractions;
@@ -25,14 +27,17 @@ namespace Microsoft.TemplateEngine.Cli
                   builtIns,
                   fallbackHostNames,
                   loggerFactory: Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-                    builder
-                        .SetMinimumLevel(logLevel)
-                        .AddConsole(config => config.FormatterName = nameof(CliConsoleFormatter))
-                        .AddConsoleFormatter<CliConsoleFormatter, ConsoleFormatterOptions>(config =>
-                        {
-                            config.IncludeScopes = true;
-                            config.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff";
-                        })))
+                  {
+                      builder
+                          .SetMinimumLevel(logLevel)
+                          .AddConsole(config => config.FormatterName = nameof(CliConsoleFormatter));
+                      builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, CliConsoleFormatter>());
+                      builder.Services.Configure<ConsoleFormatterOptions>(nameof(CliConsoleFormatter), config =>
+                      {
+                          config.IncludeScopes = true;
+                          config.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff";
+                      });
+                  }))
         {
             string workingPath = FileSystem.GetCurrentDirectory();
             IsCustomOutputPath = outputPath != null;

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -9,6 +9,12 @@
     <DefineConstants>$(DefineConstants);WCWIDTH_VISIBILITY_INTERNAL</DefineConstants>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cli/dotnet/BuildServer/VBCSCompilerServer.cs
+++ b/src/Cli/dotnet/BuildServer/VBCSCompilerServer.cs
@@ -17,7 +17,7 @@ internal class VBCSCompilerServer(ICommandFactory commandFactory = null) : IBuil
     private static readonly string s_shutdownArg = "-shutdown";
 
     internal static readonly string VBCSCompilerPath = Path.Combine(
-            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            AppContext.BaseDirectory,
             "Roslyn",
             "bincore",
             "VBCSCompiler.dll");

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -27,7 +27,9 @@ public class MSBuildForwardingApp : CommandBase
                 Type loggerType = typeof(MSBuildLogger);
                 Type forwardingLoggerType = typeof(MSBuildForwardingLogger);
 
+#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
                 msbuildArgs.OtherMSBuildArgs.Add($"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}");
+#pragma warning restore IL3000
                 return msbuildArgs;
             }
             catch (Exception)

--- a/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
+++ b/src/Cli/dotnet/Commands/New/BuiltInTemplatePackageProvider.cs
@@ -44,7 +44,10 @@ internal sealed class BuiltInTemplatePackageProvider(BuiltInTemplatePackageProvi
     {
         var templateFoldersToInstall = new List<string>();
 
+#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
         var sdkDirectory = Path.GetDirectoryName(typeof(Utils.DotnetFiles).Assembly.Location);
+#pragma warning restore IL3000
+
         var dotnetRootPath = Path.GetDirectoryName(Path.GetDirectoryName(sdkDirectory));
 
         // First grab templates from dotnet\templates\M.m folders, in ascending order, up to our version

--- a/src/Cli/dotnet/Commands/New/OptionalWorkloadProvider.cs
+++ b/src/Cli/dotnet/Commands/New/OptionalWorkloadProvider.cs
@@ -33,7 +33,9 @@ internal class OptionalWorkloadProvider : ITemplatePackageProvider
     {
         var list = new List<TemplatePackage>();
         var optionalWorkloadLocator = new TemplateLocator.TemplateLocator();
+#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
         var sdkDirectory = Path.GetDirectoryName(typeof(DotnetFiles).Assembly.Location);
+#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
         var sdkVersion = Path.GetFileName(sdkDirectory);
         var dotnetRootPath = Path.GetDirectoryName(Path.GetDirectoryName(sdkDirectory));
         string userProfileDir = CliFolderPathCalculator.DotnetUserProfileFolderPath;

--- a/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CommandLine;
 using Microsoft.CodeAnalysis.CSharp;
@@ -21,6 +22,11 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 /// </summary>
 internal sealed partial class CSharpCompilerCommand
 {
+    [JsonSerializable(typeof(string))]
+    private partial class CSharpCompilerCommandJsonSerializerContext : JsonSerializerContext
+    {
+    }
+
     private static readonly SearchValues<char> s_additionalShouldSurroundWithQuotes = SearchValues.Create('=', ',');
 
     /// <summary>
@@ -285,25 +291,25 @@ internal sealed partial class CSharpCompilerCommand
                 build_property.EnableAotAnalyzer = true
                 build_property.EnableSingleFileAnalyzer = true
                 build_property.EnableTrimAnalyzer = true
-                build_property.IncludeAllContentForSelfExtract = 
-                build_property.VerifyReferenceTrimCompatibility = 
-                build_property.VerifyReferenceAotCompatibility = 
+                build_property.IncludeAllContentForSelfExtract =
+                build_property.VerifyReferenceTrimCompatibility =
+                build_property.VerifyReferenceAotCompatibility =
                 build_property.TargetFramework = net{TargetFrameworkVersion}
                 build_property.TargetFrameworkIdentifier = .NETCoreApp
                 build_property.TargetFrameworkVersion = v{TargetFrameworkVersion}
-                build_property.TargetPlatformMinVersion = 
-                build_property.UsingMicrosoftNETSdkWeb = 
-                build_property.ProjectTypeGuids = 
-                build_property.InvariantGlobalization = 
-                build_property.PlatformNeutralAssembly = 
-                build_property.EnforceExtendedAnalyzerRules = 
+                build_property.TargetPlatformMinVersion =
+                build_property.UsingMicrosoftNETSdkWeb =
+                build_property.ProjectTypeGuids =
+                build_property.InvariantGlobalization =
+                build_property.PlatformNeutralAssembly =
+                build_property.EnforceExtendedAnalyzerRules =
                 build_property._SupportedPlatformList = Linux,macOS,Windows
                 build_property.RootNamespace = {fileNameWithoutExtension}
                 build_property.ProjectDir = {fileDirectory}{Path.DirectorySeparatorChar}
-                build_property.EnableComHosting = 
+                build_property.EnableComHosting =
                 build_property.EnableGeneratedComInterfaceComImportInterop = false
                 build_property.EffectiveAnalysisLevelStyle = {TargetFrameworkVersion}
-                build_property.EnableCodeStyleSeverity = 
+                build_property.EnableCodeStyleSeverity =
 
                 """);
         }
@@ -329,11 +335,11 @@ internal sealed partial class CSharpCompilerCommand
                     "tfm": "net{{TargetFrameworkVersion}}",
                     "framework": {
                       "name": "Microsoft.NETCore.App",
-                      "version": {{JsonSerializer.Serialize(DefaultRuntimeVersion)}}
+                      "version": {{JsonSerializer.Serialize(DefaultRuntimeVersion, CSharpCompilerCommandJsonSerializerContext.Default.String)}}
                     },
                     "configProperties": {
-                      "EntryPointFilePath": {{JsonSerializer.Serialize(EntryPointFileFullPath)}},
-                      "EntryPointFileDirectoryPath": {{JsonSerializer.Serialize(fileDirectory)}},
+                      "EntryPointFilePath": {{JsonSerializer.Serialize(EntryPointFileFullPath, CSharpCompilerCommandJsonSerializerContext.Default.String)}},
+                      "EntryPointFileDirectoryPath": {{JsonSerializer.Serialize(fileDirectory, CSharpCompilerCommandJsonSerializerContext.Default.String)}},
                       "Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability": true,
                       "System.ComponentModel.DefaultValueAttribute.IsSupported": false,
                       "System.ComponentModel.Design.IDesignerHost.IsSupported": false,

--- a/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
@@ -283,6 +283,8 @@ internal sealed partial class CSharpCompilerCommand
                 """);
         }
 
+        // NOTE: MSBuild writes empty values as "property = " (with a trailing space).
+        // Use an interpolation expression to preserve the trailing space from editor trimming.
         string editorconfig = Path.Join(objDir, $"{fileNameWithoutExtension}.GeneratedMSBuildEditorConfig.editorconfig");
         if (ShouldEmit(editorconfig))
         {
@@ -291,25 +293,25 @@ internal sealed partial class CSharpCompilerCommand
                 build_property.EnableAotAnalyzer = true
                 build_property.EnableSingleFileAnalyzer = true
                 build_property.EnableTrimAnalyzer = true
-                build_property.IncludeAllContentForSelfExtract =
-                build_property.VerifyReferenceTrimCompatibility =
-                build_property.VerifyReferenceAotCompatibility =
+                build_property.IncludeAllContentForSelfExtract ={" "}
+                build_property.VerifyReferenceTrimCompatibility ={" "}
+                build_property.VerifyReferenceAotCompatibility ={" "}
                 build_property.TargetFramework = net{TargetFrameworkVersion}
                 build_property.TargetFrameworkIdentifier = .NETCoreApp
                 build_property.TargetFrameworkVersion = v{TargetFrameworkVersion}
-                build_property.TargetPlatformMinVersion =
-                build_property.UsingMicrosoftNETSdkWeb =
-                build_property.ProjectTypeGuids =
-                build_property.InvariantGlobalization =
-                build_property.PlatformNeutralAssembly =
-                build_property.EnforceExtendedAnalyzerRules =
+                build_property.TargetPlatformMinVersion ={" "}
+                build_property.UsingMicrosoftNETSdkWeb ={" "}
+                build_property.ProjectTypeGuids ={" "}
+                build_property.InvariantGlobalization ={" "}
+                build_property.PlatformNeutralAssembly ={" "}
+                build_property.EnforceExtendedAnalyzerRules ={" "}
                 build_property._SupportedPlatformList = Linux,macOS,Windows
                 build_property.RootNamespace = {fileNameWithoutExtension}
                 build_property.ProjectDir = {fileDirectory}{Path.DirectorySeparatorChar}
-                build_property.EnableComHosting =
+                build_property.EnableComHosting ={" "}
                 build_property.EnableGeneratedComInterfaceComImportInterop = false
                 build_property.EffectiveAnalysisLevelStyle = {TargetFrameworkVersion}
-                build_property.EnableCodeStyleSeverity =
+                build_property.EnableCodeStyleSeverity ={" "}
 
                 """);
         }

--- a/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.cs
@@ -23,9 +23,7 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 internal sealed partial class CSharpCompilerCommand
 {
     [JsonSerializable(typeof(string))]
-    private partial class CSharpCompilerCommandJsonSerializerContext : JsonSerializerContext
-    {
-    }
+    private partial class CSharpCompilerCommandJsonSerializerContext : JsonSerializerContext;
 
     private static readonly SearchValues<char> s_additionalShouldSurroundWithQuotes = SearchValues.Create('=', ',');
 

--- a/src/Cli/dotnet/Commands/Sdk/Check/SdkCheckCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Check/SdkCheckCommand.cs
@@ -5,6 +5,7 @@
 
 using System.CommandLine;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.NativeWrapper;
 using EnvironmentProvider = Microsoft.DotNet.NativeWrapper.EnvironmentProvider;
@@ -29,7 +30,7 @@ public class SdkCheckCommand : CommandBase
     {
         _dotnetPath = dotnetRoot ?? EnvironmentProvider.GetDotnetExeDirectory();
         var configFilePath = Path.Combine(_dotnetPath, "sdk", dotnetVersion ?? Product.Version, "sdk-check-config.json");
-        _sdkCheckConfig = File.Exists(configFilePath) ? JsonSerializer.Deserialize<SdkCheckConfig>(File.ReadAllText(configFilePath)) : null;
+        _sdkCheckConfig = File.Exists(configFilePath) ? JsonSerializer.Deserialize(File.ReadAllText(configFilePath), SdkCheckJsonSerializerContext.Default.SdkCheckConfig) : null;
         _reporter = reporter ?? Reporter.Output;
         _netBundleProvider = bundleProvider == null ? new NETBundlesNativeWrapper() : bundleProvider;
         _productCollectionProvider = productCollectionProvider == null ? new ProductCollectionProvider() : productCollectionProvider;
@@ -89,3 +90,6 @@ internal class SdkCheckConfig
     public string ReleasesFilePath { get; set; }
     public string CommandOutputReplacementString { get; set; }
 }
+
+[JsonSerializable(typeof(SdkCheckConfig))]
+internal partial class SdkCheckJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Test/TestCommandDefinition.cs
+++ b/src/Cli/dotnet/Commands/Test/TestCommandDefinition.cs
@@ -38,14 +38,7 @@ internal abstract partial class TestCommandDefinition : Command
 
         string jsonText = File.ReadAllText(globalJsonPath);
 
-        // This code path is hit exactly once during the whole life of the dotnet process.
-        // So, no concern about caching JsonSerializerOptions.
-        var globalJson = JsonSerializer.Deserialize<GlobalJsonModel>(jsonText, new JsonSerializerOptions()
-        {
-            AllowDuplicateProperties = false,
-            AllowTrailingCommas = false,
-            ReadCommentHandling = JsonCommentHandling.Skip,
-        });
+        var globalJson = JsonSerializer.Deserialize(jsonText, GlobalJsonSerializerContext.Default.GlobalJsonModel);
 
         var name = globalJson?.Test?.RunnerName;
 
@@ -90,4 +83,8 @@ internal abstract partial class TestCommandDefinition : Command
         [JsonPropertyName("runner")]
         public string RunnerName { get; set; } = null!;
     }
+
+    [JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip)]
+    [JsonSerializable(typeof(GlobalJsonModel))]
+    private partial class GlobalJsonSerializerContext : JsonSerializerContext;
 }

--- a/src/Cli/dotnet/Commands/Tool/List/ToolListGlobalOrToolPathCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/List/ToolListGlobalOrToolPathCommand.cs
@@ -123,7 +123,7 @@ internal sealed class ToolListGlobalOrToolPathCommand(
                 Commands = [p.Command.Name.Value]
             })]
         };
-        var jsonText = System.Text.Json.JsonSerializer.Serialize(jsonData, JsonHelper.NoEscapeSerializerOptions);
+        var jsonText = System.Text.Json.JsonSerializer.Serialize(jsonData, JsonHelper.JsonContext.VersionedDataContractToolListJsonContractArray);
         _reporter.WriteLine(jsonText);
     }
 }

--- a/src/Cli/dotnet/Commands/Tool/List/ToolListJsonHelper.cs
+++ b/src/Cli/dotnet/Commands/Tool/List/ToolListJsonHelper.cs
@@ -15,7 +15,7 @@ internal sealed class VersionedDataContract<TContract>
         /// </summary>
     [JsonPropertyName("version")]
     public int Version { get; init; } = 1;
-    
+
     [JsonPropertyName("data")]
     public required TContract Data { get; init; }
 }
@@ -24,10 +24,10 @@ internal class ToolListJsonContract
 {
     [JsonPropertyName("packageId")]
     public required string PackageId { get; init; }
-    
+
     [JsonPropertyName("version")]
     public required string Version { get; init; }
-    
+
     [JsonPropertyName("commands")]
     public required string[] Commands { get; init; }
 }
@@ -46,8 +46,12 @@ internal enum ToolListOutputFormat
 
 internal static class JsonHelper
 {
-    public static readonly JsonSerializerOptions NoEscapeSerializerOptions = new()
+    public static readonly ToolListJsonSerializerContext JsonContext = new(new JsonSerializerOptions()
     {
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
+    });
 }
+
+[JsonSerializable(typeof(VersionedDataContract<ToolListJsonContract[]>))]
+[JsonSerializable(typeof(VersionedDataContract<LocalToolListJsonContract[]>))]
+internal partial class ToolListJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Tool/List/ToolListLocalCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/List/ToolListLocalCommand.cs
@@ -89,7 +89,7 @@ internal sealed class ToolListLocalCommand : CommandBase<ToolListCommandDefiniti
                 Manifest = p.SourceManifest.Value
             })]
         };
-        var jsonText = System.Text.Json.JsonSerializer.Serialize(jsonData, JsonHelper.NoEscapeSerializerOptions);
+        var jsonText = System.Text.Json.JsonSerializer.Serialize(jsonData, JsonHelper.JsonContext.VersionedDataContractLocalToolListJsonContractArray);
         _reporter.WriteLine(jsonText);
     }
 }

--- a/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
+++ b/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Cli.Commands.Workload;
@@ -11,12 +12,6 @@ namespace Microsoft.DotNet.Cli.Commands.Workload;
 internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string dotnetDir)
 {
     public string Path { get; } = System.IO.Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, dotnetDir), "globaljsonworkloadsets.json");
-
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
 
     public void RecordWorkloadSetInGlobalJson(string globalJsonPath, string workloadSetVersion)
     {
@@ -28,7 +23,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             Dictionary<string, string> globalJsonWorkloadSetVersions;
             if (fileStream.Length > 0)
             {
-                globalJsonWorkloadSetVersions = JsonSerializer.Deserialize<Dictionary<string, string>>(fileStream, _jsonSerializerOptions);
+                globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
             }
             else
             {
@@ -36,7 +31,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             }
             globalJsonWorkloadSetVersions[globalJsonPath] = workloadSetVersion;
             fileStream.Seek(0, SeekOrigin.Begin);
-            JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, _jsonSerializerOptions);
+            JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
         }
     }
 
@@ -66,7 +61,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
                 return [];
             }
 
-            var globalJsonWorkloadSetVersions = JsonSerializer.Deserialize<Dictionary<string, string>>(fileStream, _jsonSerializerOptions);
+            var globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
             bool updated = false;
 
             //  Create copy of dictionary for iteration so we can modify the original in the loop
@@ -86,7 +81,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             if (updated)
             {
                 fileStream.Seek(0, SeekOrigin.Begin);
-                JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, _jsonSerializerOptions);
+                JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
             }
 
             return globalJsonWorkloadSetVersions;
@@ -106,3 +101,9 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
         }
     }
 }
+
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class GlobalJsonWorkloadSetsJsonContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
+++ b/src/Cli/dotnet/Commands/Workload/GlobalJsonWorkloadSetFile.cs
@@ -23,7 +23,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             Dictionary<string, string> globalJsonWorkloadSetVersions;
             if (fileStream.Length > 0)
             {
-                globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
+                globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonSerializerContext.Default.DictionaryStringString);
             }
             else
             {
@@ -31,7 +31,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             }
             globalJsonWorkloadSetVersions[globalJsonPath] = workloadSetVersion;
             fileStream.Seek(0, SeekOrigin.Begin);
-            JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
+            JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonSerializerContext.Default.DictionaryStringString);
         }
     }
 
@@ -61,7 +61,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
                 return [];
             }
 
-            var globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
+            var globalJsonWorkloadSetVersions = JsonSerializer.Deserialize(fileStream, GlobalJsonWorkloadSetsJsonSerializerContext.Default.DictionaryStringString);
             bool updated = false;
 
             //  Create copy of dictionary for iteration so we can modify the original in the loop
@@ -81,7 +81,7 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
             if (updated)
             {
                 fileStream.Seek(0, SeekOrigin.Begin);
-                JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonContext.Default.DictionaryStringString);
+                JsonSerializer.Serialize(fileStream, globalJsonWorkloadSetVersions, GlobalJsonWorkloadSetsJsonSerializerContext.Default.DictionaryStringString);
             }
 
             return globalJsonWorkloadSetVersions;
@@ -106,4 +106,4 @@ internal class GlobalJsonWorkloadSetsFile(SdkFeatureBand sdkFeatureBand, string 
     WriteIndented = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(Dictionary<string, string>))]
-internal partial class GlobalJsonWorkloadSetsJsonContext : JsonSerializerContext;
+internal partial class GlobalJsonWorkloadSetsJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
@@ -539,7 +539,7 @@ internal class FileBasedInstaller : IInstaller
             if (!Directory.GetFileSystemEntries(installationRecordDirectory).Any())
             {
                 //  There are no installation records for the workload pack anymore, so we can delete the pack
-                var packToDelete = JsonSerializer.Deserialize<PackInfo>(jsonPackInfo);
+                var packToDelete = JsonSerializer.Deserialize(jsonPackInfo, PackInfoJsonSerializerContext.Default.PackInfo);
                 DeletePack(packToDelete);
 
                 //  Delete now-empty pack installation record directory
@@ -631,7 +631,7 @@ internal class FileBasedInstaller : IInstaller
         var historyDirectory = GetWorkloadHistoryDirectory();
         Directory.CreateDirectory(historyDirectory);
         string logFile = Path.Combine(historyDirectory, $"{workloadHistoryRecord.TimeStarted:yyyy'-'MM'-'dd'T'HHmmss}_{workloadHistoryRecord.CommandName}.json");
-        File.WriteAllText(logFile, JsonSerializer.Serialize(workloadHistoryRecord, new JsonSerializerOptions() { WriteIndented = true }));
+        File.WriteAllText(logFile, JsonSerializer.Serialize(workloadHistoryRecord, WorkloadHistoryJsonSerializerContext.Default.WorkloadHistoryRecord));
     }
 
     public IEnumerable<WorkloadHistoryRecord> GetWorkloadHistoryRecords(string sdkFeatureBand)
@@ -642,7 +642,7 @@ internal class FileBasedInstaller : IInstaller
     public void Shutdown()
     {
         // Perform any additional cleanup here that's intended to run at the end of the command, regardless
-        // of success or failure. For file based installs, there shouldn't be any additional work to 
+        // of success or failure. For file based installs, there shouldn't be any additional work to
         // perform.
     }
 
@@ -874,7 +874,7 @@ internal class FileBasedInstaller : IInstaller
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path));
         }
-        File.WriteAllText(path, JsonSerializer.Serialize(packInfo));
+        File.WriteAllText(path, JsonSerializer.Serialize(packInfo, PackInfoJsonSerializerContext.Default.PackInfo));
     }
 
     private void DeletePackInstallationRecord(PackInfo packInfo, SdkFeatureBand featureBand)

--- a/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/MsiInstallerBase.cs
@@ -36,12 +36,6 @@ internal abstract class MsiInstallerBase(InstallElevationContextBase elevationCo
     /// </summary>
     private string _dotNetHome;
 
-    private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
-
     /// <summary>
     /// Full path to the root directory for storing workload data.
     /// </summary>
@@ -382,7 +376,7 @@ internal abstract class MsiInstallerBase(InstallElevationContextBase elevationCo
         var historyDirectory = GetWorkloadHistoryDirectory(sdkFeatureBand);
         string logFile = Path.Combine(historyDirectory, $"{workloadHistoryRecord.TimeStarted:yyyy'-'MM'-'dd'T'HHmmss}_{workloadHistoryRecord.CommandName}.json");
         Directory.CreateDirectory(historyDirectory);
-        File.WriteAllText(logFile, JsonSerializer.Serialize(workloadHistoryRecord, new JsonSerializerOptions() { WriteIndented = true }));
+        File.WriteAllText(logFile, JsonSerializer.Serialize(workloadHistoryRecord, WorkloadHistoryJsonSerializerContext.Default.WorkloadHistoryRecord));
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.PackGroup.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.PackGroup.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 
@@ -16,7 +17,11 @@ internal partial class NetSdkMsiInstallerClient
         public string GroupPackageId { get; set; }
         public string GroupPackageVersion { get; set; }
 
-        public List<WorkloadPackJson> Packs { get; set; } = [];
+        public List<WorkloadPackJson> Packs
+        {
+            get;
+            set => field = value ?? [];
+        } = [];
     }
 
     private class WorkloadPackJson
@@ -42,7 +47,7 @@ internal partial class NetSdkMsiInstallerClient
             var packGroupFile = Path.Combine(manifest.ManifestDirectory, "WorkloadPackGroups.json");
             if (File.Exists(packGroupFile))
             {
-                var packGroups = JsonSerializer.Deserialize<IList<WorkloadPackGroupJson>>(File.ReadAllText(packGroupFile));
+                var packGroups = JsonSerializer.Deserialize(File.ReadAllText(packGroupFile), WorkloadPackGroupJsonSerializerContext.Default.IListWorkloadPackGroupJson);
                 foreach (var packGroup in packGroups)
                 {
                     foreach (var packJson in packGroup.Packs)
@@ -110,4 +115,7 @@ internal partial class NetSdkMsiInstallerClient
     {
         return new WorkloadDownload(packInfo.ResolvedPackageId, GetMsiPackageId(packInfo), packInfo.Version);
     }
+
+    [JsonSerializable(typeof(IList<WorkloadPackGroupJson>))]
+    private partial class WorkloadPackGroupJsonSerializerContext : JsonSerializerContext;
 }

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallCommand.cs
@@ -5,6 +5,7 @@
 
 using System.CommandLine;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
@@ -145,7 +146,7 @@ internal sealed class WorkloadInstallCommand : InstallingWorkloadCommand
 
             var packageUrls = GetPackageDownloadUrlsAsync(workloadsToDownload, _skipManifestUpdate, _includePreviews, NullReporter.Instance, packageDownloader).GetAwaiter().GetResult();
 
-            Reporter.WriteLine(JsonSerializer.Serialize(packageUrls, new JsonSerializerOptions() { WriteIndented = true }));
+            Reporter.WriteLine(JsonSerializer.Serialize(packageUrls, WorkloadInstallJsonSerializerContext.Default.IEnumerableString));
         }
         else if (!string.IsNullOrWhiteSpace(_downloadToCacheOption))
         {
@@ -353,3 +354,7 @@ internal sealed class WorkloadInstallCommand : InstallingWorkloadCommand
         }.Run(context => a(context));
     }
 }
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(IEnumerable<string>))]
+internal partial class WorkloadInstallJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
@@ -138,7 +138,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         var installedWorkloads = _workloadRecordRepo.GetInstalledWorkloads(_sdkFeatureBand);
         var updatableWorkloads = GetUpdatableWorkloadsToAdvertise(installedWorkloads);
         var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
-        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonContext.Default.StringArray);
+        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
         if (Directory.Exists(Path.GetDirectoryName(filePath)))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
@@ -164,7 +164,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
             var adUpdatesFile = GetAdvertisingWorkloadsFilePath(CliFolderPathCalculator.DotnetUserProfileFolderPath, featureBand);
             if (!backgroundUpdatesDisabled && File.Exists(adUpdatesFile))
             {
-                var updatableWorkloads = JsonSerializer.Deserialize(File.ReadAllText(adUpdatesFile), WorkloadManifestUpdaterJsonContext.Default.StringArray);
+                var updatableWorkloads = JsonSerializer.Deserialize(File.ReadAllText(adUpdatesFile), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
                 if (updatableWorkloads != null && updatableWorkloads.Any())
                 {
                     Console.WriteLine();
@@ -531,4 +531,4 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
 }
 
 [JsonSerializable(typeof(string[]))]
-internal partial class WorkloadManifestUpdaterJsonContext : JsonSerializerContext;
+internal partial class WorkloadManifestUpdaterJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
 using Microsoft.DotNet.Cli.Commands.Workload.List;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -86,7 +87,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         }
         else
         {
-            // this updates all the manifests 
+            // this updates all the manifests
             var manifests = _workloadResolver.GetInstalledManifests();
             await Task.WhenAll(manifests.Select(manifest => UpdateAdvertisingManifestAsync(manifest, includePreviews, offlineCache))).ConfigureAwait(false);
             WriteUpdatableWorkloadsFile();
@@ -137,7 +138,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         var installedWorkloads = _workloadRecordRepo.GetInstalledWorkloads(_sdkFeatureBand);
         var updatableWorkloads = GetUpdatableWorkloadsToAdvertise(installedWorkloads);
         var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
-        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray());
+        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonContext.Default.StringArray);
         if (Directory.Exists(Path.GetDirectoryName(filePath)))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
@@ -163,7 +164,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
             var adUpdatesFile = GetAdvertisingWorkloadsFilePath(CliFolderPathCalculator.DotnetUserProfileFolderPath, featureBand);
             if (!backgroundUpdatesDisabled && File.Exists(adUpdatesFile))
             {
-                var updatableWorkloads = JsonSerializer.Deserialize<string[]>(File.ReadAllText(adUpdatesFile));
+                var updatableWorkloads = JsonSerializer.Deserialize(File.ReadAllText(adUpdatesFile), WorkloadManifestUpdaterJsonContext.Default.StringArray);
                 if (updatableWorkloads != null && updatableWorkloads.Any())
                 {
                     Console.WriteLine();
@@ -528,3 +529,6 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
 
     private record ManifestVersionWithBand(ManifestVersion Version, SdkFeatureBand Band);
 }
+
+[JsonSerializable(typeof(string[]))]
+internal partial class WorkloadManifestUpdaterJsonContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/InstallStateContents.cs
+++ b/src/Cli/dotnet/Commands/Workload/InstallStateContents.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -23,16 +21,9 @@ internal class InstallStateContents
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? WorkloadVersion { get; set; }
 
-    private static readonly JsonSerializerOptions s_options = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        AllowTrailingCommas = true,
-    };
-
     public static InstallStateContents FromString(string contents)
     {
-        return JsonSerializer.Deserialize<InstallStateContents>(contents, s_options) ?? new InstallStateContents();
+        return JsonSerializer.Deserialize(contents, InstallStateJsonSerializerContext.Default.InstallStateContents) ?? new InstallStateContents();
     }
 
     public static InstallStateContents FromPath(string path)
@@ -42,10 +33,17 @@ internal class InstallStateContents
 
     public override string ToString()
     {
-        return JsonSerializer.Serialize(this, s_options);
+        return JsonSerializer.Serialize(this, InstallStateJsonSerializerContext.Default.InstallStateContents);
     }
 
     public bool ShouldUseWorkloadSets() => UseWorkloadSets ?? true;
 }
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    AllowTrailingCommas = true)]
+[JsonSerializable(typeof(InstallStateContents))]
+internal partial class InstallStateJsonSerializerContext : JsonSerializerContext;
 
 #pragma warning restore CS8632

--- a/src/Cli/dotnet/Commands/Workload/List/WorkloadListCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/WorkloadListCommand.cs
@@ -5,6 +5,7 @@
 
 using System.CommandLine;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
 using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
@@ -72,7 +73,7 @@ internal sealed class WorkloadListCommand : WorkloadCommandBase<WorkloadListComm
             var installed = installedList.Select(id => id.ToString()).ToArray();
             ListOutput listOutput = new(installed, [.. updateAvailable]);
 
-            Reporter.WriteLine(JsonSerializer.Serialize(listOutput, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+            Reporter.WriteLine(JsonSerializer.Serialize(listOutput, WorkloadListJsonSerializerContext.Default.ListOutput));
         }
         else
         {
@@ -162,3 +163,7 @@ internal sealed class WorkloadListCommand : WorkloadCommandBase<WorkloadListComm
     internal record UpdateAvailableEntry(string ExistingManifestVersion, string AvailableUpdateManifestVersion,
         string Description, string WorkloadId);
 }
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(WorkloadListCommand.ListOutput))]
+internal partial class WorkloadListJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Search/WorkloadSearchVersionsCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Search/WorkloadSearchVersionsCommand.cs
@@ -102,7 +102,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
                 Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => new Dictionary<string, string>()
                 {
                     { "workloadVersion", version }
-                }), WorkloadSearchVersionsJsonContext.Default.IEnumerableDictionaryStringString));
+                }), WorkloadSearchVersionsJsonSerializerContext.Default.IEnumerableDictionaryStringString));
             }
             else
             {
@@ -123,7 +123,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
             }
             else if (_workloadSetOutputFormat?.Equals("json", StringComparison.OrdinalIgnoreCase) == true)
             {
-                Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v)), WorkloadSearchVersionsJsonContext.Default.IEnumerableDictionaryStringString));
+                Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v)), WorkloadSearchVersionsJsonSerializerContext.Default.IEnumerableDictionaryStringString));
             }
             else
             {
@@ -139,7 +139,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
                 Reporter.WriteLine(JsonSerializer.Serialize(new Dictionary<string, Dictionary<string, string>>()
                 {
                     { "manifestVersions", set.ToDictionaryForJson() }
-                }, WorkloadSearchVersionsJsonContext.Default.DictionaryStringDictionaryStringString));
+                }, WorkloadSearchVersionsJsonSerializerContext.Default.DictionaryStringDictionaryStringString));
             }
             else
             {
@@ -207,4 +207,4 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(IEnumerable<Dictionary<string, string>>))]
 [JsonSerializable(typeof(Dictionary<string, Dictionary<string, string>>))]
-internal partial class WorkloadSearchVersionsJsonContext : JsonSerializerContext;
+internal partial class WorkloadSearchVersionsJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Search/WorkloadSearchVersionsCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Search/WorkloadSearchVersionsCommand.cs
@@ -5,6 +5,7 @@
 
 using System.CommandLine;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
@@ -17,7 +18,7 @@ using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Cli.Commands.Workload.Search;
 
-internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<WorkloadSearchVersionsCommandDefinition>   
+internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<WorkloadSearchVersionsCommandDefinition>
 {
     private readonly ReleaseVersion _sdkVersion;
     private readonly int _numberOfWorkloadSetsToTake;
@@ -101,7 +102,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
                 Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => new Dictionary<string, string>()
                 {
                     { "workloadVersion", version }
-                })));
+                }), WorkloadSearchVersionsJsonContext.Default.IEnumerableDictionaryStringString));
             }
             else
             {
@@ -122,7 +123,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
             }
             else if (_workloadSetOutputFormat?.Equals("json", StringComparison.OrdinalIgnoreCase) == true)
             {
-                Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v))));
+                Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v)), WorkloadSearchVersionsJsonContext.Default.IEnumerableDictionaryStringString));
             }
             else
             {
@@ -138,7 +139,7 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
                 Reporter.WriteLine(JsonSerializer.Serialize(new Dictionary<string, Dictionary<string, string>>()
                 {
                     { "manifestVersions", set.ToDictionaryForJson() }
-                }, new JsonSerializerOptions { WriteIndented = true }));
+                }, WorkloadSearchVersionsJsonContext.Default.DictionaryStringDictionaryStringString));
             }
             else
             {
@@ -202,3 +203,8 @@ internal sealed class WorkloadSearchVersionsCommand : WorkloadCommandBase<Worklo
         }).Take(numberOfWorkloadSetsToTake);
     }
 }
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(IEnumerable<Dictionary<string, string>>))]
+[JsonSerializable(typeof(Dictionary<string, Dictionary<string, string>>))]
+internal partial class WorkloadSearchVersionsJsonContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/SignCheck_Windows.cs
+++ b/src/Cli/dotnet/Commands/Workload/SignCheck_Windows.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.Reflection;
+using System.Diagnostics;
 
 #if !DOT_NET_BUILD_FROM_SOURCE
 using Microsoft.DotNet.Cli.Installer.Windows.Security;
@@ -20,7 +18,7 @@ internal static class SignCheck
 
     private static readonly string s_WorkloadPolicyKey = @"SOFTWARE\Policies\Microsoft\dotnet\Workloads";
 
-    private static readonly string s_dotnet = Environment.ProcessPath;
+    private static readonly string? s_dotnet = Environment.ProcessPath;
 
     /// <summary>
     /// Determines whether dotnet.dll is signed.
@@ -31,6 +29,13 @@ internal static class SignCheck
         if (OperatingSystem.IsWindows())
         {
 #if !DOT_NET_BUILD_FROM_SOURCE
+            Debug.Assert(s_dotnet is not null, "Environment.ProcessPath should not be null when running in the dotnet host.");
+
+            if (s_dotnet is null)
+            {
+                return false;
+            }
+
             // API is only available on XP and Server 2003 or later versions. .NET requires Win7 minimum.
 #pragma warning disable CA1416
             // We don't care about trust in this case, only whether or not the file has a signature as that determines
@@ -51,7 +56,7 @@ internal static class SignCheck
     {
         if (OperatingSystem.IsWindows())
         {
-            using RegistryKey policyKey = Registry.LocalMachine.OpenSubKey(s_WorkloadPolicyKey);
+            using RegistryKey? policyKey = Registry.LocalMachine.OpenSubKey(s_WorkloadPolicyKey);
 
             return ((int?)policyKey?.GetValue(OnlineRevocationCheckPolicyKeyName) ?? 1) != 0;
         }
@@ -67,7 +72,7 @@ internal static class SignCheck
     {
         if (OperatingSystem.IsWindows())
         {
-            using RegistryKey policyKey = Registry.LocalMachine.OpenSubKey(s_WorkloadPolicyKey);
+            using RegistryKey? policyKey = Registry.LocalMachine.OpenSubKey(s_WorkloadPolicyKey);
 
             return ((int?)policyKey?.GetValue(VerifySignaturesPolicyKeyName) ?? 0) != 0;
         }

--- a/src/Cli/dotnet/Commands/Workload/SignCheck_Windows.cs
+++ b/src/Cli/dotnet/Commands/Workload/SignCheck_Windows.cs
@@ -20,7 +20,7 @@ internal static class SignCheck
 
     private static readonly string s_WorkloadPolicyKey = @"SOFTWARE\Policies\Microsoft\dotnet\Workloads";
 
-    private static readonly string s_dotnet = Assembly.GetExecutingAssembly().Location;
+    private static readonly string s_dotnet = Environment.ProcessPath;
 
     /// <summary>
     /// Determines whether dotnet.dll is signed.

--- a/src/Cli/dotnet/Commands/Workload/Update/WorkloadUpdateCommand.cs
+++ b/src/Cli/dotnet/Commands/Workload/Update/WorkloadUpdateCommand.cs
@@ -100,7 +100,7 @@ internal sealed class WorkloadUpdateCommand : InstallingWorkloadCommand
                 verifySignatures: VerifySignatures);
 
             var packageUrls = GetUpdatablePackageUrlsAsync(_includePreviews, NullReporter.Instance, packageDownloader).GetAwaiter().GetResult();
-            Reporter.WriteLine(JsonSerializer.Serialize(packageUrls, new JsonSerializerOptions() { WriteIndented = true }));
+            Reporter.WriteLine(JsonSerializer.Serialize(packageUrls, WorkloadInstallJsonSerializerContext.Default.IEnumerableString));
         }
         else if (_adManifestOnlyOption)
         {

--- a/src/Cli/dotnet/Commands/Workload/WorkloadJsonSerializerContext.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadJsonSerializerContext.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload;
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(WorkloadHistoryRecord))]
+internal partial class WorkloadHistoryJsonSerializerContext : JsonSerializerContext;
+
+/// <summary>
+/// Local converter for <see cref="WorkloadPackId"/> so the source generator can access it
+/// (the original converter in WorkloadManifestReader is internal).
+/// </summary>
+internal sealed class WorkloadPackIdJsonConverter : JsonConverter<WorkloadPackId>
+{
+    public override WorkloadPackId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetString() ?? string.Empty);
+
+    public override void Write(Utf8JsonWriter writer, WorkloadPackId value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString());
+}
+
+[JsonSourceGenerationOptions(Converters = [typeof(WorkloadPackIdJsonConverter)])]
+[JsonSerializable(typeof(PackInfo))]
+internal partial class PackInfoJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
@@ -32,7 +32,7 @@ internal sealed class InstallClientElevationContext(ISynchronizingLogger logger)
             // Use the path of the current host, otherwise we risk resolving against the wrong SDK version.
             // To trigger UAC, UseShellExecute must be true and Verb must be "runas".
             ProcessStartInfo startInfo = new($@"""{Environment.ProcessPath}""",
-                    $@"""{Assembly.GetExecutingAssembly().Location}"" workload elevate")
+                    $@"""{Environment.ProcessPath}"" workload elevate")
             {
                 Verb = "runas",
                 UseShellExecute = true,

--- a/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallClientElevationContext.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics;
 using System.IO.Pipes;
-using System.Reflection;
 using System.Runtime.Versioning;
 
 namespace Microsoft.DotNet.Cli.Installer.Windows;
@@ -31,8 +30,10 @@ internal sealed class InstallClientElevationContext(ISynchronizingLogger logger)
         {
             // Use the path of the current host, otherwise we risk resolving against the wrong SDK version.
             // To trigger UAC, UseShellExecute must be true and Verb must be "runas".
-            ProcessStartInfo startInfo = new($@"""{Environment.ProcessPath}""",
-                    $@"""{Environment.ProcessPath}"" workload elevate")
+            string currentProcessPath = Environment.ProcessPath
+                ?? throw new InvalidOperationException("Unable to determine the path to the current dotnet process.");
+
+            ProcessStartInfo startInfo = new(currentProcessPath, "workload elevate")
             {
                 Verb = "runas",
                 UseShellExecute = true,

--- a/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Utils.Extensions;
@@ -96,7 +95,7 @@ internal abstract class InstallerBase(InstallElevationContextBase elevationConte
     /// <summary>
     /// The name of the SDK directory, e.g. 6.0.100.
     /// </summary>
-    protected static string SdkDirectory => Path.GetFileName(AppContext.BaseDirectory);
+    protected static string SdkDirectory => Path.GetFileName(Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory));
 
     /// <summary>
     /// Gets whether signatures for workload packages and installers should be verified.
@@ -117,7 +116,7 @@ internal abstract class InstallerBase(InstallElevationContextBase elevationConte
     /// <summary>
     /// Checks the specified error code to determine whether it indicates a success result. If not, additional extended information
     /// is retrieved before throwing a <see cref="WorkloadException"/>.
-    /// 
+    ///
     /// The <see cref="Restart"/> property will be set to <see langword="true" /> if the error is either <see cref="Error.SUCCESS_REBOOT_INITIATED"/>
     /// or <see cref="Error.SUCCESS_REBOOT_REQUIRED"/>.
     /// </summary>
@@ -167,7 +166,7 @@ internal abstract class InstallerBase(InstallElevationContextBase elevationConte
     /// Logs a message if the specified error code does not indicate a success result. The <see cref="Restart"/>
     /// property will be set to <see langword="true" /> if the error is either <see cref="Error.SUCCESS_REBOOT_INITIATED"/>
     /// or <see cref="Error.SUCCESS_REBOOT_REQUIRED"/>.
-    /// 
+    ///
     /// No exception is thrown by this method. See <see cref="ExitOnError(uint, string)"/> for more detail.
     /// </summary>
     /// <param name="error">The error code to log.</param>

--- a/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
+++ b/src/Cli/dotnet/Installer/Windows/InstallerBase.cs
@@ -96,7 +96,7 @@ internal abstract class InstallerBase(InstallElevationContextBase elevationConte
     /// <summary>
     /// The name of the SDK directory, e.g. 6.0.100.
     /// </summary>
-    protected static string SdkDirectory => Path.GetFileName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+    protected static string SdkDirectory => Path.GetFileName(AppContext.BaseDirectory);
 
     /// <summary>
     /// Gets whether signatures for workload packages and installers should be verified.

--- a/src/Cli/dotnet/NugetPackageDownloader/WorkloadUnixFilePermissionsFileList.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/WorkloadUnixFilePermissionsFileList.cs
@@ -26,18 +26,24 @@ public class FileList
 
     public static FileList Deserialize(string pathToXml)
     {
-        var serializer = new XmlSerializer(typeof(FileList));
-
+        var files = new List<FileListFile>();
         using var fs = new FileStream(pathToXml, FileMode.Open);
-        var reader = XmlReader.Create(fs);
-        FileList fileList = (FileList)serializer.Deserialize(reader);
-        return fileList;
+        using var reader = XmlReader.Create(fs);
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "File")
+            {
+                files.Add(new FileListFile
+                {
+                    Path = reader.GetAttribute("Path"),
+                    Permission = reader.GetAttribute("Permission")
+                });
+            }
+        }
+        return new FileList { File = files.ToArray() };
     }
 }
 
-[Serializable]
-[DesignerCategory("code")]
-[XmlType(AnonymousType = true)]
 public class FileListFile
 {
     private string pathField;

--- a/src/Cli/dotnet/NugetSearch/NugetSearchApiResultDeserializer.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetSearchApiResultDeserializer.cs
@@ -4,24 +4,27 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Commands.Tool.Search;
 using Microsoft.DotNet.Cli.NugetSearch.NugetSearchApiSerializable;
 using Microsoft.DotNet.Cli.ToolPackage;
 
 namespace Microsoft.DotNet.Cli.NugetSearch;
 
+[JsonSerializable(typeof(NugetSearchApiContainerSerializable))]
+[JsonSourceGenerationOptions(
+    AllowTrailingCommas = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    Converters = [typeof(AuthorsConverter)])]
+internal partial class NugetSearchApiJsonSerializerContext : JsonSerializerContext
+{
+}
+
 internal static class NugetSearchApiResultDeserializer
 {
     public static IReadOnlyCollection<SearchResultPackage> Deserialize(string json)
     {
-        var options = new JsonSerializerOptions
-        {
-            Converters = { new AuthorsConverter() },
-            AllowTrailingCommas = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-
-        var deserialized = JsonSerializer.Deserialize<NugetSearchApiContainerSerializable>(json, options);
+        var deserialized = JsonSerializer.Deserialize(json, NugetSearchApiJsonSerializerContext.Default.NugetSearchApiContainerSerializable);
         var resultPackages = new List<SearchResultPackage>();
         foreach (var deserializedPackage in deserialized.Data)
         {

--- a/src/Cli/dotnet/NugetSearch/NugetSearchApiResultDeserializer.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetSearchApiResultDeserializer.cs
@@ -11,14 +11,12 @@ using Microsoft.DotNet.Cli.ToolPackage;
 
 namespace Microsoft.DotNet.Cli.NugetSearch;
 
-[JsonSerializable(typeof(NugetSearchApiContainerSerializable))]
 [JsonSourceGenerationOptions(
     AllowTrailingCommas = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     Converters = [typeof(AuthorsConverter)])]
-internal partial class NugetSearchApiJsonSerializerContext : JsonSerializerContext
-{
-}
+[JsonSerializable(typeof(NugetSearchApiContainerSerializable))]
+internal partial class NugetSearchApiJsonSerializerContext : JsonSerializerContext;
 
 internal static class NugetSearchApiResultDeserializer
 {

--- a/src/Cli/dotnet/ToolPackage/LocalToolsResolverCache.cs
+++ b/src/Cli/dotnet/ToolPackage/LocalToolsResolverCache.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.Extensions.EnvironmentAbstractions;
@@ -12,7 +13,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
-internal class LocalToolsResolverCache : ILocalToolsResolverCache
+internal partial class LocalToolsResolverCache : ILocalToolsResolverCache
 {
     private readonly DirectoryPath _cacheVersionedDirectory;
     private readonly IFileSystem _fileSystem;
@@ -49,7 +50,7 @@ internal class LocalToolsResolverCache : ILocalToolsResolverCache
 
                 _fileSystem.File.WriteAllText(
                     packageCacheFile,
-                    JsonSerializer.Serialize(existingCacheTable.Concat(diffedRow)));
+                    JsonSerializer.Serialize(existingCacheTable.Concat(diffedRow), LocalToolsCacheJsonContext.Default.IEnumerableCacheRow));
             }
             else
             {
@@ -62,7 +63,7 @@ internal class LocalToolsResolverCache : ILocalToolsResolverCache
 
                 _fileSystem.File.WriteAllText(
                     packageCacheFile,
-                    JsonSerializer.Serialize(rowsToAdd));
+                    JsonSerializer.Serialize(rowsToAdd, LocalToolsCacheJsonContext.Default.IEnumerableCacheRow));
             }
         }
     }
@@ -94,7 +95,7 @@ internal class LocalToolsResolverCache : ILocalToolsResolverCache
         try
         {
             cacheTable =
-                JsonSerializer.Deserialize<CacheRow[]>(_fileSystem.File.ReadAllText(packageCacheFile));
+                JsonSerializer.Deserialize(_fileSystem.File.ReadAllText(packageCacheFile), LocalToolsCacheJsonContext.Default.CacheRowArray);
         }
         catch (JsonException)
         {
@@ -188,4 +189,8 @@ internal class LocalToolsResolverCache : ILocalToolsResolverCache
         public string Runner { get; set; }
         public string PathToExecutable { get; set; }
     }
+
+    [JsonSerializable(typeof(CacheRow[]))]
+    [JsonSerializable(typeof(IEnumerable<CacheRow>))]
+    private partial class LocalToolsCacheJsonContext : JsonSerializerContext;
 }

--- a/src/Cli/dotnet/ToolPackage/LocalToolsResolverCache.cs
+++ b/src/Cli/dotnet/ToolPackage/LocalToolsResolverCache.cs
@@ -50,7 +50,7 @@ internal partial class LocalToolsResolverCache : ILocalToolsResolverCache
 
                 _fileSystem.File.WriteAllText(
                     packageCacheFile,
-                    JsonSerializer.Serialize(existingCacheTable.Concat(diffedRow), LocalToolsCacheJsonContext.Default.IEnumerableCacheRow));
+                    JsonSerializer.Serialize(existingCacheTable.Concat(diffedRow), LocalToolsCacheJsonSerializerContext.Default.IEnumerableCacheRow));
             }
             else
             {
@@ -63,7 +63,7 @@ internal partial class LocalToolsResolverCache : ILocalToolsResolverCache
 
                 _fileSystem.File.WriteAllText(
                     packageCacheFile,
-                    JsonSerializer.Serialize(rowsToAdd, LocalToolsCacheJsonContext.Default.IEnumerableCacheRow));
+                    JsonSerializer.Serialize(rowsToAdd, LocalToolsCacheJsonSerializerContext.Default.IEnumerableCacheRow));
             }
         }
     }
@@ -95,7 +95,7 @@ internal partial class LocalToolsResolverCache : ILocalToolsResolverCache
         try
         {
             cacheTable =
-                JsonSerializer.Deserialize(_fileSystem.File.ReadAllText(packageCacheFile), LocalToolsCacheJsonContext.Default.CacheRowArray);
+                JsonSerializer.Deserialize(_fileSystem.File.ReadAllText(packageCacheFile), LocalToolsCacheJsonSerializerContext.Default.CacheRowArray);
         }
         catch (JsonException)
         {
@@ -192,5 +192,5 @@ internal partial class LocalToolsResolverCache : ILocalToolsResolverCache
 
     [JsonSerializable(typeof(CacheRow[]))]
     [JsonSerializable(typeof(IEnumerable<CacheRow>))]
-    private partial class LocalToolsCacheJsonContext : JsonSerializerContext;
+    private partial class LocalToolsCacheJsonSerializerContext : JsonSerializerContext;
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
@@ -54,7 +54,7 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
         _currentWorkingDirectory = currentWorkingDirectory;
 
         _localToolAssetDir = new DirectoryPath(_fileSystem.Directory.CreateTemporarySubdirectory());
-        _runtimeJsonPath = runtimeJsonPathForTests ?? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "RuntimeIdentifierGraph.json");
+        _runtimeJsonPath = runtimeJsonPathForTests ?? Path.Combine(AppContext.BaseDirectory!, "RuntimeIdentifierGraph.json");
     }
 
     protected abstract INuGetPackageDownloader CreateNuGetPackageDownloader(

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -21,6 +21,12 @@
 
     <!-- Ignore checking for OS API compatibility as we aren't targeting just the Windows platform  -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="'$(TargetFramework)' != '$(NetFrameworkToolCurrent)'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/WorkloadFileBasedInstall.cs
+++ b/src/Common/WorkloadFileBasedInstall.cs
@@ -58,7 +58,7 @@ internal static class WorkloadFileBasedInstall
         {
             try
             {
-                var historyRecord = JsonSerializer.Deserialize<WorkloadHistoryRecord>(File.ReadAllText(file));
+                var historyRecord = JsonSerializer.Deserialize(File.ReadAllText(file), WorkloadHistoryJsonSerializerContext.Default.WorkloadHistoryRecord);
                 if (historyRecord is not null)
                 {
                     historyRecords.Add(historyRecord);

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
@@ -18,7 +18,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
 
     public override LaunchProfileParseResult ParseProfile(string launchSettingsPath, string? launchProfileName, string json)
     {
-        var profile = JsonSerializer.Deserialize<ExecutableLaunchProfile>(json);
+        var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ExecutableLaunchProfile);
         if (profile == null)
         {
             return LaunchProfileParseResult.Failure(Resources.LaunchProfileIsNotAJsonObject);

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfile.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfile.cs
@@ -18,5 +18,9 @@ public abstract class LaunchProfile
     public string? CommandLineArgs { get; init; }
 
     [JsonPropertyName("environmentVariables")]
-    public ImmutableDictionary<string, string> EnvironmentVariables { get; init; } = [];
+    public ImmutableDictionary<string, string> EnvironmentVariables
+    {
+        get;
+        init => field = value ?? [];
+    } = [];
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileJsonSerializerContext.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileJsonSerializerContext.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DotNet.ProjectTools;
+
+[JsonSerializable(typeof(ProjectLaunchProfile))]
+[JsonSerializable(typeof(ExecutableLaunchProfile))]
+internal partial class LaunchProfileJsonSerializerContext : JsonSerializerContext;

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
@@ -17,7 +17,7 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
 
     public override LaunchProfileParseResult ParseProfile(string launchSettingsPath, string? launchProfileName, string json)
     {
-        var profile = JsonSerializer.Deserialize<ProjectLaunchProfile>(json);
+        var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ProjectLaunchProfile);
         if (profile == null)
         {
             return LaunchProfileParseResult.Failure(Resources.LaunchProfileIsNotAJsonObject);

--- a/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
+++ b/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
@@ -5,6 +5,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -10,6 +10,12 @@
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     <!-- https://github.com/dotnet/sdk/issues/14801 -->
     <AssemblyVersion Condition="'$(TargetFramework)' == '$(NetFrameworkToolCurrent)'">5.0.100.0</AssemblyVersion>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="'$(TargetFramework)' != '$(NetFrameworkToolCurrent)'">true</IsAotCompatible>
   </PropertyGroup>
 
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">

--- a/src/Microsoft.Win32.Msi/Microsoft.Win32.Msi.csproj
+++ b/src/Microsoft.Win32.Msi/Microsoft.Win32.Msi.csproj
@@ -4,6 +4,12 @@
     <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Microsoft.Win32.Msi</RootNamespace>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="'$(TargetFramework)' != '$(NetFrameworkToolCurrent)'">true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/Resolvers/Microsoft.DotNet.SdkResolver/Microsoft.DotNet.SdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.SdkResolver/Microsoft.DotNet.SdkResolver.csproj
@@ -8,6 +8,12 @@
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     <RootNamespace>Microsoft.DotNet.DotNetSdkResolver</RootNamespace>
+
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net472'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPackId.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadPackId.cs
@@ -12,6 +12,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
     /// This internal struct helps preserve/annotate these semantics.
     /// </summary>
     /// <remarks>This is distinct from <see cref="WorkloadId"/> to prevent accidental confusion, but the behavior is identical</remarks>
+    [JsonConverter(typeof(PackIdJsonConverter))]
     public struct WorkloadPackId : IComparable<WorkloadPackId>, IEquatable<WorkloadPackId>
     {
         string _id;
@@ -45,7 +46,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         public static bool operator !=(WorkloadPackId a, WorkloadPackId b) => !a.Equals(b);
     }
 
-    internal class PackIdJsonConverter : JsonConverter<WorkloadPackId>
+    public class PackIdJsonConverter : JsonConverter<WorkloadPackId>
     {
         public override WorkloadPackId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
             new(reader.GetString() ?? string.Empty);

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -674,7 +674,6 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             /// <summary>
             /// The workload pack ID. The NuGet package ID <see cref="ResolvedPackageId"/> may differ from this.
             /// </summary>
-            [JsonConverter(typeof(PackIdJsonConverter))]
             public WorkloadPackId Id { get; }
 
             public string Version { get; }
@@ -746,7 +745,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             {
                 return value.info.Version;
             }
-            
+
             throw new Exception(string.Format(Strings.ManifestDoesNotExist, manifestId));
         }
 
@@ -760,7 +759,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
             throw new Exception(string.Format(Strings.ManifestDoesNotExist, manifestId));
         }
-            
+
         public IEnumerable<WorkloadManifestInfo> GetInstalledManifests()
         {
             InitializeManifests();

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSet.cs
@@ -65,12 +65,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public static WorkloadSet FromJson(string json, SdkFeatureBand defaultFeatureBand)
         {
-            var jsonSerializerOptions = new JsonSerializerOptions()
-            {
-                AllowTrailingCommas = true,
-                ReadCommentHandling = JsonCommentHandling.Skip
-            };
-            return FromDictionaryForJson(JsonSerializer.Deserialize<IDictionary<string, string>>(json, jsonSerializerOptions)!, defaultFeatureBand);
+            return FromDictionaryForJson(JsonSerializer.Deserialize(json, WorkloadSetJsonSerializerContext.Default.IDictionaryStringString)!, defaultFeatureBand);
         }
 
         public static WorkloadSet? FromWorkloadSetFolder(string path, string workloadSetVersion, SdkFeatureBand defaultFeatureBand)
@@ -120,7 +115,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
 
         public string ToJson()
         {
-            var json = JsonSerializer.Serialize(ToDictionaryForJson(), new JsonSerializerOptions() { WriteIndented = true });
+            var json = JsonSerializer.Serialize(ToDictionaryForJson(), WorkloadSetJsonSerializerContext.Default.DictionaryStringString);
             return json;
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSetJsonSerializerContext.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadSetJsonSerializerContext.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.NET.Sdk.WorkloadManifestReader;
+
+[JsonSourceGenerationOptions(
+    AllowTrailingCommas = true,
+    ReadCommentHandling = JsonCommentHandling.Skip,
+    WriteIndented = true)]
+[JsonSerializable(typeof(IDictionary<string, string>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class WorkloadSetJsonSerializerContext : JsonSerializerContext;

--- a/start-code.cmd
+++ b/start-code.cmd
@@ -1,0 +1,26 @@
+@ECHO OFF
+SETLOCAL
+
+:: This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
+
+FOR /f "delims=" %%a IN ('where.exe code') DO @SET vscode=%%a& GOTO break
+:break
+
+IF ["%vscode%"] == [""] (
+    echo [ERROR] Visual Studio Code is not installed or can't be found.
+    exit /b 1
+)
+
+:: This tells .NET Core to use the same dotnet.exe that build scripts use
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
+    echo [ERROR] .NET has not yet been installed. Run `%~dp0restore.cmd` to install tools
+    exit /b 1
+)
+
+"%vscode%" "."

--- a/test/dotnet.Tests/CommandTests/Workload/Clean/GivenDotnetWorkloadClean.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Clean/GivenDotnetWorkloadClean.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Workload.Install.Tests;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.Text.Json;
+using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Commands.Workload.Clean;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
 
@@ -146,7 +147,7 @@ namespace Microsoft.DotNet.Cli.Workload.Clean.Tests
             var packRecordPath = Path.Combine(installRoot, "metadata", "workloads", "InstalledPacks", "v1", "Test.Pack.A", "1.0.0", sdkBand);
             var packPath = Path.Combine(installRoot, "packs", "Test.Pack.A", "1.0.0");
             Directory.CreateDirectory(Path.GetDirectoryName(packRecordPath));
-            var packRecordContents = JsonSerializer.Serialize<WorkloadResolver.PackInfo>(new(new WorkloadPackId("Test.Pack.A"), "1.0.0", WorkloadPackKind.Sdk, packPath, "Test.Pack.A"));
+            var packRecordContents = JsonSerializer.Serialize(new WorkloadResolver.PackInfo(new WorkloadPackId("Test.Pack.A"), "1.0.0", WorkloadPackKind.Sdk, packPath, "Test.Pack.A"), PackInfoJsonSerializerContext.Default.PackInfo);
             File.WriteAllText(packRecordPath, packRecordContents);
             return packRecordPath;
         }

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenFileBasedWorkloadInstall.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenFileBasedWorkloadInstall.cs
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
                 {
                     var packRecordPath = Path.Combine(installedPacksPath, pack.Id, pack.Version, sdkVersion);
                     Directory.CreateDirectory(Path.GetDirectoryName(packRecordPath));
-                    var packRecordContents = JsonSerializer.Serialize<WorkloadResolver.PackInfo>(pack);
+                    var packRecordContents = JsonSerializer.Serialize(pack, PackInfoJsonSerializerContext.Default.PackInfo);
                     File.WriteAllText(packRecordPath, packRecordContents);
                     Directory.CreateDirectory(pack.Path);
                 }

--- a/test/dotnet.Tests/CommandTests/Workload/Install/WorkloadGarbageCollectionTests.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/WorkloadGarbageCollectionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 using System.Text.Json;
+using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
 
 namespace Microsoft.DotNet.Cli.Workload.Install.Tests
@@ -323,7 +324,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             //  Write pack installation record
             var packRecordPath = PackRecord(pack, sdkFeatureBand);
             Directory.CreateDirectory(Path.GetDirectoryName(packRecordPath.FullName));
-            var packRecordContents = JsonSerializer.Serialize<WorkloadResolver.PackInfo>(pack);
+            var packRecordContents = JsonSerializer.Serialize(pack, PackInfoJsonSerializerContext.Default.PackInfo);
             File.WriteAllText(packRecordPath.FullName, packRecordContents);
 
             //  Create fake pack install
@@ -397,7 +398,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var manifestProvider = new SdkDirectoryWorkloadManifestProvider(_dotnetRoot, sdkVersion, userProfileDir: null, globalJsonPath: null);
 
             var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, _dotnetRoot);
-            
+
 
             IWorkloadResolver GetResolver(string workloadSetVersion)
             {

--- a/test/dotnet.Tests/CommandTests/Workload/Repair/GivenDotnetWorkloadRepair.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Repair/GivenDotnetWorkloadRepair.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.Text.Json;
 using ManifestReaderTests;
 using Microsoft.DotNet.Cli.Commands;
+using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
 using Microsoft.DotNet.Cli.Commands.Workload.Repair;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -88,7 +89,7 @@ namespace Microsoft.DotNet.Cli.Workload.Repair.Tests
             Directory.CreateDirectory(Path.GetDirectoryName(extraPackRecordPath));
             var extraPackPath = Path.Combine(installRoot, "packs", "Test.Pack.A", "1.0.0");
             Directory.CreateDirectory(extraPackPath);
-            var packRecordContents = JsonSerializer.Serialize<WorkloadResolver.PackInfo>(new(new WorkloadPackId("Test.Pack.A"), "1.0.0", WorkloadPackKind.Sdk, extraPackPath, "Test.Pack.A"));
+            var packRecordContents = JsonSerializer.Serialize(new WorkloadResolver.PackInfo(new WorkloadPackId("Test.Pack.A"), "1.0.0", WorkloadPackKind.Sdk, extraPackPath, "Test.Pack.A"), PackInfoJsonSerializerContext.Default.PackInfo);
             File.WriteAllText(extraPackRecordPath, packRecordContents);
 
             var repairCommand = new WorkloadRepairCommand(_parseResult, reporter: _reporter, workloadResolverFactory,


### PR DESCRIPTION
Replace reflection-based patterns with AOT-compatible alternatives across the CLI codebase:

- **Source-generated JSON serialization**: Replace `JsonSerializer.Serialize<T>`/`Deserialize<T>` calls with source-generated `JsonSerializerContext` types throughout workload, tool list, SDK check, template, and manifest commands. This eliminates reliance on reflection-based `DefaultJsonTypeInfoResolver`.

- **Replace `Assembly.GetExecutingAssembly().Location`** with `AppContext.BaseDirectory` or `Environment.ProcessPath` in `VBCSCompilerServer`, `InstallerBase`, `InstallClientElevationContext`, `SignCheck`, and `ToolPackageDownloaderBase`, since `Assembly.Location` returns empty in single-file/AOT deployments.

- **Replace `XmlSerializer` with manual XML parsing**: Use `XDocument`/`XmlReader` in `ToolConfigurationDeserializer` and `WorkloadUnixFilePermissionsFileList` to avoid runtime code generation.

- **AOT-compatible logging registration**: Change `CliTemplateEngineHost` to use `Services.TryAddEnumerable` instead of the generic `AddConsoleFormatter<T>` overload that relies on `MakeGenericType`.

- **Enable AOT compatibility analyzers**: Add `<IsAotCompatible>true</IsAotCompatible>` to `dotnet.csproj`, `Microsoft.DotNet.Configurer`, `Microsoft.DotNet.InternalAbstractions`, `Microsoft.TemplateEngine.Cli`, `Microsoft.DotNet.ProjectTools`, `Microsoft.DotNet.TemplateLocator`, `Microsoft.Win32.Msi`, and `Microsoft.DotNet.SdkResolver` project files.

- **Suppress IL3000 warnings** with `#pragma` in locations where `Assembly.Location` is unavoidable (`MSBuildForwardingApp`, `BuiltInTemplatePackageProvider`, `OptionalWorkloadProvider`).