### PR TITLE
Rename TestContext to SdkTestContext to avoid conflicts with xUnit v3

### DIFF
--- a/test/ArgumentForwarding.Tests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwarding.Tests/ArgumentForwardingTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = TestContext.Current.ToolsetUnderTest.DotNetHostPath,
+                    FileName = SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath,
                     Arguments = $"{ReflectorPath} {testUserArgument}",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,

--- a/test/Common/Program.cs
+++ b/test/Common/Program.cs
@@ -68,7 +68,7 @@ partial class Program
     {
         var log = new StringTestLogger();
         var command = new DotnetCommand(log, "--info");
-        var testDirectory = TestDirectory.Create(Path.Combine(TestContext.Current.TestExecutionDirectory, "sdkinfo"));
+        var testDirectory = TestDirectory.Create(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "sdkinfo"));
 
         command.WorkingDirectory = testDirectory.Path;
 

--- a/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -59,7 +59,7 @@ namespace EndToEnd.Tests
                     project.Root.Add(itemGroup);
                 });
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new RestoreCommand(testInstance)
                 .Execute()
@@ -93,7 +93,7 @@ namespace EndToEnd.Tests
                     project.Root.Add(itemGroup);
                 });
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new RestoreCommand(testInstance)
                 .Execute()

--- a/test/EndToEnd.Tests/GivenSdkArchives.cs
+++ b/test/EndToEnd.Tests/GivenSdkArchives.cs
@@ -18,7 +18,7 @@ public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
         }
 
         // Find and extract archive
-        string archivePath = TestContext.FindSdkAcquisitionArtifact("dotnet-sdk-*.tar.gz");
+        string archivePath = SdkTestContext.FindSdkAcquisitionArtifact("dotnet-sdk-*.tar.gz");
         Log.WriteLine($"Found SDK archive: {Path.GetFileName(archivePath)}");
         string extractedPath = ExtractArchive(archivePath);
 

--- a/test/EndToEnd.Tests/ProjectBuildTests.cs
+++ b/test/EndToEnd.Tests/ProjectBuildTests.cs
@@ -402,7 +402,7 @@ namespace EndToEnd.Tests
 
         private static string DetectExpectedDefaultFramework(string template = "")
         {
-            string dotnetFolder = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            string dotnetFolder = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
             string[] runtimeFolders = Directory.GetDirectories(Path.Combine(dotnetFolder, "shared", "Microsoft.NETCore.App"));
             int latestMajorVersion = runtimeFolders.Select(folder => int.Parse(Path.GetFileName(folder).Split('.').First())).Max();
             if (latestMajorVersion == 11)
@@ -468,7 +468,7 @@ namespace EndToEnd.Tests
                     $"/bl:{templateName}-{(selfContained ? "selfcontained" : "fdd")}-{language}-{framework}-{{}}.binlog"
                 ];
 
-                string dotnetRoot = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+                string dotnetRoot = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
                 new DotnetBuildCommand(Log, projectDirectory)
                      .WithEnvironmentVariable("PATH", dotnetRoot) // override PATH since razor rely on PATH to find dotnet
                      .WithWorkingDirectory(projectDirectory)

--- a/test/EndToEnd.Tests/Utilities/SymbolicLinkHelpers.cs
+++ b/test/EndToEnd.Tests/Utilities/SymbolicLinkHelpers.cs
@@ -52,7 +52,7 @@ internal static class SymbolicLinkHelpers
             return;
         }
 
-        if (!TestContext.FindOptionalSdkAcquisitionArtifact(filePattern, excludeSubstrings, out string? installerPath))
+        if (!SdkTestContext.FindOptionalSdkAcquisitionArtifact(filePattern, excludeSubstrings, out string? installerPath))
         {
             log.WriteLine($"SKIPPED: No artifact matching '{filePattern}' found in shipping packages directory");
             return;

--- a/test/EndToEnd.Tests/ValidateInsertedManifests.cs
+++ b/test/EndToEnd.Tests/ValidateInsertedManifests.cs
@@ -12,7 +12,7 @@ namespace EndToEnd.Tests
         [Fact]
         public void ManifestReaderCanReadManifests()
         {
-            var sdkManifestDir = Path.Combine(Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath), "sdk-manifests");
+            var sdkManifestDir = Path.Combine(Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath), "sdk-manifests");
             var sdkversionDir = new DirectoryInfo(sdkManifestDir).EnumerateDirectories().First();
             foreach (var manifestVersionDir in sdkversionDir.EnumerateDirectories())
             {

--- a/test/EndToEnd.Tests/VersionTests.cs
+++ b/test/EndToEnd.Tests/VersionTests.cs
@@ -13,7 +13,7 @@ namespace EndToEnd.Tests
             var result = new DotnetCommand(Log).Execute("--version");
             result.Should().Pass();
 
-            var dotnetFolder = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            var dotnetFolder = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
             var sdkFolders = Directory.GetDirectories(Path.Combine(dotnetFolder, "sdk"));
             sdkFolders.Length.Should().Be(1, "Only one SDK folder is expected in the layout");
 

--- a/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/DotNetWatchLauncherTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/DotNetWatchLauncherTests.cs
@@ -16,7 +16,7 @@ public class DotNetWatchLauncherTests(ITestOutputHelper logger)
             .WithSource();
 
         var path = Path.ChangeExtension(typeof(DotNetWatchLauncher).Assembly.Location, PathUtilities.ExecutableExtension).TrimEnd('.');
-        var sdkRootDirectory = TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest;
+        var sdkRootDirectory = SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest;
         var projectDir = Path.Combine(testAsset.Path, "AppWithDeps");
         var projectPath = Path.Combine(projectDir, "App.WithDeps.csproj");
 

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         public string CreateTestTool(ITestOutputHelper log, TestToolSettings toolSettings, bool collectBinlogs = true)
         {
-            var targetDirectory = Path.Combine(TestContext.Current.TestExecutionDirectory, "TestTools", toolSettings.GetIdentifier());
+            var targetDirectory = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "TestTools", toolSettings.GetIdentifier());
 
             var testProject = new TestProject(toolSettings.ToolPackageId)
             {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         public DotnetEnvironmentTestFixture()
         {
-            string dotnetRootUnderTest = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+            string dotnetRootUnderTest = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
             _originalPath = Environment.GetEnvironmentVariable(_PATH_VAR_NAME);
             Environment.SetEnvironmentVariable(_PATH_VAR_NAME, dotnetRootUnderTest + Path.PathSeparator + _originalPath);
         }
@@ -730,7 +730,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
             WriteNugetConfigFile(fileSystem, nugetConfigPath, true);
 
-            var testRuntimeJsonPath = Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
+            var testRuntimeJsonPath = Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
 
             var downloader = new ToolPackageDownloader(
                 store: store,
@@ -899,7 +899,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 store = storeAndQuery;
                 storeQuery = storeAndQuery;
                 downloader = new ToolPackageDownloaderMock2(storeAndQuery,
-                    runtimeJsonPathForTests: TestContext.GetRuntimeGraphFilePath(),
+                    runtimeJsonPathForTests: SdkTestContext.GetRuntimeGraphFilePath(),
                     currentWorkingDirectory: root.Value,
                     fileSystem);
 
@@ -912,7 +912,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 var toolPackageStore = new ToolPackageStoreAndQuery(toolsRoot);
                 store = toolPackageStore;
                 storeQuery = toolPackageStore;
-                var testRuntimeJsonPath = Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
+                var testRuntimeJsonPath = Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
                 downloader = new ToolPackageDownloader(store, testRuntimeJsonPath, root.Value);
                 uninstaller = new ToolPackageUninstaller(store);
             }

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             {
                 fileSystem = new FileSystemWrapper();
                 store = new ToolPackageStoreAndQuery(root);
-                var runtimeJsonPathForTests = Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
+                var runtimeJsonPathForTests = Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
                 downloader = new ToolPackageDownloader(store, runtimeJsonPathForTests);
             }
 

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 var toolPackageStore = new ToolPackageStoreAndQuery(root);
                 store = toolPackageStore;
                 storeQuery = toolPackageStore;
-                var testRuntimeJsonPath = Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
+                var testRuntimeJsonPath = Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "RuntimeIdentifierGraph.json");
                 downloader = new ToolPackageDownloader(store, testRuntimeJsonPath);
                 uninstaller = new ToolPackageUninstaller(store);
             }

--- a/test/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
+++ b/test/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
         {
             _resolver = new TemplateLocator(Environment.GetEnvironmentVariable, null, VSSettings.Ambient, null, null);
             _fakeDotnetRootDirectory =
-                Path.Combine(TestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
+                Path.Combine(SdkTestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
 
             var fakeSdkDirectory = Path.Combine(_fakeDotnetRootDirectory, "sdk", "5.0.102");
             Directory.CreateDirectory(fakeSdkDirectory);
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
         public void GivenNoManifestDirectoryItShouldReturnEmpty()
         {
             var fakeDotnetRootDirectory =
-                Path.Combine(TestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
+                Path.Combine(SdkTestContext.Current.TestExecutionDirectory, Path.GetRandomFileName());
             var result = _resolver.GetDotnetSdkTemplatePackages("5.0.102", fakeDotnetRootDirectory, userProfileDir: null);
             result.Should().BeEmpty();
         }

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -555,7 +555,7 @@ public class EndToEndTests : IDisposable
 
         if (addPackageReference)
         {
-            File.Copy(Path.Combine(TestContext.Current.TestExecutionDirectory, "NuGet.config"), Path.Combine(newProjectDir.FullName, "NuGet.config"));
+            File.Copy(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "NuGet.config"), Path.Combine(newProjectDir.FullName, "NuGet.config"));
 
             (string? packagePath, string? packageVersion) = ToolsetUtils.GetContainersPackagePath();
 
@@ -725,7 +725,7 @@ public class EndToEndTests : IDisposable
             .Should().Pass();
         ChangeTargetFrameworkAfterAppCreation(newProjectDir.FullName);
 
-        File.Copy(Path.Combine(TestContext.Current.TestExecutionDirectory, "NuGet.config"), Path.Combine(newProjectDir.FullName, "NuGet.config"));
+        File.Copy(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "NuGet.config"), Path.Combine(newProjectDir.FullName, "NuGet.config"));
 
         (string? packagePath, string? packageVersion) = ToolsetUtils.GetContainersPackagePath();
 

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -596,6 +596,6 @@ public class CreateNewImageToolTaskTests
 
     private static string GetPathToContainerize()
     {
-        return Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "containerize");
+        return Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "Container", "containerize");
     }
 }

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/PackageTests.cs
@@ -22,7 +22,7 @@ public class PackageTests
             "..\\..\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj"
         };
 
-        string projectFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "containerize.csproj");
+        string projectFilePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "containerize.csproj");
         XDocument project = XDocument.Load(projectFilePath);
         XNamespace ns = project.Root?.Name.Namespace ?? throw new InvalidOperationException("Project file is empty");
 
@@ -52,7 +52,7 @@ public class PackageTests
             "..\\..\\Microsoft.Extensions.Logging.MSBuild\\Microsoft.Extensions.Logging.MSBuild.csproj"
         };
 
-        string projectFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "Microsoft.NET.Build.Containers.csproj");
+        string projectFilePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "Container", "ProjectFiles", "Microsoft.NET.Build.Containers.csproj");
         XDocument project = XDocument.Load(projectFilePath);
         XNamespace ns = project.Root?.Name.Namespace ?? throw new InvalidOperationException("Project file is empty");
 

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -14,7 +14,7 @@ public sealed class ProjectInitializer
 
     static ProjectInitializer()
     {
-        var artifactPackagingDirectory = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "packaging");
+        var artifactPackagingDirectory = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "Container", "packaging");
         var targetsFile = Path.Combine(artifactPackagingDirectory, "Microsoft.NET.Build.Containers.targets");
         var propsFile = Path.ChangeExtension(targetsFile, ".props");
         _combinedTargetsLocation = CombineFiles(propsFile, targetsFile);

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
@@ -23,7 +23,7 @@ internal static class TestSettings
                 {
                     if (_testArtifactsDir == null)
                     {
-                        string tmpDir = Path.Combine(TestContext.Current.TestExecutionDirectory, "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
+                        string tmpDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
                         if (!Directory.Exists(tmpDir))
                         {
                             Directory.CreateDirectory(tmpDir);

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ToolsetUtils.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ToolsetUtils.cs
@@ -11,7 +11,7 @@ internal static class ToolsetUtils
     /// <returns></returns>
     internal static string GetRuntimeGraphFilePath()
     {
-        return TestContext.GetRuntimeGraphFilePath();
+        return SdkTestContext.GetRuntimeGraphFilePath();
     }
 
     internal static IManifestPicker RidGraphManifestPicker { get; } = new RidGraphManifestPicker(GetRuntimeGraphFilePath());
@@ -22,12 +22,12 @@ internal static class ToolsetUtils
     /// <returns></returns>
     internal static (string? PackagePath, string? PackageVersion) GetContainersPackagePath()
     {
-        string packageDir = Path.Combine(TestContext.Current.TestExecutionDirectory, "Container", "package");
+        string packageDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "Container", "package");
 
-        //until the package is stabilized, the package version matches TestContext.Current.ToolsetUnderTest.SdkVersion
+        //until the package is stabilized, the package version matches SdkTestContext.Current.ToolsetUnderTest.SdkVersion
         //after the package is stabilized, the package version doesn't have -prefix (-dev, -ci) anymore
         //so one of those is expected
-        string?[] expectedPackageVersions = new[] { TestContext.Current.ToolsetUnderTest?.SdkVersion, TestContext.Current.ToolsetUnderTest?.SdkVersion?.Split('-')[0] };
+        string?[] expectedPackageVersions = new[] { SdkTestContext.Current.ToolsetUnderTest?.SdkVersion, SdkTestContext.Current.ToolsetUnderTest?.SdkVersion?.Split('-')[0] };
 
         foreach (string? expectedVersion in expectedPackageVersions)
         {

--- a/test/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/test/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Build.Tests
             new RunExeCommand(Log, Path.Combine(outputDirectory.FullName, hostExecutable))
                 .WithEnvironmentVariable(
                     Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
-                    Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath))
+                    Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath))
                 .Execute()
                 .Should()
                 .Pass()

--- a/test/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
+++ b/test/Microsoft.NET.Build.Tests/AspNetCoreOnFullFramework.cs
@@ -87,7 +87,7 @@ class Class1
             {
                 FileName = exePath
             };
-            TestContext.Current.AddTestEnvironmentVariables(toolCommandSpec.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(toolCommandSpec.Environment);
 
             ICommand toolCommand = toolCommandSpec.ToCommand().CaptureStdOut();
 

--- a/test/Microsoft.NET.Build.Tests/DeleteNuGetArtifactsFixture.cs
+++ b/test/Microsoft.NET.Build.Tests/DeleteNuGetArtifactsFixture.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tests
             try
             {
                 //  Delete the generated NuGet packages in the cache.
-                foreach (string dir in Directory.EnumerateDirectories(TestContext.Current.NuGetCachePath, ConstantStringValues.DependencyDirectoryNamePrefix + "*"))
+                foreach (string dir in Directory.EnumerateDirectories(SdkTestContext.Current.NuGetCachePath, ConstantStringValues.DependencyDirectoryNamePrefix + "*"))
                 {
                     Directory.Delete(dir, true);
                 }

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenPackageCannotBeFound.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantDiagnosticsWhenPackageCannotBeFound.cs
@@ -56,13 +56,13 @@ namespace Microsoft.NET.Build.Tests
             // only that file here to confirm that behavior and mitigate risk of a typo
             // here resulting in an overly aggressive recursive directory deletion.
             var shaFile = Path.Combine(
-               TestContext.Current.NuGetCachePath,
+               SdkTestContext.Current.NuGetCachePath,
                package.ID,
                package.Version,
                $"{package.ID}.{package.Version}.nupkg.sha512");
 
             var nupkgMetadataFile = Path.Combine(
-               TestContext.Current.NuGetCachePath,
+               SdkTestContext.Current.NuGetCachePath,
                package.ID,
                package.Version,
                $".nupkg.metadata");

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -208,7 +208,7 @@ namespace Microsoft.NET.Build.Tests
 
                         target.Add(new XElement(ns + "FindUnderPath",
                             new XAttribute("Files", "@(_ConflictPackageFiles)"),
-                            new XAttribute("Path", TestContext.Current.ToolsetUnderTest.GetMicrosoftNETBuildExtensionsPath()),
+                            new XAttribute("Path", SdkTestContext.Current.ToolsetUnderTest.GetMicrosoftNETBuildExtensionsPath()),
                             new XElement(ns + "Output",
                                 new XAttribute("TaskParameter", "InPath"),
                                 new XAttribute("ItemName", "_ConflictsInSupportLibs"))

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -437,12 +437,12 @@ public static class {project.Name}
             string correctHttpReference;
             if (useFacades)
             {
-                string microsoftNETBuildExtensionsPath = TestContext.Current.ToolsetUnderTest.GetMicrosoftNETBuildExtensionsPath();
+                string microsoftNETBuildExtensionsPath = SdkTestContext.Current.ToolsetUnderTest.GetMicrosoftNETBuildExtensionsPath();
                 correctHttpReference = Path.Combine(microsoftNETBuildExtensionsPath, @"net461\lib\System.Net.Http.dll");
             }
             else
             {
-                correctHttpReference = Path.Combine(TestContext.Current.NuGetCachePath, "system.net.http", "4.3.2", "ref", "net46", "System.Net.Http.dll");
+                correctHttpReference = Path.Combine(SdkTestContext.Current.NuGetCachePath, "system.net.http", "4.3.2", "ref", "net46", "System.Net.Http.dll");
             }
 
             var valuesWithMetadata = getValuesCommand.GetValuesWithMetadata();

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -389,7 +389,7 @@ namespace Microsoft.NET.Build.Tests
         {
             if (targetPlatformIdentifier.Equals("windows", StringComparison.OrdinalIgnoreCase))
             {
-                var sdkVersion = SemanticVersion.Parse(TestContext.Current.ToolsetUnderTest.SdkVersion);
+                var sdkVersion = SemanticVersion.Parse(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
                 if (new SemanticVersion(sdkVersion.Major, sdkVersion.Minor, sdkVersion.Patch) < new SemanticVersion(7, 0, 200))
                 {
                     //  Fixed in 7.0.200: https://github.com/dotnet/sdk/pull/29009

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("netcoreapp1.1", true, true, "1.1.13")]
         [InlineData("netcoreapp1.1", false, false, "1.1.2")]
         [InlineData("netcoreapp2.0", false, true, "2.0.0")]
-        [InlineData("netcoreapp2.0", true, true, TestContext.LatestRuntimePatchForNetCoreApp2_0)]
+        [InlineData("netcoreapp2.0", true, true, SdkTestContext.LatestRuntimePatchForNetCoreApp2_0)]
         [InlineData("netcoreapp2.0", false, false, "2.0.0")]
         public void It_targets_the_right_framework_depending_on_output_type(string targetFramework, bool selfContained, bool isExe, string expectedFrameworkVersion)
         {
@@ -101,10 +101,10 @@ namespace Microsoft.NET.Build.Tests
             //  Test that the resolved version is greater than or equal to the latest runtime patch
             //  we know about, so that when a new runtime patch is released the test doesn't
             //  immediately start failing
-            var minimumExpectedVersion = new NuGetVersion(TestContext.LatestRuntimePatchForNetCoreApp2_0);
+            var minimumExpectedVersion = new NuGetVersion(SdkTestContext.LatestRuntimePatchForNetCoreApp2_0);
             netCoreAppLibrary.Version.CompareTo(minimumExpectedVersion).Should().BeGreaterThanOrEqualTo(0,
                 "the version resolved from a RuntimeFrameworkVersion of '{0}' should be at least {1}",
-                testProject.RuntimeFrameworkVersion, TestContext.LatestRuntimePatchForNetCoreApp2_0);
+                testProject.RuntimeFrameworkVersion, SdkTestContext.LatestRuntimePatchForNetCoreApp2_0);
         }
 
         private void It_targets_the_right_framework(

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildASelfContainedApp.cs
@@ -281,7 +281,7 @@ namespace Microsoft.NET.Build.Tests
             var testAsset = TestAssetsManager.CreateTestProject(testProject);
 
             //  Set up test workload manifest that will suply targeting and runtime pack versions
-            string sdkVersionBand = GetVersionBand(TestContext.Current.ToolsetUnderTest.SdkVersion);
+            string sdkVersionBand = GetVersionBand(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
             string manifestRoot = Path.Combine(testAsset.TestRoot, "manifests");
             string manifestFolder = Path.Combine(manifestRoot, sdkVersionBand, "RuntimePackVersionTestWorkload");
             Directory.CreateDirectory(manifestFolder);
@@ -349,7 +349,7 @@ namespace Microsoft.NET.Build.Tests
         {
 
             // There's a bug when using the 6.0 SDK with 17.4 but we have limited control over the VS version used in helix
-            Version.TryParse(TestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version msbuildVersion);
+            Version.TryParse(SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version msbuildVersion);
             Version.TryParse("17.4.0", out Version maximumVersion);
             if (msbuildVersion >= maximumVersion)
                 return;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -195,7 +195,7 @@ namespace Microsoft.NET.Build.Tests
         {
             if (!setInTargetframework)
             {
-                var sdkVersion = SemanticVersion.Parse(TestContext.Current.ToolsetUnderTest.SdkVersion);
+                var sdkVersion = SemanticVersion.Parse(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
                 if (new SemanticVersion(sdkVersion.Major, sdkVersion.Minor, sdkVersion.Patch) < new SemanticVersion(7, 0, 200))
                 {
                     //  Fixed in 7.0.200: https://github.com/dotnet/sdk/pull/29009

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -93,8 +93,8 @@ class Program
         //  This method duplicates a lot of logic from the CLI in order to test generating deps files for tools in the SDK repo
         private CommandResult GenerateDepsAndRunTool(TestProject toolProject, [CallerMemberName] string callingMethod = "")
         {
-            DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
-            DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
+            DeleteFolder(Path.Combine(SdkTestContext.Current.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
+            DeleteFolder(Path.Combine(SdkTestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
 
             var toolProjectInstance = TestAssetsManager.CreateTestProject(toolProject, callingMethod, identifier: toolProject.Name);
 
@@ -135,13 +135,13 @@ class Program
             var restoreCommand = toolReferencerInstance.GetRestoreCommand(Log, toolReferencer.Name);
             restoreCommand.Execute("/v:n").Should().Pass();
 
-            string toolAssetsFilePath = Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "1.0.0", toolProject.TargetFrameworks, "project.assets.json");
+            string toolAssetsFilePath = Path.Combine(SdkTestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "1.0.0", toolProject.TargetFrameworks, "project.assets.json");
             var toolAssetsFile = new LockFileFormat().Read(toolAssetsFilePath);
 
             var args = new List<string>();
 
 
-            string currentToolsetSdksPath = TestContext.Current.ToolsetUnderTest.SdksPath;
+            string currentToolsetSdksPath = SdkTestContext.Current.ToolsetUnderTest.SdksPath;
 
             string generateDepsProjectDirectoryPath = Path.Combine(currentToolsetSdksPath, "Microsoft.NET.Sdk", "targets", "GenerateDeps");
             string generateDepsProjectFileName = "GenerateDeps.proj";
@@ -226,10 +226,10 @@ class Program
 
             var toolCommandSpec = new SdkCommandSpec()
             {
-                FileName = TestContext.Current.ToolsetUnderTest.DotNetHostPath,
+                FileName = SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath,
                 Arguments = dotnetArgs
             };
-            TestContext.Current.AddTestEnvironmentVariables(toolCommandSpec.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(toolCommandSpec.Environment);
             toolCommandSpec.Environment.Add("DOTNET_ROLL_FORWARD","LatestMajor");
 
             ICommand toolCommand = toolCommandSpec.ToCommand().CaptureStdOut();

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToUseAnalyzers.cs
@@ -346,18 +346,18 @@ namespace Microsoft.NET.Build.Tests
 
         static readonly List<string> nugetRoots = new()
             {
-                TestContext.Current.NuGetCachePath,
+                SdkTestContext.Current.NuGetCachePath,
                 Path.Combine(CliFolderPathCalculator.DotnetHomePath, ".dotnet", "NuGetFallbackFolder"),
-                Path.Combine(TestContext.Current.ToolsetUnderTest.DotNetRoot, "packs")
+                Path.Combine(SdkTestContext.Current.ToolsetUnderTest.DotNetRoot, "packs")
             };
 
         static (string package, string version, string path) GetPackageAndPath(string absolutePath)
         {
             absolutePath = Path.GetFullPath(absolutePath);
 
-            if (absolutePath.StartsWith(TestContext.Current.ToolsetUnderTest.SdksPath))
+            if (absolutePath.StartsWith(SdkTestContext.Current.ToolsetUnderTest.SdksPath))
             {
-                string path = absolutePath.Substring(TestContext.Current.ToolsetUnderTest.SdksPath.Length + 1)
+                string path = absolutePath.Substring(SdkTestContext.Current.ToolsetUnderTest.SdksPath.Length + 1)
                     .Replace(Path.DirectorySeparatorChar, '/');
                 var components = path.Split(new char[] { '/' }, 2);
                 string sdkName = components[0];

--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -269,7 +269,7 @@ namespace Microsoft.NET.Build.Tests
         public void Given_multi_target_It_should_get_suggested_workload_by_GetRequiredWorkloads_target(string mainTfm, string referencingTfm, string expected)
         {
             // Skip Test if SDK is < 6.0.400
-            var sdkVersion = SemanticVersion.Parse(TestContext.Current.ToolsetUnderTest.SdkVersion);
+            var sdkVersion = SemanticVersion.Parse(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
             if (new SemanticVersion(sdkVersion.Major, sdkVersion.Minor, sdkVersion.Patch) < new SemanticVersion(6, 0, 400))
                 return; // MAUI was removed from earlier versions of the SDK
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -85,7 +85,7 @@ namespace Microsoft.NET.Publish.Tests
                 new RunExeCommand(Log, Path.Combine(publishDirectory.FullName, appHostName))
                     .WithEnvironmentVariable(
                         Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
-                        Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath))
+                        Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath))
                     .Execute()
                     .Should()
                     .Pass()

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -1157,12 +1157,12 @@ public static class Program
                 case "AppRelative":
                     // Copy the host and runtime to the expected .NET root
                     expectedRoot = Path.Combine(publishDirectory, appRelativeDotNet);
-                    CopyDirectory(Path.Combine(TestContext.Current.ToolsetUnderTest.DotNetRoot, "host"), Path.Combine(expectedRoot, "host"));
-                    CopyDirectory(Path.Combine(TestContext.Current.ToolsetUnderTest.DotNetRoot, "shared", "Microsoft.NETCore.App"), Path.Combine(expectedRoot, "shared", "Microsoft.NETCore.App"));
+                    CopyDirectory(Path.Combine(SdkTestContext.Current.ToolsetUnderTest.DotNetRoot, "host"), Path.Combine(expectedRoot, "host"));
+                    CopyDirectory(Path.Combine(SdkTestContext.Current.ToolsetUnderTest.DotNetRoot, "shared", "Microsoft.NETCore.App"), Path.Combine(expectedRoot, "shared", "Microsoft.NETCore.App"));
                     break;
                 case "EnvironmentVariable":
                     // Set DOTNET_ROOT_<arch> environment variable to the expected .NET root
-                    expectedRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+                    expectedRoot = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
                     runCommand = runCommand.WithEnvironmentVariable($"DOTNET_ROOT_{RuntimeInformation.OSArchitecture.ToString().ToUpperInvariant()}", expectedRoot);
                     break;
                 default:

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishTrimmedWindowsFormsAndWPFApps.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishTrimmedWindowsFormsAndWPFApps.cs
@@ -172,7 +172,7 @@ namespace Microsoft.NET.Publish.Tests
                 FileName = Path.Combine(publishDirectory, Path.GetFileName(testDir.Path) + ".exe")
             };
 
-            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
 
             var result = runAppCommand.ToCommand()
                 .CaptureStdErr()
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Publish.Tests
                 FileName = Path.Combine(publishDirectory, Path.GetFileName(testDir.Path) + ".exe")
             };
 
-            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
 
             var result = runAppCommand.ToCommand()
                 .CaptureStdErr()

--- a/test/Microsoft.NET.Publish.Tests/PublishWebApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/PublishWebApp.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Publish.Tests
                 FileName = Path.Combine(publishDirectory.FullName, testProject.Name + EnvironmentInfo.ExecutableExtension)
             };
 
-            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
 
             var result = runAppCommand.ToCommand()
                 .CaptureStdErr()

--- a/test/Microsoft.NET.Publish.Tests/PublishWpfApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/PublishWpfApp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Publish.Tests
                 FileName = Path.Combine(publishDirectory, Path.GetFileName(testDir.Path) + ".exe")
             };
 
-            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(TestContext.Current.ToolsetUnderTest.DotNetHostPath);
+            runAppCommand.Environment["DOTNET_ROOT"] = Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath);
 
             var result = runAppCommand.ToCommand()
                 .CaptureStdErr()

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NET.Restore.Tests
                 .And
                 .HaveStdOutContaining($"warning NETSDK1059: The tool '{obsoletePackageId}' is now included in the .NET SDK. Information on resolving this warning is available at (https://aka.ms/dotnetclitools-in-box).");
 
-            string toolAssetsFilePath = Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "99.99.99", toolProject.TargetFrameworks, "project.assets.json");
+            string toolAssetsFilePath = Path.Combine(SdkTestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant(), "99.99.99", toolProject.TargetFrameworks, "project.assets.json");
             Assert.False(File.Exists(toolAssetsFilePath), "Tool assets path should not have been generated");
         }
     }

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
@@ -50,8 +50,8 @@ namespace Microsoft.NET.Restore.Tests
 
             TestAsset toolReferenceProjectInstance = TestAssetsManager.CreateTestProject(toolReferenceProject, identifier: toolReferenceProject.Name);
 
-            DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
-            DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
+            DeleteFolder(Path.Combine(SdkTestContext.Current.NuGetCachePath, toolProject.Name.ToLowerInvariant()));
+            DeleteFolder(Path.Combine(SdkTestContext.Current.NuGetCachePath, ".tools", toolProject.Name.ToLowerInvariant()));
             NuGetConfigWriter.Write(toolReferenceProjectInstance.TestRoot, nupkgPath);
 
             RestoreCommand restoreCommand =
@@ -60,7 +60,7 @@ namespace Microsoft.NET.Restore.Tests
             var restoreResult = restoreCommand
                 .Execute("/v:n");
 
-            var assetsJsonPath = Path.Combine(TestContext.Current.NuGetCachePath,
+            var assetsJsonPath = Path.Combine(SdkTestContext.Current.NuGetCachePath,
                                              ".tools",
                                              toolProject.Name.ToLowerInvariant(),
                                              ProjectToolVersion,

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -34,10 +34,10 @@ namespace Microsoft.NET.Restore.Tests
             string testProjectName = $"{projectPrefix}Fallback";
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
-            var packagesFolder = Path.Combine(TestContext.Current.TestExecutionDirectory, "packages", testProjectName);
+            var packagesFolder = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "packages", testProjectName);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
-            restoreCommand.Execute($"/p:RestorePackagesPath={packagesFolder}", $"/p:_NugetFallbackFolder={TestContext.Current.NuGetFallbackFolder}").Should().Pass();
+            restoreCommand.Execute($"/p:RestorePackagesPath={packagesFolder}", $"/p:_NugetFallbackFolder={SdkTestContext.Current.NuGetFallbackFolder}").Should().Pass();
 
             File.Exists(Path.Combine(
                 packagesFolder,
@@ -56,7 +56,7 @@ namespace Microsoft.NET.Restore.Tests
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
-            restoreCommand.Execute($"/p:_NugetFallbackFolder={TestContext.Current.NuGetFallbackFolder}").Should().Pass();
+            restoreCommand.Execute($"/p:_NugetFallbackFolder={SdkTestContext.Current.NuGetFallbackFolder}").Should().Pass();
         }
 
         [Theory]
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Restore.Tests
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
-            restoreCommand.Execute($"/p:_NugetFallbackFolder={TestContext.Current.NuGetFallbackFolder}", "/p:DisableImplicitNuGetFallbackFolder=true").Should().Fail();
+            restoreCommand.Execute($"/p:_NugetFallbackFolder={SdkTestContext.Current.NuGetFallbackFolder}", "/p:DisableImplicitNuGetFallbackFolder=true").Should().Fail();
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Restore.Tests
             TestAsset testProjectTestAsset = CreateTestAsset(testProjectName, frameworks);
 
             var restoreCommand = testProjectTestAsset.GetRestoreCommand(Log, relativePath: testProjectName);
-            var executeResult = restoreCommand.Execute($"/p:_NugetFallbackFolder={TestContext.Current.NuGetFallbackFolder}", "/p:DisableImplicit1xNuGetFallbackFolder=true");
+            var executeResult = restoreCommand.Execute($"/p:_NugetFallbackFolder={SdkTestContext.Current.NuGetFallbackFolder}", "/p:DisableImplicit1xNuGetFallbackFolder=true");
 
             if (shouldExecutePass)
             {
@@ -132,7 +132,7 @@ namespace Microsoft.NET.Restore.Tests
                 new TestPackageReference(
                     projectInNuGetFallbackFolder.Name,
                     "1.0.0",
-                    TestContext.Current.NuGetFallbackFolder);
+                    SdkTestContext.Current.NuGetFallbackFolder);
 
             if (!projectInNuGetFallbackFolderPackageReference.NuGetPackageExists())
             {
@@ -146,14 +146,14 @@ namespace Microsoft.NET.Restore.Tests
                     projectInNuGetFallbackFolder.Name);
                 var packagePackCommand =
                     new PackCommand(Log, dependencyProjectDirectory)
-                    .Execute($"/p:PackageOutputPath={TestContext.Current.NuGetFallbackFolder}").Should().Pass();
+                    .Execute($"/p:PackageOutputPath={SdkTestContext.Current.NuGetFallbackFolder}").Should().Pass();
 
                 ExtractNupkg(
-                    TestContext.Current.NuGetFallbackFolder,
-                    Path.Combine(TestContext.Current.NuGetFallbackFolder, $"{projectInNuGetFallbackFolder.Name}.1.0.0.nupkg"));
+                    SdkTestContext.Current.NuGetFallbackFolder,
+                    Path.Combine(SdkTestContext.Current.NuGetFallbackFolder, $"{projectInNuGetFallbackFolder.Name}.1.0.0.nupkg"));
 
                 // make sure there is no package in cache
-                DeleteFolder(Path.Combine(TestContext.Current.NuGetCachePath, projectInNuGetFallbackFolder.Name.ToLowerInvariant()));
+                DeleteFolder(Path.Combine(SdkTestContext.Current.NuGetCachePath, projectInNuGetFallbackFolder.Name.ToLowerInvariant()));
             }
 
             return projectInNuGetFallbackFolderPackageReference;

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NET.Restore.Tests
 
             var testAsset = TestAssetsManager.CreateTestProject(testProject);
 
-            var packagesFolder = Path.Combine(TestContext.Current.TestExecutionDirectory, "packages", testProjectName);
+            var packagesFolder = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "packages", testProjectName);
 
             var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand
@@ -55,7 +55,7 @@ namespace Microsoft.NET.Restore.Tests
 
             var testAsset = TestAssetsManager.CreateTestProject(testProject);
 
-            var packagesFolder = Path.Combine(TestContext.Current.TestExecutionDirectory, "packages", testProjectName);
+            var packagesFolder = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "packages", testProjectName);
 
             var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Restore.Tests
             var testAsset = TestAssetsManager
                 .CreateTestProject(project);
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             var customPackagesDir = Path.Combine(testAsset.Path, "nuget-packages");
 
@@ -65,7 +65,7 @@ namespace Microsoft.NET.Restore.Tests
             var testAsset = TestAssetsManager
                 .CreateTestProject(project);
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             var customPackagesDir = Path.Combine(testAsset.Path, "nuget-packages");
 
@@ -153,7 +153,7 @@ namespace Microsoft.NET.Restore.Tests
             var testAsset = TestAssetsManager
                 .CreateTestProject(project);
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             var customPackagesDir = Path.Combine(testAsset.Path, "nuget-packages");
 
@@ -176,7 +176,7 @@ namespace Microsoft.NET.Restore.Tests
                 .CopyTestAsset("DesktopWpf")
                 .WithSource();
                 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             var buildCommand = new BuildCommand(testAsset, relativePathToProject: "FxWpf")
             {

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest60.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorLegacyIntegrationTest60.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
             string.Join('.', "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
 
         protected override string ComputeBaselineFolder() =>
-            Path.Combine(TestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
+            Path.Combine(SdkTestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
 
         [CoreMSBuildOnlyFact]
         public void Build60Hosted_Works()

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmBaselineTests.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/BlazorWasmBaselineTests.cs
@@ -10,6 +10,6 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
         protected override string EmbeddedResourcePrefix => string.Join('.', "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
 
         protected override string ComputeBaselineFolder() =>
-            Path.Combine(TestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
+            Path.Combine(SdkTestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.BlazorWebAssembly.Tests", "StaticWebAssetsBaselines");
     }
 }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/AspNetSdkBaselineTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/AspNetSdkBaselineTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
         private static StaticWebAssetsBaselineFactory CreateBaselineFactory() => StaticWebAssetsBaselineFactory.Instance;
 
         protected virtual string ComputeBaselineFolder() =>
-            Path.Combine(TestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.StaticWebAssets.Tests", "StaticWebAssetsBaselines");
+            Path.Combine(SdkTestContext.GetRepoRoot() ?? AppContext.BaseDirectory, "test", "Microsoft.NET.Sdk.StaticWebAssets.Tests", "StaticWebAssetsBaselines");
 
         protected virtual string EmbeddedResourcePrefix => string.Join('.', "Microsoft.NET.Sdk.StaticWebAssets.Tests", "StaticWebAssetsBaselines");
 
@@ -143,7 +143,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
                     .Distinct()
                     .OrderBy(f => f, StringComparer.Ordinal)
                     .ToArray(),
-                GetNuGetCachePath() ?? TestContext.Current.NuGetCachePath,
+                GetNuGetCachePath() ?? SdkTestContext.Current.NuGetCachePath,
                 ProjectDirectory.TestRoot,
                 intermediateOutputPath,
                 outputFolder).ToArray();
@@ -239,7 +239,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
                     .Concat(copyToPublishDirectoryFiles)
                     .Distinct()
                     .OrderBy(f => f, StringComparer.Ordinal)],
-                GetNuGetCachePath() ?? TestContext.Current.NuGetCachePath,
+                GetNuGetCachePath() ?? SdkTestContext.Current.NuGetCachePath,
                 ProjectDirectory.TestRoot,
                 intermediateOutputPath,
                 publishFolder);
@@ -287,14 +287,14 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
                 _baselineFactory.ToTemplate(
                     actual,
                     ProjectDirectory.Path,
-                    GetNuGetCachePath() ?? TestContext.Current.NuGetCachePath,
+                    GetNuGetCachePath() ?? SdkTestContext.Current.NuGetCachePath,
                     runtimeIdentifier);
 
                 _comparer.AssertManifest(expected, actual);
             }
             else
             {
-                var template = Templatize(actual, ProjectDirectory.Path, GetNuGetCachePath() ?? TestContext.Current.NuGetCachePath, runtimeIdentifier);
+                var template = Templatize(actual, ProjectDirectory.Path, GetNuGetCachePath() ?? SdkTestContext.Current.NuGetCachePath, runtimeIdentifier);
                 if (!Directory.Exists(Path.Combine(BaselinesFolder)))
                 {
                     Directory.CreateDirectory(Path.Combine(BaselinesFolder));

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/IsolatedNuGetPackageFolderAspNetSdkBaselineTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/IsolatedNuGetPackageFolderAspNetSdkBaselineTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
 
         public IsolatedNuGetPackageFolderAspNetSdkBaselineTest(ITestOutputHelper log, string restoreNugetPackagePath) : base(log)
         {
-            _cachePath = Path.GetFullPath(Path.Combine(TestContext.Current.TestExecutionDirectory, Shorten(restoreNugetPackagePath)));
+            _cachePath = Path.GetFullPath(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, Shorten(restoreNugetPackagePath)));
         }
 
         private static string Shorten(string restoreNugetPackagePath) =>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/AssetToCompressTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/AssetToCompressTest.cs
@@ -21,7 +21,7 @@ public class AssetToCompressTest : IDisposable
 
     public AssetToCompressTest()
     {
-        _testDirectory = Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(AssetToCompressTest), Guid.NewGuid().ToString("N"));
+        _testDirectory = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(AssetToCompressTest), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_testDirectory);
         _testFilePath = Path.Combine(_testDirectory, "test-asset.js");
         File.WriteAllText(_testFilePath, "// test content");

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsTest.cs
@@ -19,7 +19,7 @@ public class DiscoverPrecompressedAssetsTest
 
     public DiscoverPrecompressedAssetsTest()
     {
-        OutputBasePath = Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(ResolveCompressedAssetsTest));
+        OutputBasePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(ResolveCompressedAssetsTest));
         ItemSpec = Path.Combine(OutputBasePath, Guid.NewGuid().ToString("N") + ".tmp");
         OriginalItemSpec = Path.Combine(OutputBasePath, Guid.NewGuid().ToString("N") + ".tmp");
     }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestTest.cs
@@ -13,8 +13,8 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
     {
         public GenerateStaticWebAssetsManifestTest()
         {
-            Directory.CreateDirectory(Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(GenerateStaticWebAssetsManifestTest)));
-            TempFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(GenerateStaticWebAssetsManifestTest), Guid.NewGuid().ToString("N") + ".json");
+            Directory.CreateDirectory(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(GenerateStaticWebAssetsManifestTest)));
+            TempFilePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(GenerateStaticWebAssetsManifestTest), Guid.NewGuid().ToString("N") + ".json");
         }
 
         public string TempFilePath { get; }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
@@ -14,8 +14,8 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
     {
         public ReadStaticWebAssetsManifestFileTest()
         {
-            Directory.CreateDirectory(Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(ReadStaticWebAssetsManifestFileTest)));
-            TempFilePath = Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(ReadStaticWebAssetsManifestFileTest), Guid.NewGuid().ToString("N") + ".json");
+            Directory.CreateDirectory(Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(ReadStaticWebAssetsManifestFileTest)));
+            TempFilePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(ReadStaticWebAssetsManifestFileTest), Guid.NewGuid().ToString("N") + ".json");
         }
 
         public string TempFilePath { get; }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ResolveCompressedAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ResolveCompressedAssetsTest.cs
@@ -23,7 +23,7 @@ public class ResolveCompressedAssetsTest
 
     public ResolveCompressedAssetsTest()
     {
-        OutputBasePath = Path.Combine(TestContext.Current.TestExecutionDirectory, nameof(ResolveCompressedAssetsTest));
+        OutputBasePath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, nameof(ResolveCompressedAssetsTest));
         ItemSpec = Path.Combine(OutputBasePath, Guid.NewGuid().ToString("N") + ".tmp");
         OriginalItemSpec = Path.Combine(OutputBasePath, Guid.NewGuid().ToString("N") + ".tmp");
     }

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackGroupTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/WorkloadPackGroupTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
         public void TestGetManifestFeatureBands()
         {
             var manifestProvider = CreateManifestProvider();
-            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, TestContext.Current.ToolsetUnderTest.DotNetRoot);
+            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, SdkTestContext.Current.ToolsetUnderTest.DotNetRoot);
 
             foreach (var manifestInfo in workloadResolver.GetInstalledManifests())
             {
@@ -93,7 +93,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
 
         SdkDirectoryWorkloadManifestProvider CreateManifestProvider()
         {
-            return new(TestContext.Current.ToolsetUnderTest.DotNetRoot, TestContext.Current.ToolsetUnderTest.SdkVersion, userProfileDir: null, globalJsonPath: null);
+            return new(SdkTestContext.Current.ToolsetUnderTest.DotNetRoot, SdkTestContext.Current.ToolsetUnderTest.SdkVersion, userProfileDir: null, globalJsonPath: null);
         }
 
         public IEnumerable<WorkloadManifest> GetManifests(SdkDirectoryWorkloadManifestProvider? manifestProvider = null)
@@ -149,7 +149,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader.Tests
 
             var manifestProvider = CreateManifestProvider();
             var manifests = GetManifests(manifestProvider);
-            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, TestContext.Current.ToolsetUnderTest.DotNetRoot);
+            var workloadResolver = WorkloadResolver.CreateForTests(manifestProvider, SdkTestContext.Current.ToolsetUnderTest.DotNetRoot);
 
             foreach (var manifest in manifests)
             {

--- a/test/Microsoft.NET.TestFramework/Assertions/StringAssertionsExtensions.cs
+++ b/test/Microsoft.NET.TestFramework/Assertions/StringAssertionsExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.TestFramework.Assertions
             params object[] becauseArgs
         )
         {
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 return BeVisuallyEquivalentTo(assertions, expected, because, becauseArgs);
             }
@@ -75,7 +75,7 @@ namespace Microsoft.NET.TestFramework.Assertions
 
         public static AndConstraint<StringAssertions> ContainVisuallySameFragmentIfNotLocalized(this StringAssertions assertions, string expected, string because = "", params object[] becauseArgs)
         {
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 return ContainVisuallySameFragment(assertions, expected, because, becauseArgs);
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyFactAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyFactAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public CoreMSBuildAndWindowsOnlyFactAttribute()
         {
-            if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Skip = "This test requires Core MSBuild and Windows to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyTheoryAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildAndWindowsOnlyTheoryAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public CoreMSBuildAndWindowsOnlyTheoryAttribute()
         {
-            if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Skip = "This test requires Core MSBuild and Windows to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyFactAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyFactAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public CoreMSBuildOnlyFactAttribute()
         {
-            if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+            if (SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
                 Skip = "This test requires Core MSBuild to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyTheoryAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/CoreMSBuildOnlyTheoryAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public CoreMSBuildOnlyTheoryAttribute()
         {
-            if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+            if (SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
                 Skip = "This test requires Core MSBuild to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyFactAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyFactAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public FullMSBuildOnlyFactAttribute()
         {
-            if (!TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+            if (!SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
                 Skip = "This test requires Full MSBuild to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyTheoryAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/FullMSBuildOnlyTheoryAttribute.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.TestFramework
     {
         public FullMSBuildOnlyTheoryAttribute()
         {
-            if (!TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+            if (!SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
                 Skip = "This test requires Full MSBuild to run";
             }

--- a/test/Microsoft.NET.TestFramework/Attributes/RequiresMSBuildVersionTheoryAttribute.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/RequiresMSBuildVersionTheoryAttribute.cs
@@ -17,9 +17,9 @@ namespace Microsoft.NET.TestFramework
 
         public static void CheckForRequiredMSBuildVersion(FactAttribute attribute, string version)
         {
-            if (!Version.TryParse(TestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version? msbuildVersion))
+            if (!Version.TryParse(SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version? msbuildVersion))
             {
-                attribute.Skip = $"Failed to determine the version of MSBuild ({TestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+                attribute.Skip = $"Failed to determine the version of MSBuild ({SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
                 return;
             }
             if (!Version.TryParse(version, out Version? requiredVersion))
@@ -29,7 +29,7 @@ namespace Microsoft.NET.TestFramework
             }
             if (requiredVersion > msbuildVersion)
             {
-                attribute.Skip = $"This test requires MSBuild version {version} to run (using {TestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+                attribute.Skip = $"This test requires MSBuild version {version} to run (using {SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
             }
         }
     }

--- a/test/Microsoft.NET.TestFramework/Commands/DotnetCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/DotnetCommand.cs
@@ -14,11 +14,11 @@ namespace Microsoft.NET.TestFramework.Commands
         {
             var sdkCommandSpec = new SdkCommandSpec()
             {
-                FileName = TestContext.Current.ToolsetUnderTest.DotNetHostPath,
+                FileName = SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath,
                 Arguments = args.ToList(),
                 WorkingDirectory = WorkingDirectory
             };
-            TestContext.Current.AddTestEnvironmentVariables(sdkCommandSpec.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(sdkCommandSpec.Environment);
             return sdkCommandSpec;
         }
     }

--- a/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/GetValuesCommand.cs
@@ -135,7 +135,7 @@ namespace Microsoft.NET.TestFramework.Commands
             var outputDirectory = GetValuesOutputDirectory(_targetFramework);
             outputDirectory.Create();
 
-            return TestContext.Current.ToolsetUnderTest.CreateCommandForTarget(TargetName, newArgs);
+            return SdkTestContext.Current.ToolsetUnderTest.CreateCommandForTarget(TargetName, newArgs);
         }
 
         public List<string> GetValues()

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildCommand.cs
@@ -165,7 +165,7 @@ namespace Microsoft.NET.TestFramework.Commands
             var newArgs = args.ToList();
             newArgs.Insert(0, FullPathProjectFile);
 
-            return TestContext.Current.ToolsetUnderTest.CreateCommandForTarget(Target, newArgs);
+            return SdkTestContext.Current.ToolsetUnderTest.CreateCommandForTarget(Target, newArgs);
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/Commands/MSBuildVersionCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/MSBuildVersionCommand.cs
@@ -9,11 +9,11 @@ namespace Microsoft.NET.TestFramework.Commands
 
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
         {
-            if (TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+            if (SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
             {
                 return new SdkCommandSpec()
                 {
-                    FileName = TestContext.Current.ToolsetUnderTest.FullFrameworkMSBuildPath,
+                    FileName = SdkTestContext.Current.ToolsetUnderTest.FullFrameworkMSBuildPath,
                     Arguments = { "-version" },
                     WorkingDirectory = WorkingDirectory
                 };
@@ -22,7 +22,7 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 return new SdkCommandSpec()
                 {
-                    FileName = TestContext.Current.ToolsetUnderTest.DotNetHostPath,
+                    FileName = SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath,
                     Arguments = { "msbuild", "-version" },
                     WorkingDirectory = WorkingDirectory
                 };

--- a/test/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/NuGetExeRestoreCommand.cs
@@ -24,12 +24,12 @@ namespace Microsoft.NET.TestFramework.Commands
 
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
         {
-            if (string.IsNullOrEmpty(TestContext.Current.NuGetExePath))
+            if (string.IsNullOrEmpty(SdkTestContext.Current.NuGetExePath))
             {
                 throw new InvalidOperationException("Path to nuget.exe not set");
             }
 
-            var nugetExePath = TestContext.Current.NuGetExePath;
+            var nugetExePath = SdkTestContext.Current.NuGetExePath;
             if (!string.IsNullOrEmpty(NuGetExeVersion))
             {
                 nugetExePath = Path.Combine(Path.GetDirectoryName(nugetExePath) ?? string.Empty, NuGetExeVersion, "nuget.exe");
@@ -66,12 +66,12 @@ namespace Microsoft.NET.TestFramework.Commands
                     "restore",
                     FullPathProjectFile,
                     "-PackagesDirectory",
-                    PackagesDirectory ?? TestContext.Current.NuGetCachePath ?? string.Empty,
+                    PackagesDirectory ?? SdkTestContext.Current.NuGetCachePath ?? string.Empty,
                     .. args
                 ]
             };
 
-            TestContext.Current.AddTestEnvironmentVariables(ret.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(ret.Environment);
 
             return ret;
         }

--- a/test/Microsoft.NET.TestFramework/Commands/RunExeCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/RunExeCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.TestFramework.Commands
                 Arguments = args.ToList(),
                 WorkingDirectory = WorkingDirectory,
             };
-            TestContext.Current.AddTestEnvironmentVariables(sdkCommandSpec.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(sdkCommandSpec.Environment);
             return sdkCommandSpec;
         }
     }

--- a/test/Microsoft.NET.TestFramework/SdkTest.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTest.cs
@@ -5,7 +5,7 @@ namespace Microsoft.NET.TestFramework
 {
     public abstract class SdkTest
     {
-        protected bool? UsingFullFrameworkMSBuild => TestContext.Current.ToolsetUnderTest?.ShouldUseFullFrameworkMSBuild;
+        protected bool? UsingFullFrameworkMSBuild => SdkTestContext.Current.ToolsetUnderTest?.ShouldUseFullFrameworkMSBuild;
 
         protected ITestOutputHelper Log { get; }
 

--- a/test/Microsoft.NET.TestFramework/SdkTestContext.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTestContext.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.NET.TestFramework
 {
-    public class TestContext
+    public class SdkTestContext
     {
         //  Generally the folder the test DLL is in
         private string? _testExecutionDirectory;
@@ -135,9 +135,9 @@ namespace Microsoft.NET.TestFramework
             }
         }
 
-        private static TestContext? _current;
+        private static SdkTestContext? _current;
 
-        public static TestContext Current
+        public static SdkTestContext Current
         {
             get
             {
@@ -147,7 +147,7 @@ namespace Microsoft.NET.TestFramework
                     //  (ie when using test explorer or another runner)
                     Initialize(TestCommandLine.Parse(Array.Empty<string>()));
                 }
-                return _current ?? throw new InvalidOperationException("TestContext.Current should never be null.");
+                return _current ?? throw new InvalidOperationException("SdkTestContext.Current should never be null.");
             }
             set
             {
@@ -159,7 +159,7 @@ namespace Microsoft.NET.TestFramework
 
         public static string GetRuntimeGraphFilePath()
         {
-            string dotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+            string dotnetRoot = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
 
             DirectoryInfo sdksDir = new(Path.Combine(dotnetRoot, "sdk"));
 
@@ -201,7 +201,7 @@ namespace Microsoft.NET.TestFramework
             //  one running the tests, it won't interfere
             Environment.SetEnvironmentVariable("MSBuildSdksPath", null);
 
-            TestContext testContext = new();
+            SdkTestContext testContext = new();
 
             bool runAsTool = false;
             if (Directory.Exists(Path.Combine(AppContext.BaseDirectory, "TestAssets")))
@@ -338,8 +338,8 @@ namespace Microsoft.NET.TestFramework
 
             testContext.ToolsetUnderTest = ToolsetInfo.Create(repoRoot, artifactsDir, repoConfiguration, commandLine);
 
-            //  Important to set this before below code which ends up calling through TestContext.Current, which would
-            //  result in infinite recursion / stack overflow if TestContext.Current wasn't set
+            //  Important to set this before below code which ends up calling through SdkTestContext.Current, which would
+            //  result in infinite recursion / stack overflow if SdkTestContext.Current wasn't set
             Current = testContext;
 
             //  Set up test hooks for in-process tests

--- a/test/Microsoft.NET.TestFramework/TestAssetsManager.cs
+++ b/test/Microsoft.NET.TestFramework/TestAssetsManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.TestFramework
 
         public TestAssetsManager(ITestOutputHelper log)
         {
-            var testAssetsDirectory = TestContext.Current.TestAssetsDirectory;
+            var testAssetsDirectory = SdkTestContext.Current.TestAssetsDirectory;
             Log = log;
 
             if (!Directory.Exists(testAssetsDirectory))
@@ -46,7 +46,7 @@ namespace Microsoft.NET.TestFramework
             testDestinationDirectory ??= GetTestDestinationDirectoryPath(testProjectName, callingMethod + "_" + fileName, identifier, allowCopyIfPresent);
             TestDestinationDirectories.Add(testDestinationDirectory);
 
-            var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, TestContext.Current.SdkVersion, Log);
+            var testAsset = new TestAsset(testProjectDirectory, testDestinationDirectory, SdkTestContext.Current.SdkVersion, Log);
             return testAsset;
         }
 
@@ -125,7 +125,7 @@ namespace Microsoft.NET.TestFramework
             IEnumerable<TestProject> testProjects,
             string testDestinationDirectory)
         {
-            var testAsset = new TestAsset(testDestinationDirectory, TestContext.Current.SdkVersion, Log);
+            var testAsset = new TestAsset(testDestinationDirectory, SdkTestContext.Current.SdkVersion, Log);
 
             Stack<TestProject> projectStack = new(testProjects);
             HashSet<TestProject> createdProjects = new();
@@ -151,7 +151,7 @@ namespace Microsoft.NET.TestFramework
         public TestDirectory CreateTestDirectory([CallerMemberName] string? testName = null, string? identifier = null, string? baseDirectory = null)
         {
             string dir = GetTestDestinationDirectoryPath(testName, testName, identifier ?? string.Empty, baseDirectory: baseDirectory);
-            return new TestDirectory(dir, TestContext.Current.SdkVersion);
+            return new TestDirectory(dir, SdkTestContext.Current.SdkVersion);
         }
 
         public string GetAndValidateTestProjectDirectory(string testProjectName, string testAssetSubdirectory = "")
@@ -177,7 +177,7 @@ namespace Microsoft.NET.TestFramework
             bool allowCopyIfPresent = false,
             string? baseDirectory = null)
         {
-            baseDirectory ??= TestContext.Current.TestExecutionDirectory;
+            baseDirectory ??= SdkTestContext.Current.TestExecutionDirectory;
             var directoryName = new StringBuilder(callingMethodAndFileName).Append(identifier);
 
             if (testProjectName != callingMethodAndFileName)

--- a/test/Microsoft.NET.TestFramework/TestCommandLine.cs
+++ b/test/Microsoft.NET.TestFramework/TestCommandLine.cs
@@ -288,7 +288,7 @@ namespace Microsoft.NET.TestFramework
 
             if (!commandLine.ShouldShowHelp)
             {
-                TestContext.Initialize(commandLine);
+                SdkTestContext.Initialize(commandLine);
             }
 
             return commandLine;

--- a/test/Microsoft.NET.TestFramework/TestDirectory.cs
+++ b/test/Microsoft.NET.TestFramework/TestDirectory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.TestFramework
 
         public static TestDirectory Create(string path)
         {
-            return new TestDirectory(path, TestContext.Current.SdkVersion);
+            return new TestDirectory(path, SdkTestContext.Current.SdkVersion);
         }
 
         public string Path { get; private set; }
@@ -50,7 +50,7 @@ namespace Microsoft.NET.TestFramework
 
             Directory.CreateDirectory(path);
 
-            TestContext.WriteGlobalJson(path, sdkVersion);
+            SdkTestContext.WriteGlobalJson(path, sdkVersion);
         }
     }
 }

--- a/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
+++ b/test/Microsoft.NET.TestFramework/ToolsetInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.TestFramework
                 if (_sdkVersion == null)
                 {
                     //  Initialize SdkVersion lazily, as we call `dotnet --version` to get it, so we need to wait
-                    //  for the TestContext to finish being initialize
+                    //  for the SdkTestContext to finish being initialize
                     InitSdkVersion();
                 }
                 return _sdkVersion ?? throw new InvalidOperationException("SdkVersion should never be null."); ;
@@ -46,7 +46,7 @@ namespace Microsoft.NET.TestFramework
                 if (_msbuildVersion == null)
                 {
                     //  Initialize MSBuildVersion lazily, as we call `dotnet msbuild -version` to get it, so we need to wait
-                    //  for the TestContext to finish being initialize
+                    //  for the SdkTestContext to finish being initialize
                     InitMSBuildVersion();
                 }
                 return _msbuildVersion;
@@ -94,7 +94,7 @@ namespace Microsoft.NET.TestFramework
                 var logger = new StringTestLogger();
                 var command = new DotnetCommand(logger, "--version")
                 {
-                    WorkingDirectory = TestContext.Current.TestExecutionDirectory
+                    WorkingDirectory = SdkTestContext.Current.TestExecutionDirectory
                 };
 
                 var result = command.Execute();
@@ -117,7 +117,7 @@ namespace Microsoft.NET.TestFramework
             var logger = new StringTestLogger();
             var command = new MSBuildVersionCommand(logger)
             {
-                WorkingDirectory = TestContext.Current.TestExecutionDirectory
+                WorkingDirectory = SdkTestContext.Current.TestExecutionDirectory
             };
 
             var result = command.Execute();
@@ -243,7 +243,7 @@ namespace Microsoft.NET.TestFramework
                 ret.Arguments = newArgs;
             }
 
-            TestContext.Current.AddTestEnvironmentVariables(ret.Environment);
+            SdkTestContext.Current.AddTestEnvironmentVariables(ret.Environment);
 
             return ret;
         }

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -139,7 +139,7 @@ namespace Microsoft.NET.ToolPack.Tests
         [InlineData(false, ToolsetInfo.CurrentTargetFramework)]
         public void It_uses_customized_PackagedShimOutputRootDirectory(bool multiTarget, string targetFramework)
         {
-            string shimoutputPath = Path.Combine(TestContext.Current.TestExecutionDirectory, "shimoutput");
+            string shimoutputPath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "shimoutput");
             TestAsset helloWorldAsset = TestAssetsManager
                 .CopyTestAsset("PortableTool", "PackagedShimOutputRootDirectory" + multiTarget.ToString(), identifier: multiTarget.ToString() + targetFramework)
                 .WithSource()

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         /// <summary>
         /// Gets a path to the folder with dotnet new test assets.
         /// </summary>
-        public static string DotnetNewTestAssets { get; } = VerifyExists(Path.Combine(TestContext.Current.TestAssetsDirectory, "TestPackages", "dotnet-new"));
+        public static string DotnetNewTestAssets { get; } = VerifyExists(Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "TestPackages", "dotnet-new"));
 
         /// <summary>
         /// Gets a path to the folder with dotnet new test NuGet template packages.
@@ -55,7 +55,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
         private static string GetAndVerifyRepoRoot()
         {
-            string repoRoot = Path.GetFullPath(Path.Combine(TestContext.Current.TestAssetsDirectory, "..", ".."));
+            string repoRoot = Path.GetFullPath(Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "..", ".."));
             if (!Directory.Exists(repoRoot))
             {
                 Assert.Fail($"The repo root cannot be evaluated.");

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -140,11 +140,11 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
             var installedSdkFolder = $@"c:\Program Files\dotnet\sdk\{existingVersionToOverwrite}";
 
-            Log.WriteLine($"Deploying SDK from {TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest} to {installedSdkFolder} on VM.");
+            Log.WriteLine($"Deploying SDK from {SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest} to {installedSdkFolder} on VM.");
 
             //  TODO: It would be nice if the description included the date/time of the SDK build, to distinguish different snapshots
             VM.CreateActionGroup("Deploy Stage 2 SDK",
-                    VM.CopyFolder(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, installedSdkFolder),
+                    VM.CopyFolder(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, installedSdkFolder),
                     ChangeVersionFileContents(existingVersionToOverwrite))
                 .Execute()
                 .Should()
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
             var installedSdkFolder = $@"c:\Program Files\dotnet\sdk\{sdkVersion}";
             var vmVersionFilePath = Path.Combine(installedSdkFolder, ".version");
 
-            var newVersionFileContents = File.ReadAllLines(Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, ".version"));
+            var newVersionFileContents = File.ReadAllLines(Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, ".version"));
             newVersionFileContents[1] = sdkVersion;
 
             return VM.WriteFile(vmVersionFilePath, string.Join(Environment.NewLine, newVersionFileContents));

--- a/test/dotnet-format.UnitTests/Analyzers/AnalyzerAssemblyGenerator.cs
+++ b/test/dotnet-format.UnitTests/Analyzers/AnalyzerAssemblyGenerator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             // Resolve the targeting pack and the target framework used to compile the test assembly.
             var sdkTargetFrameworkTargetingPackVersion = (string)AppContext.GetData("ReferenceAssemblies.SdkTargetFramework.TargetingPackVersion")!;
             var sdkTargetFrameworkTargetFramework = (string)AppContext.GetData("ReferenceAssemblies.SdkTargetFramework.TargetFramework")!;
-            var nugetConfigPath = Path.Combine(TestContext.Current.TestExecutionDirectory, "NuGet.config");
+            var nugetConfigPath = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "NuGet.config");
             ReferenceAssemblies sdkTargetFrameworkReferenceAssemblies = new(sdkTargetFrameworkTargetFramework,
                 new PackageIdentity("Microsoft.NETCore.App.Ref", sdkTargetFrameworkTargetingPackVersion),
                 Path.Combine("ref", sdkTargetFrameworkTargetFramework));

--- a/test/dotnet-format.UnitTests/Utilities/TestProjectsPathHelper.cs
+++ b/test/dotnet-format.UnitTests/Utilities/TestProjectsPathHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Utilities
         {
             if (s_projectsDirectory == null)
             {
-                var assetsDirectory = Path.Combine(TestContext.Current.TestAssetsDirectory, "dotnet-format");
+                var assetsDirectory = Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "dotnet-format");
                 if (Directory.Exists(assetsDirectory))
                 {
                     s_projectsDirectory = assetsDirectory;

--- a/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
+++ b/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         /// <summary>
         /// Gets a path to the folder with dotnet new test assets.
         /// </summary>
-        public static string DotnetNewTestAssets { get; } = VerifyExists(Path.Combine(TestContext.Current.TestAssetsDirectory, "TestPackages", "dotnet-new"));
+        public static string DotnetNewTestAssets { get; } = VerifyExists(Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "TestPackages", "dotnet-new"));
 
         /// <summary>
         /// Gets a path to the folder with dotnet new test NuGet template packages.
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         private static string GetAndVerifyRepoRoot()
         {
-            string repoRoot = Path.GetFullPath(Path.Combine(TestContext.Current.TestAssetsDirectory, "..", ".."));
+            string repoRoot = Path.GetFullPath(Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "..", ".."));
             if (!Directory.Exists(repoRoot))
             {
                 Assert.Fail($"The repo root cannot be evaluated.");

--- a/test/dotnet-new.IntegrationTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/CommonTemplatesTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public async Task AllCommonItemsCreate(string expectedTemplateName, string templateShortName, string[]? args)
         {
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
 
             string itemName = expectedTemplateName.Replace(' ', '-').Replace('.', '-');
 
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 VerifyCommandOutput = true,
                 VerificationExcludePatterns = new[] { "*/stderr.txt", "*\\stderr.txt" },
                 SettingsDirectory = _fixture.HomeDirectory,
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
                 DoNotPrependTemplateNameToScenarioName = true,
                 UniqueFor = expectedTemplateName.Equals("NuGet Config") ? UniqueForOption.OsPlatform : null,
             }
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             string finalProjectName = Path.Combine(projectDir, $"{projName}.{extension}");
 
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: name)
             {
@@ -222,7 +222,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 DoNotAppendTemplateArgsToScenarioName = true,
                 ScenarioName = language.Replace('#', 's').ToLower(),
                 VerificationExcludePatterns = new[] { "*/stderr.txt", "*\\stderr.txt" },
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
             }
             .WithCustomEnvironment(environmentUnderTest)
             .WithCustomScrubbers(
@@ -404,7 +404,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
             environmentUnderTest["CheckEolTargetFramework"] = false.ToString();
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: name)
             {
@@ -421,7 +421,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     + '#' + (language == null ? "cs" : language.Replace('#', 's').ToLower())
                     + (langVersion == null ? "#NoLangVer" : (langVersionUnsupported ? "#UnsuportedLangVer" : null)),
                 VerificationExcludePatterns = new[] { "*/stderr.txt", "*\\stderr.txt" },
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
             }
             .WithCustomEnvironment(environmentUnderTest)
             .WithCustomScrubbers(

--- a/test/dotnet-new.IntegrationTests/DotnetClassTemplateTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetClassTemplateTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             // prevents logging a welcome message from sdk installation
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
 
             string folderName = GetFolderName(templateShortName, langVersion, targetFramework);
             string workingDir = CreateTemporaryFolder($"{nameof(DotnetCSharpClassTemplatesTest)}.{folderName}");
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     "*project.*.*"
                 },
                 SettingsDirectory = _fixture.HomeDirectory,
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
                 DoNotAppendTemplateArgsToScenarioName = true,
                 DoNotPrependTemplateNameToScenarioName = true,
                 ScenarioName = folderName,
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             // prevents logging a welcome message from sdk installation
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
 
             string folderName = GetFolderName(templateShortName, langVersion, targetFramework);
             string workingDir = CreateTemporaryFolder($"{nameof(DotnetVisualBasicClassTemplatesTest)}.{folderName}");
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     "*project.*.*"
                 },
                 SettingsDirectory = _fixture.HomeDirectory,
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
                 DoNotAppendTemplateArgsToScenarioName = true,
                 DoNotPrependTemplateNameToScenarioName = true,
                 ScenarioName = folderName,

--- a/test/dotnet-new.IntegrationTests/DotnetNewInstantiateTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewInstantiateTests.cs
@@ -361,7 +361,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             cmd.ExitCode.Should().NotBe(0);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 cmd.StdErr.Should().StartWith("No templates or subcommands found");
             }
@@ -436,7 +436,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             cmd.ExitCode.Should().NotBe(0);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 cmd.StdErr.Should().StartWith("No templates or subcommands found matching: 'c'.");
             }

--- a/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             _log.LogInformation($"Template with {caseDescription}");
             Dictionary<string, string> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
-            TestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
+            SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
             FileExtensions.AddTextExtension(".cshtml");
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: shortName)
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 SnapshotsDirectory = "Approvals",
                 SettingsDirectory = _sharedHome.HomeDirectory,
                 DoNotAppendTemplateArgsToScenarioName = true,
-                DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,
+                DotnetExecutablePath = SdkTestContext.Current.ToolsetUnderTest?.DotNetHostPath,
                 DoNotPrependCallerMethodNameToScenarioName = true,
                 ScenarioName = $"{folderName.Substring(folderName.IndexOf("-") + 1)}{GetScenarioName(arguments)}"
             }

--- a/test/dotnet-new.IntegrationTests/Utilities.cs
+++ b/test/dotnet-new.IntegrationTests/Utilities.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         /// </summary>
         internal static string GetTestExecutionTempFolder()
         {
-            return Path.Combine(TestContext.Current.TestExecutionDirectory, "dotnet-new.IntegrationTests");
+            return Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "dotnet-new.IntegrationTests");
         }
 
         /// <summary>

--- a/test/dotnet-watch.Tests/Build/EvaluationTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         private readonly TestAssetsManager _testAssets = new(output);
 
         private static string MuxerPath
-            => TestContext.Current.ToolsetUnderTest.DotNetHostPath;
+            => SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath;
 
         private static string InspectPath(string path, string rootDir)
             => path.Substring(rootDir.Length + 1).Replace("\\", "/");

--- a/test/dotnet-watch.Tests/CommandLine/BinaryLoggerTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/BinaryLoggerTests.cs
@@ -37,7 +37,7 @@ public class BinaryLoggerTests
         Assert.NotNull(value);
         Assert.NotNull(expected);
 
-        var dir = TestContext.Current.TestExecutionDirectory;
+        var dir = SdkTestContext.Current.TestExecutionDirectory;
         Directory.SetCurrentDirectory(dir);
 
         var bl = new BinaryLogger() { Parameters = value };

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -517,7 +517,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [Fact]
         public void ForwardedBuildOptions_ArtifactsPath()
         {
-            var path = TestContext.Current.TestAssetsDirectory;
+            var path = SdkTestContext.Current.TestAssetsDirectory;
 
             var args = new[] { "--artifacts-path", path };
             var buildArgs = new[] { NugetInteractiveProperty, @"--property:ArtifactsPath=" + path };

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var program = Program.TryCreate(
                 TestOptions.GetCommandLineOptions(["--verbose"]),
                 console,
-                TestOptions.GetEnvironmentOptions(workingDirectory: testAsset.Path, TestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset),
+                TestOptions.GetEnvironmentOptions(workingDirectory: testAsset.Path, SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset),
                 loggerFactory,
                 reporter,
                 out var errorCode);

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         {
             var logger = new TestLogger(output);
             var watcher = new TestFileWatcher(logger);
-            string root = TestContext.Current.TestExecutionDirectory;
+            string root = SdkTestContext.Current.TestExecutionDirectory;
 
             var dirA = Path.Combine(root, "A");
             var dirB = Path.Combine(root, "B");

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -98,7 +98,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         var console = new TestConsole(Logger);
         var reporter = new TestReporter(Logger);
         var loggerFactory = new LoggerFactory(reporter, LogLevel.Trace);
-        var environmentOptions = TestOptions.GetEnvironmentOptions(workingDirectory ?? testAsset.Path, TestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset);
+        var environmentOptions = TestOptions.GetEnvironmentOptions(workingDirectory ?? testAsset.Path, SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath, testAsset);
         var processRunner = new ProcessRunner(environmentOptions.GetProcessCleanupTimeout(isHotReloadEnabled: true));
 
         var program = Program.TryCreate(

--- a/test/dotnet-watch.Tests/TestUtilities/ModuleInitializer.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/ModuleInitializer.cs
@@ -20,7 +20,7 @@ public static class ModuleInitializer
         // does not have any public type that has a dependency on msbuild.
         // xUnit loads all public types and any reference to msbuild assembly will trigger its load.
 
-        var toolset = TestContext.Current.ToolsetUnderTest;
+        var toolset = SdkTestContext.Current.ToolsetUnderTest;
         var sdkDir = toolset.SdkFolderUnderTest;
         var watchDir = Path.Combine(sdkDir, "DotnetTools", "dotnet-watch", toolset.SdkVersion, "tools", ToolsetInfo.CurrentTargetFramework, "any");
 

--- a/test/dotnet.Tests/CommandFactoryTests/GivenADotnetToolsCommandResolver.cs
+++ b/test/dotnet.Tests/CommandFactoryTests/GivenADotnetToolsCommandResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Tests
 
         public GivenADotnetToolsCommandResolver(ITestOutputHelper log) : base(log)
         {
-            var dotnetToolPath = Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "DotnetTools");
+            var dotnetToolPath = Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "DotnetTools");
             _dotnetToolsCommandResolver = new DotnetToolsCommandResolver(dotnetToolPath);
         }
 

--- a/test/dotnet.Tests/CommandFactoryTests/GivenAProjectDependencyCommandResolver.cs
+++ b/test/dotnet.Tests/CommandFactoryTests/GivenAProjectDependencyCommandResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tests
         {
             Environment.SetEnvironmentVariable(
                 Constants.MSBUILD_EXE_PATH,
-                Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
+                Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
 
             _configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
         }
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tests
                 TestAssetsManager.CopyTestAsset("TestAppWithProjDepTool")
                     .WithSource();
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             new DotnetBuildCommand(Log)
                 .WithWorkingDirectory(testAsset.Path)
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Tests
                 TestAssetsManager.CopyTestAsset("TestAppWithProjDepTool")
                     .WithSource();
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             new DotnetBuildCommand(Log)
                 .WithWorkingDirectory(testAsset.Path)
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Tests
                 TestAssetsManager.CopyTestAsset("TestAppWithProjDepTool")
                     .WithSource();
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             new RestoreCommand(testAsset)
                 .Execute()
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Tests
                 TestAssetsManager.CopyTestAsset("TestAppWithProjDepTool")
                     .WithSource();
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             new RestoreCommand(testAsset)
                 .Execute()
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Tests
         {
             Environment.SetEnvironmentVariable(
                 Constants.MSBUILD_EXE_PATH,
-                Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
+                Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
 
             environment = environment ?? new EnvironmentProvider();
 

--- a/test/dotnet.Tests/CommandFactoryTests/GivenAProjectToolsCommandResolver.cs
+++ b/test/dotnet.Tests/CommandFactoryTests/GivenAProjectToolsCommandResolver.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -219,7 +219,7 @@ namespace Microsoft.DotNet.Tests
                 .WithSource()
                 .WithRepoGlobalPackages();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Tests
                 ProjectDirectory = testInstance.Path
             };
 
-            var nugetPackagesRoot = TestContext.Current.TestGlobalPackagesFolder;
+            var nugetPackagesRoot = SdkTestContext.Current.TestGlobalPackagesFolder;
 
             var toolPathCalculator = new ToolPathCalculator(nugetPackagesRoot);
 
@@ -265,11 +265,11 @@ namespace Microsoft.DotNet.Tests
                 .WithSource()
                 .WithRepoGlobalPackages();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
-            var toolPathCalculator = new ToolPathCalculator(TestContext.Current.TestGlobalPackagesFolder);
+            var toolPathCalculator = new ToolPathCalculator(SdkTestContext.Current.TestGlobalPackagesFolder);
 
             var lockFilePath = toolPathCalculator.GetLockFilePath(
                 "dotnet-portable",
@@ -302,7 +302,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(TestProjectName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -331,7 +331,7 @@ namespace Microsoft.DotNet.Tests
             var testProjectDirectory = testInstance.Path;
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
 
-            var nugetConfig = UseNuGetConfigWithFallbackFolder(testInstance, fallbackFolder, TestContext.Current.TestPackages);
+            var nugetConfig = UseNuGetConfigWithFallbackFolder(testInstance, fallbackFolder, SdkTestContext.Current.TestPackages);
 
             PopulateFallbackFolder(testProjectDirectory, fallbackFolder);
 
@@ -357,7 +357,7 @@ namespace Microsoft.DotNet.Tests
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
             var nugetPackages = Path.Combine(testProjectDirectory, "nugetPackages");
 
-            var nugetConfig = UseNuGetConfigWithFallbackFolder(testInstance, fallbackFolder, TestContext.Current.TestPackages);
+            var nugetConfig = UseNuGetConfigWithFallbackFolder(testInstance, fallbackFolder, SdkTestContext.Current.TestPackages);
 
             PopulateFallbackFolder(testProjectDirectory, fallbackFolder);
 
@@ -429,7 +429,7 @@ namespace Microsoft.DotNet.Tests
         {
             //  When using the product, the ToolDepsJsonGeneratorProject property is used to get this path, but for testing
             //  we'll hard code the path inside the SDK since we don't have a project to evaluate here
-            return Path.Combine(TestContext.Current.ToolsetUnderTest.SdksPath, "Microsoft.NET.Sdk", "targets", "GenerateDeps", "GenerateDeps.proj");
+            return Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdksPath, "Microsoft.NET.Sdk", "targets", "GenerateDeps", "GenerateDeps.proj");
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Build/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Build/GivenDotnetBuildBuildsCsproj.cs
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             cmd.Should().Pass();
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 cmd.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
             }
@@ -341,7 +341,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             var testAsset = TestAssetsManager.CreateTestProject(testProject, identifier: compilerApiVersion);
 
-            NuGetConfigWriter.Write(testAsset.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
 
             var command = new GetValuesCommand(testAsset,
                 "Analyzer",
@@ -378,7 +378,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
         static readonly List<string?> nugetRoots = new()
         {
-            TestContext.Current.NuGetCachePath,
+            SdkTestContext.Current.NuGetCachePath,
             Path.Combine(CliFolderPathCalculator.DotnetHomePath, ".dotnet", "NuGetFallbackFolder")
         };
 

--- a/test/dotnet.Tests/CommandTests/New/SdkInfoProviderTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/SdkInfoProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
         [Fact]
         public async Task GetInstalledVersionsAsync_ShouldContainCurrentVersion()
         {
-            string? dotnetRootUnderTest = TestContext.Current.ToolsetUnderTest?.DotNetRoot;
+            string? dotnetRootUnderTest = SdkTestContext.Current.ToolsetUnderTest?.DotNetRoot;
             string? pathOrig = Environment.GetEnvironmentVariable("PATH");
             Environment.SetEnvironmentVariable("PATH", dotnetRootUnderTest + Path.PathSeparator + pathOrig);
 

--- a/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
+++ b/test/dotnet.Tests/CommandTests/NuGet/GivenANuGetCommand.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .WithSource();
             var projectDirectory = testAsset.Path;
 
-            NuGetConfigWriter.Write(projectDirectory, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(projectDirectory, SdkTestContext.Current.TestPackages);
 
             new DotnetCommand(Log, "package", "add", "dotnet-hello@1.0.0")
                 .WithWorkingDirectory(projectDirectory)

--- a/test/dotnet.Tests/CommandTests/Pack/PackTests.cs
+++ b/test/dotnet.Tests/CommandTests/Pack/PackTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Pack.Tests
                 .Execute("--no-build");
 
             result.Should().Fail();
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.Should().NotHaveStdOutContaining("Restore")
                     .And.HaveStdOutContaining("project.assets.json");
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.Pack.Tests
 
             result.Should().Pass();
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
             }

--- a/test/dotnet.Tests/CommandTests/Publish/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet.Tests/CommandTests/Publish/GivenDotnetPublishPublishesProjects.cs
@@ -412,7 +412,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             cmd.Should().Pass();
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 cmd.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
             }

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRootEnv.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRootEnv.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void ItShouldSetDotnetRootToDirectoryOfMuxer(string targetFramework)
         {
-            string expectDotnetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+            string expectDotnetRoot = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
             string expectOutput = GetExpectOutput(expectDotnetRoot, targetFramework);
 
             var projectRoot = SetupDotnetRootEchoProject(null, targetFramework);

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("--no-build", "-v:m");
 
             result.Should().Fail();
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.Should().NotHaveStdOutContaining("Restore");
             }
@@ -705,7 +705,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             result.Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.Should().HaveStdOutContaining("Restore")
                     .And.HaveStdOutContaining("CoreCompile");
@@ -1035,7 +1035,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("--project", nonExistentProject, "--no-build");
 
             result.Should().Fail();
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 // After the fix, we should get a clear error message about the file not existing
                 var stderr = result.StdErr;
@@ -1079,7 +1079,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining(TestContext.Current.ToolsetUnderTest.SdkVersion);
+                .And.HaveStdOutContaining(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -123,7 +123,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         Directory.CreateDirectory(outOfTreeBaseDirectory);
 
         // Create NuGet.config in our out-of-tree base directory.
-        var sourceNuGetConfig = Path.Join(TestContext.Current.TestExecutionDirectory, "NuGet.config");
+        var sourceNuGetConfig = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "NuGet.config");
         var targetNuGetConfig = Path.Join(outOfTreeBaseDirectory, "NuGet.config");
         File.Copy(sourceNuGetConfig, targetNuGetConfig, overwrite: true);
 
@@ -3071,9 +3071,9 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
         var msbuildCallArgsString = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(msbuildCallArgs);
 
         // Generate argument template code.
-        string sdkPath = NormalizePath(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest);
-        string dotNetRootPath = NormalizePath(TestContext.Current.ToolsetUnderTest.DotNetRoot);
-        string nuGetCachePath = NormalizePath(TestContext.Current.NuGetCachePath!);
+        string sdkPath = NormalizePath(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest);
+        string dotNetRootPath = NormalizePath(SdkTestContext.Current.ToolsetUnderTest.DotNetRoot);
+        string nuGetCachePath = NormalizePath(SdkTestContext.Current.NuGetCachePath!);
         string artifactsDirNormalized = NormalizePath(artifactsDir);
         string objPath = $"{artifactsDirNormalized}/obj/debug";
         string entryPointPathNormalized = NormalizePath(entryPointPath);
@@ -3248,7 +3248,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
 
         // Save the code.
         var codeFolder = new DirectoryInfo(Path.Join(
-            TestContext.Current.ToolsetUnderTest.RepoRoot,
+            SdkTestContext.Current.ToolsetUnderTest.RepoRoot,
             "src", "Cli", "dotnet", "Commands", "Run"));
         var nonGeneratedFile = codeFolder.File("CSharpCompilerCommand.cs");
         if (!nonGeneratedFile.Exists)
@@ -3898,7 +3898,7 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             }
             """);
 
-        var expectedDotNetRoot = TestContext.Current.ToolsetUnderTest.DotNetRoot;
+        var expectedDotNetRoot = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
 
         var cscResult = new DotnetCommand(Log, "run", "Program.cs", "-bl")
             .WithWorkingDirectory(testInstance.Path)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
 
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, configuration, "Discovered 0 tests"), result.StdOut);
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 1 tests", ["Test0"]), result.StdOut);
                 Assert.Matches(@"Discovered 1 tests.*", result.StdOut);
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 2 tests", ["Test0", "Test2"]), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", true, configuration, "Discovered 1 tests", ["Test1"]), result.StdOut);
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", false, configuration, "Discovered 3 tests", ["TestMethod1", "TestMethod2", "TestMethod3"]), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", true, configuration, "Discovered 2 tests", ["TestMethod1", "TestMethod3"]), result.StdOut);
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsHelp.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsHelp.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute(CliConstants.HelpOptionKey, "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(@"Extension Options:\s+--[\s\S]*", result.StdOut);
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute(CliConstants.HelpOptionKey, "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(@"Extension Options:\s+--[\s\S]*", result.StdOut);
                 Assert.Matches(@"Options:\s+--[\s\S]*", result.StdOut);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestBasedOnGlobbingFilter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
 
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, TestingConstants.Debug), result.StdOut);
 
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Assert that the bin folder hasn't been modified
             Assert.Equal(binDirectoryLastWriteTime, binDirectory?.LastWriteTime);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, TestingConstants.Debug), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, TestingConstants.Debug), result.StdOut);
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--test-modules", $"**/bin/**/Debug/{ToolsetInfo.CurrentTargetFramework}/TestProject.dll".Replace('/', Path.DirectorySeparatorChar),
                                     "--root-directory", testInstance.TestRoot);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, TestingConstants.Debug), result.StdOut);
 

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithVersionVariables()
                 .Path;
 
-            NuGetConfigWriter.Write(testProjectDirectory, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testProjectDirectory, SdkTestContext.Current.TestPackages);
 
             var runtime = EnvironmentInfo.GetCompatibleRid();
 
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(ConsoleLoggerOutputNormal);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 3")
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                        .Execute(ConsoleLoggerOutputNormal);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 // for target framework net46
                 result.StdOut.Should().Contain("Total tests: 3");

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromDll.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromDll.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call vstest
             var result = new DotnetTestCommand(Log, disableNewOutput: false)
                 .Execute(outputDll, "--logger:console;verbosity=normal");
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 2")
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call vstest
             var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(outputDll, "--arch", "wrongArchitecture");
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().StartWith("Invalid platform type: wrongArchitecture. Valid platform types are ");
             }
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var result = new DotnetTestCommand(Log, disableNewOutput: true)
                 .Execute(arg);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.");
             }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .Execute(ConsoleLoggerOutputNormal);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .Execute(ConsoleLoggerOutputNormal);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.ExitCode.Should().Be(1);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Failed TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
                 result.StdOut.Should().Contain("Total:     2");
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "console;verbosity=normal", "--", "RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 // We append current date time to trx file name, hence modifying this check
                 Assert.True(Directory.EnumerateFiles(trxLoggerDirectory, trxFileNamePattern).Any());
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                        .Execute("--no-build", "-v:m");
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotContain("Restore");
                 //  https://github.com/dotnet/sdk/issues/3684
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .WithWorkingDirectory(rootPath)
                                         .Execute("--no-restore");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -350,7 +350,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .Execute("-v", verbosity);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 if (shouldShowPassedTests)
                 {
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .And
                 .HaveStdOutContaining(rid);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -422,7 +422,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                        .Execute("--nologo");
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotContain("Microsoft (R) Test Execution Command Line Tool Version");
                 result.StdOut.Should().Contain("Total:     2");
@@ -457,7 +457,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                 result.StdOut + Environment.NewLine + result.StdErr);
 
             // Verify test results
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -493,7 +493,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "--results-directory", resultsDirectory);
 
             // Verify test results
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -529,7 +529,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "--results-directory", resultsDirectory);
 
             // Verify test results
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -566,7 +566,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "--results-directory", resultsDirectory);
 
             // Verify test results
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -598,7 +598,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "--filter", "VSTestPassTest");
 
             // Verify test results
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("No code coverage data available. Code coverage is currently supported only on Windows, Linux x64 and macOS x64.");
                 result.StdOut.Should().Contain("Total:     1");
@@ -626,7 +626,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute();
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Important text");
             }
@@ -673,7 +673,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute("--arch", "wrongArchitecture");
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("error NETSDK1083: The specified RuntimeIdentifier");
                 result.StdOut.Should().Contain("wrongArchitecture");
@@ -701,7 +701,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute("--filter", filter);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     1");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -724,7 +724,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute(flag, pathWithComma);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -772,7 +772,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute(flag, flagDirectory + slashesOrBackslashes);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -795,7 +795,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute(testProjectDirectory, arg);
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total:     2");
                 result.StdOut.Should().Contain("Passed:     1");
@@ -824,7 +824,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .Execute(ConsoleLoggerOutputNormal.Concat([property]));
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("Total tests: 2");
                 result.StdOut.Should().Contain("Passed: 1");
@@ -845,7 +845,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute(ConsoleLoggerOutputNormal.Concat(["-dl:my.dll"]));
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 // This ensures that this was passed to MSBuild and not vstest.console.
                 result.StdOut.Should().Contain("error MSB1021: Cannot create an instance of the logger my.dll.");

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsprojWithCorrectTestRunParameters.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         }));
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         }));
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Zero tests ran")
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("(try 2)")
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Zero tests ran")
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Passed!")
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithEnvironmentVariable("TEST_ENV_VAR", "TestValue1")
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Using launch settings from")
@@ -255,7 +255,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Failed!")
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--minimum-expected-tests", "2",
                                         "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.ZeroTestsRan, true, configuration, "8"), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Failed, true, configuration, "2"), result.StdOut);
@@ -310,7 +310,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
@@ -330,7 +330,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(string.Format(CliCommandStrings.CmdUnsupportedVSTestTestApplicationsDescription, "AnotherTestProject.csproj"));
             }
@@ -350,7 +350,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
@@ -370,7 +370,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(CliCommandStrings.CmdNoProjectOrSolutionFileErrorDescription);
             }
@@ -390,7 +390,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain(CliCommandStrings.CmdMultipleProjectOrSolutionFilesErrorDescription);
             }
@@ -416,7 +416,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute(args);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Passed!")
@@ -446,7 +446,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         "-c", configuration,
                                         "--property", "PROPERTY_TO_ENABLE_MTP=1");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Test run summary: Passed!")
@@ -504,7 +504,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute();
 
             result.ExitCode.Should().NotBe(ExitCodes.Success);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 /*
                 The following exception occurred when running the test module with RunCommand 'C:\Users\ygerges\Desktop\sdk\artifacts\tmp\Debug\testing\19cefafa-91c4---0D0799BD\TestProject1\bin\Debug\net10.0\TestProject1.exe' and RunArguments ' ':
@@ -542,7 +542,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             // The test asset exits with Environment.Exit(47);
             result.ExitCode.Should().Be(47);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().NotContain("A test session start event was received without a corresponding test session end");
 
@@ -573,7 +573,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         "-c", configuration,
                                         "--environment", "DUMMY_TEST_ENV_VAR=ENV_VAR_CMD_LINE");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Using launch settings from")

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
                 MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, useCurrentVersion: true, configuration));
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
                 MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true, configuration));
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (testTfmsInParallel)
             {
-                if (!TestContext.IsLocalized())
+                if (!SdkTestContext.IsLocalized())
                 {
                     result.StdOut
                         .Should().Contain("Test run summary: Failed!")
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("-c", configuration,
                                     "--arch", arch);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("error NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specify the RID at the individual project level instead.");
             }
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 MatchCollection previousDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: false, configuration));
                 MatchCollection currentDotnetProjectMatches = Regex.Matches(result.StdOut!, RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, useCurrentVersion: true, configuration));

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithArtifacts.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithArtifacts.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(@".*Test6.*testNodeFile.txt", result.StdOut);
 
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             // Read MSTestPackageVersion from Version.Details.props and update the .csproj file
             // Search for Version.Details.props file from the current directory up to the root
-            string? versionsPropsPath = PathUtility.FindFileInParentDirectories(TestContext.Current.TestExecutionDirectory, $"eng{Path.DirectorySeparatorChar}Version.Details.props") ?? throw new FileNotFoundException("Version.Details.props file not found.");
+            string? versionsPropsPath = PathUtility.FindFileInParentDirectories(SdkTestContext.Current.TestExecutionDirectory, $"eng{Path.DirectorySeparatorChar}Version.Details.props") ?? throw new FileNotFoundException("Version.Details.props file not found.");
             string msTestVersion = testInstance.ReadMSTestPackageVersionFromProps(versionsPropsPath);
             testInstance.UpdateProjectFileWithMSTestPackageVersion(Path.Combine($@"{testInstance.Path}{PathUtility.GetDirectorySeparatorChar()}TestProject", "TestProject.csproj"), msTestVersion);
 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--coverage", "-c", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 string pattern = $@"In\sprocess\sfile\sartifacts\sproduced:\s+.*{PathUtility.GetDirectorySeparatorChar()}TestResults{PathUtility.GetDirectorySeparatorChar()}.*\.coverage";
 

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--arch", arch,
                                              "--configuration", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().Contain("error NETSDK1134: Building a solution with a specific RuntimeIdentifier is not supported. If you would like to publish for a single RID, specify the RID at the individual project level instead.");
             }
@@ -392,7 +392,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                             "--configuration", configuration,
                                             "--property:WarningLevel=2", $"--property:Configuration={configuration}");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                   .Should().Contain("Test run summary: Passed!")
@@ -417,7 +417,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--configuration", configuration,
                                             "--property:WarningLevel=2");
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                   .Should().Contain("Test run summary: Failed!")
@@ -442,7 +442,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--framework", ToolsetInfo.CurrentTargetFramework,
                                              "--configuration", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Passed, true, configuration), result.StdOut);
 
@@ -481,7 +481,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 error NETSDK1005: Assets file 'path\to\OtherTestProject\obj\project.assets.json' doesn't have a target for 'net9.0'. Ensure that restore has run and that you have included 'net9.0' in the TargetFrameworks for your project.
                 Get projects properties with MSBuild didn't execute properly with exit code: 1.
             */
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                  .Should().NotContain("Test run summary")
@@ -514,7 +514,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .Execute("--framework", ToolsetInfo.CurrentTargetFramework,
                                              "--configuration", configuration);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, configuration), result.StdOut);
                 Assert.Matches(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, configuration), result.StdOut);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestContainsEnvironmentVariables.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestContainsEnvironmentVariables.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                   .And.Contain(EnvironmentVariable2)
                   .And.Contain(EnvironmentVariable3);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 1")
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                   .And.Contain(EnvironmentVariable2)
                   .And.Contain(EnvironmentVariable3);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 1")

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestContainsMSBuildParameters.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestContainsMSBuildParameters.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                     .WithWorkingDirectory(testRoot)
                                     .Execute("--logger", "console;verbosity=detailed", MSBuildParameter);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 1")

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardDotnetRootEnvironmentVariables.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             command.EnvironmentToRemove.Add("DOTNET_ROOT(x86)");
             var result = command.Execute(ConsoleLoggerOutputDetailed);
 
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 1")

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandValidationTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute("--my-arg", filename);
 
             result.ExitCode.Should().NotBe(0);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain(expectedErrorStart);
             }
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute("--myarg", "test_directory");
 
             result.ExitCode.Should().NotBe(0);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain("Specifying a directory for 'dotnet test' should be via '--project' or '--solution'.");
             }
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute("--my-arg", "test.dll");
 
             result.ExitCode.Should().NotBe(0);
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdErr.Should().Contain("Specifying dlls or executables for 'dotnet test' should be via '--test-modules'.");
             }

--- a/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallCommandTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             Directory.CreateDirectory("/tmp/folder/sub");
             var directory = Directory.GetCurrentDirectory();
-            var ridGraphPath = TestContext.GetRuntimeGraphFilePath();
+            var ridGraphPath = SdkTestContext.GetRuntimeGraphFilePath();
             try
             {
                 Directory.SetCurrentDirectory("/tmp/folder");

--- a/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                     _fileSystem);
             _toolPackageUninstallerMock = new ToolPackageUninstallerMock(_fileSystem, store);
             _toolPackageDownloader = new ToolPackageDownloaderMock2(_toolPackageStore,
-                runtimeJsonPathForTests: TestContext.GetRuntimeGraphFilePath(),
+                runtimeJsonPathForTests: SdkTestContext.GetRuntimeGraphFilePath(),
                 currentWorkingDirectory: null,
                 fileSystem: _fileSystem);
 
@@ -605,7 +605,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             const string nugetSourcePath = "https://api.nuget.org/v3/index.json";
             var testDir = TestAssetsManager.CreateTestDirectory().Path;
-            var ridGraphPath = TestContext.GetRuntimeGraphFilePath();
+            var ridGraphPath = SdkTestContext.GetRuntimeGraphFilePath();
 
             var toolInstallCommand = new ToolInstallGlobalOrToolPathCommand(Parser.Parse($"dotnet tool install -g {UnlistedPackageId} --version {version} --add-source {nugetSourcePath}"),
                 createToolPackageStoreDownloaderUninstaller: (nonGlobalLocation, _, _) =>

--- a/test/dotnet.Tests/CommandTests/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Uninstall/ToolUninstallGlobalOrToolPathCommandTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             var toolPackageUninstallerMock = new ToolPackageUninstallerMock(_fileSystem, store);
 
             var toolPackageDownloaderMock = new ToolPackageDownloaderMock2(store,
-                runtimeJsonPathForTests: TestContext.GetRuntimeGraphFilePath(),
+                runtimeJsonPathForTests: SdkTestContext.GetRuntimeGraphFilePath(),
                 currentWorkingDirectory: null,
                 fileSystem: _fileSystem);
 

--- a/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Update/ToolUpdateGlobalOrToolPathCommandTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             };
 
             _toolPackageDownloader = new ToolPackageDownloaderMock2(_store,
-                runtimeJsonPathForTests: TestContext.GetRuntimeGraphFilePath(),
+                runtimeJsonPathForTests: SdkTestContext.GetRuntimeGraphFilePath(),
                 currentWorkingDirectory: null,
                 fileSystem: _fileSystem);
 

--- a/test/dotnet.Tests/CommandTests/VSTest/VSTestTests.cs
+++ b/test/dotnet.Tests/CommandTests/VSTest/VSTestTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
             // Call vstest
             var result = new DotnetVSTestCommand(Log)
                 .Execute(outputDll, "--logger:console;verbosity=normal");
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut
                     .Should().Contain("Total tests: 2")
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                                         });
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                                         });
 
             // Verify
-            if (!TestContext.IsLocalized())
+            if (!SdkTestContext.IsLocalized())
             {
                 result.StdOut.Should().NotMatch("The test run parameter argument '*' is invalid.");
                 result.StdOut.Should().Contain("Total tests: 1");

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenWorkloadManifestUpdater.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenWorkloadManifestUpdater.cs
@@ -581,7 +581,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("HelloWorld", identifier: commandName)
                 .WithSource()
                 .Restore(Log);
-            var sdkFeatureBand = new SdkFeatureBand(TestContext.Current.ToolsetUnderTest.SdkVersion);
+            var sdkFeatureBand = new SdkFeatureBand(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
             // Write fake updates file
             Directory.CreateDirectory(Path.Combine(testInstance.Path, ".dotnet"));
             File.WriteAllText(Path.Combine(testInstance.Path, ".dotnet", $".workloadAdvertisingUpdates{sdkFeatureBand}"), @"[""maui""]");
@@ -619,7 +619,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("HelloWorld")
                 .WithSource()
                 .Restore(Log);
-            var sdkFeatureBand = new SdkFeatureBand(TestContext.Current.ToolsetUnderTest.SdkVersion);
+            var sdkFeatureBand = new SdkFeatureBand(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
             // Write fake updates file
             Directory.CreateDirectory(Path.Combine(testInstance.Path, ".dotnet"));
             File.WriteAllText(Path.Combine(testInstance.Path, ".dotnet", $".workloadAdvertisingUpdates6.0.100"), @"[""maui""]");

--- a/test/dotnet.Tests/CompletionTests/DotnetCliSnapshotTests.cs
+++ b/test/dotnet.Tests/CompletionTests/DotnetCliSnapshotTests.cs
@@ -14,7 +14,7 @@ public class DotnetCliSnapshotTests : SdkTest
     [Theory(Skip = "https://github.com/dotnet/sdk/issues/48817")]
     public async Task VerifyCompletions(string shellName)
     {
-        if (!shellName.Equals("zsh") || !TestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
+        if (!shellName.Equals("zsh") || !SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild)
         {
             // This has been unstable lately; skipping
             return;

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -243,7 +243,7 @@ namespace Microsoft.DotNet.Tests
 
         private string GetDotnetVersion()
         {
-            return TestContext.Current.ToolsetUnderTest.SdkVersion;
+            return SdkTestContext.Current.ToolsetUnderTest.SdkVersion;
         }
     }
 }

--- a/test/dotnet.Tests/GivenThatWeWantToBeBackwardsCompatibleWith1xProjects.cs
+++ b/test/dotnet.Tests/GivenThatWeWantToBeBackwardsCompatibleWith1xProjects.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                 .CopyTestAsset("11TestAppWith10CLIToolReferences")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new RestoreCommand(testInstance)
                 .Execute()

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(appName)
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new BuildCommand(testInstance)
                 .Execute()
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("AppWithToolDependency", identifier: toolPrefersCLIRuntime ? "preferCLIRuntime" : "")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance = testInstance.WithProjectChanges(project =>
             {
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("AppWithToolDependency")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             string projectFolder = null;
 
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("AppWithDepOnToolWithOutputName")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new BuildCommand(testInstance)
                 .Execute()
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("DependencyContextFromTool")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             testInstance.Restore(Log);
 
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssetsManager.CopyTestAsset("AppWithDirectDep")
                 .WithSource();
 
-            NuGetConfigWriter.Write(testInstance.Path, TestContext.Current.TestPackages);
+            NuGetConfigWriter.Write(testInstance.Path, SdkTestContext.Current.TestPackages);
 
             new BuildCommand(testInstance)
                 .Execute()

--- a/test/dotnet.Tests/ShellShimTests/AppHostShellShimMakerTests.cs
+++ b/test/dotnet.Tests/ShellShimTests/AppHostShellShimMakerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         {
             var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(tempDirectory);
-            var appHostShellShimMaker = new AppHostShellShimMaker(Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "AppHostTemplate"));
+            var appHostShellShimMaker = new AppHostShellShimMaker(Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "AppHostTemplate"));
             string shimPath = Path.Combine(tempDirectory, Path.GetRandomFileName());
 
             appHostShellShimMaker.CreateApphostShellShim(

--- a/test/dotnet.Tests/ShellShimTests/ShellShimRepositoryTests.cs
+++ b/test/dotnet.Tests/ShellShimTests/ShellShimRepositoryTests.cs
@@ -471,12 +471,12 @@ namespace Microsoft.DotNet.ShellShim.Tests
             if (Environment.Is64BitProcess)
             {
                 processStartInfo.EnvironmentVariables["DOTNET_ROOT"] =
-                    TestContext.Current.ToolsetUnderTest.DotNetRoot;
+                    SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
             }
             else
             {
                 processStartInfo.EnvironmentVariables["DOTNET_ROOT(x86)"] =
-                    TestContext.Current.ToolsetUnderTest.DotNetRoot;
+                    SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
             }
 
             processStartInfo.ExecuteAndCaptureOutput(out var stdOut, out var stdErr);
@@ -489,7 +489,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         private static string GetAppHostTemplateFromStage2()
         {
             var stage2AppHostTemplateDirectory =
-                Path.Combine(TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "AppHostTemplate");
+                Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "AppHostTemplate");
             return stage2AppHostTemplateDirectory;
         }
 

--- a/test/dotnet.Tests/TestAssetExtensions.cs
+++ b/test/dotnet.Tests/TestAssetExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 var ns = project.Root.Name.Namespace;
                 project.Root.Element(ns + "PropertyGroup")
-                    .Add(new XElement(ns + "RestorePackagesPath", TestContext.Current.TestGlobalPackagesFolder));
+                    .Add(new XElement(ns + "RestorePackagesPath", SdkTestContext.Current.TestGlobalPackagesFolder));
             });
         }
     }

--- a/test/trustedroots.Tests/CtlFileTests.cs
+++ b/test/trustedroots.Tests/CtlFileTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tests
         public CtlFileTests(string fileName)
         {
             _filePath = Path.Combine(
-                TestContext.Current.ToolsetUnderTest.SdkFolderUnderTest,
+                SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest,
                 "trustedroots",
                 fileName);
         }


### PR DESCRIPTION
Related to #52914 

xUnit v3 introduces Xunit.TestContext which conflicts with the SDK's Microsoft.NET.TestFramework.TestContext. Rename to SdkTestContext to prevent ambiguity and avoid needing global using workarounds.