### PR TITLE
Add IMultiThreadableTask and TaskEnvironment polyfills for multithrea…

### DIFF
--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -74,10 +74,38 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            if (!Path.IsPathRooted(path))
+            if (!IsPathFullyQualified(path))
             {
                 throw new ArgumentException("Path must be rooted.", nameof(path));
             }
+        }
+
+        private static bool IsPathFullyQualified(string path)
+        {
+            if (!Path.IsPathRooted(path))
+            {
+                return false;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows, reject drive-relative paths like "C:foo".
+                if (path.Length >= 2 && path[1] == ':')
+                {
+                    if (path.Length < 3)
+                    {
+                        return false;
+                    }
+
+                    char separator = path[2];
+                    if (separator != Path.DirectorySeparatorChar && separator != Path.AltDirectorySeparatorChar)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is a polyfill for the AbsolutePath struct from MSBuild.
+// See: https://github.com/dotnet/msbuild/blob/main/src/Framework/PathHelpers/AbsolutePath.cs
+
+#if NETFRAMEWORK
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Represents an absolute file system path.
+    /// </summary>
+    internal readonly struct AbsolutePath : IEquatable<AbsolutePath>
+    {
+        private static readonly bool s_isFileSystemCaseSensitive = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                                                   && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        private static readonly StringComparer s_pathComparer = s_isFileSystemCaseSensitive
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+
+        /// <summary>
+        /// The normalized string representation of this path.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// The original string used to create this path.
+        /// </summary>
+        public string OriginalValue { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbsolutePath"/> struct.
+        /// </summary>
+        public AbsolutePath(string path)
+        {
+            ValidatePath(path);
+            Value = path;
+            OriginalValue = path;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbsolutePath"/> struct.
+        /// </summary>
+        internal AbsolutePath(string path, bool ignoreRootedCheck)
+            : this(path, path, ignoreRootedCheck)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbsolutePath"/> struct.
+        /// </summary>
+        internal AbsolutePath(string path, string original, bool ignoreRootedCheck)
+        {
+            if (!ignoreRootedCheck)
+            {
+                ValidatePath(path);
+            }
+            Value = path;
+            OriginalValue = original;
+        }
+
+        private static void ValidatePath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Path must not be null or empty.", nameof(path));
+            }
+
+            if (!Path.IsPathRooted(path))
+            {
+                throw new ArgumentException("Path must be rooted.", nameof(path));
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance by combining an absolute base path with a relative path.
+        /// </summary>
+        public AbsolutePath(string path, AbsolutePath basePath)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Path must not be null or empty.", nameof(path));
+            }
+
+            Value = Path.Combine(basePath.Value, path);
+            OriginalValue = path;
+        }
+
+        /// <summary>
+        /// Implicitly converts an AbsolutePath to a string.
+        /// </summary>
+        public static implicit operator string(AbsolutePath path) => path.Value;
+
+        /// <summary>
+        /// Returns the canonical form of this path.
+        /// </summary>
+        internal AbsolutePath GetCanonicalForm()
+        {
+            if (string.IsNullOrEmpty(Value))
+            {
+                return this;
+            }
+
+            bool hasRelativeSegment = Value.Contains("/.") || Value.Contains("\\.");
+            bool needsSeparatorNormalization = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                              && Value.IndexOf(Path.AltDirectorySeparatorChar) >= 0;
+
+            if (!hasRelativeSegment && !needsSeparatorNormalization)
+            {
+                return this;
+            }
+
+            return new AbsolutePath(Path.GetFullPath(Value), OriginalValue, ignoreRootedCheck: true);
+        }
+
+        public static bool operator ==(AbsolutePath left, AbsolutePath right) => left.Equals(right);
+        public static bool operator !=(AbsolutePath left, AbsolutePath right) => !left.Equals(right);
+
+        public override bool Equals(object? obj) => obj is AbsolutePath other && Equals(other);
+
+        public bool Equals(AbsolutePath other) => s_pathComparer.Equals(Value, other.Value);
+
+        public override int GetHashCode() => Value is null ? 0 : s_pathComparer.GetHashCode(Value);
+
+        public override string ToString() => Value;
+    }
+}
+
+#endif

--- a/src/Tasks/Common/IMultiThreadableTask.cs
+++ b/src/Tasks/Common/IMultiThreadableTask.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is a polyfill for the IMultiThreadableTask interface from MSBuild.
+// MSBuild detects this interface by its namespace and name only, ignoring the defining assembly.
+// This allows us to use the interface before the MSBuild version containing it is available.
+// See: https://github.com/dotnet/msbuild/blob/main/src/Framework/IMultiThreadableTask.cs
+
+// This polyfill is only needed for .NET Framework builds since the newer MSBuild packages
+// for .NET Core already include the interface. When targeting .NET Core, we use the
+// interface from Microsoft.Build.Framework directly.
+
+#if NETFRAMEWORK
+
+#nullable enable
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Interface for tasks that can execute in a thread-safe manner within MSBuild's multithreaded execution model.
+    /// Tasks that implement this interface declare their capability to run in multiple threads within one process.
+    /// </summary>
+    internal interface IMultiThreadableTask : ITask
+    {
+        /// <summary>
+        /// Gets or sets the task execution environment, which provides access to project current directory
+        /// and environment variables in a thread-safe manner.
+        /// </summary>
+        TaskEnvironment TaskEnvironment { get; set; }
+    }
+}
+
+#endif

--- a/src/Tasks/Common/ITaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ITaskEnvironmentDriver.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is a polyfill for the ITaskEnvironmentDriver interface from MSBuild.
+// See: https://github.com/dotnet/msbuild/blob/main/src/Framework/ITaskEnvironmentDriver.cs
+
+#if NETFRAMEWORK
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Internal interface for managing task execution environment, including environment variables and working directory.
+    /// </summary>
+    internal interface ITaskEnvironmentDriver : IDisposable
+    {
+        /// <summary>
+        /// Gets or sets the current working directory for the task environment.
+        /// </summary>
+        AbsolutePath ProjectDirectory { get; set; }
+
+        /// <summary>
+        /// Gets an absolute path from the specified path, resolving relative paths against the current project directory.
+        /// </summary>
+        AbsolutePath GetAbsolutePath(string path);
+
+        /// <summary>
+        /// Gets the value of the specified environment variable.
+        /// </summary>
+        string? GetEnvironmentVariable(string name);
+
+        /// <summary>
+        /// Gets all environment variables for this task environment.
+        /// </summary>
+        IReadOnlyDictionary<string, string> GetEnvironmentVariables();
+
+        /// <summary>
+        /// Sets an environment variable to the specified value.
+        /// </summary>
+        void SetEnvironmentVariable(string name, string? value);
+
+        /// <summary>
+        /// Sets the environment to match the specified collection of variables.
+        /// </summary>
+        void SetEnvironment(IDictionary<string, string> newEnvironment);
+
+        /// <summary>
+        /// Gets a ProcessStartInfo configured with the current environment and working directory.
+        /// </summary>
+        ProcessStartInfo GetProcessStartInfo();
+    }
+}
+
+#endif

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Framework
             // Populate environment from the scoped environment dictionary
             foreach (var kvp in _environmentVariables)
             {
-                startInfo.Environment[kvp.Key] = kvp.Value;
+                startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
             }
 
             return startInfo;

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Framework
         {
             if (Path.IsPathRooted(path))
             {
-                return new AbsolutePath(path, ignoreRootedCheck: true);
+                return new AbsolutePath(path);
             }
 
             return new AbsolutePath(path, _projectDirectory);

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is a polyfill for the MultiProcessTaskEnvironmentDriver from MSBuild.
+// Adapted for use in the SDK tasks project where NativeMethodsShared is not available.
+// See: https://github.com/dotnet/msbuild/blob/main/src/Build/BackEnd/TaskExecutionHost/MultiProcessTaskEnvironmentDriver.cs
+
+#if NETFRAMEWORK
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Default implementation of <see cref="ITaskEnvironmentDriver"/> that directly interacts with the file system
+    /// and environment variables. Used for multi-process mode and as a test helper.
+    /// </summary>
+    internal sealed class ProcessTaskEnvironmentDriver : ITaskEnvironmentDriver
+    {
+        private AbsolutePath _projectDirectory;
+
+        /// <summary>
+        /// Initializes a new instance with the specified project directory.
+        /// </summary>
+        public ProcessTaskEnvironmentDriver(string projectDirectory)
+        {
+            _projectDirectory = new AbsolutePath(projectDirectory);
+        }
+
+        /// <inheritdoc/>
+        public AbsolutePath ProjectDirectory
+        {
+            get => _projectDirectory;
+            set => _projectDirectory = value;
+        }
+
+        /// <inheritdoc/>
+        public AbsolutePath GetAbsolutePath(string path)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return new AbsolutePath(path, ignoreRootedCheck: true);
+            }
+
+            return new AbsolutePath(path, _projectDirectory);
+        }
+
+        /// <inheritdoc/>
+        public string? GetEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name);
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && entry.Value is string value)
+                {
+                    result[key] = value;
+                }
+            }
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public void SetEnvironmentVariable(string name, string? value)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        /// <inheritdoc/>
+        public void SetEnvironment(IDictionary<string, string> newEnvironment)
+        {
+            // Remove variables not in the new set, update others
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key)
+                {
+                    if (!newEnvironment.ContainsKey(key))
+                    {
+                        Environment.SetEnvironmentVariable(key, null);
+                    }
+                }
+            }
+
+            foreach (var kvp in newEnvironment)
+            {
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+        }
+
+        /// <inheritdoc/>
+        public ProcessStartInfo GetProcessStartInfo()
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                WorkingDirectory = _projectDirectory.Value,
+            };
+
+            // Populate environment from current process environment
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && entry.Value is string value)
+                {
+                    startInfo.Environment[key] = value;
+                }
+            }
+
+            return startInfo;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // No resources to clean up in this implementation.
+        }
+    }
+}
+
+#endif

--- a/src/Tasks/Common/TaskEnvironment.cs
+++ b/src/Tasks/Common/TaskEnvironment.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is a polyfill for the TaskEnvironment class from MSBuild.
+// See: https://github.com/dotnet/msbuild/blob/main/src/Framework/TaskEnvironment.cs
+
+#if NETFRAMEWORK
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Provides an <see cref="IMultiThreadableTask"/> with access to a run-time execution environment including
+    /// environment variables, file paths, and process management capabilities.
+    /// </summary>
+    internal sealed class TaskEnvironment
+    {
+        private readonly ITaskEnvironmentDriver _driver;
+
+        /// <summary>
+        /// Initializes a new instance of the TaskEnvironment class.
+        /// </summary>
+        internal TaskEnvironment(ITaskEnvironmentDriver driver)
+        {
+            _driver = driver;
+        }
+
+        /// <summary>
+        /// Gets or sets the project directory for the task execution.
+        /// </summary>
+        public AbsolutePath ProjectDirectory
+        {
+            get => _driver.ProjectDirectory;
+            internal set => _driver.ProjectDirectory = value;
+        }
+
+        /// <summary>
+        /// Converts a relative or absolute path string to an absolute path.
+        /// This function resolves paths relative to <see cref="ProjectDirectory"/>.
+        /// </summary>
+        public AbsolutePath GetAbsolutePath(string path) => _driver.GetAbsolutePath(path);
+
+        /// <summary>
+        /// Gets the value of an environment variable.
+        /// </summary>
+        public string? GetEnvironmentVariable(string name) => _driver.GetEnvironmentVariable(name);
+
+        /// <summary>
+        /// Gets a dictionary containing all environment variables.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables() => _driver.GetEnvironmentVariables();
+
+        /// <summary>
+        /// Sets the value of an environment variable.
+        /// </summary>
+        public void SetEnvironmentVariable(string name, string? value) => _driver.SetEnvironmentVariable(name, value);
+
+        /// <summary>
+        /// Updates the environment to match the provided dictionary.
+        /// </summary>
+        internal void SetEnvironment(IDictionary<string, string> newEnvironment) => _driver.SetEnvironment(newEnvironment);
+
+        /// <summary>
+        /// Creates a new ProcessStartInfo configured for the current task execution environment.
+        /// </summary>
+        public ProcessStartInfo GetProcessStartInfo() => _driver.GetProcessStartInfo();
+
+        /// <summary>
+        /// Disposes the underlying driver, cleaning up any thread-local state.
+        /// </summary>
+        internal void Dispose() => _driver.Dispose();
+    }
+}
+
+#endif

--- a/src/Tasks/Common/TaskEnvironment.cs
+++ b/src/Tasks/Common/TaskEnvironment.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Framework
     /// Provides an <see cref="IMultiThreadableTask"/> with access to a run-time execution environment including
     /// environment variables, file paths, and process management capabilities.
     /// </summary>
-    internal sealed class TaskEnvironment
+    public sealed class TaskEnvironment
     {
         private readonly ITaskEnvironmentDriver _driver;
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TaskEnvironmentHelper.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TaskEnvironmentHelper.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Helper class for creating TaskEnvironment instances in tests.
+// NOT gated with #if — always available in the test project.
+// Adapted from: https://github.com/dotnet/msbuild/blob/main/src/UnitTests.Shared/TaskEnvironmentHelper.cs
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    /// <summary>
+    /// Helper class for creating TaskEnvironment instances in tests.
+    /// </summary>
+    public static class TaskEnvironmentHelper
+    {
+        /// <summary>
+        /// Creates a TaskEnvironment using the current working directory as the project directory.
+        /// </summary>
+        public static TaskEnvironment CreateForTest()
+        {
+            return CreateForTest(Directory.GetCurrentDirectory());
+        }
+
+        /// <summary>
+        /// Creates a TaskEnvironment with the specified project directory.
+        /// Uses reflection to work around internal visibility of ITaskEnvironmentDriver and TaskEnvironment ctor.
+        /// </summary>
+        public static TaskEnvironment CreateForTest(string projectDirectory)
+        {
+            // Get the internal ITaskEnvironmentDriver type from Microsoft.Build.Framework
+            var driverInterfaceType = typeof(TaskEnvironment).Assembly
+                .GetType("Microsoft.Build.Framework.ITaskEnvironmentDriver", throwOnError: true)!;
+
+            // Create a DispatchProxy that implements ITaskEnvironmentDriver dynamically.
+            // DispatchProxy.Create<TInterface, TProxy>() is called via reflection since TInterface is internal.
+            var createMethod = typeof(DispatchProxy)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .First(m => m.Name == nameof(DispatchProxy.Create) && m.GetGenericArguments().Length == 2)
+                .MakeGenericMethod(driverInterfaceType, typeof(TestDriverProxy));
+
+            var proxy = createMethod.Invoke(null, null)!;
+
+            // Initialize the proxy with the project directory
+            ((TestDriverProxy)proxy).Initialize(projectDirectory);
+
+            // Call the internal TaskEnvironment(ITaskEnvironmentDriver) constructor via reflection
+            var ctor = typeof(TaskEnvironment).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+            return (TaskEnvironment)ctor[0].Invoke(new[] { proxy });
+        }
+    }
+
+    /// <summary>
+    /// DispatchProxy-based implementation of the internal ITaskEnvironmentDriver interface.
+    /// Stores its own project directory independently from the process's CWD,
+    /// enabling tests to verify tasks resolve paths relative to ProjectDirectory, not CWD.
+    /// </summary>
+    public class TestDriverProxy : DispatchProxy
+    {
+        private string _projectDirectory = string.Empty;
+
+        internal void Initialize(string projectDirectory)
+        {
+            _projectDirectory = projectDirectory;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod == null) return null;
+
+            return targetMethod.Name switch
+            {
+                "get_ProjectDirectory" => new AbsolutePath(_projectDirectory),
+                "set_ProjectDirectory" => SetProjectDir(args),
+                "GetAbsolutePath" => ResolveAbsolutePath((string)args![0]!),
+                "GetEnvironmentVariable" => Environment.GetEnvironmentVariable((string)args![0]!),
+                "GetEnvironmentVariables" => GetEnvVars(),
+                "SetEnvironmentVariable" => DoSetEnvVar(args),
+                "SetEnvironment" => DoSetEnv(args),
+                "GetProcessStartInfo" => CreateProcessStartInfo(),
+                "Dispose" => null,
+                _ => null,
+            };
+        }
+
+        private object? SetProjectDir(object?[]? args)
+        {
+            _projectDirectory = ((AbsolutePath)args![0]!).Value;
+            return null;
+        }
+
+        private AbsolutePath ResolveAbsolutePath(string path)
+        {
+            if (Path.IsPathRooted(path))
+                return new AbsolutePath(path);
+            return new AbsolutePath(path, new AbsolutePath(_projectDirectory));
+        }
+
+        private static IReadOnlyDictionary<string, string> GetEnvVars()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && entry.Value is string value)
+                    result[key] = value;
+            }
+            return result;
+        }
+
+        private static object? DoSetEnvVar(object?[]? args)
+        {
+            Environment.SetEnvironmentVariable((string)args![0]!, (string?)args[1]);
+            return null;
+        }
+
+        private static object? DoSetEnv(object?[]? args)
+        {
+            var newEnv = (IDictionary<string, string>)args![0]!;
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && !newEnv.ContainsKey(key))
+                    Environment.SetEnvironmentVariable(key, null);
+            }
+            foreach (var kvp in newEnv)
+                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            return null;
+        }
+
+        private ProcessStartInfo CreateProcessStartInfo()
+        {
+            var psi = new ProcessStartInfo { WorkingDirectory = _projectDirectory };
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && entry.Value is string value)
+                    psi.Environment[key] = value;
+            }
+            return psi;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TaskEnvironmentHelperTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TaskEnvironmentHelperTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class TaskEnvironmentHelperTests
+    {
+        [Fact]
+        public void CreateForTest_WithProjectDirectory_SetsProjectDirectory()
+        {
+            var tempDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            var env = TaskEnvironmentHelper.CreateForTest(tempDir);
+            Assert.Equal(tempDir, env.ProjectDirectory.Value);
+        }
+
+        [Fact]
+        public void CreateForTest_GetAbsolutePath_ResolvesRelativeToProjectDir()
+        {
+            var tempDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            var env = TaskEnvironmentHelper.CreateForTest(tempDir);
+            var resolved = env.GetAbsolutePath("subdir/file.txt");
+            Assert.StartsWith(tempDir, resolved.Value);
+            Assert.Contains("subdir", resolved.Value);
+        }
+
+        [Fact]
+        public void CreateForTest_GetAbsolutePath_ReturnsAbsolutePathUnchanged()
+        {
+            var tempDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            var env = TaskEnvironmentHelper.CreateForTest(tempDir);
+            var absoluteInput = Path.Combine(tempDir, "some", "path.txt");
+            var resolved = env.GetAbsolutePath(absoluteInput);
+            Assert.Equal(absoluteInput, resolved.Value);
+        }
+    }
+}


### PR DESCRIPTION
…ding support

- Add polyfill files in src/Tasks/Common/ (gated with #if NETFRAMEWORK):
  - IMultiThreadableTask.cs: Interface declaring thread-safe task capability
  - TaskEnvironment.cs: Sealed class providing thread-safe environment access
  - AbsolutePath.cs: Readonly struct for absolute path representation
  - ITaskEnvironmentDriver.cs: Internal driver interface for TaskEnvironment
  - ProcessTaskEnvironmentDriver.cs: Driver wrapping real process state
- Add TaskEnvironmentHelper.cs in test project (not gated):
  - Uses DispatchProxy + reflection to construct TaskEnvironment for tests
  - Supports custom ProjectDirectory independent from process CWD
- Add TaskEnvironmentHelperTests.cs with smoke tests
- Existing attribute polyfill (MSBuildMultiThreadableTaskAttribute.cs) unchanged
- All existing tests pass (214 passed, 11 pre-existing failures)