### PR TITLE
Fix invalid MSBuild ItemGroup syntax in WASM HotReload

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -42,7 +42,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmHotReloadModule Include="$(_WasmHotReloadIntermediatePath)Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js">
         <RelativePath>_framework/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js</RelativePath>
       </_WasmHotReloadModule>
-      <_WasmHotReloadModule OriginalItemSpec="%(Identity)" />
+      <_WasmHotReloadModule Update="@(_WasmHotReloadModule)">
+        <OriginalItemSpec>%(Identity)</OriginalItemSpec>
+      </_WasmHotReloadModule>
       <FileWrites Include="$(_WasmHotReloadIntermediatePath)Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes the invalid MSBuild syntax identified in PR #52879 review comments.

## Issue

The original code in #52879 used incorrect MSBuild syntax:
```xml
<_WasmHotReloadModule OriginalItemSpec="%(Identity)" />
```

This creates a **new empty item** instead of updating the existing item's metadata, which could cause `DefineStaticWebAssets` to process phantom assets with empty Identity values.

## Fix

Changed to the correct MSBuild `Update` pattern:
```xml
<_WasmHotReloadModule Update="@(_WasmHotReloadModule)">
  <OriginalItemSpec>%(Identity)</OriginalItemSpec>
</_WasmHotReloadModule>
```

This properly updates the existing item's metadata instead of creating a new item.

## Review Feedback

This addresses the feedback from @copilot-pull-request-reviewer in #52879:
https://github.com/dotnet/sdk/pull/52879#discussion_r2775613748

> `<_WasmHotReloadModule OriginalItemSpec="%(Identity)" />` inside the `ItemGroup` appears to create a *new* item (with an empty Include) rather than setting metadata on the existing `_WasmHotReloadModule` item.

## Testing

The existing test `Publish_HostingMultipleBlazorWebApps_Works` validates this scenario works correctly.

## Risk

Very low - this is a surgical fix to use correct MSBuild syntax that follows the established pattern used elsewhere in the SDK.