### PR TITLE
[StaticWebAssets] Add `Framework` source type to prevent duplicate asset crashes

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticAssetsManifest.cs
@@ -193,7 +193,7 @@ public partial class StaticWebAssetsManifest : IEquatable<StaticWebAssetsManifes
         internal static bool ShouldIncludeAssetInCurrentProject(StaticWebAsset asset, string projectMode) => IsRoot(projectMode) && !asset.IsForReferencedProjectsOnly();
 
         internal static bool ShouldIncludeAssetAsReference(StaticWebAsset asset, string projectMode) =>
-            IsRoot(projectMode) && !asset.IsForReferencedProjectsOnly() ||
+            IsRoot(projectMode) && !asset.IsForReferencedProjectsOnly() && !asset.IsFramework() ||
             IsDefault(projectMode) && !asset.IsForCurrentProjectOnly();
 
     }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -590,6 +590,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
             case SourceTypes.Computed:
             case SourceTypes.Project:
             case SourceTypes.Package:
+            case SourceTypes.Framework:
                 break;
             default:
                 throw new InvalidOperationException($"Unknown source type '{SourceType}' for '{Identity}'.");
@@ -771,6 +772,9 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     public bool IsPackage()
         => string.Equals(SourceType, SourceTypes.Package, StringComparison.Ordinal);
+
+    public bool IsFramework()
+        => string.Equals(SourceType, SourceTypes.Framework, StringComparison.Ordinal);
 
     public bool IsBuildOnly()
         => string.Equals(AssetKind, AssetKinds.Build, StringComparison.Ordinal);
@@ -1017,6 +1021,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         public const string Computed = nameof(Computed);
         public const string Project = nameof(Project);
         public const string Package = nameof(Package);
+        public const string Framework = nameof(Framework);
 
         public static bool IsPackage(string sourceType) => string.Equals(Package, sourceType, StringComparison.Ordinal);
     }


### PR DESCRIPTION
### Summary

Adds a new `SourceType="Framework"` for static web assets to prevent the `DiscoverPrecompressedAssets` crash when one Blazor Web App references another.

This will require a companion change in the `Microsoft.AspNetCore.App.Internal.Assets` package targets (`SourceType="Discovered"` -> `SourceType="Framework"`).

### Description

The `Microsoft.AspNetCore.App.Internal.Assets` NuGet package contributes framework files (`blazor.web.js`, etc.) as static web assets. When Blazor Web App A references Blazor Web App B, both independently resolve this package and get their own copy of `blazor.web.js`. Both default to `StaticWebAssetProjectMode=Root`, and Root mode exports `CurrentProject` assets to consumers. So, B exports its `blazor.web.js` to A, which already has one. This duplication causes `DiscoverPrecompressedAssets` to throw.

The new `"Framework"` source type allows assets to be included in root projects without getting exported to referencing projects.

The change has been validated with new unit tests and manual end-to-end testing.


