### PR TITLE
Remove redundant using statements from test projects

### DIFF
--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using Xunit;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.CodeAnalysis;
 

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Xunit;
 
 // Copied from
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs and

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/MSBuildCollection.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/MSBuildCollection.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
-using Xunit;
-
 /// <summary>
 /// Collection definition for tests that require MSBuild to be run.
 /// </summary>

--- a/test/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -3,9 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
-using Microsoft.NET.TestFramework;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.NET.Build.Containers.UnitTests;
 

--- a/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Runtime.CompilerServices;
-using Microsoft.NET.TestFramework.Commands;
 
 namespace Microsoft.NET.Build.Tests
 {

--- a/test/Microsoft.NET.Build.Tests/RuntimeIdentifierGraphTests.cs
+++ b/test/Microsoft.NET.Build.Tests/RuntimeIdentifierGraphTests.cs
@@ -9,13 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Microsoft.NET.TestFramework;
-using Microsoft.NET.TestFramework.Assertions;
-using Microsoft.NET.TestFramework.Commands;
-using Microsoft.NET.TestFramework.ProjectConstruction;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.NET.Build.Tests
 {

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/FolderPublish50.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/FolderPublish50.cs
@@ -1,7 +1,5 @@
 using System;
 using System.IO;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
 {

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/ProcessWrapper.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EndToEnd/ProcessWrapper.cs
@@ -4,7 +4,6 @@ using System.IO;
 #if NET472
 using System.Management;
 #endif
-using Xunit.Abstractions;
 
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests.EndToEnd
 {

--- a/test/Microsoft.NET.TestFramework/Assertions/AssemblyAssertions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/AssemblyAssertions.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using FluentAssertions;
 
 namespace Microsoft.NET.TestFramework.Assertions
 {

--- a/test/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkFactAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkFactAttribute.cs
@@ -3,8 +3,6 @@
 
 #if NETCOREAPP
 
-using Xunit;
-
 namespace Microsoft.NET.TestFramework
 {
     public class RequiresSpecificFrameworkFactAttribute : FactAttribute

--- a/test/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkTheoryAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/RequiresSpecificFrameworkTheoryAttribute.cs
@@ -3,11 +3,7 @@
 
 #if NETCOREAPP
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.DotNet.Tools.Test.Utilities;
-using Xunit;
 
 namespace Microsoft.NET.TestFramework
 {

--- a/test/Microsoft.NET.TestFramework/Commands/ComposeStoreCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/ComposeStoreCommand.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Xunit.Abstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
 {

--- a/test/System.CommandLine.StaticCompletions.Tests/BashShellProviderTests.cs
+++ b/test/System.CommandLine.StaticCompletions.Tests/BashShellProviderTests.cs
@@ -6,8 +6,6 @@
 namespace System.CommandLine.StaticCompletions.Tests;
 
 using System.CommandLine.StaticCompletions.Shells;
-using Xunit;
-using Xunit.Abstractions;
 
 public class BashShellProviderTests(ITestOutputHelper log)
 {

--- a/test/System.CommandLine.StaticCompletions.Tests/HelpExtensionsTests.cs
+++ b/test/System.CommandLine.StaticCompletions.Tests/HelpExtensionsTests.cs
@@ -7,8 +7,6 @@ namespace System.CommandLine.StaticCompletions.Tests;
 
 using System.CommandLine.Help;
 using System.CommandLine.StaticCompletions;
-using FluentAssertions;
-using Xunit;
 
 public class HelpExtensionsTests
 {

--- a/test/System.CommandLine.StaticCompletions.Tests/PowershellProviderTests.cs
+++ b/test/System.CommandLine.StaticCompletions.Tests/PowershellProviderTests.cs
@@ -7,8 +7,6 @@ namespace System.CommandLine.StaticCompletions.Tests;
 
 using System.CommandLine.StaticCompletions.Shells;
 using EmptyFiles;
-using Xunit;
-using Xunit.Abstractions;
 
 public class PowershellProviderTests(ITestOutputHelper log)
 {

--- a/test/System.CommandLine.StaticCompletions.Tests/ZshShellProviderTests.cs
+++ b/test/System.CommandLine.StaticCompletions.Tests/ZshShellProviderTests.cs
@@ -7,8 +7,6 @@ namespace System.CommandLine.StaticCompletions.Tests;
 
 using System.CommandLine.Help;
 using System.CommandLine.StaticCompletions.Shells;
-using Xunit;
-using Xunit.Abstractions;
 
 public class ZshShellProviderTests(ITestOutputHelper log)
 {

--- a/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceFinderTests.cs
+++ b/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceFinderTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
 using Microsoft.CodeAnalysis.Tools.Workspaces;
-using Microsoft.NET.TestFramework;
 
 namespace Microsoft.CodeAnalysis.Tools.Tests.MSBuild
 {

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -8,7 +8,6 @@ using System.IO;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Moq;
-using Xunit;
 
 namespace dotnet.Tests.CommandTests.Test;
 

--- a/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
+++ b/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks;
-using Microsoft.NET.TestFramework.Commands;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 


### PR DESCRIPTION
## Summary

- Remove explicit `using` directives that duplicate the global usings defined in `test/Directory.Build.props` (`Xunit`, `Xunit.Abstractions`, `FluentAssertions`, `Microsoft.NET.TestFramework`, and related namespaces)
- No functional change

This is in support of the xUnit v3 upgrade (#52914). xUnit v3 removes the `Xunit.Abstractions` namespace entirely (e.g. `ITestOutputHelper` moves to `Xunit`). Cleaning up these redundant usings now reduces the number of files that need to be touched during the migration.